### PR TITLE
Enabling HTTPS in test deployment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -81,17 +81,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: Environment deployed at http://${{ env.GITHUB_REF_SLUG }}.workadventure.test.thecodingmachine.com
+          msg: Environment deployed at https://${{ env.GITHUB_REF_SLUG }}.workadventure.test.thecodingmachine.com
           check_for_duplicate_msg: true
 
       - name: Run Cypress tests
         uses: cypress-io/github-action@v1
         env:
-          CYPRESS_BASE_URL: http://${{ env.GITHUB_REF_SLUG }}.workadventure.test.thecodingmachine.com
+          CYPRESS_BASE_URL: https://${{ env.GITHUB_REF_SLUG }}.workadventure.test.thecodingmachine.com
         with:
           env: host=${{ env.GITHUB_REF_SLUG }}.workadventure.test.thecodingmachine.com,port=80
           spec: cypress/integration/spec.js
-          wait-on: http://${{ env.GITHUB_REF_SLUG }}.workadventure.test.thecodingmachine.com
+          wait-on: https://${{ env.GITHUB_REF_SLUG }}.workadventure.test.thecodingmachine.com
           working-directory: e2e
 
       - name: "Upload the screenshot on test failure"

--- a/deeployer.libsonnet
+++ b/deeployer.libsonnet
@@ -7,7 +7,8 @@
      "back": {
        "image": "thecodingmachine/workadventure-back:"+tag,
        "host": {
-         "url": "api."+namespace+".workadventure.test.thecodingmachine.com"
+         "url": "api."+namespace+".workadventure.test.thecodingmachine.com",
+         "https": "enable"
        },
        "ports": [8080],
        "env": {
@@ -17,12 +18,18 @@
     "front": {
       "image": "thecodingmachine/workadventure-front:"+tag,
       "host": {
-        "url": namespace+".workadventure.test.thecodingmachine.com"
+        "url": namespace+".workadventure.test.thecodingmachine.com",
+        "https": "enable"
       },
       "ports": [80],
       "env": {
         "API_URL": "http://api."+namespace+".workadventure.test.thecodingmachine.com"
       }
+    }
+  },
+  "config": {
+    "https": {
+      "mail": "d.negrier@thecodingmachine.com"
     }
   }
 }

--- a/deeployer.libsonnet
+++ b/deeployer.libsonnet
@@ -23,7 +23,7 @@
       },
       "ports": [80],
       "env": {
-        "API_URL": "http://api."+namespace+".workadventure.test.thecodingmachine.com"
+        "API_URL": "https://api."+namespace+".workadventure.test.thecodingmachine.com"
       }
     }
   },


### PR DESCRIPTION
This should hopefully work if the new version of Deeployer does the job!

Replaces #55 