### PR TITLE
Refactoring searchClientById

### DIFF
--- a/back/src/Model/World.ts
+++ b/back/src/Model/World.ts
@@ -60,7 +60,6 @@ export class World {
     public leave(user : Identificable){
         let userObj = this.users.get(user.id);
         if (userObj === undefined) {
-            // FIXME: this seems always wrong. I guess user.id is different from userPosition.userId
             console.warn('User ', user.id, 'does not belong to world! It should!');
         }
         if (userObj !== undefined && typeof userObj.group !== 'undefined') {


### PR DESCRIPTION
searchClientById was scanning through all open sockets to find the right one (which is inefficient if we have many).
Instead, I created a new Map that directly maps ids to sockets.
Furthermore, this solves a long-standing issue (when a socket is disconnected, we cannot find it anymore in the sockets list but it is still available in the disconnect callback from the map)
As a result, we should not have any remaining circles any more.

Closes #104 