### PR TITLE
[rC3] front: add AnimatedTiles plugin

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -27,6 +27,7 @@
     "generic-type-guard": "^3.2.0",
     "google-protobuf": "^3.13.0",
     "phaser": "^3.22.0",
+    "phaser-animated-tiles": "Informatic/phaser-animated-tiles#2d5c66a9bc426dd4cb2d856c1d599494a74f8067",
     "queue-typescript": "^1.0.1",
     "quill": "^1.3.7",
     "simple-peer": "^9.6.2",

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -68,6 +68,8 @@ import {SelectCharacterScene, SelectCharacterSceneName} from "../Login/SelectCha
 import {TextureError} from "../../Exception/TextureError";
 import {TextField} from "../Components/TextField";
 
+import AnimatedTiles from "phaser-animated-tiles";
+
 export interface GameSceneInitInterface {
     initPosition: PointInterface|null,
     reconnecting: boolean
@@ -114,6 +116,7 @@ export class GameScene extends ResizableScene implements CenterListener {
     Layers!: Array<Phaser.Tilemaps.TilemapLayer>;
     Objects!: Array<Phaser.Physics.Arcade.Sprite>;
     mapFile!: ITiledMap;
+    animatedTiles!: AnimatedTiles;
     groups: Map<number, Sprite>;
     startX!: number;
     startY!: number;
@@ -189,6 +192,7 @@ export class GameScene extends ResizableScene implements CenterListener {
                 file: file.src
             });
         });
+        this.load.scenePlugin('AnimatedTiles', AnimatedTiles, 'animatedTiles', 'animatedTiles');
         this.load.on('filecomplete-tilemapJSON-'+this.MapUrlFile, (key: string, type: string, data: unknown) => {
             this.onMapLoad(data);
         });
@@ -400,6 +404,7 @@ export class GameScene extends ResizableScene implements CenterListener {
         
         this.initCamera();
 
+        this.animatedTiles.init(this.Map);
         this.initCirclesCanvas();
 
         // Let's pause the scene if the connection is not established yet

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -8,6 +8,7 @@
     "downlevelIteration": true,
     "jsx": "react",
     "allowJs": true,
+    "esModuleInterop": true,
 
     "strict": true,                           /* Enable all strict type-checking options. */
      "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -3663,6 +3663,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+phaser-animated-tiles@Informatic/phaser-animated-tiles#2d5c66a9bc426dd4cb2d856c1d599494a74f8067:
+  version "2.0.2"
+  resolved "https://codeload.github.com/Informatic/phaser-animated-tiles/tar.gz/2d5c66a9bc426dd4cb2d856c1d599494a74f8067"
+
 phaser@^3.22.0:
   version "3.51.0"
   resolved "https://registry.yarnpkg.com/phaser/-/phaser-3.51.0.tgz#b0c7ee2b21e795830d74f476dd30816a42b023bd"


### PR DESCRIPTION
This likely replaces #443, as it properly bundles phaser-animated-tiles in webpack build.

Due to some various bugs in phaser-animated-tiles needed to be forked into https://github.com/Informatic/phaser-animated-tiles/commits/rc3-world-fixes. You could either pull that fork into your own GitHub organization, or wait for the changes on phaser-animated-tiles to get upstreamed and released on NPM.

cc @Palid 