### PR TITLE
Enabling stricter lint: forbidding usage of any

### DIFF
--- a/back/.eslintrc.json
+++ b/back/.eslintrc.json
@@ -7,7 +7,8 @@
     },
     "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/eslint-recommended"
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking"
     ],
     "globals": {
         "Atomics": "readonly",
@@ -16,12 +17,14 @@
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": 2018,
-        "sourceType": "module"
+        "sourceType": "module",
+        "project": "./tsconfig.json"
     },
     "plugins": [
         "@typescript-eslint"
     ],
     "rules": {
-        "no-unused-vars": "off"
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-explicit-any": "error"
     }
 }


### PR DESCRIPTION
See #168

This is important to be usre we validate any data received from the outside (that is currently casted into an interface without any real check)
We should use "unlknown" instead of "any" everywhere we manipulate data we are not sure of.