### PR TITLE
Refactoring connection to be part of a GameScene

### DIFF
--- a/front/src/Phaser/Login/SelectCharacterScene.ts
+++ b/front/src/Phaser/Login/SelectCharacterScene.ts
@@ -117,34 +117,31 @@ export class SelectCharacterScene extends Phaser.Scene {
     }
 
     private async login(name: string): Promise<StartMapInterface> {
-        return gameManager.connect(name, this.selectedPlayer.texture.key).then(() => {
-            // Do we have a start URL in the address bar? If so, let's redirect to this address
-            const instanceAndMapUrl = this.findMapUrl();
-            if (instanceAndMapUrl !== null) {
-                const [mapUrl, instance] = instanceAndMapUrl;
-                const key = gameManager.loadMap(mapUrl, this.scene, instance);
-                this.scene.start(key, {
-                    startLayerName: window.location.hash ? window.location.hash.substr(1) : undefined
-                } as GameSceneInitInterface);
-                return {
-                    mapUrlStart: mapUrl,
-                    startInstance: instance
-                };
-            } else {
-                // If we do not have a map address in the URL, let's ask the server for a start map.
-                return gameManager.loadStartMap().then((startMap: StartMapInterface) => {
-                    const key = gameManager.loadMap(window.location.protocol + "//" + startMap.mapUrlStart, this.scene, startMap.startInstance);
-                    this.scene.start(key);
-                    return startMap;
-                }).catch((err) => {
-                    console.error(err);
-                    throw err;
-                });
-            }
-        }).catch((err) => {
-            console.error(err);
-            throw err;
-        });
+        gameManager.storePlayerDetails(name, this.selectedPlayer.texture.key);
+
+        // Do we have a start URL in the address bar? If so, let's redirect to this address
+        const instanceAndMapUrl = this.findMapUrl();
+        if (instanceAndMapUrl !== null) {
+            const [mapUrl, instance] = instanceAndMapUrl;
+            const key = gameManager.loadMap(mapUrl, this.scene, instance);
+            this.scene.start(key, {
+                startLayerName: window.location.hash ? window.location.hash.substr(1) : undefined
+            } as GameSceneInitInterface);
+            return {
+                mapUrlStart: mapUrl,
+                startInstance: instance
+            };
+        } else {
+            // If we do not have a map address in the URL, let's ask the server for a start map.
+            return gameManager.loadStartMap().then((startMap: StartMapInterface) => {
+                const key = gameManager.loadMap(window.location.protocol + "//" + startMap.mapUrlStart, this.scene, startMap.startInstance);
+                this.scene.start(key);
+                return startMap;
+            }).catch((err) => {
+                console.error(err);
+                throw err;
+            });
+        }
     }
 
     /**

--- a/front/src/WebRtc/SimplePeer.ts
+++ b/front/src/WebRtc/SimplePeer.ts
@@ -1,5 +1,5 @@
 import {
-    ConnectionInterface,
+    Connection,
     WebRtcDisconnectMessageInterface,
     WebRtcSignalMessageInterface,
     WebRtcStartMessageInterface
@@ -18,7 +18,7 @@ export interface UserSimplePeer{
  * This class manages connections to all the peers in the same group as me.
  */
 export class SimplePeer {
-    private Connection: ConnectionInterface;
+    private Connection: Connection;
     private WebRtcRoomId: string;
     private Users: Array<UserSimplePeer> = new Array<UserSimplePeer>();
 
@@ -26,7 +26,7 @@ export class SimplePeer {
 
     private PeerConnectionArray: Map<string, SimplePeerNamespace.Instance> = new Map<string, SimplePeerNamespace.Instance>();
 
-    constructor(Connection: ConnectionInterface, WebRtcRoomId: string = "test-webrtc") {
+    constructor(Connection: Connection, WebRtcRoomId: string = "test-webrtc") {
         this.Connection = Connection;
         this.WebRtcRoomId = WebRtcRoomId;
         this.MediaManager = new MediaManager((stream : MediaStream) => {


### PR DESCRIPTION
Most of the refactoring issues we are seeing are probably due to the fact that we are trying to manipulate a ScenePlugin out of a Scene (the GameManager is not a Scene and holds a reference to a ScenePlugin coming from a Scene that might get invalidated by Phaser 3).
Furthermore, if we want in the future to be able to scale, scenes could be hosted on different servers. Therefore, it makes no sense to have one connexion for the whole application.
Instead, we should have one connexion for each scene.

This PR will almost destroy the notion of GameManager (bye bye!)