### PR TITLE
*: Dockerfiles cleanup, docker-compose.prod.yaml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/node_modules/**
+**/Dockerfile

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,16 +1,26 @@
-FROM thecodingmachine/workadventure-back-base:latest as builder
-WORKDIR /var/www/messages
-COPY --chown=docker:docker messages .
+# protobuf build
+FROM node:14.15.4-buster-slim@sha256:cbae886186467bbfd274b82a234a1cdfbbd31201c2a6ee63a6893eefcf3c6e76 as builder
+WORKDIR /usr/src
+COPY messages .
 RUN yarn install && yarn proto
 
-FROM thecodingmachine/nodejs:12
-
-COPY --chown=docker:docker back .
-COPY --from=builder --chown=docker:docker /var/www/messages/generated /usr/src/app/src/Messages/generated
+# typescript build
+FROM node:14.15.4-buster-slim@sha256:cbae886186467bbfd274b82a234a1cdfbbd31201c2a6ee63a6893eefcf3c6e76 as builder2
+WORKDIR /usr/src
+COPY back/yarn.lock back/package.json ./
 RUN yarn install
-
+COPY back .
+COPY --from=builder /usr/src/generated src/Messages/generated
 ENV NODE_ENV=production
 RUN yarn run tsc
 
-CMD ["yarn", "run", "runprod"]
+# final production image
+FROM node:14.15.4-buster-slim@sha256:cbae886186467bbfd274b82a234a1cdfbbd31201c2a6ee63a6893eefcf3c6e76
+WORKDIR /usr/src
+COPY back/yarn.lock back/package.json ./
+COPY --from=builder2 /usr/src/dist /usr/src/dist
+ENV NODE_ENV=production
+RUN yarn install --production
 
+USER node
+CMD ["yarn", "run", "runprod"]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,0 +1,62 @@
+version: "3"
+services:
+  reverse-proxy:
+    image: traefik:v2.3.7
+    command:
+      - --providers.docker
+      - --entryPoints.web.address=:80
+      - --entryPoints.websecure.address=:443
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - back
+      - front
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  front:
+    build:
+      context: .
+      dockerfile: front/Dockerfile
+      args:
+        BASE_DOMAIN: ${BASE_DOMAIN:-workadventure.localhost}
+    labels:
+      - "traefik.http.routers.front.rule=Host(`play.${BASE_DOMAIN:-workadventure.localhost}`)"
+      - "traefik.http.routers.front.entryPoints=web"
+      - "traefik.http.services.front.loadbalancer.server.port=8000"
+      - "traefik.http.routers.front-ssl.rule=Host(`play.${BASE_DOMAIN:-workadventure.localhost}`)"
+      - "traefik.http.routers.front-ssl.entryPoints=websecure"
+      - "traefik.http.routers.front-ssl.tls=true"
+      - "traefik.http.routers.front-ssl.service=front"
+
+  back:
+    build:
+      context: .
+      dockerfile: back/Dockerfile
+    environment:
+      SECRET_KEY: yourSecretKey
+      SECRET_JITSI_KEY: "$SECRET_JITSI_KEY"
+      ADMIN_API_TOKEN: "$ADMIN_API_TOKEN"
+      JITSI_URL: $JITSI_URL
+      JITSI_ISS: $JITSI_ISS
+
+  pusher:
+    build:
+      context: .
+      dockerfile: pusher/Dockerfile
+    environment:
+      SECRET_KEY: yourSecretKey
+      SECRET_JITSI_KEY: "$SECRET_JITSI_KEY"
+      ADMIN_API_TOKEN: "$ADMIN_API_TOKEN"
+      API_URL: back:50051
+      JITSI_URL: $JITSI_URL
+      JITSI_ISS: $JITSI_ISS
+    labels:
+      - "traefik.http.routers.pusher.rule=Host(`pusher.${BASE_DOMAIN:-workadventure.localhost}`)"
+      - "traefik.http.routers.pusher.entryPoints=web"
+      - "traefik.http.services.pusher.loadbalancer.server.port=8080"
+      - "traefik.http.routers.pusher-ssl.rule=Host(`pusher.${BASE_DOMAIN:-workadventure.localhost}`)"
+      - "traefik.http.routers.pusher-ssl.entryPoints=websecure"
+      - "traefik.http.routers.pusher-ssl.tls=true"
+      - "traefik.http.routers.pusher-ssl.service=pusher"

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,15 +1,28 @@
-FROM thecodingmachine/workadventure-back-base:latest as builder
-WORKDIR /var/www/messages
-COPY --chown=docker:docker messages .
+# protobuf build
+FROM node:14.15.4-buster-slim@sha256:cbae886186467bbfd274b82a234a1cdfbbd31201c2a6ee63a6893eefcf3c6e76 as builder
+WORKDIR /usr/src
+COPY messages .
 RUN yarn install && yarn proto
 
-# we are rebuilding on each deploy to cope with the API_URL environment URL
-FROM thecodingmachine/nodejs:14-apache
-
-COPY --chown=docker:docker front .
-COPY --from=builder --chown=docker:docker /var/www/messages/generated /var/www/html/src/Messages/generated
+# webpack build
+FROM node:14.15.4-buster-slim@sha256:cbae886186467bbfd274b82a234a1cdfbbd31201c2a6ee63a6893eefcf3c6e76 as builder2
+WORKDIR /usr/src
+COPY front/yarn.lock front/package.json ./
 RUN yarn install
 
+COPY front .
+COPY --from=builder /usr/src/generated src/Messages/generated
 ENV NODE_ENV=production
-ENV STARTUP_COMMAND_1="yarn run build"
-ENV APACHE_DOCUMENT_ROOT=dist/
+
+ARG BASE_DOMAIN=workadventure.localhost
+ARG API_URL=pusher.$BASE_DOMAIN
+ARG UPLOADER_URL=uploader.$BASE_DOMAIN
+ARG ADMIN_URL=admin.$BASE_DOMAIN
+
+RUN API_URL=$API_URL UPLOADER_URL=$UPLOADER_URL ADMIN_URL=$ADMIN_URL \
+    yarn run build
+
+# final production image
+FROM nginx:1.19.6-alpine@sha256:01747306a7247dbe928db991eab42e4002118bf636dd85b4ffea05dd907e5b66
+COPY front/nginx-vhost.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder2 /usr/src/dist /usr/share/nginx/html

--- a/front/nginx-vhost.conf
+++ b/front/nginx-vhost.conf
@@ -1,0 +1,14 @@
+server {
+    listen       8000;
+    listen  [::]:8000;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    location ~ ^/[@_]/ {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/maps/.dockerignore
+++ b/maps/.dockerignore
@@ -1,0 +1,4 @@
+/node_modules/
+/dist/bundle.js
+/yarn-error.log
+/Dockerfile

--- a/messages/.dockerignore
+++ b/messages/.dockerignore
@@ -1,0 +1,4 @@
+/node_modules/
+/dist/bundle.js
+/yarn-error.log
+/Dockerfile

--- a/pusher/Dockerfile
+++ b/pusher/Dockerfile
@@ -1,15 +1,26 @@
-FROM thecodingmachine/workadventure-back-base:latest as builder
-WORKDIR /var/www/messages
-COPY --chown=docker:docker messages .
+# protobuf build
+FROM node:14.15.4-buster-slim@sha256:cbae886186467bbfd274b82a234a1cdfbbd31201c2a6ee63a6893eefcf3c6e76 as builder
+WORKDIR /usr/src
+COPY messages .
 RUN yarn install && yarn proto
 
-FROM thecodingmachine/nodejs:12
-
-COPY --chown=docker:docker pusher .
-COPY --from=builder --chown=docker:docker /var/www/messages/generated /usr/src/app/src/Messages/generated
+# typescript build
+FROM node:14.15.4-buster-slim@sha256:cbae886186467bbfd274b82a234a1cdfbbd31201c2a6ee63a6893eefcf3c6e76 as builder2
+WORKDIR /usr/src
+COPY pusher/yarn.lock pusher/package.json ./
 RUN yarn install
-
+COPY pusher .
+COPY --from=builder /usr/src/generated src/Messages/generated
 ENV NODE_ENV=production
 RUN yarn run tsc
 
+# final production image
+FROM node:14.15.4-buster-slim@sha256:cbae886186467bbfd274b82a234a1cdfbbd31201c2a6ee63a6893eefcf3c6e76
+WORKDIR /usr/src
+COPY pusher/yarn.lock pusher/package.json ./
+COPY --from=builder2 /usr/src/dist /usr/src/dist
+ENV NODE_ENV=production
+RUN yarn install --production
+
+USER node
 CMD ["yarn", "run", "runprod"]

--- a/pusher/Dockerfile.prod
+++ b/pusher/Dockerfile.prod
@@ -1,0 +1,17 @@
+FROM node:12.19.0-slim
+
+RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
+WORKDIR /home/node/app
+
+USER node
+ENV NODE_ENV=production
+ENV DEBUG=*
+
+COPY --chown=node:node package.json yarn.lock ./
+
+RUN yarn install --prod --frozen-lockfile
+
+COPY --chown=node:node ./dist/ ./dist/
+
+EXPOSE 8080
+CMD ["yarn", "run", "runprod"]

--- a/uploader/Dockerfile
+++ b/uploader/Dockerfile
@@ -1,9 +1,19 @@
-FROM thecodingmachine/nodejs:12
-
-COPY --chown=docker:docker uploader .
+# typescript build
+FROM node:14.15.4-buster-slim@sha256:cbae886186467bbfd274b82a234a1cdfbbd31201c2a6ee63a6893eefcf3c6e76 as builder2
+WORKDIR /usr/src
+COPY uploader/yarn.lock uploader/package.json ./
 RUN yarn install
-
+COPY uploader .
 ENV NODE_ENV=production
 RUN yarn run tsc
 
+# final production image
+FROM node:14.15.4-buster-slim@sha256:cbae886186467bbfd274b82a234a1cdfbbd31201c2a6ee63a6893eefcf3c6e76
+WORKDIR /usr/src
+COPY uploader/yarn.lock uploader/package.json ./
+COPY --from=builder2 /usr/src/dist /usr/src/dist
+ENV NODE_ENV=production
+RUN yarn install --production
+
+USER node
 CMD ["yarn", "run", "runprod"]

--- a/website/.dockerignore
+++ b/website/.dockerignore
@@ -1,0 +1,5 @@
+/dist/
+/node_modules/
+/dist/bundle.js
+/yarn-error.log
+/Dockerfile


### PR DESCRIPTION
New docker-compose.prod.yaml should provide a production-ish deployment of WorkAdventure for people willing to host it themselves.

All backend services are now split into 3 phases: protobuf build, typescript build, final production image (with only production dependencies present), hopefully giving smaller container images in the end. (#576 will surely help with that)

Biggest issue with this setup is that frontend URLs are customized in buildtime via args, instead of runtime. This could be brought back without bringing back whole javascript/nodejs environment into frontend container by extracting configuration into runtime variable set in index.html and then appending/modifying index.html on startup using envsubst or similar tool. I can follow up with that solution, if I get some initial approval.