### PR TITLE
Fixing disconnection taking ~15 seconds

### DIFF
--- a/back/src/Controller/IoSocketController.ts
+++ b/back/src/Controller/IoSocketController.ts
@@ -388,6 +388,17 @@ export class IoSocketController {
             userId: userId
         });
 
+        // Most of the time, sending a disconnect event to one of the players is enough (the player will close the connection
+        // which will be shut for the other player).
+        // However! In the rare case where the WebRTC connection is not yet established, if we close the connection on one of the player,
+        // the other player will try connecting until a timeout happens (during this time, the connection icon will be displayed for nothing).
+        // So we also send the disconnect event to the other player.
+        for (let user of group.getUsers()) {
+            Client.emit(SockerIoEvent.WEBRTC_DISCONNECT, {
+                userId: user.id
+            });
+        }
+
         //disconnect webrtc room
         if(!Client.webRtcRoomId){
             return;

--- a/front/src/Connection.ts
+++ b/front/src/Connection.ts
@@ -7,6 +7,7 @@ import {SetPlayerDetailsMessage} from "./Messages/SetPlayerDetailsMessage";
 const SocketIo = require('socket.io-client');
 import Socket = SocketIOClient.Socket;
 import {PlayerAnimationNames} from "./Phaser/Player/Animation";
+import {UserSimplePeer} from "./WebRtc/SimplePeer";
 
 
 enum EventMessage{
@@ -97,6 +98,15 @@ export interface GroupCreatedUpdatedMessageInterface {
     groupId: string
 }
 
+export interface WebRtcStartMessageInterface {
+    roomId: string,
+    clients: UserSimplePeer[]
+}
+
+export interface WebRtcDisconnectMessageInterface {
+    userId: string
+}
+
 export interface ConnectionInterface {
     socket: Socket|null;
     token: string|null;
@@ -116,9 +126,9 @@ export interface ConnectionInterface {
 
     receiveWebrtcSignal(callBack: Function): void;
 
-    receiveWebrtcStart(callBack: Function): void;
+    receiveWebrtcStart(callBack: (message: WebRtcStartMessageInterface) => void): void;
 
-    disconnectMessage(callBack: Function): void;
+    disconnectMessage(callBack: (message: WebRtcDisconnectMessageInterface) => void): void;
 }
 
 export class Connection implements ConnectionInterface {
@@ -277,7 +287,7 @@ export class Connection implements ConnectionInterface {
         });
     }
 
-    receiveWebrtcStart(callback: Function) {
+    receiveWebrtcStart(callback: (message: WebRtcStartMessageInterface) => void) {
         this.getSocket().on(EventMessage.WEBRTC_START, callback);
     }
 
@@ -305,7 +315,7 @@ export class Connection implements ConnectionInterface {
         });
     }
 
-    disconnectMessage(callback: Function): void {
+    disconnectMessage(callback: (message: WebRtcDisconnectMessageInterface) => void): void {
         this.getSocket().on(EventMessage.WEBRTC_DISCONNECT, callback);
     }
 }


### PR DESCRIPTION
Most of the time, sending a disconnect event to one of the players is enough (the player will close the connection
which will be shut for the other player).
However! In the rare case where the WebRTC connection is not yet established, if we close the connection on one of the player,
the other player will try connecting until a timeout happens (during this time, the circle with the name is displayed for nothing).

So now, we send disconnection event to every body (not only the people in the group, but also to the person leaving the group)

Closes #153