### PR TITLE
When a user moves, do not trigger group creation

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -56,7 +56,7 @@ export class GameRoom {
         this.anonymous = isRoomAnonymous(roomId);
         this.tags = [];
         this.policyType = GameRoomPolicyTypes.ANONYMUS_POLICY;
-        
+
         if (this.anonymous) {
             this.roomSlug = extractRoomSlugPublicRoomId(this.roomId);
         } else {
@@ -65,8 +65,8 @@ export class GameRoom {
             this.organizationSlug = organizationSlug;
             this.worldSlug = worldSlug;
         }
-        
-        
+
+
         this.users = new Map<number, User>();
         this.groups = new Set<Group>();
         this.connectCallback = connectCallback;
@@ -138,6 +138,12 @@ export class GameRoom {
         if (user.group === undefined) {
             // If the user is not part of a group:
             //  should he join a group?
+
+            // If the user is moving, don't try to join
+            if (user.getPosition().moving) {
+                return;
+            }
+
             const closestItem: User|Group|null = this.searchClosestAvailableUserOrGroup(user);
 
             if (closestItem !== null) {
@@ -275,7 +281,7 @@ export class GameRoom {
         return this.itemsState;
     }
 
-   
+
     setViewport(socket : Identificable, viewport: ViewportInterface): Movable[] {
         const user = this.users.get(socket.userId);
         if(typeof user === 'undefined') {

--- a/back/tests/GameRoomTest.ts
+++ b/back/tests/GameRoomTest.ts
@@ -11,7 +11,7 @@ function createMockUser(userId: number): ExSocketInterface {
     } as ExSocketInterface;
 }
 
-describe("World", () => {
+describe("GameRoom", () => {
     it("should connect user1 and user2", () => {
         let connectCalledNumber: number = 0;
         const connect: ConnectCallback = (user: User, group: Group): void => {


### PR DESCRIPTION
In order to avoid triggering group creation when walking next to someone we should avoid creating a group unless the user stops next to the other members of the group.