### PR TITLE
[WIP] Performance: Sending position only for players in the viewport

### DIFF
--- a/back/src/Controller/IoSocketController.ts
+++ b/back/src/Controller/IoSocketController.ts
@@ -41,7 +41,7 @@ enum SockerIoEvent {
     BATCH = "batch",
 }
 
-function emitInBatch(socket: ExSocketInterface, event: string | symbol, payload: any): void {
+function emitInBatch(socket: ExSocketInterface, event: string | symbol, payload: unknown): void {
     socket.batchedMessages.push({ event, payload});
 
     if (socket.batchTimeout === null) {
@@ -169,7 +169,7 @@ export class IoSocketController {
             const client : ExSocketInterface = socket as ExSocketInterface;
             client.batchedMessages = [];
             client.batchTimeout = null;
-            client.emitInBatch = (event: string | symbol, payload: any): void => {
+            client.emitInBatch = (event: string | symbol, payload: unknown): void => {
                 emitInBatch(client, event, payload);
             }
             this.sockets.set(client.userId, client);

--- a/back/src/Controller/IoSocketController.ts
+++ b/back/src/Controller/IoSocketController.ts
@@ -223,6 +223,14 @@ export class IoSocketController {
                         return new MessageUserPosition(user.id, player.name, player.characterLayers, player.position);
                     }, users);
 
+                    //console.warn('ANSWER PLAYER POSITIONS', listOfUsers);
+                    if (answerFn === undefined && ALLOW_ARTILLERY === true) {
+                        /*console.error("TYPEOF answerFn", typeof(answerFn));
+                        console.error("answerFn", answerFn);
+                        process.exit(1)*/
+                        // For some reason, answerFn can be undefined if we use Artillery (?)
+                        return;
+                    }
                     answerFn(listOfUsers);
                 } catch (e) {
                     console.error('An error occurred on "join_room" event');
@@ -244,7 +252,7 @@ export class IoSocketController {
 
                     const world = this.Worlds.get(Client.roomId);
                     if (!world) {
-                        console.error("Could not find world with id '", Client.roomId, "'");
+                        console.error("In SET_VIEWPORT, could not find world with id '", Client.roomId, "'");
                         return;
                     }
                     world.setViewport(Client, Client.viewport);
@@ -255,7 +263,7 @@ export class IoSocketController {
             });
 
             socket.on(SockerIoEvent.USER_POSITION, (userMovesMessage: unknown): void => {
-                console.log(SockerIoEvent.USER_POSITION, userMovesMessage);
+                //console.log(SockerIoEvent.USER_POSITION, userMovesMessage);
                 try {
                     if (!isUserMovesInterface(userMovesMessage)) {
                         socket.emit(SockerIoEvent.MESSAGE_ERROR, {message: 'Invalid USER_POSITION message.'});
@@ -272,7 +280,7 @@ export class IoSocketController {
                     // update position in the world
                     const world = this.Worlds.get(Client.roomId);
                     if (!world) {
-                        console.error("Could not find world with id '", Client.roomId, "'");
+                        console.error("In USER_POSITION, could not find world with id '", Client.roomId, "'");
                         return;
                     }
                     world.updatePosition(Client, Client.position);
@@ -351,7 +359,7 @@ export class IoSocketController {
                     // update position in the world
                     const world = this.Worlds.get(Client.roomId);
                     if (!world) {
-                        console.error("Could not find world with id '", Client.roomId, "'");
+                        console.error("In SET_SILENT, could not find world with id '", Client.roomId, "'");
                         return;
                     }
                     world.setSilent(Client, silent);

--- a/back/src/Model/PositionNotifier.ts
+++ b/back/src/Model/PositionNotifier.ts
@@ -1,0 +1,106 @@
+/**
+ * Tracks the position of every player on the map, and sends notifications to the players interested in knowing about the move
+ * (i.e. players that are looking at the zone the player is currently in)
+ *
+ * Internally, the PositionNotifier works with Zones. A zone is a square area of a map.
+ * Each player is in a given zone, and each player tracks one or many zones (depending on the player viewport)
+ *
+ * The PositionNotifier is important for performance. It allows us to send the position of players only to a restricted
+ * number of players around the current player.
+ */
+import {UserEntersCallback, UserLeavesCallback, UserMovesCallback, Zone} from "./Zone";
+import {PointInterface} from "_Model/Websocket/PointInterface";
+import {UserInterface} from "_Model/UserInterface";
+import {ViewportInterface} from "_Model/Websocket/ViewportMessage";
+
+interface ZoneDescriptor {
+    i: number;
+    j: number;
+}
+
+export class PositionNotifier {
+
+    // TODO: we need a way to clean the zones if noone is in the zone and noone listening (to free memory!)
+
+    private zones: Zone[][] = [];
+
+    constructor(private zoneWidth: number, private zoneHeight: number, private onUserEnters: UserEntersCallback, private onUserMoves: UserMovesCallback, private onUserLeaves: UserLeavesCallback) {
+    }
+
+    private getZoneDescriptorFromCoordinates(x: number, y: number): ZoneDescriptor {
+        return {
+            i: Math.floor(x / this.zoneWidth),
+            j: Math.floor(y / this.zoneHeight),
+        }
+    }
+
+    public setViewport(user: UserInterface, viewport: ViewportInterface): void {
+        if (viewport.left > viewport.right || viewport.top > viewport.bottom) {
+            console.warn('Invalid viewport received: ', viewport);
+            return;
+        }
+
+        const oldZones = user.listenedZones;
+        const newZones = new Set<Zone>();
+
+        const topLeftDesc = this.getZoneDescriptorFromCoordinates(viewport.left, viewport.top);
+        const bottomRightDesc = this.getZoneDescriptorFromCoordinates(viewport.right, viewport.bottom);
+
+        for (let j = topLeftDesc.j; j <= bottomRightDesc.j; j++) {
+            for (let i = topLeftDesc.i; i <= bottomRightDesc.i; i++) {
+                newZones.add(this.getZone(i, j));
+            }
+        }
+
+        const addedZones = [...newZones].filter(x => !oldZones.has(x));
+        const removedZones = [...oldZones].filter(x => !newZones.has(x));
+
+        for (const zone of addedZones) {
+            zone.startListening(user);
+        }
+        for (const zone of removedZones) {
+            zone.stopListening(user);
+        }
+    }
+
+    public updatePosition(user: UserInterface, userPosition: PointInterface): void {
+        // Did we change zone?
+        const oldZoneDesc = this.getZoneDescriptorFromCoordinates(user.position.x, user.position.y);
+        const newZoneDesc = this.getZoneDescriptorFromCoordinates(userPosition.x, userPosition.y);
+
+        if (oldZoneDesc.i != newZoneDesc.i || oldZoneDesc.j != newZoneDesc.j) {
+            const oldZone = this.getZone(oldZoneDesc.i, oldZoneDesc.j);
+            const newZone = this.getZone(newZoneDesc.i, newZoneDesc.j);
+
+            // Leave old zone
+            oldZone.leave(user, newZone);
+
+            // Enter new zone
+            newZone.enter(user, oldZone, userPosition);
+        } else {
+            const zone = this.getZone(oldZoneDesc.i, oldZoneDesc.j);
+            zone.move(user, userPosition);
+        }
+    }
+
+    public leave(user: UserInterface): void {
+        const oldZoneDesc = this.getZoneDescriptorFromCoordinates(user.position.x, user.position.y);
+        const oldZone = this.getZone(oldZoneDesc.i, oldZoneDesc.j);
+        oldZone.leave(user, null);
+    }
+
+    private getZone(i: number, j: number): Zone {
+        let zoneRow = this.zones[j];
+        if (zoneRow === undefined) {
+            zoneRow = new Array<Zone>();
+            this.zones[j] = zoneRow;
+        }
+
+        let zone = this.zones[j][i];
+        if (zone === undefined) {
+            zone = new Zone(this.onUserEnters, this.onUserMoves, this.onUserLeaves);
+            this.zones[j][i] = zone;
+        }
+        return zone;
+    }
+}

--- a/back/src/Model/UserInterface.ts
+++ b/back/src/Model/UserInterface.ts
@@ -1,9 +1,11 @@
 import { Group } from "./Group";
 import { PointInterface } from "./Websocket/PointInterface";
+import {Zone} from "_Model/Zone";
 
 export interface UserInterface {
     id: string,
     group?: Group,
     position: PointInterface,
-    silent: boolean
+    silent: boolean,
+    listenedZones: Set<Zone>
 }

--- a/back/src/Model/Websocket/ExSocketInterface.ts
+++ b/back/src/Model/Websocket/ExSocketInterface.ts
@@ -17,7 +17,7 @@ export interface ExSocketInterface extends Socket, Identificable {
     /**
      * Pushes an event that will be sent in the next batch of events
      */
-    emitInBatch: (event: string | symbol, payload: any) => void;
-    batchedMessages: Array<{ event: string | symbol, payload: any }>;
+    emitInBatch: (event: string | symbol, payload: unknown) => void;
+    batchedMessages: Array<{ event: string | symbol, payload: unknown }>;
     batchTimeout: NodeJS.Timeout|null;
 }

--- a/back/src/Model/Websocket/ExSocketInterface.ts
+++ b/back/src/Model/Websocket/ExSocketInterface.ts
@@ -2,6 +2,7 @@ import {Socket} from "socket.io";
 import {PointInterface} from "./PointInterface";
 import {Identificable} from "./Identificable";
 import {TokenInterface} from "../../Controller/AuthenticateController";
+import {ViewportInterface} from "_Model/Websocket/ViewportMessage";
 
 export interface ExSocketInterface extends Socket, Identificable {
     token: string;
@@ -11,5 +12,12 @@ export interface ExSocketInterface extends Socket, Identificable {
     name: string;
     characterLayers: string[];
     position: PointInterface;
+    viewport: ViewportInterface;
     isArtillery: boolean; // Whether this socket is opened by Artillery for load testing (hack)
+    /**
+     * Pushes an event that will be sent in the next batch of events
+     */
+    emitInBatch: (event: string | symbol, payload: any) => void;
+    batchedMessages: Array<{ event: string | symbol, payload: any }>;
+    batchTimeout: NodeJS.Timeout|null;
 }

--- a/back/src/Model/Websocket/JoinRoomMessage.ts
+++ b/back/src/Model/Websocket/JoinRoomMessage.ts
@@ -1,9 +1,11 @@
 import * as tg from "generic-type-guard";
 import {isPointInterface} from "./PointInterface";
+import {isViewport} from "./ViewportMessage";
 
 export const isJoinRoomMessageInterface =
     new tg.IsInterface().withProperties({
         roomId: tg.isString,
         position: isPointInterface,
+        viewport: isViewport
     }).get();
 export type JoinRoomMessageInterface = tg.GuardedType<typeof isJoinRoomMessageInterface>;

--- a/back/src/Model/Websocket/UserMovesMessage.ts
+++ b/back/src/Model/Websocket/UserMovesMessage.ts
@@ -1,0 +1,11 @@
+import * as tg from "generic-type-guard";
+import {isPointInterface} from "./PointInterface";
+import {isViewport} from "./ViewportMessage";
+
+
+export const isUserMovesInterface =
+    new tg.IsInterface().withProperties({
+        position: isPointInterface,
+        viewport: isViewport,
+    }).get();
+export type UserMovesInterface = tg.GuardedType<typeof isUserMovesInterface>;

--- a/back/src/Model/Websocket/ViewportMessage.ts
+++ b/back/src/Model/Websocket/ViewportMessage.ts
@@ -1,0 +1,10 @@
+import * as tg from "generic-type-guard";
+
+export const isViewport =
+    new tg.IsInterface().withProperties({
+        left: tg.isNumber,
+        top: tg.isNumber,
+        right: tg.isNumber,
+        bottom: tg.isNumber,
+    }).get();
+export type ViewportInterface = tg.GuardedType<typeof isViewport>;

--- a/back/src/Model/World.ts
+++ b/back/src/Model/World.ts
@@ -6,7 +6,9 @@ import {UserInterface} from "./UserInterface";
 import {ExSocketInterface} from "_Model/Websocket/ExSocketInterface";
 import {PositionInterface} from "_Model/PositionInterface";
 import {Identificable} from "_Model/Websocket/Identificable";
-import {Zone} from "_Model/Zone";
+import {UserEntersCallback, UserLeavesCallback, UserMovesCallback, Zone} from "_Model/Zone";
+import {PositionNotifier} from "./PositionNotifier";
+import {ViewportInterface} from "_Model/Websocket/ViewportMessage";
 
 export type ConnectCallback = (user: string, group: Group) => void;
 export type DisconnectCallback = (user: string, group: Group) => void;
@@ -28,12 +30,17 @@ export class World {
     private readonly groupUpdatedCallback: GroupUpdatedCallback;
     private readonly groupDeletedCallback: GroupDeletedCallback;
 
+    private readonly positionNotifier: PositionNotifier;
+
     constructor(connectCallback: ConnectCallback,
                 disconnectCallback: DisconnectCallback,
                 minDistance: number,
                 groupRadius: number,
                 groupUpdatedCallback: GroupUpdatedCallback,
-                groupDeletedCallback: GroupDeletedCallback)
+                groupDeletedCallback: GroupDeletedCallback,
+                onUserEnters: UserEntersCallback,
+                onUserMoves: UserMovesCallback,
+                onUserLeaves: UserLeavesCallback)
     {
         this.users = new Map<string, UserInterface>();
         this.groups = new Set<Group>();
@@ -43,6 +50,8 @@ export class World {
         this.groupRadius = groupRadius;
         this.groupUpdatedCallback = groupUpdatedCallback;
         this.groupDeletedCallback = groupDeletedCallback;
+        // A zone is 10 sprites wide.
+        this.positionNotifier = new PositionNotifier(320, 320, onUserEnters, onUserMoves, onUserLeaves);
     }
 
     public getGroups(): Group[] {
@@ -73,6 +82,10 @@ export class World {
             this.leaveGroup(userObj);
         }
         this.users.delete(user.userId);
+
+        if (userObj !== undefined) {
+            this.positionNotifier.leave(userObj);
+        }
     }
 
     public isEmpty(): boolean {
@@ -84,6 +97,8 @@ export class World {
         if(typeof user === 'undefined') {
             return;
         }
+
+        this.positionNotifier.updatePosition(user, userPosition);
 
         user.position = userPosition;
 
@@ -318,4 +333,12 @@ export class World {
         }
         return 0;
     }*/
+    setViewport(socket : Identificable, viewport: ViewportInterface): UserInterface[] {
+        const user = this.users.get(socket.userId);
+        if(typeof user === 'undefined') {
+            console.warn('In setViewport, could not find user with ID "'+socket.userId+'" in world.');
+            return [];
+        }
+        return this.positionNotifier.setViewport(user, viewport);
+    }
 }

--- a/back/src/Model/World.ts
+++ b/back/src/Model/World.ts
@@ -6,6 +6,7 @@ import {UserInterface} from "./UserInterface";
 import {ExSocketInterface} from "_Model/Websocket/ExSocketInterface";
 import {PositionInterface} from "_Model/PositionInterface";
 import {Identificable} from "_Model/Websocket/Identificable";
+import {Zone} from "_Model/Zone";
 
 export type ConnectCallback = (user: string, group: Group) => void;
 export type DisconnectCallback = (user: string, group: Group) => void;
@@ -56,7 +57,8 @@ export class World {
         this.users.set(socket.userId, {
             id: socket.userId,
             position: userPosition,
-            silent: false // FIXME: silent should be set at the correct value when joining a room.
+            silent: false, // FIXME: silent should be set at the correct value when joining a room.
+            listenedZones: new Set<Zone>()
         });
         // Let's call update position to trigger the join / leave room
         this.updatePosition(socket, userPosition);

--- a/back/src/Model/Zone.ts
+++ b/back/src/Model/Zone.ts
@@ -1,0 +1,85 @@
+import {UserInterface} from "./UserInterface";
+import {PointInterface} from "_Model/Websocket/PointInterface";
+import {PositionInterface} from "_Model/PositionInterface";
+
+export type UserEntersCallback = (user: UserInterface) => void;
+export type UserMovesCallback = (user: UserInterface, position: PointInterface) => void;
+export type UserLeavesCallback = (user: UserInterface) => void;
+
+export class Zone {
+    private players: Set<UserInterface> = new Set<UserInterface>();
+    private listeners: Set<UserInterface> = new Set<UserInterface>();
+
+    constructor(private onUserEnters: UserEntersCallback, private onUserMoves: UserMovesCallback, private onUserLeaves: UserLeavesCallback) {
+    }
+
+    /**
+     * A user leaves the zone
+     */
+    public leave(user: UserInterface, newZone: Zone|null) {
+        this.players.delete(user);
+        this.notifyUserLeft(user, newZone);
+    }
+
+    /**
+     * Notify listeners of this zone that this user left
+     */
+    private notifyUserLeft(user: UserInterface, newZone: Zone|null) {
+        for (const listener of this.listeners) {
+            if (listener !== user && (newZone === null || !listener.listenedZones.has(newZone))) {
+                this.onUserLeaves(user);
+            }
+        }
+    }
+
+    public enter(user: UserInterface, oldZone: Zone|null, position: PointInterface) {
+        this.players.add(user);
+        this.notifyUserEnter(user, oldZone, position);
+    }
+
+    /**
+     * Notify listeners of this zone that this user entered
+     */
+    private notifyUserEnter(user: UserInterface, oldZone: Zone|null, position: PointInterface) {
+        for (const listener of this.listeners) {
+            if (listener === user) {
+                continue;
+            }
+            if (oldZone === null || !listener.listenedZones.has(oldZone)) {
+                this.onUserEnters(user);
+            } else {
+                this.onUserMoves(user, position);
+            }
+        }
+    }
+
+    public move(user: UserInterface, position: PointInterface) {
+        for (const listener of this.listeners) {
+            if (listener !== user) {
+                this.onUserMoves(user,position);
+            }
+        }
+    }
+
+    public startListening(user: UserInterface): void {
+        for (const player of this.players) {
+            if (player !== user) {
+                this.onUserEnters(user);
+            }
+        }
+
+        this.listeners.add(user);
+        user.listenedZones.add(this);
+    }
+
+    public stopListening(user: UserInterface): void {
+        for (const player of this.players) {
+            if (player !== user) {
+                this.onUserLeaves(user);
+            }
+        }
+
+        this.listeners.delete(user);
+        user.listenedZones.delete(this);
+    }
+}

--- a/back/tests/PositionNotifierTest.ts
+++ b/back/tests/PositionNotifierTest.ts
@@ -32,7 +32,7 @@ describe("PositionNotifier", () => {
             leaveTriggered = true;
         });
 
-        let user1 = {
+        const user1 = {
             id: "1",
             position: {
                 x: 500,
@@ -43,7 +43,7 @@ describe("PositionNotifier", () => {
             listenedZones: new Set<Zone>(),
         } as UserInterface;
 
-        let user2 = {
+        const user2 = {
             id: "2",
             position: {
                 x: -9999,
@@ -117,7 +117,7 @@ describe("PositionNotifier", () => {
             leaveTriggered = true;
         });
 
-        let user1 = {
+        const user1 = {
             id: "1",
             position: {
                 x: 500,
@@ -128,7 +128,7 @@ describe("PositionNotifier", () => {
             listenedZones: new Set<Zone>(),
         } as UserInterface;
 
-        let user2 = {
+        const user2 = {
             id: "2",
             position: {
                 x: -9999,

--- a/back/tests/PositionNotifierTest.ts
+++ b/back/tests/PositionNotifierTest.ts
@@ -139,12 +139,14 @@ describe("PositionNotifier", () => {
             listenedZones: new Set<Zone>(),
         } as UserInterface;
 
-        positionNotifier.setViewport(user1, {
+        let newUsers = positionNotifier.setViewport(user1, {
             left: 200,
             right: 600,
             top: 100,
             bottom: 500
         });
+
+        expect(newUsers.length).toBe(0);
 
         move(user2, 500, 500, positionNotifier);
 
@@ -178,7 +180,7 @@ describe("PositionNotifier", () => {
         leaveTriggered = false;
 
         // Move the viewport back on the user.
-        positionNotifier.setViewport(user1, {
+        newUsers = positionNotifier.setViewport(user1, {
             left: 200,
             right: 600,
             top: 100,
@@ -189,5 +191,6 @@ describe("PositionNotifier", () => {
         expect(moveTriggered).toBe(false);
         expect(leaveTriggered).toBe(false);
         enterTriggered = false;
+        expect(newUsers.length).toBe(1);
     });
 })

--- a/back/tests/PositionNotifierTest.ts
+++ b/back/tests/PositionNotifierTest.ts
@@ -1,0 +1,193 @@
+import "jasmine";
+import {World, ConnectCallback, DisconnectCallback } from "../src/Model/World";
+import {Point} from "../src/Model/Websocket/MessageUserPosition";
+import { Group } from "../src/Model/Group";
+import {PositionNotifier} from "../src/Model/PositionNotifier";
+import {UserInterface} from "../src/Model/UserInterface";
+import {PointInterface} from "../src/Model/Websocket/PointInterface";
+import {Zone} from "_Model/Zone";
+
+function move(user: UserInterface, x: number, y: number, positionNotifier: PositionNotifier): void {
+    positionNotifier.updatePosition(user, {
+        x,
+        y,
+        moving: false,
+        direction: 'down'
+    });
+    user.position.x = x;
+    user.position.y = y;
+}
+
+describe("PositionNotifier", () => {
+    it("should receive notifications when player moves", () => {
+        let enterTriggered = false;
+        let moveTriggered = false;
+        let leaveTriggered = false;
+
+        const positionNotifier = new PositionNotifier(300, 300, (user: UserInterface) => {
+            enterTriggered = true;
+        }, (user: UserInterface, position: PointInterface) => {
+            moveTriggered = true;
+        }, (user: UserInterface) => {
+            leaveTriggered = true;
+        });
+
+        let user1 = {
+            id: "1",
+            position: {
+                x: 500,
+                y: 500,
+                moving: false,
+                direction: 'down'
+            },
+            listenedZones: new Set<Zone>(),
+        } as UserInterface;
+
+        let user2 = {
+            id: "2",
+            position: {
+                x: -9999,
+                y: -9999,
+                moving: false,
+                direction: 'down'
+            },
+            listenedZones: new Set<Zone>(),
+        } as UserInterface;
+
+        positionNotifier.setViewport(user1, {
+            left: 200,
+            right: 600,
+            top: 100,
+            bottom: 500
+        });
+
+        move(user2, 500, 500, positionNotifier);
+
+        expect(enterTriggered).toBe(true);
+        expect(moveTriggered).toBe(false);
+        enterTriggered = false;
+
+        // Move inside the zone
+        move(user2, 501, 500, positionNotifier);
+
+        expect(enterTriggered).toBe(false);
+        expect(moveTriggered).toBe(true);
+        moveTriggered = false;
+
+        // Move out of the zone in a zone that we don't track
+        move(user2, 901, 500, positionNotifier);
+
+        expect(enterTriggered).toBe(false);
+        expect(moveTriggered).toBe(false);
+        expect(leaveTriggered).toBe(true);
+        leaveTriggered = false;
+
+        // Move back in
+        move(user2, 500, 500, positionNotifier);
+        expect(enterTriggered).toBe(true);
+        expect(moveTriggered).toBe(false);
+        expect(leaveTriggered).toBe(false);
+        enterTriggered = false;
+
+        // Move out of the zone in a zone that we do track
+        move(user2, 200, 500, positionNotifier);
+        expect(enterTriggered).toBe(false);
+        expect(moveTriggered).toBe(true);
+        expect(leaveTriggered).toBe(false);
+        moveTriggered = false;
+
+        // Leave the room
+        positionNotifier.leave(user2);
+        expect(enterTriggered).toBe(false);
+        expect(moveTriggered).toBe(false);
+        expect(leaveTriggered).toBe(true);
+        leaveTriggered = false;
+    });
+
+    it("should receive notifications when camera moves", () => {
+        let enterTriggered = false;
+        let moveTriggered = false;
+        let leaveTriggered = false;
+
+        const positionNotifier = new PositionNotifier(300, 300, (user: UserInterface) => {
+            enterTriggered = true;
+        }, (user: UserInterface, position: PointInterface) => {
+            moveTriggered = true;
+        }, (user: UserInterface) => {
+            leaveTriggered = true;
+        });
+
+        let user1 = {
+            id: "1",
+            position: {
+                x: 500,
+                y: 500,
+                moving: false,
+                direction: 'down'
+            },
+            listenedZones: new Set<Zone>(),
+        } as UserInterface;
+
+        let user2 = {
+            id: "2",
+            position: {
+                x: -9999,
+                y: -9999,
+                moving: false,
+                direction: 'down'
+            },
+            listenedZones: new Set<Zone>(),
+        } as UserInterface;
+
+        positionNotifier.setViewport(user1, {
+            left: 200,
+            right: 600,
+            top: 100,
+            bottom: 500
+        });
+
+        move(user2, 500, 500, positionNotifier);
+
+        expect(enterTriggered).toBe(true);
+        expect(moveTriggered).toBe(false);
+        enterTriggered = false;
+
+        // Move the viewport but the user stays inside.
+        positionNotifier.setViewport(user1, {
+            left: 201,
+            right: 601,
+            top: 100,
+            bottom: 500
+        });
+
+        expect(enterTriggered).toBe(false);
+        expect(moveTriggered).toBe(false);
+        expect(leaveTriggered).toBe(false);
+
+        // Move the viewport out of the user.
+        positionNotifier.setViewport(user1, {
+            left: 901,
+            right: 1001,
+            top: 100,
+            bottom: 500
+        });
+
+        expect(enterTriggered).toBe(false);
+        expect(moveTriggered).toBe(false);
+        expect(leaveTriggered).toBe(true);
+        leaveTriggered = false;
+
+        // Move the viewport back on the user.
+        positionNotifier.setViewport(user1, {
+            left: 200,
+            right: 600,
+            top: 100,
+            bottom: 500
+        });
+
+        expect(enterTriggered).toBe(true);
+        expect(moveTriggered).toBe(false);
+        expect(leaveTriggered).toBe(false);
+        enterTriggered = false;
+    });
+})

--- a/back/tests/WorldTest.ts
+++ b/back/tests/WorldTest.ts
@@ -13,7 +13,7 @@ describe("World", () => {
 
         }
 
-        const world = new World(connect, disconnect, 160, 160, () => {}, () => {});
+        const world = new World(connect, disconnect, 160, 160, () => {}, () => {}, () => {}, () => {}, () => {});
 
         world.join({ userId: "foo" }, new Point(100, 100));
 
@@ -40,7 +40,7 @@ describe("World", () => {
 
         }
 
-        const world = new World(connect, disconnect, 160, 160, () => {}, () => {});
+        const world = new World(connect, disconnect, 160, 160, () => {}, () => {}, () => {}, () => {}, () => {});
 
         world.join({ userId: "foo" }, new Point(100, 100));
 
@@ -69,7 +69,7 @@ describe("World", () => {
             disconnectCallNumber++;
         }
 
-        const world = new World(connect, disconnect, 160, 160, () => {}, () => {});
+        const world = new World(connect, disconnect, 160, 160, () => {}, () => {}, () => {}, () => {}, () => {});
 
         world.join({ userId: "foo" }, new Point(100, 100));
 

--- a/back/tsconfig.json
+++ b/back/tsconfig.json
@@ -12,7 +12,7 @@
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */

--- a/benchmark/socketio-load-test.yaml
+++ b/benchmark/socketio-load-test.yaml
@@ -28,6 +28,11 @@ scenarios:
               y: 170
               direction: 'down'
               moving: false
+            viewport:
+              left: 500
+              top: 0
+              right: 800
+              bottom: 200
       - think: 1
       - loop:
         - function: "setYRandom"

--- a/benchmark/socketio-load-test.yaml
+++ b/benchmark/socketio-load-test.yaml
@@ -34,10 +34,16 @@ scenarios:
         - emit:
             channel: "user-position"
             data:
-              x: "{{ x }}"
-              y: "{{ y }}"
-              direction: 'down'
-              moving: false
+              position:
+                x: "{{ x }}"
+                y: "{{ y }}"
+                direction: 'down'
+                moving: false
+              viewport:
+                left: "{{ left }}"
+                top: "{{ top }}"
+                right: "{{ right }}"
+                bottom: "{{ bottom }}"
         - think: 0.2
         count: 100
       - think: 10

--- a/benchmark/socketioLoadTest.js
+++ b/benchmark/socketioLoadTest.js
@@ -5,7 +5,11 @@ module.exports = {
 };
 
 function setYRandom(context, events, done) {
-    context.vars.x = (883 +  Math.round(Math.random() * 300));
-    context.vars.y = (270 +  Math.round(Math.random() * 300));
+    context.vars.x = (0 +  Math.round(Math.random() * 1472));
+    context.vars.y = (0 +  Math.round(Math.random() * 1090));
+    context.vars.left = context.vars.x - 320;
+    context.vars.top = context.vars.y - 200;
+    context.vars.right = context.vars.x + 320;
+    context.vars.bottom = context.vars.y + 200;
     return done();
 }

--- a/benchmark/socketioLoadTest.js
+++ b/benchmark/socketioLoadTest.js
@@ -5,8 +5,13 @@ module.exports = {
 };
 
 function setYRandom(context, events, done) {
-    context.vars.x = (0 +  Math.round(Math.random() * 1472));
-    context.vars.y = (0 +  Math.round(Math.random() * 1090));
+    if (context.angle === undefined) {
+        context.angle = Math.random() * Math.PI * 2;
+    }
+    context.angle += 0.05;
+
+    context.vars.x = 320 + 1472/2 * (1 + Math.sin(context.angle));
+    context.vars.y = 200 + 1090/2 * (1 + Math.cos(context.angle));
     context.vars.left = context.vars.x - 320;
     context.vars.top = context.vars.y - 200;
     context.vars.right = context.vars.x + 320;

--- a/front/src/Connection.ts
+++ b/front/src/Connection.ts
@@ -14,7 +14,7 @@ enum EventMessage{
     WEBRTC_SCREEN_SHARING_SIGNAL = "webrtc-screen-sharing-signal",
     WEBRTC_START = "webrtc-start",
     JOIN_ROOM = "join-room", // bi-directional
-    USER_POSITION = "user-position", // bi-directional
+    USER_POSITION = "user-position", // From client to server
     USER_MOVED = "user-moved", // From server to client
     USER_LEFT = "user-left", // From server to client
     MESSAGE_ERROR = "message-error",
@@ -25,6 +25,8 @@ enum EventMessage{
 
     CONNECT_ERROR = "connect_error",
     SET_SILENT = "set_silent", // Set or unset the silent mode for this user.
+    SET_VIEWPORT = "set-viewport",
+    BATCH = "batch",
 }
 
 export interface PointInterface {
@@ -95,6 +97,23 @@ export interface StartMapInterface {
     startInstance: string
 }
 
+export interface ViewportInterface {
+    left: number,
+    top: number,
+    right: number,
+    bottom: number,
+}
+
+export interface UserMovesInterface {
+    position: PositionInterface,
+    viewport: ViewportInterface,
+}
+
+export interface BatchedMessageInterface {
+    event: string,
+    payload: any
+}
+
 export class Connection implements Connection {
     private readonly socket: Socket;
     private userId: string|null = null;
@@ -110,6 +129,18 @@ export class Connection implements Connection {
 
         this.socket.on(EventMessage.MESSAGE_ERROR, (message: string) => {
             console.error(EventMessage.MESSAGE_ERROR, message);
+        })
+
+        /**
+         * Messages inside batched messages are extracted and sent to listeners directly.
+         */
+        this.socket.on(EventMessage.BATCH, (batchedMessages: BatchedMessageInterface[]) => {
+            for (const message of batchedMessages) {
+                const listeners = this.socket.listeners(message.event);
+                for (const listener of listeners) {
+                    listener(message.payload);
+                }
+            }
         })
     }
 
@@ -160,12 +191,12 @@ export class Connection implements Connection {
         return promise;
     }
 
-    public sharePosition(x : number, y : number, direction : string, moving: boolean) : void{
+    public sharePosition(x : number, y : number, direction : string, moving: boolean, viewport: ViewportInterface) : void{
         if(!this.socket){
             return;
         }
         const point = new Point(x, y, direction, moving);
-        this.socket.emit(EventMessage.USER_POSITION, point);
+        this.socket.emit(EventMessage.USER_POSITION, { position: point, viewport } as UserMovesInterface);
     }
 
     public setSilent(silent: boolean): void {

--- a/front/src/Connection.ts
+++ b/front/src/Connection.ts
@@ -182,11 +182,15 @@ export class Connection implements Connection {
     }
 
 
-    public joinARoom(roomId: string, startX: number, startY: number, direction: string, moving: boolean): Promise<MessageUserPositionInterface[]> {
+    public joinARoom(roomId: string, startX: number, startY: number, direction: string, moving: boolean, viewport: ViewportInterface): Promise<MessageUserPositionInterface[]> {
         const promise = new Promise<MessageUserPositionInterface[]>((resolve, reject) => {
-            this.socket.emit(EventMessage.JOIN_ROOM, { roomId, position: {x: startX, y: startY, direction, moving }}, (userPositions: MessageUserPositionInterface[]) => {
-                resolve(userPositions);
-            });
+            this.socket.emit(EventMessage.JOIN_ROOM, {
+                    roomId,
+                    position: {x: startX, y: startY, direction, moving },
+                    viewport,
+                }, (userPositions: MessageUserPositionInterface[]) => {
+                    resolve(userPositions);
+                });
         })
         return promise;
     }
@@ -201,6 +205,10 @@ export class Connection implements Connection {
 
     public setSilent(silent: boolean): void {
         this.socket.emit(EventMessage.SET_SILENT, silent);
+    }
+
+    public setViewport(viewport: ViewportInterface): void {
+        this.socket.emit(EventMessage.SET_VIEWPORT, viewport);
     }
 
     public onUserJoins(callback: (message: MessageUserJoined) => void): void {

--- a/front/src/Connection.ts
+++ b/front/src/Connection.ts
@@ -111,7 +111,7 @@ export interface UserMovesInterface {
 
 export interface BatchedMessageInterface {
     event: string,
-    payload: any
+    payload: unknown
 }
 
 export class Connection implements Connection {

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -677,7 +677,13 @@ export class GameScene extends Phaser.Scene implements CenterListener {
     private doPushPlayerPosition(event: HasMovedEvent): void {
         this.lastMoveEventSent = event;
         this.lastSentTick = this.currentTick;
-        this.connection.sharePosition(event.x, event.y, event.direction, event.moving);
+        const camera = this.cameras.main;
+        this.connection.sharePosition(event.x, event.y, event.direction, event.moving, {
+            left: camera.scrollX,
+            top: camera.scrollY,
+            right: camera.scrollX + camera.width,
+            bottom: camera.scrollY + camera.height,
+        });
     }
 
     EventToClickOnTile(){


### PR DESCRIPTION
Instead of sending data to anyone in the room, we send position data to people near us.
This should help limit the amount of data sent.

The system is based on a notion of "zones". A class PositionNotifier is in charge of tracking which user is looking at which part of the screen and which user is in which zone.