### PR TITLE
Completely getting rid of "userid"

### DIFF
--- a/back/src/Controller/AuthenticateController.ts
+++ b/back/src/Controller/AuthenticateController.ts
@@ -4,7 +4,7 @@ import {BAD_REQUEST, OK} from "http-status-codes";
 import {SECRET_KEY, URL_ROOM_STARTED} from "../Enum/EnvironmentVariable"; //TODO fix import by "_Enum/..."
 import { uuid } from 'uuidv4';
 
-export class AuthenticateController{
+export class AuthenticateController {
     App : Application;
 
     constructor(App : Application) {
@@ -14,7 +14,8 @@ export class AuthenticateController{
 
     //permit to login on application. Return token to connect on Websocket IO.
     login(){
-        this.App.post("/login", (req: Request, res: Response) => {
+        // For now, let's completely forget the /login route.
+        /*this.App.post("/login", (req: Request, res: Response) => {
             let param = req.body;
             if(!param.email){
                 return res.status(BAD_REQUEST).send({
@@ -29,6 +30,6 @@ export class AuthenticateController{
                 mapUrlStart: URL_ROOM_STARTED,
                 userId: userId,
             });
-        });
+        });*/
     }
 }

--- a/back/src/Model/Websocket/ExSocketInterface.ts
+++ b/back/src/Model/Websocket/ExSocketInterface.ts
@@ -1,11 +1,12 @@
 import {Socket} from "socket.io";
 import {PointInterface} from "./PointInterface";
+import {Identificable} from "./Identificable";
 
-export interface ExSocketInterface extends Socket {
+export interface ExSocketInterface extends Socket, Identificable {
     token: any;
     roomId: string;
     webRtcRoomId: string;
-    userId: string;
+    //userId: string;
     name: string;
     character: string;
     position: PointInterface;

--- a/back/src/Model/Websocket/ExtRooms.ts
+++ b/back/src/Model/Websocket/ExtRooms.ts
@@ -22,7 +22,7 @@ let RefreshUserPositionFunction = function(rooms : ExtRooms, Io: socketIO.Server
             continue;
         }
         let data = {
-            userId: socket.userId,
+            userId: socket.id,
             roomId: socket.roomId,
             position: socket.position,
             name: socket.name,

--- a/back/src/Model/Websocket/Identificable.ts
+++ b/back/src/Model/Websocket/Identificable.ts
@@ -1,0 +1,3 @@
+export interface Identificable {
+    id: string;
+}

--- a/back/src/Model/Websocket/Message.ts
+++ b/back/src/Model/Websocket/Message.ts
@@ -16,6 +16,7 @@ export class Message {
     }
 
     toJson() {
+
         return {
             userId: this.userId,
             roomId: this.roomId,

--- a/back/tests/WorldTest.ts
+++ b/back/tests/WorldTest.ts
@@ -17,36 +17,36 @@ describe("World", () => {
 
         let world = new World(connect, disconnect, 160, 160, () => {}, () => {});
 
-        world.join(new MessageUserPosition({
-            userId: "foo",
+        world.join({ id: "foo" }, new MessageUserPosition({
+            userId: "foofoo",
             roomId: 1,
             position: new Point(100, 100)
         }));
 
-        world.join(new MessageUserPosition({
-            userId: "bar",
+        world.join({ id: "bar" }, new MessageUserPosition({
+            userId: "barbar",
             roomId: 1,
             position: new Point(500, 100)
         }));
 
-        world.updatePosition(new MessageUserPosition({
-            userId: "bar",
+        world.updatePosition({ id: "bar" }, new MessageUserPosition({
+            userId: "barbar",
             roomId: 1,
             position: new Point(261, 100)
         }));
 
         expect(connectCalledNumber).toBe(0);
 
-        world.updatePosition(new MessageUserPosition({
-            userId: "bar",
+        world.updatePosition({ id: "bar" }, new MessageUserPosition({
+            userId: "barbar",
             roomId: 1,
             position: new Point(101, 100)
         }));
 
         expect(connectCalledNumber).toBe(2);
 
-        world.updatePosition(new MessageUserPosition({
-            userId: "bar",
+        world.updatePosition({ id: "bar" }, new MessageUserPosition({
+            userId: "barbar",
             roomId: 1,
             position: new Point(102, 100)
         }));
@@ -64,14 +64,14 @@ describe("World", () => {
 
         let world = new World(connect, disconnect, 160, 160, () => {}, () => {});
 
-        world.join(new MessageUserPosition({
-            userId: "foo",
+        world.join({ id: "foo" }, new MessageUserPosition({
+            userId: "foofoo",
             roomId: 1,
             position: new Point(100, 100)
         }));
 
-        world.join(new MessageUserPosition({
-            userId: "bar",
+        world.join({ id: "bar" }, new MessageUserPosition({
+            userId: "barbar",
             roomId: 1,
             position: new Point(200, 100)
         }));
@@ -80,16 +80,16 @@ describe("World", () => {
         connectCalled = false;
 
         // baz joins at the outer limit of the group
-        world.join(new MessageUserPosition({
-            userId: "baz",
+        world.join({ id: "baz" }, new MessageUserPosition({
+            userId: "bazbaz",
             roomId: 1,
             position: new Point(311, 100)
         }));
 
         expect(connectCalled).toBe(false);
 
-        world.updatePosition(new MessageUserPosition({
-            userId: "baz",
+        world.updatePosition({ id: "baz" }, new MessageUserPosition({
+            userId: "bazbaz",
             roomId: 1,
             position: new Point(309, 100)
         }));
@@ -109,14 +109,14 @@ describe("World", () => {
 
         let world = new World(connect, disconnect, 160, 160, () => {}, () => {});
 
-        world.join(new MessageUserPosition({
-            userId: "foo",
+        world.join({ id: "foo" }, new MessageUserPosition({
+            userId: "foofoo",
             roomId: 1,
             position: new Point(100, 100)
         }));
 
-        world.join(new MessageUserPosition({
-            userId: "bar",
+        world.join({ id: "bar" }, new MessageUserPosition({
+            userId: "barbar",
             roomId: 1,
             position: new Point(259, 100)
         }));
@@ -124,16 +124,16 @@ describe("World", () => {
         expect(connectCalled).toBe(true);
         expect(disconnectCallNumber).toBe(0);
 
-        world.updatePosition(new MessageUserPosition({
-            userId: "bar",
+        world.updatePosition({ id: "bar" }, new MessageUserPosition({
+            userId: "barbar",
             roomId: 1,
             position: new Point(100+160+160+1, 100)
         }));
 
         expect(disconnectCallNumber).toBe(2);
 
-        world.updatePosition(new MessageUserPosition({
-            userId: "bar",
+        world.updatePosition({ id: "bar" }, new MessageUserPosition({
+            userId: "barbar",
             roomId: 1,
             position: new Point(262, 100)
         }));

--- a/front/src/Phaser/Game/GameManager.ts
+++ b/front/src/Phaser/Game/GameManager.ts
@@ -67,7 +67,7 @@ export class GameManager {
      */
     createCurrentPlayer(): void {
         //Get started room send by the backend
-        this.currentGameScene.createCurrentPlayer(this.ConnexionInstance.userId);
+        this.currentGameScene.createCurrentPlayer();
         this.status = StatusGameManagerEnum.CURRENT_USER_CREATED;
     }
 
@@ -117,6 +117,10 @@ export class GameManager {
 
     getPlayerName(): string {
         return this.playerName;
+    }
+
+    getPlayerId(): string {
+        return this.ConnexionInstance.userId;
     }
 
     getCharacterSelected(): string {

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -15,7 +15,7 @@ export enum Textures {
 
 export interface GameSceneInterface extends Phaser.Scene {
     Map: Phaser.Tilemaps.Tilemap;
-    createCurrentPlayer(UserId : string) : void;
+    createCurrentPlayer() : void;
     shareUserPosition(UsersPosition : Array<MessageUserPositionInterface>): void;
     shareGroupPosition(groupPositionMessage: GroupCreatedUpdatedMessageInterface): void;
     updateOrCreateMapPlayer(UsersPosition : Array<MessageUserPositionInterface>): void;
@@ -266,11 +266,11 @@ export class GameScene extends Phaser.Scene implements GameSceneInterface, Creat
         })
     }
 
-    createCurrentPlayer(UserId : string){
+    createCurrentPlayer(){
         //initialise player
         //TODO create animation moving between exit and strat
         this.CurrentPlayer = new Player(
-            UserId,
+            null, // The current player is not has no id (because the id can change if connexion is lost and we should check that id using the GameManager.
             this,
             this.startX,
             this.startY,
@@ -347,9 +347,11 @@ export class GameScene extends Phaser.Scene implements GameSceneInterface, Creat
             return;
         }
 
+        let currentPlayerId = this.GameManager.getPlayerId();
+
         //add or create new user
         UsersPosition.forEach((userPosition : MessageUserPositionInterface) => {
-            if(userPosition.userId === this.CurrentPlayer.userId){
+            if(userPosition.userId === currentPlayerId){
                 return;
             }
             let player = this.findPlayerInMap(userPosition.userId);

--- a/front/src/Phaser/Login/LogincScene.ts
+++ b/front/src/Phaser/Login/LogincScene.ts
@@ -90,7 +90,7 @@ export class LogincScene extends Phaser.Scene implements GameSceneInterface {
         });
 
         /*create user*/
-        this.createCurrentPlayer("test");
+        this.createCurrentPlayer();
         cypressAsserter.initFinished();
     }
 
@@ -144,7 +144,7 @@ export class LogincScene extends Phaser.Scene implements GameSceneInterface {
         throw new Error("Method not implemented.");
     }
 
-    createCurrentPlayer(UserId: string): void {
+    createCurrentPlayer(): void {
         for (let i = 0; i <PLAYER_RESOURCES.length; i++) {
             let playerResource = PLAYER_RESOURCES[i];
             let player = this.physics.add.sprite(playerResource.x, playerResource.y, playerResource.name, playerResource.name);

--- a/front/src/Phaser/Player/Player.ts
+++ b/front/src/Phaser/Player/Player.ts
@@ -7,7 +7,6 @@ import {PlayableCaracter} from "../Entity/PlayableCaracter";
 
 export const hasMovedEventName = "hasMoved";
 export interface CurrentGamerInterface extends PlayableCaracter{
-    userId : string;
     initAnimation() : void;
     moveUser(delta: number) : void;
     say(text : string) : void;


### PR DESCRIPTION
Previously, userid was generated by the "/login" route and passed along.
This commit completely removes the uuid "userid" (and disables the LoginController too and any Jwt check).

"userid" is replaced by the "socket id" of the connection.
So a user is now identified using a socket id, which is unique for a given connection.

See #114 