### PR TITLE
Fixing reconnect issue

### DIFF
--- a/front/src/Connection.ts
+++ b/front/src/Connection.ts
@@ -325,6 +325,7 @@ export class Connection implements ConnectionInterface {
         });
 
         this.getSocket().on(EventMessage.RECONNECT, () => {
+            console.log('Reconnect event triggered');
             this.connectSocketServer();
             if (this.lastPositionShared === null) {
                 throw new Error('No last position shared found while reconnecting');

--- a/front/src/Phaser/Game/GameManager.ts
+++ b/front/src/Phaser/Game/GameManager.ts
@@ -204,8 +204,8 @@ export class GameManager {
             // Wait a bit for scene to load. Otherwise, starting ReconnectingSceneName and then starting GameScene one after the other fails for some reason.
             this.timeoutCallback = setTimeout(() => {
                 console.log('Reconnecting to game scene from setTimeout');
-                this.reconnectToGameScene(lastPositionShared);
                 this.timeoutCallback = null;
+                this.reconnectToGameScene(lastPositionShared);
             }, 500);
             return;
         }


### PR DESCRIPTION
In the case the reconnect event was triggered on "wake-up", the disconnect event was not sent. But because of a bug in the way we handle the setTimeout, the reconnection to the GameScene never happened after we forced the disconnect scene.
This fixes the issue.