### PR TITLE
Computing movement amount from framerate

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -182,8 +182,12 @@ export class GameScene extends Phaser.Scene implements GameSceneInterface{
         });
     }
 
-    update() : void {
-        this.CurrentPlayer.moveUser();
+    /**
+     * @param time
+     * @param delta The delta time in ms since the last frame. This is a smoothed and capped value based on the FPS rate.
+     */
+    update(time: number, delta: number) : void {
+        this.CurrentPlayer.moveUser(delta);
     }
 
     /**

--- a/front/src/Phaser/Player/Player.ts
+++ b/front/src/Phaser/Player/Player.ts
@@ -9,7 +9,7 @@ export interface CurrentGamerInterface extends PlayableCaracter{
     userId : string;
     PlayerValue : string;
     initAnimation() : void;
-    moveUser() : void;
+    moveUser(delta: number) : void;
     say(text : string) : void;
 }
 
@@ -57,31 +57,32 @@ export class Player extends PlayableCaracter implements CurrentGamerInterface, G
         })
     }
 
-    moveUser(): void {
+    moveUser(delta: number): void {
         //if user client on shift, camera and player speed
         let haveMove = false;
         let direction = null;
 
         let activeEvents = this.userInputManager.getEventListForGameTick();
-        let speedMultiplier = activeEvents.get(UserInputEvent.SpeedUp) ? 500 : 100;
+        let speedMultiplier = activeEvents.get(UserInputEvent.SpeedUp) ? 25 : 9;
+        let moveAmount = speedMultiplier * delta;
 
         if (activeEvents.get(UserInputEvent.MoveUp)) {
-            this.move(0, -speedMultiplier);
+            this.move(0, -moveAmount);
             haveMove = true;
             direction = PlayerAnimationNames.WalkUp;
         }
         if (activeEvents.get(UserInputEvent.MoveLeft)) {
-            this.move(-speedMultiplier, 0);
+            this.move(-moveAmount, 0);
             haveMove = true;
             direction = PlayerAnimationNames.WalkLeft;
         }
         if (activeEvents.get(UserInputEvent.MoveDown)) {
-            this.move(0, speedMultiplier);
+            this.move(0, moveAmount);
             haveMove = true;
             direction = PlayerAnimationNames.WalkDown;
         }
         if (activeEvents.get(UserInputEvent.MoveRight)) {
-            this.move(speedMultiplier, 0);
+            this.move(moveAmount, 0);
             haveMove = true;
             direction = PlayerAnimationNames.WalkRight;
         }


### PR DESCRIPTION
Depending on the amount of power a computer has, the framerate will not be the same.
Hence, the amount of movement of a user should be constant on each frame.
If a frame was slow to print, the movement should be higher to keep a constant speed.

This PR takes the framerate into account when moving the players.