### PR TITLE
Cleanup: renaming "frame" to "character"

### DIFF
--- a/back/src/Controller/IoSocketController.ts
+++ b/back/src/Controller/IoSocketController.ts
@@ -216,7 +216,7 @@ export class IoSocketController {
         socket.roomId = message.roomId;
         socket.userId = message.userId;
         socket.name = message.name;
-        socket.frame = message.frame;
+        socket.character = message.character;
     }
 
     refreshUserPosition() {

--- a/back/src/Model/Websocket/ExSocketInterface.ts
+++ b/back/src/Model/Websocket/ExSocketInterface.ts
@@ -7,6 +7,6 @@ export interface ExSocketInterface extends Socket {
     webRtcRoomId: string;
     userId: string;
     name: string;
-    frame: string;
+    character: string;
     position: PointInterface;
 }

--- a/back/src/Model/Websocket/ExtRoom.ts
+++ b/back/src/Model/Websocket/ExtRoom.ts
@@ -25,7 +25,7 @@ let RefreshUserPositionFunction = function(rooms : ExtRooms, Io: socketIO.Server
             roomId: socket.roomId,
             position: socket.position,
             name: socket.name,
-            frame: socket.frame,
+            character: socket.character,
         };
         let dataArray = <any>[];
         if (mapPositionUserByRoom.get(data.roomId)) {

--- a/back/src/Model/Websocket/Message.ts
+++ b/back/src/Model/Websocket/Message.ts
@@ -2,7 +2,7 @@ export class Message {
     userId: string;
     roomId: string;
     name: string;
-    frame: string;
+    character: string;
 
     constructor(data: any) {
         if (!data.userId || !data.roomId) {
@@ -11,7 +11,7 @@ export class Message {
         this.userId = data.userId;
         this.roomId = data.roomId;
         this.name = data.name;
-        this.frame = data.frame;
+        this.character = data.character;
     }
 
     toJson() {
@@ -19,7 +19,7 @@ export class Message {
             userId: this.userId,
             roomId: this.roomId,
             name: this.name,
-            frame: this.frame
+            character: this.character
         }
     }
 }

--- a/back/tests/MessageTest.ts
+++ b/back/tests/MessageTest.ts
@@ -8,7 +8,7 @@ describe("Message Model", () => {
         expect(messageObject.userId).toBe("test1");
         expect(messageObject.roomId).toBe("test2");
         expect(messageObject.name).toBe("foo");
-        expect(messageObject.frame).toBe("user");
+        expect(messageObject.character).toBe("user");
     })
 
     it("should expose a toJson method", () => {

--- a/back/tests/MessageTest.ts
+++ b/back/tests/MessageTest.ts
@@ -3,7 +3,7 @@ import {Message} from "../src/Model/Websocket/Message";
 
 describe("Message Model", () => {
     it("should find userId and roomId", () => {
-        let message = {userId: "test1", roomId: "test2", name: "foo", frame: "user"};
+        let message = {userId: "test1", roomId: "test2", name: "foo", character: "user"};
         let messageObject = new Message(message);
         expect(messageObject.userId).toBe("test1");
         expect(messageObject.roomId).toBe("test2");
@@ -12,9 +12,9 @@ describe("Message Model", () => {
     })
 
     it("should expose a toJson method", () => {
-        let message = {userId: "test1", roomId: "test2", name: "foo", frame: "user"};
+        let message = {userId: "test1", roomId: "test2", name: "foo", character: "user"};
         let messageObject = new Message(message);
-        expect(messageObject.toJson()).toEqual({userId: "test1", roomId: "test2", name: "foo", frame: "user"});
+        expect(messageObject.toJson()).toEqual({userId: "test1", roomId: "test2", name: "foo", character: "user"});
     });
 
     it("should find throw error when no userId", () => {

--- a/front/src/Connexion.ts
+++ b/front/src/Connexion.ts
@@ -18,13 +18,13 @@ class Message {
     userId: string;
     roomId: string;
     name: string;
-    frame: string;
+    character: string;
 
-    constructor(userId : string, roomId : string, name: string, frame: string) {
+    constructor(userId : string, roomId : string, name: string, character: string) {
         this.userId = userId;
         this.roomId = roomId;
         this.name = name;
-        this.frame = frame;
+        this.character = character;
     }
 
     toJson() {
@@ -32,7 +32,7 @@ class Message {
             userId: this.userId,
             roomId: this.roomId,
             name: this.name,
-            frame: this.frame
+            character: this.character
         }
     }
 }
@@ -71,15 +71,15 @@ export interface MessageUserPositionInterface {
     userId: string;
     roomId: string;
     name: string;
-    frame: string;
+    character: string;
     position: PointInterface;
 }
 
 class MessageUserPosition extends Message implements MessageUserPositionInterface{
     position: PointInterface;
 
-    constructor(userId : string, roomId : string, point : Point, name: string, frame: string) {
-        super(userId, roomId, name, frame);
+    constructor(userId : string, roomId : string, point : Point, name: string, character: string) {
+        super(userId, roomId, name, character);
         this.position = point;
     }
 
@@ -116,7 +116,7 @@ class ListMessageUserPosition {
                     userPosition.position.direction
                 ),
                 userPosition.name,
-                userPosition.frame
+                userPosition.character
             ));
         });
     }
@@ -129,11 +129,11 @@ export interface ConnexionInterface {
     userId: string;
     startedRoom: string;
 
-    createConnexion(frameSelected: string): Promise<any>;
+    createConnexion(characterSelected: string): Promise<any>;
 
-    joinARoom(roomId: string, frame: string): void;
+    joinARoom(roomId: string, character: string): void;
 
-    sharePosition(x: number, y: number, direction: string, frame: string): void;
+    sharePosition(x: number, y: number, direction: string, character: string): void;
 
     positionOfAllUser(): void;
 
@@ -161,7 +161,7 @@ export class Connexion implements ConnexionInterface {
         this.GameManager = GameManager;
     }
 
-    createConnexion(frameSelected: string): Promise<ConnexionInterface> {
+    createConnexion(characterSelected: string): Promise<ConnexionInterface> {
         return Axios.post(`${API_URL}/login`, {email: this.email})
             .then((res) => {
                 this.token = res.data.token;
@@ -175,10 +175,10 @@ export class Connexion implements ConnexionInterface {
                 });
 
                 //join the room
-                this.joinARoom(this.startedRoom, frameSelected);
+                this.joinARoom(this.startedRoom, characterSelected);
 
                 //share your first position
-                this.sharePosition(0, 0, frameSelected);
+                this.sharePosition(0, 0, characterSelected);
 
                 this.positionOfAllUser();
 
@@ -195,15 +195,15 @@ export class Connexion implements ConnexionInterface {
     /**
      *
      * @param roomId
-     * @param frame
+     * @param character
      */
-    joinARoom(roomId: string, frame: string): void {
+    joinARoom(roomId: string, character: string): void {
         let messageUserPosition = new MessageUserPosition(
             this.userId,
             this.startedRoom,
             new Point(0, 0),
             this.email,
-            frame
+            character
         );
         this.socket.emit(EventMessage.JOIN_ROOM, messageUserPosition.toString());
     }
@@ -212,10 +212,10 @@ export class Connexion implements ConnexionInterface {
      *
      * @param x
      * @param y
-     * @param frame
+     * @param character
      * @param direction
      */
-    sharePosition(x : number, y : number, frame : string, direction : string = "none") : void{
+    sharePosition(x : number, y : number, character : string, direction : string = "none") : void{
         if(!this.socket){
             return;
         }
@@ -224,7 +224,7 @@ export class Connexion implements ConnexionInterface {
             ROOM[0],
             new Point(x, y, direction),
             this.email,
-            frame
+            character
         );
         this.socket.emit(EventMessage.USER_POSITION, messageUserPosition.toString());
     }

--- a/front/src/Phaser/Game/GameManager.ts
+++ b/front/src/Phaser/Game/GameManager.ts
@@ -13,7 +13,7 @@ export interface HasMovedEvent {
     direction: string;
     x: number;
     y: number;
-    frame: string;
+    character: string;
 }
 
 export class GameManager {
@@ -22,17 +22,17 @@ export class GameManager {
     private currentGameScene: GameScene;
     private playerName: string;
     SimplePeer : SimplePeerInterface;
-    private frameUserSelected: string;
+    private characterUserSelected: string;
 
     constructor() {
         this.status = StatusGameManagerEnum.IN_PROGRESS;
     }
 
-    connect(name: string, frameUserSelected : string) {
+    connect(name: string, characterUserSelected : string) {
         this.playerName = name;
-        this.frameUserSelected = frameUserSelected;
+        this.characterUserSelected = characterUserSelected;
         this.ConnexionInstance = new Connexion(name, this);
-        return this.ConnexionInstance.createConnexion(frameUserSelected).then(() => {
+        return this.ConnexionInstance.createConnexion(characterUserSelected).then(() => {
             this.SimplePeer = new SimplePeer(this.ConnexionInstance);
         });
     }
@@ -70,12 +70,12 @@ export class GameManager {
         return this.playerName;
     }
 
-    getFrameSelected(): string {
-        return this.frameUserSelected;
+    getCharacterSelected(): string {
+        return this.characterUserSelected;
     }
 
     pushPlayerPosition(event: HasMovedEvent) {
-        this.ConnexionInstance.sharePosition(event.x, event.y, event.frame, event.direction);
+        this.ConnexionInstance.sharePosition(event.x, event.y, event.character, event.direction);
     }
 }
 

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -167,7 +167,7 @@ export class GameScene extends Phaser.Scene implements GameSceneInterface{
             this.startX,
             this.startY,
             this.GameManager.getPlayerName(),
-            this.GameManager.getFrameSelected()
+            this.GameManager.getCharacterSelected()
         );
         this.CurrentPlayer.initAnimation();
 
@@ -261,15 +261,15 @@ export class GameScene extends Phaser.Scene implements GameSceneInterface{
             MessageUserPosition.position.x,
             MessageUserPosition.position.y,
             MessageUserPosition.name,
-            MessageUserPosition.frame
+            MessageUserPosition.character
         );
         player.initAnimation();
         this.MapPlayers.add(player);
         player.updatePosition(MessageUserPosition);
 
-        //init colision
-        this.physics.add.collider(this.CurrentPlayer, player, (CurrentPlayer: CurrentGamerInterface, MapPlayer: GamerInterface) => {
+        //init collision
+        /*this.physics.add.collider(this.CurrentPlayer, player, (CurrentPlayer: CurrentGamerInterface, MapPlayer: GamerInterface) => {
             CurrentPlayer.say("Hello, how are you ? ");
-        });
+        });*/
     }
 }

--- a/front/src/Phaser/Player/Player.ts
+++ b/front/src/Phaser/Player/Player.ts
@@ -83,12 +83,12 @@ export class Player extends PlayableCaracter implements CurrentGamerInterface, G
         }
         if (x !== 0 || y !== 0) {
             this.move(x, y);
-            this.emit(hasMovedEventName, {direction, x: this.x, y: this.y, frame: this.PlayerTexture});
+            this.emit(hasMovedEventName, {direction, x: this.x, y: this.y, character: this.PlayerTexture});
         } else {
             if (this.previousMove !== PlayerAnimationNames.None) {
                 direction = PlayerAnimationNames.None;
                 this.stop();
-                this.emit(hasMovedEventName, {direction, x: this.x, y: this.y, frame: this.PlayerTexture});
+                this.emit(hasMovedEventName, {direction, x: this.x, y: this.y, character: this.PlayerTexture});
             }
         }
 


### PR DESCRIPTION
The "frame" variable actually contains a string pointing to the character selected.
It has nothing to do with a frame which is usually a particular image in an animation.

I'm renaming the variable accross the application to avoid confusion.