### PR TITLE
Fixing events fired multiple times

### DIFF
--- a/front/src/Connection.ts
+++ b/front/src/Connection.ts
@@ -158,6 +158,16 @@ export class Connection implements ConnectionInterface {
                         token: this.token
                     }
                 });
+
+                //listen event
+                this.disconnectServer();
+                this.errorMessage();
+                this.groupUpdatedOrCreated();
+                this.groupDeleted();
+                this.onUserJoins();
+                this.onUserMoved();
+                this.onUserLeft();
+
                 return this.connectSocketServer();
             })
             .catch((err) => {
@@ -178,15 +188,6 @@ export class Connection implements ConnectionInterface {
      * @param character
      */
     connectSocketServer(): Promise<ConnectionInterface>{
-        //listen event
-        this.disconnectServer();
-        this.errorMessage();
-        this.groupUpdatedOrCreated();
-        this.groupDeleted();
-        this.onUserJoins();
-        this.onUserMoved();
-        this.onUserLeft();
-
         return new Promise<ConnectionInterface>((resolve, reject) => {
             this.getSocket().emit(EventMessage.SET_PLAYER_DETAILS, {
                 name: this.name,

--- a/front/src/Phaser/Game/GameManager.ts
+++ b/front/src/Phaser/Game/GameManager.ts
@@ -188,15 +188,18 @@ export class GameManager {
     private timeoutCallback: NodeJS.Timeout|null = null;
     reconnectToGameScene(lastPositionShared: PointInterface) {
         if (this.reconnectScene === null && this.currentGameScene && this.timeoutCallback === null) {
+            console.log('Reconnect called without switchToDisconnectedScene called first');
             // In case we are asked to reconnect even if switchToDisconnectedScene was not triggered (can happen when a laptop goes to sleep)
             this.switchToDisconnectedScene();
             // Wait a bit for scene to load. Otherwise, starting ReconnectingSceneName and then starting GameScene one after the other fails for some reason.
             this.timeoutCallback = setTimeout(() => {
+                console.log('Reconnecting to game scene from setTimeout');
                 this.reconnectToGameScene(lastPositionShared);
                 this.timeoutCallback = null;
             }, 500);
             return;
         }
+        console.log('Reconnecting to game scene');
         const game : Phaser.Scene = GameScene.createFromUrl(this.oldMapUrlFile, this.oldInstance);
         this.reconnectScene?.scene.add(this.oldSceneKey, game, true, { initPosition: lastPositionShared });
     }


### PR DESCRIPTION
Callbacks for socket.io events were registered each time a disconnect was called, leading to message being dispatched plenty of times if there was several disconnections.