### PR TITLE
Fixing suspend/resume

### DIFF
--- a/front/src/Connection.ts
+++ b/front/src/Connection.ts
@@ -232,6 +232,8 @@ export class Connection implements ConnectionInterface {
     }
 
     joinARoom(roomId: string, startX: number, startY: number, direction: string, moving: boolean): void {
+        let point = new Point(startX, startY, direction, moving);
+        this.lastPositionShared = point;
         this.getSocket().emit(EventMessage.JOIN_ROOM, { roomId, position: {x: startX, y: startY, direction, moving }}, (userPositions: MessageUserPositionInterface[]) => {
             this.GameManager.initUsersPosition(userPositions);
         });

--- a/front/src/Phaser/Game/GameManager.ts
+++ b/front/src/Phaser/Game/GameManager.ts
@@ -35,7 +35,7 @@ export interface MapObject {
 export class GameManager {
     //status: number;
     private ConnectionInstance: Connection;
-    private currentGameScene: GameScene|null;
+    private currentGameScene: GameScene|null = null;
     private playerName: string;
     SimplePeer : SimplePeer;
     private characterUserSelected: string;
@@ -168,7 +168,7 @@ export class GameManager {
     private oldMapUrlFile : string;
     private oldInstance : string;
     private scenePlugin: ScenePlugin;
-    private reconnectScene: Scene|null;
+    private reconnectScene: Scene|null = null;
     switchToDisconnectedScene(): void {
         if (this.currentGameScene === null) {
             return;

--- a/front/src/Phaser/Game/GameManager.ts
+++ b/front/src/Phaser/Game/GameManager.ts
@@ -189,6 +189,9 @@ export class GameManager {
         if (this.reconnectScene === null && this.currentGameScene) {
             // In case we are asked to reconnect even if switchToDisconnectedScene was not triggered (can happen when a laptop goes to sleep)
             this.switchToDisconnectedScene();
+            // Wait a bit for scene to load. Otherwise, starting ReconnectingSceneName and then starting GameScene one after the other fails for some reason.
+            setTimeout(() => this.reconnectToGameScene(lastPositionShared), 500);
+            return;
         }
         const game : Phaser.Scene = GameScene.createFromUrl(this.oldMapUrlFile, this.oldInstance);
         this.reconnectScene?.scene.add(this.oldSceneKey, game, true, { initPosition: lastPositionShared });

--- a/front/src/Phaser/Game/GameManager.ts
+++ b/front/src/Phaser/Game/GameManager.ts
@@ -168,7 +168,7 @@ export class GameManager {
     private oldMapUrlFile : string;
     private oldInstance : string;
     private scenePlugin: ScenePlugin;
-    private reconnectScene: Scene;
+    private reconnectScene: Scene|null;
     switchToDisconnectedScene(): void {
         if (this.currentGameScene === null) {
             return;
@@ -186,8 +186,12 @@ export class GameManager {
     }
 
     reconnectToGameScene(lastPositionShared: PointInterface) {
+        if (this.reconnectScene === null && this.currentGameScene) {
+            // In case we are asked to reconnect even if switchToDisconnectedScene was not triggered (can happen when a laptop goes to sleep)
+            this.switchToDisconnectedScene();
+        }
         const game : Phaser.Scene = GameScene.createFromUrl(this.oldMapUrlFile, this.oldInstance);
-        this.reconnectScene.scene.add(this.oldSceneKey, game, true, { initPosition: lastPositionShared });
+        this.reconnectScene?.scene.add(this.oldSceneKey, game, true, { initPosition: lastPositionShared });
     }
 
     private getCurrentGameScene(): GameScene {


### PR DESCRIPTION
In case we suspend a laptop and resume it, the RECONNECT event is called by socket.io without any error being thrown (so without us being redirected to the Reconnect Scene).
This fix makes sure we go to the reconnect scene before going back to the main scene.

Closes #176
Closes #178 