### PR TITLE
Adding Prometheus support in K8S

### DIFF
--- a/deeployer.libsonnet
+++ b/deeployer.libsonnet
@@ -42,6 +42,23 @@
   "config": {
     "https": {
       "mail": "d.negrier@thecodingmachine.com"
-    }
+    },
+    k8sextension(k8sConf)::
+        k8sConf + {
+          back+: {
+            deployment+: {
+              spec+: {
+                template+: {
+                  metadata+: {
+                    annotations+: {
+                      "prometheus.io/port": "8080",
+                      "prometheus.io/scrape": "true"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
   }
 }


### PR DESCRIPTION
This adds an annotation in the back container that will allow the Prometheus to autodetect containers in the cluster.