### PR TITLE
feat: adds property openWebsitePolicy property to set "allow" property in iframe

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -604,7 +604,7 @@ export class GameScene extends ResizableScene implements CenterListener {
                 coWebsiteManager.closeCoWebsite();
             }else{
                 const openWebsiteFunction = () => {
-                    coWebsiteManager.loadCoWebsite(newValue as string);
+                    coWebsiteManager.loadCoWebsite(newValue as string, allProps.get('openWebsitePolicy') as string | undefined);
                     layoutManager.removeActionButton('openWebsite', this.userInputManager);
                 };
 

--- a/front/src/WebRtc/CoWebsiteManager.ts
+++ b/front/src/WebRtc/CoWebsiteManager.ts
@@ -42,7 +42,7 @@ class CoWebsiteManager {
         this.opened = iframeStates.opened;
     }
 
-    public loadCoWebsite(url: string): void {
+    public loadCoWebsite(url: string, allowPolicy?: string): void {
         this.load();
         this.cowebsiteDiv.innerHTML = `<button class="close-btn" id="cowebsite-close">
                     <img src="resources/logos/close.svg">
@@ -56,6 +56,9 @@ class CoWebsiteManager {
         const iframe = document.createElement('iframe');
         iframe.id = 'cowebsite-iframe';
         iframe.src = url;
+        if (allowPolicy) {
+            iframe.allow = allowPolicy; 
+        }
         const onloadPromise = new Promise((resolve) => {
             iframe.onload = () => resolve();
         });


### PR DESCRIPTION
Hello and greetings from rc3 ;)

First things first: I love your project! It is (almost) exactly what I always imagined and what I want to have. That's why I've spent quite some time playing with it.

One of my goals was to include an external jitsi via an iframe. That's not a problem in itself, but it brings the feature policy into it: https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy.

Meaning: I can't share my microphone and camera within the iframe. I'm really no expert at this, but here's what should solve the problem:

I introduced a new property on the layer: Called `openWebsitePolicy`. This allows to set the "allow" attribute of the iframe. This allows the mapper to explicitly allow what the iframe is allowed to do. 
To include Jitsi via iframe, it should be sufficient to set the property `openWebsitePolicy` with `camera; microphone` in addition to the property `openWebsite` to enable camera and microphone.

Unfortunately I can't test this properly. Maybe you see another way to solve this. 

Or: Maybe you can review this and put it in one of the next releases.  That would make me very happy!

Many greetings
Oliver