### PR TITLE
Fixing loading of same custom texture several time

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -1266,6 +1266,10 @@ export class GameScene extends ResizableScene implements CenterListener {
 
     private loadSpritesheet(name: string, url: string): Promise<void> {
         return new Promise<void>(((resolve, reject) => {
+            if (this.textures.exists(name)) {
+                resolve();
+                return;
+            }
             this.load.spritesheet(
                 name,
                 url,


### PR DESCRIPTION
Phaser 3 does not trigger oncomplete event if the resource is already loaded.