### PR TITLE
HOTFIX: Allow exitUrl relative links to rewrite map domain and map instance

### DIFF
--- a/front/src/Connexion/Room.ts
+++ b/front/src/Connexion/Room.ts
@@ -30,8 +30,12 @@ export class Room {
         let roomId = '';
         let hash = '';
         if (!identifier.startsWith('/_/') && !identifier.startsWith('/@/')) { //relative file link
-            const absoluteExitSceneUrl = new URL(identifier, baseUrl);
-            roomId = '_/'+currentInstance+'/'+absoluteExitSceneUrl.hostname + absoluteExitSceneUrl.pathname; //in case of a relative url, we need to create a public roomId
+            //Relative identifier can be deep enough to rewrite the base domain, so we cannot use the variable 'baseUrl' as the actual base url for the URL objects.
+            //We instead use 'workadventure' as a dummy base value.
+            const baseUrlObject = new URL(baseUrl);
+            const absoluteExitSceneUrl = new URL(identifier, 'http://workadventure/_/'+currentInstance+'/'+baseUrlObject.hostname+baseUrlObject.pathname);
+            roomId = absoluteExitSceneUrl.pathname; //in case of a relative url, we need to create a public roomId
+            roomId = roomId.substring(1); //remove the leading slash
             hash = absoluteExitSceneUrl.hash;
             hash = hash.substring(1); //remove the leading diese
         } else { //absolute room Id

--- a/front/tests/Phaser/Game/RoomTest.ts
+++ b/front/tests/Phaser/Game/RoomTest.ts
@@ -34,6 +34,22 @@ describe("Room getIdFromIdentifier()", () => {
         expect(roomId).toEqual('_/global/maps.workadventu.re/floor1/Floor1.json');
         expect(hash).toEqual('');
     });
+    it("should work with a relative file link that rewrite the map domain", () => {
+        const {roomId, hash} = Room.getIdFromIdentifier('../../maps.workadventure.localhost/Floor1/floor1.json', 'https://maps.workadventu.re/floor0/Floor0.json', 'global');
+        expect(roomId).toEqual('_/global/maps.workadventure.localhost/Floor1/floor1.json');
+        expect(hash).toEqual('');
+    });
+    it("should work with a relative file link that rewrite the map instance", () => {
+        const {roomId, hash} = Room.getIdFromIdentifier('../../../notglobal/maps.workadventu.re/Floor1/floor1.json', 'https://maps.workadventu.re/floor0/Floor0.json', 'global');
+        expect(roomId).toEqual('_/notglobal/maps.workadventu.re/Floor1/floor1.json');
+        expect(hash).toEqual('');
+    });
+    it("should work with a relative file link that change the map type", () => {
+        const {roomId, hash} = Room.getIdFromIdentifier('../../../../@/tcm/is/great', 'https://maps.workadventu.re/floor0/Floor0.json', 'global');
+        expect(roomId).toEqual('@/tcm/is/great');
+        expect(hash).toEqual('');
+    });
+    
     it("should work with a relative file link and a hash as parameters", () => {
         const {roomId, hash} = Room.getIdFromIdentifier('./test2.json#start', 'https://maps.workadventu.re/test.json', 'global');
         expect(roomId).toEqual('_/global/maps.workadventu.re/test2.json');


### PR DESCRIPTION
Relative links in the map property 'exitUrl' would not allow to rewrite the base map url:

For example, if the map url was "npeguin.github.io/coders-map/map.json" and exitUrl was "../../maps.workadventu.re/Floor0/floor0.json", the computed url would be "npeguin.github.io/coders-map/Floor0/floor0.json"

This is changed to fix #343

Edit: this PR also allow to rewrite the map instance in a similar fashion to map domain.