### PR TITLE
Adding Prometheus metrics

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -32,6 +32,7 @@
     "express": "^4.17.1",
     "http-status-codes": "^1.4.0",
     "jsonwebtoken": "^8.5.1",
+    "prom-client": "^12.0.0",
     "socket.io": "^2.3.0",
     "systeminformation": "^4.26.5",
     "ts-node-dev": "^1.0.0-pre.44",

--- a/back/src/App.ts
+++ b/back/src/App.ts
@@ -6,6 +6,7 @@ import {Application, Request, Response} from 'express';
 import bodyParser = require('body-parser');
 import * as http from "http";
 import {MapController} from "./Controller/MapController";
+import {PrometheusController} from "./Controller/PrometheusController";
 
 class App {
     public app: Application;
@@ -13,6 +14,7 @@ class App {
     public ioSocketController: IoSocketController;
     public authenticateController: AuthenticateController;
     public mapController: MapController;
+    public prometheusController: PrometheusController;
 
     constructor() {
         this.app = express();
@@ -29,6 +31,7 @@ class App {
         this.ioSocketController = new IoSocketController(this.server);
         this.authenticateController = new AuthenticateController(this.app);
         this.mapController = new MapController(this.app);
+        this.prometheusController = new PrometheusController(this.app, this.ioSocketController);
     }
 
     // TODO add session user

--- a/back/src/Controller/MapController.ts
+++ b/back/src/Controller/MapController.ts
@@ -19,7 +19,7 @@ export class MapController {
     // Returns a map mapping map name to file name of the map
     getStartMap() {
         this.App.get("/start-map", (req: Request, res: Response) => {
-            return res.status(OK).send({
+            res.status(OK).send({
                 mapUrlStart: req.headers.host + "/map/files" + URL_ROOM_STARTED,
                 startInstance: "global"
             });

--- a/back/src/Controller/PrometheusController.ts
+++ b/back/src/Controller/PrometheusController.ts
@@ -1,0 +1,20 @@
+import {Application, Request, Response} from "express";
+import {IoSocketController} from "_Controller/IoSocketController";
+const register = require('prom-client').register;
+const collectDefaultMetrics = require('prom-client').collectDefaultMetrics;
+
+export class PrometheusController {
+    constructor(private App: Application, private ioSocketController: IoSocketController) {
+        collectDefaultMetrics({
+            timeout: 10000,
+            gcDurationBuckets: [0.001, 0.01, 0.1, 1, 2, 5], // These are the default buckets.
+        });
+
+        this.App.get("/metrics", this.metrics.bind(this));
+    }
+
+    private metrics(req: Request, res: Response): void {
+        res.set('Content-Type', register.contentType);
+        res.end(register.metrics());
+    }
+}

--- a/back/yarn.lock
+++ b/back/yarn.lock
@@ -266,6 +266,11 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
+
 blob@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
@@ -1333,6 +1338,13 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
 
+prom-client@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-12.0.0.tgz#9689379b19bd3f6ab88a9866124db9da3d76c6ed"
+  integrity sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==
+  dependencies:
+    tdigest "^0.1.1"
+
 proxy-addr@~2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.6.tgz#fdc2336505447d3f2f2c638ed272caf614bbb2bf"
@@ -1682,6 +1694,13 @@ table@^5.2.3:
     lodash "^4.17.14"
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
+
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
+  dependencies:
+    bintrees "1.0.1"
 
 text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This commit adds a '/metrics' endpoint in the API that can be exploited by Prometheus.

This endpoint returns:

- the number of connected sockets
- the number of users per room
- common NodeJS and system metrics

WARNING: this endpoint is public right now and should be protected

See #166 #165 