### PR TITLE
Add a PUSHER_HTTP_PORT configuration variable.

### DIFF
--- a/pusher/server.ts
+++ b/pusher/server.ts
@@ -1,3 +1,4 @@
 // lib/server.ts
 import App from "./src/App";
-App.listen(8080, () => console.log(`WorkAdventure starting on port 8080!`))
+import { PUSHER_HTTP_PORT } from "./src/Enum/EnvironmentVariable";
+App.listen(PUSHER_HTTP_PORT, () => console.log(`WorkAdventure starting on port ${PUSHER_HTTP_PORT}!`))

--- a/pusher/src/Enum/EnvironmentVariable.ts
+++ b/pusher/src/Enum/EnvironmentVariable.ts
@@ -11,6 +11,7 @@ const CPU_OVERHEAT_THRESHOLD = Number(process.env.CPU_OVERHEAT_THRESHOLD) || 80;
 const JITSI_URL : string|undefined = (process.env.JITSI_URL === '') ? undefined : process.env.JITSI_URL;
 const JITSI_ISS = process.env.JITSI_ISS || '';
 const SECRET_JITSI_KEY = process.env.SECRET_JITSI_KEY || '';
+const PUSHER_HTTP_PORT = parseInt(process.env.PUSHER_HTTP_PORT || '8080') || 8080
 export const SOCKET_IDLE_TIMER = parseInt(process.env.SOCKET_IDLE_TIMER as string) || 30; // maximum time (in second) without activity before a socket is closed
 
 export {
@@ -26,5 +27,6 @@ export {
     CPU_OVERHEAT_THRESHOLD,
     JITSI_URL,
     JITSI_ISS,
-    SECRET_JITSI_KEY
+    SECRET_JITSI_KEY,
+    PUSHER_HTTP_PORT
 }


### PR DESCRIPTION
Some deployments might not be based on docker, and not on separate
hosts. In such cases, it would be useful to be able to configure the
port pusher listens on.