### PR TITLE
Manage users when room is full

### DIFF
--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -365,6 +365,10 @@ export class SocketManager {
         }
     }
 
+    getRoomById(roomId: string) : GameRoom|undefined {
+        return this.Worlds.get(roomId)
+    }
+
     async getOrCreateRoom(roomId: string): Promise<GameRoom> {
         //check and create new world for a room
         let world = this.Worlds.get(roomId)
@@ -658,10 +662,15 @@ export class SocketManager {
         client.send(serverToClientMessage.serializeBinary().buffer, true);
     }
 
-    public emitSendUserMessage(messageToSend: {userUuid: string, message: string, type: string}): ExSocketInterface {
-        const socket = this.searchClientByUuid(messageToSend.userUuid);
+    public emitSendUserMessage(messageToSend: {userUuid: string, message: string, type: string},
+                               client?: ExSocketInterface): ExSocketInterface {
+        let socket = client;
         if(!socket){
-            throw 'socket was not found';
+            const socketFind = this.searchClientByUuid(messageToSend.userUuid);
+            if (!socketFind) {
+                throw 'socket was not found';
+            }
+            socket = socketFind;
         }
 
         const sendUserMessage = new SendUserMessage();

--- a/front/src/Administration/TypeMessage.ts
+++ b/front/src/Administration/TypeMessage.ts
@@ -4,9 +4,9 @@ import {HtmlUtils} from "../WebRtc/HtmlUtils";
 let modalTimeOut : NodeJS.Timeout;
 
 export class TypeMessageExt implements TypeMessageInterface{
-    private nbSecond = 0;
-    private maxNbSecond = 10;
-    private titleMessage = 'IMPORTANT !';
+    protected nbSecond = 0;
+    protected maxNbSecond = 10;
+    protected titleMessage = 'IMPORTANT !';
 
     showMessage(message: string, canDeleteMessage: boolean = true): void {
         //delete previous modal
@@ -37,7 +37,7 @@ export class TypeMessageExt implements TypeMessageInterface{
 
         const p : HTMLParagraphElement = document.createElement('p');
         p.id = 'body-report-user'
-        p.innerText = message;
+        p.innerHTML = message;
         div.appendChild(p);
 
         const mainSectionDiv = HtmlUtils.getElementByIdOrFail<HTMLDivElement>('main-container');
@@ -83,5 +83,12 @@ export class Ban extends TypeMessageExt {
 export class Banned extends TypeMessageExt {
     showMessage(message: string){
         super.showMessage(message, false);
+    }
+}
+
+export class RoomFull extends  TypeMessageExt {
+    showMessage(message: string){
+        this.maxNbSecond = 30;
+        super.showMessage(message);
     }
 }

--- a/front/src/Phaser/Login/CustomizeScene.ts
+++ b/front/src/Phaser/Login/CustomizeScene.ts
@@ -8,7 +8,6 @@ import Container = Phaser.GameObjects.Container;
 import {gameManager} from "../Game/GameManager";
 import {ResizableScene} from "./ResizableScene";
 import {localUserStore} from "../../Connexion/LocalUserStore";
-import {PlayerResourceDescriptionInterface} from "../Entity/Character";
 
 export const CustomizeSceneName = "CustomizeScene";
 


### PR DESCRIPTION
This merges request permit to send message of full room when the user tries to connect to the room.

![image](https://user-images.githubusercontent.com/23724509/99901315-35032280-2cb6-11eb-8de4-ff1495cc2a36.png)

Yes, I don't close the connexion. I think that the user can navigate in the room could be a good thing. Don't worry, If the room is full, the message sent will be never take by the back end. 

You tell me that the user could join a JITSI room or open a web site. Yes, I think that it's not a problem, this is managed in the front end. So we still limit interaction and calculate in the back end.