### PR TITLE
Fix mediatream manage and connection server down

### DIFF
--- a/back/src/Controller/AuthenticateController.ts
+++ b/back/src/Controller/AuthenticateController.ts
@@ -15,21 +15,21 @@ export class AuthenticateController {
     //permit to login on application. Return token to connect on Websocket IO.
     login(){
         // For now, let's completely forget the /login route.
-        /*this.App.post("/login", (req: Request, res: Response) => {
+        this.App.post("/login", (req: Request, res: Response) => {
             let param = req.body;
-            if(!param.email){
+            /*if(!param.name){
                 return res.status(BAD_REQUEST).send({
                     message: "email parameter is empty"
                 });
-            }
+            }*/
             //TODO check user email for The Coding Machine game
             let userId = uuid();
-            let token = Jwt.sign({email: param.email, userId: userId}, SECRET_KEY, {expiresIn: '24h'});
+            let token = Jwt.sign({name: param.name, userId: userId}, SECRET_KEY, {expiresIn: '24h'});
             return res.status(OK).send({
                 token: token,
                 mapUrlStart: URL_ROOM_STARTED,
                 userId: userId,
             });
-        });*/
+        });
     }
 }

--- a/back/src/Controller/IoSocketController.ts
+++ b/back/src/Controller/IoSocketController.ts
@@ -51,7 +51,7 @@ export class IoSocketController {
                     return next(new Error('Authentication error'));
                 }
                 (socket as ExSocketInterface).token = tokenDecoded;
-                (socket as ExSocketInterface).id = tokenDecoded.userId;
+                (socket as ExSocketInterface).userId = tokenDecoded.userId;
                 next();
             });
         });
@@ -97,7 +97,8 @@ export class IoSocketController {
 
     ioConnection() {
         this.Io.on(SockerIoEvent.CONNECTION, (socket: Socket) => {
-            this.sockets.set(socket.id, socket as ExSocketInterface);
+            let client : ExSocketInterface = socket as ExSocketInterface;
+            this.sockets.set(client.userId, client);
             /*join-rom event permit to join one room.
                 message :
                     userId : user identification
@@ -135,7 +136,7 @@ export class IoSocketController {
                     //add function to refresh position user in real time.
                     //this.refreshUserPosition(Client);
 
-                    let messageUserJoined = new MessageUserJoined(Client.id, Client.name, Client.character, Client.position);
+                    let messageUserJoined = new MessageUserJoined(Client.userId, Client.name, Client.character, Client.position);
 
                     socket.to(roomId).emit(SockerIoEvent.JOIN_ROOM, messageUserJoined);
 
@@ -172,7 +173,7 @@ export class IoSocketController {
                     }
                     world.updatePosition(Client, position);
 
-                    socket.to(Client.roomId).emit(SockerIoEvent.USER_MOVED, new MessageUserMoved(Client.id, Client.position));
+                    socket.to(Client.roomId).emit(SockerIoEvent.USER_MOVED, new MessageUserMoved(Client.userId, Client.position));
                 } catch (e) {
                     console.error('An error occurred on "user_position" event');
                     console.error(e);
@@ -200,9 +201,8 @@ export class IoSocketController {
             });
 
             socket.on(SockerIoEvent.DISCONNECT, () => {
+                let Client = (socket as ExSocketInterface);
                 try {
-                    let Client = (socket as ExSocketInterface);
-
                     //leave room
                     this.leaveRoom(Client);
 
@@ -218,7 +218,7 @@ export class IoSocketController {
                     console.error('An error occurred on "disconnect"');
                     console.error(e);
                 }
-                this.sockets.delete(socket.id);
+                this.sockets.delete(Client.userId);
             });
 
             // Let's send the user id to the user
@@ -226,7 +226,7 @@ export class IoSocketController {
                 let Client = (socket as ExSocketInterface);
                 Client.name = playerDetails.name;
                 Client.character = playerDetails.character;
-                answerFn(socket.id);
+                answerFn(Client.userId);
             });
         });
     }
@@ -242,7 +242,7 @@ export class IoSocketController {
     leaveRoom(Client : ExSocketInterface){
         // leave previous room and world
         if(Client.roomId){
-            Client.to(Client.roomId).emit(SockerIoEvent.USER_LEFT, Client.id);
+            Client.to(Client.roomId).emit(SockerIoEvent.USER_LEFT, Client.userId);
 
             //user leave previous world
             let world : World|undefined = this.Worlds.get(Client.roomId);
@@ -310,11 +310,11 @@ export class IoSocketController {
         clients.forEach((client: ExSocketInterface, index: number) => {
 
             let clientsId = clients.reduce((tabs: Array<any>, clientId: ExSocketInterface, indexClientId: number) => {
-                if (!clientId.id || clientId.id === client.id) {
+                if (!clientId.userId || clientId.userId === client.userId) {
                     return tabs;
                 }
                 tabs.push({
-                    userId: clientId.id,
+                    userId: clientId.userId,
                     name: clientId.name,
                     initiator: index <= indexClientId
                 });

--- a/back/src/Controller/IoSocketController.ts
+++ b/back/src/Controller/IoSocketController.ts
@@ -39,23 +39,40 @@ export class IoSocketController {
 
         // Authentication with token. it will be decoded and stored in the socket.
         // Completely commented for now, as we do not use the "/login" route at all.
-        /*this.Io.use((socket: Socket, next) => {
+        this.Io.use((socket: Socket, next) => {
             if (!socket.handshake.query || !socket.handshake.query.token) {
                 return next(new Error('Authentication error'));
             }
             if(this.searchClientByToken(socket.handshake.query.token)){
                 return next(new Error('Authentication error'));
             }
-            Jwt.verify(socket.handshake.query.token, SECRET_KEY, (err: JsonWebTokenError, tokenDecoded: object) => {
+            Jwt.verify(socket.handshake.query.token, SECRET_KEY, (err: JsonWebTokenError, tokenDecoded: any) => {
                 if (err) {
                     return next(new Error('Authentication error'));
                 }
                 (socket as ExSocketInterface).token = tokenDecoded;
+                (socket as ExSocketInterface).id = tokenDecoded.userId;
                 next();
             });
-        });*/
+        });
 
         this.ioConnection();
+    }
+
+    /**
+     *
+     * @param token
+     */
+    searchClientByToken(token: string): ExSocketInterface | null {
+        let clients: Array<any> = Object.values(this.Io.sockets.sockets);
+        for (let i = 0; i < clients.length; i++) {
+            let client: ExSocketInterface = clients[i];
+            if (client.token !== token) {
+                continue
+            }
+            return client;
+        }
+        return null;
     }
 
     private sendUpdateGroupEvent(group: Group): void {

--- a/back/src/Model/Websocket/ExSocketInterface.ts
+++ b/back/src/Model/Websocket/ExSocketInterface.ts
@@ -6,7 +6,7 @@ export interface ExSocketInterface extends Socket, Identificable {
     token: any;
     roomId: string;
     webRtcRoomId: string;
-    //userId: string;
+    userId: string;
     name: string;
     character: string;
     position: PointInterface;

--- a/back/src/Model/Websocket/Identificable.ts
+++ b/back/src/Model/Websocket/Identificable.ts
@@ -1,3 +1,3 @@
 export interface Identificable {
-    id: string;
+    userId: string;
 }

--- a/back/src/Model/World.ts
+++ b/back/src/Model/World.ts
@@ -53,8 +53,8 @@ export class World {
     }
 
     public join(socket : Identificable, userPosition: PointInterface): void {
-        this.users.set(socket.id, {
-            id: socket.id,
+        this.users.set(socket.userId, {
+            id: socket.userId,
             position: userPosition
         });
         // Let's call update position to trigger the join / leave room
@@ -62,18 +62,18 @@ export class World {
     }
 
     public leave(user : Identificable){
-        let userObj = this.users.get(user.id);
+        let userObj = this.users.get(user.userId);
         if (userObj === undefined) {
-            console.warn('User ', user.id, 'does not belong to world! It should!');
+            console.warn('User ', user.userId, 'does not belong to world! It should!');
         }
         if (userObj !== undefined && typeof userObj.group !== 'undefined') {
             this.leaveGroup(userObj);
         }
-        this.users.delete(user.id);
+        this.users.delete(user.userId);
     }
 
     public updatePosition(socket : Identificable, userPosition: PointInterface): void {
-        let user = this.users.get(socket.id);
+        let user = this.users.get(socket.userId);
         if(typeof user === 'undefined') {
             return;
         }

--- a/back/tests/WorldTest.ts
+++ b/back/tests/WorldTest.ts
@@ -15,19 +15,19 @@ describe("World", () => {
 
         let world = new World(connect, disconnect, 160, 160, () => {}, () => {});
 
-        world.join({ id: "foo" }, new Point(100, 100));
+        world.join({ userId: "foo" }, new Point(100, 100));
 
-        world.join({ id: "bar" }, new Point(500, 100));
+        world.join({ userId: "bar" }, new Point(500, 100));
 
-        world.updatePosition({ id: "bar" }, new Point(261, 100));
+        world.updatePosition({ userId: "bar" }, new Point(261, 100));
 
         expect(connectCalledNumber).toBe(0);
 
-        world.updatePosition({ id: "bar" }, new Point(101, 100));
+        world.updatePosition({ userId: "bar" }, new Point(101, 100));
 
         expect(connectCalledNumber).toBe(2);
 
-        world.updatePosition({ id: "bar" }, new Point(102, 100));
+        world.updatePosition({ userId: "bar" }, new Point(102, 100));
         expect(connectCalledNumber).toBe(2);
     });
 
@@ -42,19 +42,19 @@ describe("World", () => {
 
         let world = new World(connect, disconnect, 160, 160, () => {}, () => {});
 
-        world.join({ id: "foo" }, new Point(100, 100));
+        world.join({ userId: "foo" }, new Point(100, 100));
 
-        world.join({ id: "bar" }, new Point(200, 100));
+        world.join({ userId: "bar" }, new Point(200, 100));
 
         expect(connectCalled).toBe(true);
         connectCalled = false;
 
         // baz joins at the outer limit of the group
-        world.join({ id: "baz" }, new Point(311, 100));
+        world.join({ userId: "baz" }, new Point(311, 100));
 
         expect(connectCalled).toBe(false);
 
-        world.updatePosition({ id: "baz" }, new Point(309, 100));
+        world.updatePosition({ userId: "baz" }, new Point(309, 100));
 
         expect(connectCalled).toBe(true);
     });
@@ -71,18 +71,18 @@ describe("World", () => {
 
         let world = new World(connect, disconnect, 160, 160, () => {}, () => {});
 
-        world.join({ id: "foo" }, new Point(100, 100));
+        world.join({ userId: "foo" }, new Point(100, 100));
 
-        world.join({ id: "bar" }, new Point(259, 100));
+        world.join({ userId: "bar" }, new Point(259, 100));
 
         expect(connectCalled).toBe(true);
         expect(disconnectCallNumber).toBe(0);
 
-        world.updatePosition({ id: "bar" }, new Point(100+160+160+1, 100));
+        world.updatePosition({ userId: "bar" }, new Point(100+160+160+1, 100));
 
         expect(disconnectCallNumber).toBe(2);
 
-        world.updatePosition({ id: "bar" }, new Point(262, 100));
+        world.updatePosition({ userId: "bar" }, new Point(262, 100));
         expect(disconnectCallNumber).toBe(2);
     });
 

--- a/front/src/Connexion.ts
+++ b/front/src/Connexion.ts
@@ -165,25 +165,20 @@ export class Connexion implements ConnexionInterface {
     createConnexion(name: string, characterSelected: string): Promise<ConnexionInterface> {
         this.name = name;
         this.character = characterSelected;
-        /*return Axios.post(`${API_URL}/login`, {email: this.email})
+        return Axios.post(`${API_URL}/login`, {name: name})
             .then((res) => {
                 this.token = res.data.token;
-                this.userId = res.data.userId;*/
-
                 this.socket = SocketIo(`${API_URL}`, {
-                    /*query: {
+                    query: {
                         token: this.token
-                    }*/
+                    }
                 });
-
                 return this.connectSocketServer();
-
-         /*       return res.data;
             })
             .catch((err) => {
                 console.error(err);
                 throw err;
-            });*/
+            });
     }
 
     /**

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -3,7 +3,7 @@ import {
     GroupCreatedUpdatedMessageInterface,
     MessageUserJoined,
     MessageUserMovedInterface,
-    MessageUserPositionInterface
+    MessageUserPositionInterface, PointInterface
 } from "../../Connexion";
 import {CurrentGamerInterface, GamerInterface, hasMovedEventName, Player} from "../Player/Player";
 import { DEBUG_MODE, RESOLUTION, ROOM, ZOOM_LEVEL} from "../../Enum/EnvironmentVariable";
@@ -14,6 +14,7 @@ import Sprite = Phaser.GameObjects.Sprite;
 import CanvasTexture = Phaser.Textures.CanvasTexture;
 import {AddPlayerInterface} from "./AddPlayerInterface";
 import {PlayerAnimationNames} from "../Player/Animation";
+import {MessageUserMoved} from "../../../../back/src/Model/Websocket/MessageUserMoved";
 
 export enum Textures {
     Player = "male1"
@@ -410,6 +411,14 @@ export class GameScene extends Phaser.Scene {
      * Create new player
      */
     public addPlayer(addPlayerData : AddPlayerInterface) : void{
+        //check if exist player, if exist, move position
+        if(this.MapPlayersByKey.has(addPlayerData.userId)){
+            this.updatePlayerPosition({
+                userId: addPlayerData.userId,
+                position: addPlayerData.position
+            });
+            return;
+        }
         //initialise player
         let player = new Player(
             addPlayerData.userId,

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -1,12 +1,11 @@
-import {GameManager, gameManager, HasMovedEvent, MapObject, StatusGameManagerEnum} from "./GameManager";
+import {GameManager, gameManager, HasMovedEvent} from "./GameManager";
 import {
     GroupCreatedUpdatedMessageInterface,
-    MessageUserJoined,
     MessageUserMovedInterface,
-    MessageUserPositionInterface, PointInterface
+    MessageUserPositionInterface
 } from "../../Connexion";
 import {CurrentGamerInterface, GamerInterface, hasMovedEventName, Player} from "../Player/Player";
-import { DEBUG_MODE, RESOLUTION, ROOM, ZOOM_LEVEL} from "../../Enum/EnvironmentVariable";
+import { DEBUG_MODE, ZOOM_LEVEL} from "../../Enum/EnvironmentVariable";
 import {ITiledMap, ITiledMapLayer, ITiledTileSet} from "../Map/ITiledMap";
 import {PLAYER_RESOURCES} from "../Entity/PlayableCaracter";
 import Texture = Phaser.Textures.Texture;
@@ -14,7 +13,6 @@ import Sprite = Phaser.GameObjects.Sprite;
 import CanvasTexture = Phaser.Textures.CanvasTexture;
 import {AddPlayerInterface} from "./AddPlayerInterface";
 import {PlayerAnimationNames} from "../Player/Animation";
-import {MessageUserMoved} from "../../../../back/src/Model/Websocket/MessageUserMoved";
 
 export enum Textures {
     Player = "male1"


### PR DESCRIPTION
# MediaStream
There was an error when user switches off camera and microphone. So I used a data buffer to send messages between players. 
Why used buffer writing ? Because when user switch off camera and microphone, the `MediamStream` is null, and you cannot add `MediaStream` null. So the user doesn't receive the signal of 
`MediaStream` and cannot update status (microphone logo and display camera) for the player connected in peer connexion.

# Back end Token and UserId
I have reopened login with a token and `UserId` generated when the user connecting to the application.
 - I think that we must keep check token. Because other people could push content on the server socket.
 - I keep `UserId` generated because if we used the websocket id, it generates when socket is created. So if the server down, all sockets are destroyed and when the server reup, all of gamers have new socket and new id socket ( `userId` used in front). We receive player with new id so we create a new player and we have duplicate player on the map.
In this update, I verify token and in the token, there is `UserId` and I replace the socket id by the `UserId` generated.
I keep verification of token already exist because could be have conflict if we have same socket id.