### PR TITLE
Adding the display of a circle around the group

### DIFF
--- a/back/src/Controller/IoSocketController.ts
+++ b/back/src/Controller/IoSocketController.ts
@@ -9,6 +9,7 @@ import {ExtRooms, RefreshUserPositionFunction} from "../Model/Websocket/ExtRoom"
 import {ExtRoomsInterface} from "../Model/Websocket/ExtRoomsInterface";
 import {World} from "../Model/World";
 import {Group} from "_Model/Group";
+import {UserInterface} from "_Model/UserInterface";
 
 enum SockerIoEvent {
     CONNECTION = "connection",
@@ -20,6 +21,8 @@ enum SockerIoEvent {
     WEBRTC_START = "webrtc-start",
     WEBRTC_DISCONNECT = "webrtc-disconect",
     MESSAGE_ERROR = "message-error",
+    GROUP_CREATE_UPDATE = "group-create-update",
+    GROUP_DELETE = "group-delete",
 }
 
 export class IoSocketController {
@@ -51,7 +54,38 @@ export class IoSocketController {
             this.connectedUser(user1, group);
         }, (user1: string, group: Group) => {
             this.disConnectedUser(user1, group);
-        }, MINIMUM_DISTANCE, GROUP_RADIUS);
+        }, MINIMUM_DISTANCE, GROUP_RADIUS, (group: Group) => {
+            this.sendUpdateGroupEvent(group);
+        }, (groupUuid: string, lastUser: UserInterface) => {
+            this.sendDeleteGroupEvent(groupUuid, lastUser);
+        });
+    }
+
+    private sendUpdateGroupEvent(group: Group): void {
+        // Let's get the room of the group. To do this, let's get anyone in the group and find its room.
+        // Note: this is suboptimal
+        let userId = group.getUsers()[0].id;
+        let client: ExSocketInterface|null = this.searchClientById(userId);
+        if (client === null) {
+            return;
+        }
+        let roomId = client.roomId;
+        this.Io.in(roomId).emit(SockerIoEvent.GROUP_CREATE_UPDATE, {
+            position: group.getPosition(),
+            groupId: group.getId()
+        });
+    }
+
+    private sendDeleteGroupEvent(uuid: string, lastUser: UserInterface): void {
+        // Let's get the room of the group. To do this, let's get anyone in the group and find its room.
+        // Note: this is suboptimal
+        let userId = lastUser.id;
+        let client: ExSocketInterface|null = this.searchClientById(userId);
+        if (client === null) {
+            return;
+        }
+        let roomId = client.roomId;
+        this.Io.in(roomId).emit(SockerIoEvent.GROUP_DELETE, uuid);
     }
 
     ioConnection() {
@@ -149,7 +183,7 @@ export class IoSocketController {
     }
 
     /**
-     *
+     * TODO: each call to this method is suboptimal. It means that instead of passing an ID, we should pass a client object.
      * @param userId
      */
     searchClientById(userId: string): ExSocketInterface | null {
@@ -286,7 +320,7 @@ export class IoSocketController {
         this.joinWebRtcRoom(Client, group.getId());
     }
 
-    //connected user
+    //disconnect user
     disConnectedUser(userId: string, group: Group) {
         let Client = this.searchClientById(userId);
         if (!Client) {

--- a/back/tests/WorldTest.ts
+++ b/back/tests/WorldTest.ts
@@ -15,7 +15,7 @@ describe("World", () => {
 
         }
 
-        let world = new World(connect, disconnect, 160, 160);
+        let world = new World(connect, disconnect, 160, 160, () => {}, () => {});
 
         world.join(new MessageUserPosition({
             userId: "foo",
@@ -62,7 +62,7 @@ describe("World", () => {
 
         }
 
-        let world = new World(connect, disconnect, 160, 160);
+        let world = new World(connect, disconnect, 160, 160, () => {}, () => {});
 
         world.join(new MessageUserPosition({
             userId: "foo",
@@ -107,7 +107,7 @@ describe("World", () => {
             disconnectCallNumber++;
         }
 
-        let world = new World(connect, disconnect, 160, 160);
+        let world = new World(connect, disconnect, 160, 160, () => {}, () => {});
 
         world.join(new MessageUserPosition({
             userId: "foo",

--- a/front/src/Connexion.ts
+++ b/front/src/Connexion.ts
@@ -11,7 +11,9 @@ enum EventMessage{
     JOIN_ROOM = "join-room",
     USER_POSITION = "user-position",
     MESSAGE_ERROR = "message-error",
-    WEBRTC_DISCONNECT = "webrtc-disconect"
+    WEBRTC_DISCONNECT = "webrtc-disconect",
+    GROUP_CREATE_UPDATE = "group-create-update",
+    GROUP_DELETE = "group-delete",
 }
 
 class Message {
@@ -122,6 +124,16 @@ class ListMessageUserPosition {
     }
 }
 
+export interface PositionInterface {
+    x: number,
+    y: number
+}
+
+export interface GroupCreatedUpdatedMessageInterface {
+    position: PositionInterface,
+    groupId: string
+}
+
 export interface ConnexionInterface {
     socket: any;
     token: string;
@@ -183,6 +195,9 @@ export class Connexion implements ConnexionInterface {
                 this.positionOfAllUser();
 
                 this.errorMessage();
+
+                this.groupUpdatedOrCreated();
+                this.groupDeleted();
 
                 return this;
             })
@@ -252,6 +267,19 @@ export class Connexion implements ConnexionInterface {
                 this.GameManager.shareUserPosition(listMessageUserPosition);
             });
         });
+    }
+
+    private groupUpdatedOrCreated(): void {
+        this.socket.on(EventMessage.GROUP_CREATE_UPDATE, (groupCreateUpdateMessage: GroupCreatedUpdatedMessageInterface) => {
+            //console.log('Group ', groupCreateUpdateMessage.groupId, " position :", groupCreateUpdateMessage.position.x, groupCreateUpdateMessage.position.y)
+            this.GameManager.shareGroupPosition(groupCreateUpdateMessage);
+        })
+    }
+
+    private groupDeleted(): void {
+        this.socket.on(EventMessage.GROUP_DELETE, (groupId: string) => {
+            this.GameManager.deleteGroup(groupId);
+        })
     }
 
     sendWebrtcSignal(signal: any, roomId: string, userId? : string, receiverId? : string) {

--- a/front/src/Phaser/Game/GameManager.ts
+++ b/front/src/Phaser/Game/GameManager.ts
@@ -1,6 +1,11 @@
 import {GameScene} from "./GameScene";
 import {ROOM} from "../../Enum/EnvironmentVariable"
-import {Connexion, ConnexionInterface, ListMessageUserPositionInterface} from "../../Connexion";
+import {
+    Connexion,
+    ConnexionInterface,
+    GroupCreatedUpdatedMessageInterface,
+    ListMessageUserPositionInterface
+} from "../../Connexion";
 import {SimplePeerInterface, SimplePeer} from "../../WebRtc/SimplePeer";
 import {LogincScene} from "../Login/LogincScene";
 
@@ -61,6 +66,31 @@ export class GameManager {
         }
         try {
             this.currentGameScene.shareUserPosition(ListMessageUserPosition.listUsersPosition)
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+    /**
+     * Share group position in game
+     */
+    shareGroupPosition(groupPositionMessage: GroupCreatedUpdatedMessageInterface): void {
+        if (this.status === StatusGameManagerEnum.IN_PROGRESS) {
+            return;
+        }
+        try {
+            this.currentGameScene.shareGroupPosition(groupPositionMessage)
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+    deleteGroup(groupId: string): void {
+        if (this.status === StatusGameManagerEnum.IN_PROGRESS) {
+            return;
+        }
+        try {
+            this.currentGameScene.deleteGroup(groupId)
         } catch (e) {
             console.error(e);
         }

--- a/front/src/Phaser/Player/Animation.ts
+++ b/front/src/Phaser/Player/Animation.ts
@@ -53,7 +53,6 @@ export const playAnimation = (Player : Phaser.GameObjects.Sprite, direction : st
     if (direction !== PlayerAnimationNames.None && (!Player.anims.currentAnim || Player.anims.currentAnim.key !== direction)) {
         Player.anims.play(direction);
     } else if (direction === PlayerAnimationNames.None && Player.anims.currentAnim) {
-        //Player.anims.currentAnim.destroy();
         Player.anims.stop();
     }
 }


### PR DESCRIPTION
This PR adds the display of a circle around groups. This is useful to view where you need to go to speak to someone but also to debug.

Note: implementation is suboptimal, relying on a "graphics" object that is known to be slow. In the future, we need to use a circle as a sprite instead.