### PR TITLE
Barycenter based groups

### DIFF
--- a/back/src/Model/Group.ts
+++ b/back/src/Model/Group.ts
@@ -1,6 +1,6 @@
-import {MessageUserPosition} from "./Websocket/MessageUserPosition";
 import { World } from "./World";
 import { UserInterface } from "./UserInterface";
+import {PositionInterface} from "_Model/PositionInterface";
 
 export class Group {
     static readonly MAX_PER_GROUP = 4;
@@ -22,6 +22,25 @@ export class Group {
 
     getUsers(): UserInterface[] {
         return this.users;
+    }
+
+    /**
+     * Returns the barycenter of all users (i.e. the center of the group)
+     */
+    getPosition(): PositionInterface {
+        let x = 0;
+        let y = 0;
+        // Let's compute the barycenter of all users.
+        this.users.forEach((user: UserInterface) => {
+            x += user.position.x;
+            y += user.position.y;
+        });
+        x /= this.users.length;
+        y /= this.users.length;
+        return {
+            x,
+            y
+        };
     }
 
     isFull(): boolean {

--- a/back/src/Model/Group.ts
+++ b/back/src/Model/Group.ts
@@ -47,6 +47,10 @@ export class Group {
         return this.users.length >= Group.MAX_PER_GROUP;
     }
 
+    isEmpty(): boolean {
+        return this.users.length <= 1;
+    }
+
     join(user: UserInterface): void
     {
         // Broadcast on the right event
@@ -79,7 +83,7 @@ export class Group {
         return stillIn;
     }
 
-    removeFromGroup(users: UserInterface[]): void
+    /*removeFromGroup(users: UserInterface[]): void
     {
         for(let i = 0; i < users.length; i++){
             let user = users[i];
@@ -88,5 +92,32 @@ export class Group {
                 this.users.splice(index, 1);
             }
         }
+    }*/
+
+    leave(user: UserInterface): void
+    {
+        const index = this.users.indexOf(user, 0);
+        if (index === -1) {
+            throw new Error("Could not find user in the group");
+        }
+
+        this.users.splice(index, 1);
+        user.group = undefined;
+
+        // Broadcast on the right event
+        this.users.forEach((groupUser: UserInterface) => {
+            this.disconnectCallback(user.id, groupUser.id);
+        });
+    }
+
+    /**
+     * Let's kick everybody out.
+     * Usually used when there is only one user left.
+     */
+    destroy(): void
+    {
+        this.users.forEach((user: UserInterface) => {
+            this.leave(user);
+        })
     }
 }

--- a/back/src/Model/PositionInterface.ts
+++ b/back/src/Model/PositionInterface.ts
@@ -1,0 +1,4 @@
+export interface PositionInterface {
+    x: number,
+    y: number
+}

--- a/back/src/Model/World.ts
+++ b/back/src/Model/World.ts
@@ -4,6 +4,7 @@ import {Group} from "./Group";
 import {Distance} from "./Distance";
 import {UserInterface} from "./UserInterface";
 import {ExSocketInterface} from "_Model/Websocket/ExSocketInterface";
+import {PositionInterface} from "_Model/PositionInterface";
 
 export class World {
     static readonly MIN_DISTANCE = 160;
@@ -47,17 +48,18 @@ export class World {
         if (typeof user.group === 'undefined') {
             // If the user is not part of a group:
             //  should he join a group?
-            let closestUser: UserInterface|null = this.searchClosestAvailableUser(user);
+            let closestItem: UserInterface|Group|null = this.searchClosestAvailableUserOrGroup(user);
 
-            if (closestUser !== null) {
-                // Is the closest user part of a group?
-                if (typeof closestUser.group === 'undefined') {
+            if (closestItem !== null) {
+                if (closestItem instanceof Group) {
+                    // Let's join the group!
+                    closestItem.join(user);
+                } else {
+                    let closestUser : UserInterface = closestItem;
                     let group: Group = new Group([
                         user,
                         closestUser
                     ], this.connectCallback, this.disconnectCallback);
-                } else {
-                    closestUser.group.join(user);
                 }
             }
 
@@ -78,32 +80,16 @@ export class World {
      * - close enough (distance <= MIN_DISTANCE)
      * - not in a group OR in a group that is not full
      */
-    private searchClosestAvailableUser(user: UserInterface): UserInterface|null
+    private searchClosestAvailableUserOrGroup(user: UserInterface): UserInterface|Group|null
     {
-/*
-        let sortedUsersByDistance: UserInteface[] = Array.from(this.users.values()).sort((user1: UserInteface, user2: UserInteface): number => {
-            let distance1 = World.computeDistance(user, user1);
-            let distance2 = World.computeDistance(user, user2);
-            return distance1 - distance2;
-        });
-
-        // The first element should be the current user (distance 0). Let's remove it.
-        if (sortedUsersByDistance[0] === user) {
-            sortedUsersByDistance.shift();
-        }
-
-        for(let i = 0; i < sortedUsersByDistance.length; i++) {
-            let currentUser = sortedUsersByDistance[i];
-            let distance = World.computeDistance(currentUser, user);
-            if(distance > World.MIN_DISTANCE) {
-                return;
-            }
-        }
-*/
         let usersToBeGroupedWith: Distance[] = [];
         let minimumDistanceFound: number = World.MIN_DISTANCE;
-        let matchingUser: UserInterface | null = null;
+        let matchingItem: UserInterface | Group | null = null;
         this.users.forEach(function(currentUser, userId) {
+            // Let's only check users that are not part of a group
+            if (typeof currentUser.group !== 'undefined') {
+                return;
+            }
             if(currentUser === user) {
                 return;
             }
@@ -111,13 +97,13 @@ export class World {
             let distance = World.computeDistance(user, currentUser); // compute distance between peers.
 
             if(distance <= minimumDistanceFound) {
-
-                if (typeof currentUser.group === 'undefined' || !currentUser.group.isFull()) {
+                minimumDistanceFound = distance;
+                matchingItem = currentUser;
+            }
+                /*if (typeof currentUser.group === 'undefined' || !currentUser.group.isFull()) {
                     // We found a user we can bind to.
-                    minimumDistanceFound = distance;
-                    matchingUser = currentUser;
                     return;
-                }
+                }*/
             /*
                 if(context.groups.length > 0) {
 
@@ -148,16 +134,31 @@ export class World {
                     usersToBeGroupedWith.push(dist);
                 }
             */
+        });
+
+        this.groups.forEach(function(group: Group) {
+            if (group.isFull()) {
+                return;
             }
+            let distance = World.computeDistanceBetweenPositions(user.position, group.getPosition());
 
-        }, this.users);
+            if(distance <= minimumDistanceFound) {
+                minimumDistanceFound = distance;
+                matchingItem = group;
+            }
+        });
 
-        return matchingUser;
+        return matchingItem;
     }
 
     public static computeDistance(user1: UserInterface, user2: UserInterface): number
     {
         return Math.sqrt(Math.pow(user2.position.x - user1.position.x, 2) + Math.pow(user2.position.y - user1.position.y, 2));
+    }
+
+    public static computeDistanceBetweenPositions(position1: PositionInterface, position2: PositionInterface): number
+    {
+        return Math.sqrt(Math.pow(position2.x - position1.x, 2) + Math.pow(position2.y - position1.y, 2));
     }
 
     /*getDistancesBetweenGroupUsers(group: Group): Distance[]

--- a/back/src/Model/World.ts
+++ b/back/src/Model/World.ts
@@ -34,7 +34,10 @@ export class World {
     }
 
     public leave(user : ExSocketInterface){
-        /*TODO leaver user in group*/
+        let userObj = this.users.get(user.id);
+        if (userObj !== undefined && typeof userObj.group !== 'undefined') {
+            this.leaveGroup(user);
+        }
         this.users.delete(user.userId);
     }
 

--- a/back/tests/WorldTest.ts
+++ b/back/tests/WorldTest.ts
@@ -54,6 +54,50 @@ describe("World", () => {
         expect(connectCalled).toBe(false);
     });
 
+    it("should connect 3 users", () => {
+        let connectCalled: boolean = false;
+        let connect = (user1: string, user2: string): void => {
+            connectCalled = true;
+        }
+        let disconnect = (user1: string, user2: string): void => {
+
+        }
+
+        let world = new World(connect, disconnect);
+
+        world.join(new MessageUserPosition({
+            userId: "foo",
+            roomId: 1,
+            position: new Point(100, 100)
+        }));
+
+        world.join(new MessageUserPosition({
+            userId: "bar",
+            roomId: 1,
+            position: new Point(200, 100)
+        }));
+
+        expect(connectCalled).toBe(true);
+        connectCalled = false;
+
+        // baz joins at the outer limit of the group
+        world.join(new MessageUserPosition({
+            userId: "baz",
+            roomId: 1,
+            position: new Point(311, 100)
+        }));
+
+        expect(connectCalled).toBe(false);
+
+        world.updatePosition(new MessageUserPosition({
+            userId: "baz",
+            roomId: 1,
+            position: new Point(309, 100)
+        }));
+
+        expect(connectCalled).toBe(true);
+    });
+
     it("should disconnect user1 and user2", () => {
         let connectCalled: boolean = false;
         let disconnectCalled: boolean = false;
@@ -78,12 +122,13 @@ describe("World", () => {
             position: new Point(259, 100)
         }));
 
-        expect(connectCalled).toBe(false);
+        expect(connectCalled).toBe(true);
+        expect(disconnectCalled).toBe(false);
 
         world.updatePosition(new MessageUserPosition({
             userId: "bar",
             roomId: 1,
-            position: new Point(261, 100)
+            position: new Point(100+160+160+1, 100)
         }));
 
         expect(disconnectCalled).toBe(true);


### PR DESCRIPTION
Switching to a strategy where in order to join a group, the barycenter of the group is computed (based on users position) and you have to be near the barycenter to join this group.

- [x] 2 users in no group can form a group 
- [x] A user nearing a group can join it
- [x] Users can leave a group by walking away
- [x] When connection is lost, the user is kicked of the group