### PR TITLE
Only sending move events if the player actually moved

### DIFF
--- a/front/src/Phaser/Entity/PlayableCaracter.ts
+++ b/front/src/Phaser/Entity/PlayableCaracter.ts
@@ -50,7 +50,7 @@ export class PlayableCaracter extends Phaser.Physics.Arcade.Sprite {
 
     stop(){
         this.setVelocity(0, 0);
-        this.play(PlayerAnimationNames.None, true);
+        this.anims.stop();
     }
 
     say(text: string) {

--- a/front/src/Phaser/Player/Player.ts
+++ b/front/src/Phaser/Player/Player.ts
@@ -62,7 +62,6 @@ export class Player extends PlayableCaracter implements CurrentGamerInterface, G
 
     moveUser(delta: number): void {
         //if user client on shift, camera and player speed
-        let haveMove = false;
         let direction = null;
 
         let activeEvents = this.userInputManager.getEventListForGameTick();
@@ -87,12 +86,18 @@ export class Player extends PlayableCaracter implements CurrentGamerInterface, G
         }
         if (x !== 0 || y !== 0) {
             this.move(x, y);
+            this.emit(hasMovedEventName, {direction, x: this.x, y: this.y});
         } else {
-            direction = PlayerAnimationNames.None;
-            this.stop();
+            if (this.previousMove !== PlayerAnimationNames.None) {
+                direction = PlayerAnimationNames.None;
+                this.stop();
+                this.emit(hasMovedEventName, {direction, x: this.x, y: this.y});
+            }
         }
 
-        this.emit(hasMovedEventName, {direction, x: this.x, y: this.y});
+        if (direction !== null) {
+            this.previousMove = direction;
+        }
     }
 
     //todo: put this method into the NonPlayer class instead


### PR DESCRIPTION
If the player did not move a pixel (and if it did not change direction), then do not send an event to save bandwidth and processing.