### PR TITLE
Displaying circle on join

### DIFF
--- a/back/src/Controller/IoSocketController.ts
+++ b/back/src/Controller/IoSocketController.ts
@@ -281,12 +281,23 @@ export class IoSocketController {
             this.Worlds.set(messageUserPosition.roomId, world);
         }
 
-        //join world
         let world : World|undefined = this.Worlds.get(messageUserPosition.roomId);
+
+
         if(world) {
+            // Dispatch groups position to newly connected user
+            world.getGroups().forEach((group: Group) => {
+                Client.emit(SockerIoEvent.GROUP_CREATE_UPDATE, {
+                    position: group.getPosition(),
+                    groupId: group.getId()
+                });
+            });
+            //join world
             world.join(messageUserPosition);
             this.Worlds.set(messageUserPosition.roomId, world);
         }
+
+
     }
 
     /**

--- a/back/src/Model/World.ts
+++ b/back/src/Model/World.ts
@@ -43,6 +43,10 @@ export class World {
         this.groupDeletedCallback = groupDeletedCallback;
     }
 
+    public getGroups(): Group[] {
+        return this.groups;
+    }
+
     public join(userPosition: MessageUserPosition): void {
         this.users.set(userPosition.userId, {
             id: userPosition.userId,


### PR DESCRIPTION
So far, someone joining a map would not see the circles of groups already formed until someone moves in the group (because the "circle_moved_or_updated" event was not fired when someone arrives)

This commit fixes this behaviour. Someone entering a room will receive an event for each and every group currently formed.