### PR TITLE
Single domain deploy

### DIFF
--- a/docker-compose.single-domain.yaml
+++ b/docker-compose.single-domain.yaml
@@ -1,0 +1,179 @@
+version: "3"
+services:
+  reverse-proxy:
+    image: traefik:v2.0
+    command:
+      - --api.insecure=true
+      - --providers.docker
+      - --entryPoints.web.address=:80
+      - --entryPoints.websecure.address=:443
+    ports:
+      - "80:80"
+      - "443:443"
+      # The Web UI (enabled by --api.insecure=true)
+      - "8080:8080"
+    depends_on:
+      - back
+      - front
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  front:
+    image: thecodingmachine/nodejs:14
+    environment:
+      DEBUG_MODE: "$DEBUG_MODE"
+      JITSI_URL: $JITSI_URL
+      JITSI_PRIVATE_MODE: "$JITSI_PRIVATE_MODE"
+      HOST: "0.0.0.0"
+      NODE_ENV: development
+      API_URL: /pusher
+      UPLOADER_URL: /uploader
+      ADMIN_URL: /admin
+      MAPS_URL: /maps
+      STARTUP_COMMAND_1: yarn install
+      TURN_SERVER: "turn:coturn.workadventu.re:443,turns:coturn.workadventu.re:443"
+      TURN_USER: workadventure
+      TURN_PASSWORD: WorkAdventure123
+    command: yarn run start
+    volumes:
+      - ./front:/usr/src/app
+    labels:
+      - "traefik.http.routers.front.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.front.entryPoints=web,traefik"
+      - "traefik.http.services.front.loadbalancer.server.port=8080"
+      - "traefik.http.routers.front-ssl.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.front-ssl.entryPoints=websecure"
+      - "traefik.http.routers.front-ssl.tls=true"
+      - "traefik.http.routers.front-ssl.service=front"
+
+  pusher:
+    image: thecodingmachine/nodejs:12
+    command: yarn dev
+    #command: yarn run prod
+    #command: yarn run profile
+    environment:
+      DEBUG: "*"
+      STARTUP_COMMAND_1: yarn install
+      SECRET_JITSI_KEY: "$SECRET_JITSI_KEY"
+      SECRET_KEY: yourSecretKey
+      ADMIN_API_TOKEN: "$ADMIN_API_TOKEN"
+      API_URL: back:50051
+      JITSI_URL: $JITSI_URL
+      JITSI_ISS: $JITSI_ISS
+    volumes:
+      - ./pusher:/usr/src/app
+    labels:
+      - "traefik.http.middlewares.strip-pusher-prefix.stripprefix.prefixes=/pusher"
+      - "traefik.http.routers.pusher.rule=PathPrefix(`/pusher`)"
+      - "traefik.http.routers.pusher.middlewares=strip-pusher-prefix@docker"
+      - "traefik.http.routers.pusher.entryPoints=web"
+      - "traefik.http.services.pusher.loadbalancer.server.port=8080"
+      - "traefik.http.routers.pusher-ssl.rule=PathPrefix(`/pusher`)"
+      - "traefik.http.routers.pusher-ssl.middlewares=strip-pusher-prefix@docker"
+      - "traefik.http.routers.pusher-ssl.entryPoints=websecure"
+      - "traefik.http.routers.pusher-ssl.tls=true"
+      - "traefik.http.routers.pusher-ssl.service=pusher"
+
+  maps:
+    image: thecodingmachine/nodejs:12-apache
+    environment:
+      DEBUG_MODE: "$DEBUG_MODE"
+      HOST: "0.0.0.0"
+      NODE_ENV: development
+      #APACHE_DOCUMENT_ROOT: dist/
+      #APACHE_EXTENSIONS: headers
+      #APACHE_EXTENSION_HEADERS: 1
+      STARTUP_COMMAND_0: sudo a2enmod headers
+      STARTUP_COMMAND_1: yarn install
+      STARTUP_COMMAND_2: yarn run dev &
+    volumes:
+      - ./maps:/var/www/html
+    labels:
+      - "traefik.http.middlewares.strip-maps-prefix.stripprefix.prefixes=/maps"
+      - "traefik.http.routers.maps.rule=PathPrefix(`/maps`)"
+      - "traefik.http.routers.maps.middlewares=strip-maps-prefix@docker"
+      - "traefik.http.routers.maps.entryPoints=web,traefik"
+      - "traefik.http.services.maps.loadbalancer.server.port=80"
+      - "traefik.http.routers.maps-ssl.rule=PathPrefix(`/maps`)"
+      - "traefik.http.routers.maps-ssl.middlewares=strip-maps-prefix@docker"
+      - "traefik.http.routers.maps-ssl.entryPoints=websecure"
+      - "traefik.http.routers.maps-ssl.tls=true"
+      - "traefik.http.routers.maps-ssl.service=maps"
+
+  back:
+    image: thecodingmachine/nodejs:12
+    command: yarn dev
+    #command: yarn run profile
+    environment:
+      DEBUG: "*"
+      STARTUP_COMMAND_1: yarn install
+      SECRET_KEY: yourSecretKey
+      SECRET_JITSI_KEY: "$SECRET_JITSI_KEY"
+      ALLOW_ARTILLERY: "true"
+      ADMIN_API_TOKEN: "$ADMIN_API_TOKEN"
+      JITSI_URL: $JITSI_URL
+      JITSI_ISS: $JITSI_ISS
+    volumes:
+      - ./back:/usr/src/app
+    labels:
+      - "traefik.http.middlewares.strip-api-prefix.stripprefix.prefixes=/api"
+      - "traefik.http.routers.back.rule=PathPrefix(`/api`)"
+      - "traefik.http.routers.back.middlewares=strip-api-prefix@docker"
+      - "traefik.http.routers.back.entryPoints=web"
+      - "traefik.http.services.back.loadbalancer.server.port=8080"
+      - "traefik.http.routers.back-ssl.rule=PathPrefix(`/api`)"
+      - "traefik.http.routers.back-ssl.middlewares=strip-api-prefix@docker"
+      - "traefik.http.routers.back-ssl.entryPoints=websecure"
+      - "traefik.http.routers.back-ssl.tls=true"
+      - "traefik.http.routers.back-ssl.service=back"
+
+  uploader:
+    image: thecodingmachine/nodejs:12
+    command: yarn dev
+    #command: yarn run profile
+    environment:
+      DEBUG: "*"
+      STARTUP_COMMAND_1: yarn install
+    volumes:
+      - ./uploader:/usr/src/app
+    labels:
+      - "traefik.http.middlewares.strip-uploader-prefix.stripprefix.prefixes=/uploader"
+      - "traefik.http.routers.uploader.rule=PathPrefix(`/uploader`)"
+      - "traefik.http.routers.uploader.middlewares=strip-uploader-prefix@docker"
+      - "traefik.http.routers.uploader.entryPoints=web"
+      - "traefik.http.services.uploader.loadbalancer.server.port=8080"
+      - "traefik.http.routers.uploader-ssl.rule=PathPrefix(`/uploader`)"
+      - "traefik.http.routers.uploader-ssl.middlewares=strip-uploader-prefix@docker"
+      - "traefik.http.routers.uploader-ssl.entryPoints=websecure"
+      - "traefik.http.routers.uploader-ssl.tls=true"
+      - "traefik.http.routers.uploader-ssl.service=uploader"
+
+  website:
+    image: thecodingmachine/nodejs:12-apache
+    environment:
+      STARTUP_COMMAND_1: npm install
+      STARTUP_COMMAND_2: npm run watch &
+      APACHE_DOCUMENT_ROOT: dist/
+    volumes:
+      - ./website:/var/www/html
+    labels:
+      - "traefik.http.routers.website.rule=Host(`workadventure.localhost`)"
+      - "traefik.http.routers.website.entryPoints=web"
+      - "traefik.http.services.website.loadbalancer.server.port=80"
+      - "traefik.http.routers.website-ssl.rule=Host(`workadventure.localhost`)"
+      - "traefik.http.routers.website-ssl.entryPoints=websecure"
+      - "traefik.http.routers.website-ssl.tls=true"
+      - "traefik.http.routers.website-ssl.service=website"
+
+  messages:
+    #image: thecodingmachine/nodejs:14
+    image: thecodingmachine/workadventure-back-base:latest
+    environment:
+      #STARTUP_COMMAND_0: sudo apt-get install -y inotify-tools
+      STARTUP_COMMAND_1: yarn install
+      STARTUP_COMMAND_2: yarn run proto:watch
+    volumes:
+      - ./messages:/usr/src/app
+      - ./back:/usr/src/back
+      - ./front:/usr/src/front
+      - ./pusher:/usr/src/pusher

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,10 +26,6 @@ services:
       JITSI_PRIVATE_MODE: "$JITSI_PRIVATE_MODE"
       HOST: "0.0.0.0"
       NODE_ENV: development
-      API_HOST: pusher.workadventure.localhost
-      UPLOADER_HOST: uploader.workadventure.localhost
-      ADMIN_HOST: admin.workadventure.localhost
-      MAPS_HOST: maps.workadventure.localhost
       STARTUP_COMMAND_1: yarn install
       TURN_SERVER: "turn:coturn.workadventu.re:443,turns:coturn.workadventu.re:443"
       TURN_USER: workadventure

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,9 +26,10 @@ services:
       JITSI_PRIVATE_MODE: "$JITSI_PRIVATE_MODE"
       HOST: "0.0.0.0"
       NODE_ENV: development
-      API_URL: pusher.workadventure.localhost
-      UPLOADER_URL: uploader.workadventure.localhost
-      ADMIN_URL: admin.workadventure.localhost
+      API_HOST: pusher.workadventure.localhost
+      UPLOADER_HOST: uploader.workadventure.localhost
+      ADMIN_HOST: admin.workadventure.localhost
+      MAPS_HOST: admin.workadventure.localhost
       STARTUP_COMMAND_1: yarn install
       TURN_SERVER: "turn:coturn.workadventu.re:443,turns:coturn.workadventu.re:443"
       TURN_USER: workadventure

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       API_HOST: pusher.workadventure.localhost
       UPLOADER_HOST: uploader.workadventure.localhost
       ADMIN_HOST: admin.workadventure.localhost
-      MAPS_HOST: admin.workadventure.localhost
+      MAPS_HOST: maps.workadventure.localhost
       STARTUP_COMMAND_1: yarn install
       TURN_SERVER: "turn:coturn.workadventu.re:443,turns:coturn.workadventu.re:443"
       TURN_USER: workadventure

--- a/front/src/Connexion/ConnectionManager.ts
+++ b/front/src/Connexion/ConnectionManager.ts
@@ -1,5 +1,5 @@
 import Axios from "axios";
-import {API_URL} from "../Enum/EnvironmentVariable";
+import {MAPS_URL, API_URL} from "../Enum/EnvironmentVariable";
 import {RoomConnection} from "./RoomConnection";
 import {OnConnectInterface, PositionInterface, ViewportInterface} from "./ConnexionModels";
 import {GameConnexionTypes, urlManager} from "../Url/UrlManager";
@@ -50,7 +50,7 @@ class ConnectionManager {
             }
             let roomId: string
             if (connexionType === GameConnexionTypes.empty) {
-                const defaultMapUrl = window.location.host.replace('play.', 'maps.') + URL_ROOM_STARTED;
+                const defaultMapUrl = MAPS_URL + URL_ROOM_STARTED;
                 roomId = urlManager.editUrlForRoom(defaultMapUrl, null, null);
             } else {
                 roomId = window.location.pathname + window.location.hash;

--- a/front/src/Connexion/Room.ts
+++ b/front/src/Connexion/Room.ts
@@ -29,6 +29,7 @@ export class Room {
     public static getIdFromIdentifier(identifier: string, baseUrl: string, currentInstance: string): {roomId: string, hash: string} {
         let roomId = '';
         let hash = '';
+        const protocol = typeof(window) !== 'undefined' ? window.location.protocol : 'https:';
         if (!identifier.startsWith('/_/') && !identifier.startsWith('/@/')) { //relative file link
             //Relative identifier can be deep enough to rewrite the base domain, so we cannot use the variable 'baseUrl' as the actual base url for the URL objects.
             //We instead use 'workadventure' as a dummy base value.
@@ -37,20 +38,27 @@ export class Room {
             if (!identifier.startsWith('http://') && !identifier.startsWith('https://') && identifier.split('../').length == baseUrlObj.pathname.split('/').length) {
               // If the url is relative to the point of going one level beyond /, it attempts to change the hostname.
               // This is a compatibility layer for such broken urls.
-              exitUrl = new URL(`${window.location.protocol}//${identifier.replace(/\.\.\//g, '')}`);
+              exitUrl = new URL(`${protocol}//${identifier.replace(/\.\.\//g, '')}`);
             }
             hash = exitUrl.hash;
             hash = hash.substring(1); //remove the leading diese
             exitUrl.hash = '';
             roomId = `_/${currentInstance}/${exitUrl.href}`;
+            if (identifier.split('../').length == baseUrlObj.pathname.split('/').length + 1) {
+              const instance = exitUrl.pathname.substring(1, exitUrl.pathname.indexOf('/', 1));
+              const url = exitUrl.pathname.substring(instance.length+1);
+              roomId = `_/${instance}/${baseUrlObj.protocol}/${url}`;
+            } else if (identifier.split('../').length == baseUrlObj.pathname.split('/').length + 2) {
+              roomId = exitUrl.pathname.substring(1);
+            }
         } else { //absolute room Id
             const parts = identifier.split('#');
             roomId = parts[0];
             roomId = roomId.substring(1); //remove the leading slash
-            const roomUrl = roomId.substring(`_/${currentInstance}/`.length);
+            const roomUrl = roomId.substring(roomId.indexOf('/', 2) + 1);
             if(!roomUrl.startsWith('http://') && !roomUrl.startsWith('https://')) {
               // Compatibility for map urls without a url scheme.
-              roomId = `_/${currentInstance}/${window.location.protocol}//${roomUrl}`;
+              roomId = `${roomId.substring(0, roomId.length - roomUrl.length)}${protocol}//${roomUrl}`;
             }
             if (parts.length > 1) {
                 hash = parts[1]

--- a/front/src/Connexion/Room.ts
+++ b/front/src/Connexion/Room.ts
@@ -32,22 +32,17 @@ export class Room {
         if (!identifier.startsWith('/_/') && !identifier.startsWith('/@/')) { //relative file link
             //Relative identifier can be deep enough to rewrite the base domain, so we cannot use the variable 'baseUrl' as the actual base url for the URL objects.
             //We instead use 'workadventure' as a dummy base value.
-            const baseUrlObject = new URL(baseUrl);
-            if(identifier.startsWith('../../')) {
-                // Why is this even allowed?
-                // Anyway, this is a hack to preserve backwards compatibility with relative urls without schemes.
-                identifier = `${window.location.protocol}//${identifier.substring('../../'.length)}`;
+            const baseUrlObj = new URL(baseUrl);
+            let exitUrl = new URL(identifier, baseUrl);
+            if (!identifier.startsWith('http://') && !identifier.startsWith('https://') && identifier.split('../').length == baseUrlObj.pathname.split('/').length) {
+              // If the url is relative to the point of going one level beyond /, it attempts to change the hostname.
+              // This is a compatibility layer for such broken urls.
+              exitUrl = new URL(`${window.location.protocol}//${identifier.replace(/\.\.\//g, '')}`);
             }
-            let absoluteExitSceneUrl = new URL(identifier, 'http://workadventure/_/'+currentInstance+'/'+baseUrlObject.href);
-            roomId = absoluteExitSceneUrl.pathname; //in case of a relative url, we need to create a public roomId
-            roomId = roomId.substring(1); //remove the leading slash
-            if(identifier.startsWith('http://') || identifier.startsWith('https://')) {
-              absoluteExitSceneUrl = new URL(identifier);
-              absoluteExitSceneUrl.hash = '';
-              roomId = `_/${currentInstance}/${absoluteExitSceneUrl.href}`;
-            }
-            hash = absoluteExitSceneUrl.hash;
+            hash = exitUrl.hash;
             hash = hash.substring(1); //remove the leading diese
+            exitUrl.hash = '';
+            roomId = `_/${currentInstance}/${exitUrl.href}`;
         } else { //absolute room Id
             const parts = identifier.split('#');
             roomId = parts[0];

--- a/front/src/Connexion/Room.ts
+++ b/front/src/Connexion/Room.ts
@@ -59,7 +59,7 @@ export class Room {
             if (this.isPublic) {
                 const match = /_\/[^/]+\/(.+)/.exec(this.id);
                 if (!match) throw new Error('Could not extract url from "'+this.id+'"');
-                this.mapUrl = window.location.protocol+'//'+match[1];
+                this.mapUrl = (new URL(match[1], window.location.href)).href;
                 resolve(this.mapUrl);
                 return;
             } else {

--- a/front/src/Connexion/Room.ts
+++ b/front/src/Connexion/Room.ts
@@ -61,7 +61,6 @@ export class Room {
                 hash = parts[1]
             }
         }
-        console.log(identifier, roomId);
         return {roomId, hash}
     }
 
@@ -72,7 +71,6 @@ export class Room {
                 return;
             }
 
-            console.log('Switching rooms: ' + this.isPublic + ' ' + this.id);
             if (this.isPublic) {
                 const match = /_\/[^/]+\/(.+)/.exec(this.id);
                 if (!match) throw new Error('Could not extract url from "'+this.id+'"');

--- a/front/src/Enum/EnvironmentVariable.ts
+++ b/front/src/Enum/EnvironmentVariable.ts
@@ -1,7 +1,7 @@
 const DEBUG_MODE: boolean = process.env.DEBUG_MODE == "true";
-const API_URL = (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.API_URL || "pusher.workadventure.localhost");
-const UPLOADER_URL = (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.UPLOADER_URL || 'uploader.workadventure.localhost');
-const ADMIN_URL = (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.ADMIN_URL || "admin.workadventure.localhost");
+const API_URL = process.env.API_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.API_HOST || "pusher.workadventure.localhost");
+const UPLOADER_URL = process.env.API_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.UPLOADER_HOST || 'uploader.workadventure.localhost');
+const ADMIN_URL = process.env.API_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.ADMIN_HOST || "admin.workadventure.localhost");
 const TURN_SERVER: string = process.env.TURN_SERVER || "turn:numb.viagenie.ca";
 const TURN_USER: string = process.env.TURN_USER || 'g.parant@thecodingmachine.com';
 const TURN_PASSWORD: string = process.env.TURN_PASSWORD || 'itcugcOHxle9Acqi$';

--- a/front/src/Enum/EnvironmentVariable.ts
+++ b/front/src/Enum/EnvironmentVariable.ts
@@ -1,7 +1,7 @@
 const DEBUG_MODE: boolean = process.env.DEBUG_MODE == "true";
 const API_URL = process.env.API_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.API_HOST || "pusher.workadventure.localhost");
-const UPLOADER_URL = process.env.API_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.UPLOADER_HOST || 'uploader.workadventure.localhost');
-const ADMIN_URL = process.env.API_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.ADMIN_HOST || "admin.workadventure.localhost");
+const UPLOADER_URL = process.env.UPLOADER_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.UPLOADER_HOST || 'uploader.workadventure.localhost');
+const ADMIN_URL = process.env.ADMIN_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.ADMIN_HOST || "admin.workadventure.localhost");
 const TURN_SERVER: string = process.env.TURN_SERVER || "turn:numb.viagenie.ca";
 const TURN_USER: string = process.env.TURN_USER || 'g.parant@thecodingmachine.com';
 const TURN_PASSWORD: string = process.env.TURN_PASSWORD || 'itcugcOHxle9Acqi$';

--- a/front/src/Enum/EnvironmentVariable.ts
+++ b/front/src/Enum/EnvironmentVariable.ts
@@ -2,6 +2,7 @@ const DEBUG_MODE: boolean = process.env.DEBUG_MODE == "true";
 const API_URL = process.env.API_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.API_HOST || "pusher.workadventure.localhost");
 const UPLOADER_URL = process.env.UPLOADER_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.UPLOADER_HOST || 'uploader.workadventure.localhost');
 const ADMIN_URL = process.env.ADMIN_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.ADMIN_HOST || "admin.workadventure.localhost");
+const MAPS_URL = process.env.MAPS_URL || (process.env.MAPS_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.MAPS_HOST || "maps.workadventure.localhost");
 const TURN_SERVER: string = process.env.TURN_SERVER || "turn:numb.viagenie.ca";
 const TURN_USER: string = process.env.TURN_USER || 'g.parant@thecodingmachine.com';
 const TURN_PASSWORD: string = process.env.TURN_PASSWORD || 'itcugcOHxle9Acqi$';
@@ -17,6 +18,7 @@ export {
     API_URL,
     UPLOADER_URL,
     ADMIN_URL,
+    MAPS_URL,
     RESOLUTION,
     ZOOM_LEVEL,
     POSITION_DELAY,

--- a/front/src/Enum/EnvironmentVariable.ts
+++ b/front/src/Enum/EnvironmentVariable.ts
@@ -1,8 +1,8 @@
 const DEBUG_MODE: boolean = process.env.DEBUG_MODE == "true";
-const API_URL = (new URL(process.env.API_URL || '//pusher.workadventure.localhost', window.location.href)).href.replace(/\/$/, '');
-const UPLOADER_URL = (new URL(process.env.UPLOADER_URL || '//uploader.workadventure.localhost', window.location.href)).href.replace(/\/$/, '');
-const ADMIN_URL = (new URL(process.env.ADMIN_URL || '//admin.workadventure.localhost', window.location.href)).href.replace(/\/$/, '');
-const MAPS_URL = (new URL(process.env.MAPS_URL || '//maps.workadventure.localhost', window.location.href)).href.replace(/\/$/, '');
+const API_URL = (new URL(process.env.API_URL || '//pusher.workadventure.localhost', typeof(window) !== 'undefined'? window.location.href : 'https://l')).href.replace(/\/$/, '');
+const UPLOADER_URL = (new URL(process.env.UPLOADER_URL || '//uploader.workadventure.localhost', typeof(window) !== 'undefined' ? window.location.href : 'https://l')).href.replace(/\/$/, '');
+const ADMIN_URL = (new URL(process.env.ADMIN_URL || '//admin.workadventure.localhost', typeof(window) !== 'undefined' ? window.location.href : 'https://l')).href.replace(/\/$/, '');
+const MAPS_URL = (new URL(process.env.MAPS_URL || '//maps.workadventure.localhost', typeof(window) !== 'undefined' ? window.location.href : 'https://l')).href.replace(/\/$/, '');
 const TURN_SERVER: string = process.env.TURN_SERVER || "turn:numb.viagenie.ca";
 const TURN_USER: string = process.env.TURN_USER || 'g.parant@thecodingmachine.com';
 const TURN_PASSWORD: string = process.env.TURN_PASSWORD || 'itcugcOHxle9Acqi$';

--- a/front/src/Enum/EnvironmentVariable.ts
+++ b/front/src/Enum/EnvironmentVariable.ts
@@ -1,8 +1,8 @@
 const DEBUG_MODE: boolean = process.env.DEBUG_MODE == "true";
-const API_URL = process.env.API_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.API_HOST || "pusher.workadventure.localhost");
-const UPLOADER_URL = process.env.UPLOADER_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.UPLOADER_HOST || 'uploader.workadventure.localhost');
-const ADMIN_URL = process.env.ADMIN_URL || (process.env.API_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.ADMIN_HOST || "admin.workadventure.localhost");
-const MAPS_URL = process.env.MAPS_URL || (process.env.MAPS_PROTOCOL || (typeof(window) !== 'undefined' ? window.location.protocol : 'http:')) + '//' + (process.env.MAPS_HOST || "maps.workadventure.localhost");
+const API_URL = (new URL(process.env.API_URL || '//api.workadventure.local', window.location.href)).href;
+const UPLOADER_URL = (new URL(process.env.UPLOADER_URL || '//uploader.workadventure.local', window.location.href)).href;
+const ADMIN_URL = (new URL(process.env.ADMIN_URL || '//admin.workadventure.local', window.location.href)).href;
+const MAPS_URL = (new URL(process.env.MAPS_URL || '//maps.workadventure.local', window.location.href)).href;
 const TURN_SERVER: string = process.env.TURN_SERVER || "turn:numb.viagenie.ca";
 const TURN_USER: string = process.env.TURN_USER || 'g.parant@thecodingmachine.com';
 const TURN_PASSWORD: string = process.env.TURN_PASSWORD || 'itcugcOHxle9Acqi$';

--- a/front/src/Enum/EnvironmentVariable.ts
+++ b/front/src/Enum/EnvironmentVariable.ts
@@ -1,8 +1,8 @@
 const DEBUG_MODE: boolean = process.env.DEBUG_MODE == "true";
-const API_URL = (new URL(process.env.API_URL || '//api.workadventure.local', window.location.href)).href;
-const UPLOADER_URL = (new URL(process.env.UPLOADER_URL || '//uploader.workadventure.local', window.location.href)).href;
-const ADMIN_URL = (new URL(process.env.ADMIN_URL || '//admin.workadventure.local', window.location.href)).href;
-const MAPS_URL = (new URL(process.env.MAPS_URL || '//maps.workadventure.local', window.location.href)).href;
+const API_URL = (new URL(process.env.API_URL || '//pusher.workadventure.localhost', window.location.href)).href.replace(/\/$/, '');
+const UPLOADER_URL = (new URL(process.env.UPLOADER_URL || '//uploader.workadventure.localhost', window.location.href)).href.replace(/\/$/, '');
+const ADMIN_URL = (new URL(process.env.ADMIN_URL || '//admin.workadventure.localhost', window.location.href)).href.replace(/\/$/, '');
+const MAPS_URL = (new URL(process.env.MAPS_URL || '//maps.workadventure.localhost', window.location.href)).href.replace(/\/$/, '');
 const TURN_SERVER: string = process.env.TURN_SERVER || "turn:numb.viagenie.ca";
 const TURN_USER: string = process.env.TURN_USER || 'g.parant@thecodingmachine.com';
 const TURN_PASSWORD: string = process.env.TURN_PASSWORD || 'itcugcOHxle9Acqi$';

--- a/front/tests/Phaser/Game/RoomTest.ts
+++ b/front/tests/Phaser/Game/RoomTest.ts
@@ -4,44 +4,44 @@ import {Room} from "../../../src/Connexion/Room";
 describe("Room getIdFromIdentifier()", () => {
     it("should work with an absolute room id and no hash as parameter", () => {
         const {roomId, hash} = Room.getIdFromIdentifier('/_/global/maps.workadventu.re/test2.json', '', '');
-        expect(roomId).toEqual('_/global/maps.workadventu.re/test2.json');
+        expect(roomId).toEqual('_/global/https://maps.workadventu.re/test2.json');
         expect(hash).toEqual('');
     });
     it("should work with an absolute room id and a hash as parameters", () => {
         const {roomId, hash} = Room.getIdFromIdentifier('/_/global/maps.workadventu.re/test2.json#start', '', '');
-        expect(roomId).toEqual('_/global/maps.workadventu.re/test2.json');
+        expect(roomId).toEqual('_/global/https://maps.workadventu.re/test2.json');
         expect(hash).toEqual("start");
     });
     it("should work with an absolute room id, regardless of baseUrl or instance", () => {
         const {roomId, hash} = Room.getIdFromIdentifier('/_/global/maps.workadventu.re/test2.json', 'https://another.domain/_/global/test.json', 'lol');
-        expect(roomId).toEqual('_/global/maps.workadventu.re/test2.json');
+        expect(roomId).toEqual('_/global/https://maps.workadventu.re/test2.json');
         expect(hash).toEqual('');
     });
     
     
     it("should work with a relative file link and no hash as parameters", () => {
         const {roomId, hash} = Room.getIdFromIdentifier('./test2.json', 'https://maps.workadventu.re/test.json', 'global');
-        expect(roomId).toEqual('_/global/maps.workadventu.re/test2.json');
+        expect(roomId).toEqual('_/global/https://maps.workadventu.re/test2.json');
         expect(hash).toEqual('');
     });
     it("should work with a relative file link with no dot", () => {
         const {roomId, hash} = Room.getIdFromIdentifier('test2.json', 'https://maps.workadventu.re/test.json', 'global');
-        expect(roomId).toEqual('_/global/maps.workadventu.re/test2.json');
+        expect(roomId).toEqual('_/global/https://maps.workadventu.re/test2.json');
         expect(hash).toEqual('');
     });
     it("should work with a relative file link two levels deep", () => {
         const {roomId, hash} = Room.getIdFromIdentifier('../floor1/Floor1.json', 'https://maps.workadventu.re/floor0/Floor0.json', 'global');
-        expect(roomId).toEqual('_/global/maps.workadventu.re/floor1/Floor1.json');
+        expect(roomId).toEqual('_/global/https://maps.workadventu.re/floor1/Floor1.json');
         expect(hash).toEqual('');
     });
     it("should work with a relative file link that rewrite the map domain", () => {
         const {roomId, hash} = Room.getIdFromIdentifier('../../maps.workadventure.localhost/Floor1/floor1.json', 'https://maps.workadventu.re/floor0/Floor0.json', 'global');
-        expect(roomId).toEqual('_/global/maps.workadventure.localhost/Floor1/floor1.json');
+        expect(roomId).toEqual('_/global/https://maps.workadventure.localhost/Floor1/floor1.json');
         expect(hash).toEqual('');
     });
     it("should work with a relative file link that rewrite the map instance", () => {
         const {roomId, hash} = Room.getIdFromIdentifier('../../../notglobal/maps.workadventu.re/Floor1/floor1.json', 'https://maps.workadventu.re/floor0/Floor0.json', 'global');
-        expect(roomId).toEqual('_/notglobal/maps.workadventu.re/Floor1/floor1.json');
+        expect(roomId).toEqual('_/notglobal/https://maps.workadventu.re/Floor1/floor1.json');
         expect(hash).toEqual('');
     });
     it("should work with a relative file link that change the map type", () => {
@@ -52,7 +52,7 @@ describe("Room getIdFromIdentifier()", () => {
     
     it("should work with a relative file link and a hash as parameters", () => {
         const {roomId, hash} = Room.getIdFromIdentifier('./test2.json#start', 'https://maps.workadventu.re/test.json', 'global');
-        expect(roomId).toEqual('_/global/maps.workadventu.re/test2.json');
+        expect(roomId).toEqual('_/global/https://maps.workadventu.re/test2.json');
         expect(hash).toEqual("start");
     });
 });

--- a/front/webpack.config.js
+++ b/front/webpack.config.js
@@ -45,7 +45,12 @@ module.exports = {
         new webpack.ProvidePlugin({
             Phaser: 'phaser'
         }),
-        new webpack.EnvironmentPlugin(['API_URL', 'UPLOADER_URL', 'ADMIN_URL', 'DEBUG_MODE', 'TURN_SERVER', 'TURN_USER', 'TURN_PASSWORD', 'JITSI_URL', 'JITSI_PRIVATE_MODE'])
+        new webpack.EnvironmentPlugin([
+          'API_URL', 'UPLOADER_URL', 'ADMIN_URL', 'MAPS_URL',
+          'API_PROTOCOL', 'UPLOADER_PROTOCOL', 'ADMIN_PROTOCOL', 'MAPS_PROTOCOL',
+          'API_HOST', 'UPLOADER_HOST', 'ADMIN_HOST', 'MAPS_HOST',
+          'DEBUG_MODE', 'TURN_SERVER', 'TURN_USER', 'TURN_PASSWORD', 'JITSI_URL', 'JITSI_PRIVATE_MODE'
+        ])
     ],
 
 };

--- a/front/webpack.config.js
+++ b/front/webpack.config.js
@@ -47,8 +47,6 @@ module.exports = {
         }),
         new webpack.EnvironmentPlugin([
           'API_URL', 'UPLOADER_URL', 'ADMIN_URL', 'MAPS_URL',
-          'API_PROTOCOL', 'UPLOADER_PROTOCOL', 'ADMIN_PROTOCOL', 'MAPS_PROTOCOL',
-          'API_HOST', 'UPLOADER_HOST', 'ADMIN_HOST', 'MAPS_HOST',
           'DEBUG_MODE', 'TURN_SERVER', 'TURN_USER', 'TURN_PASSWORD', 'JITSI_URL', 'JITSI_PRIVATE_MODE'
         ])
     ],


### PR DESCRIPTION
This merge request aims to support deployments other than `{play,pusher,maps,admin,uploader}.$domain`, specifically a deployment that doesn't depend on domain names at all.

To achieve this, more changes are needed than I wanted to make. The changes made:

  * Added MAPS_URL env var, because earlier it was hardcoded as `window.location.host.replace('play.', 'maps.')`
  * `*_URL` env vars are now relative urls to `window.location`. The original behavior can be achieved by prepending `//` to the value, e.g. `//pusher.workadventure.localhost`. The defaults stay functionally the same.
  * The maps urls are now proper absolute urls, e.g `/_/global/https://domain/Floor0/floor0.json`. This is because prepending `https://` didn't work in case the MAPS_URL did not include a hostname. Besides, this works better with github maps, which have to be accessed using https.
  * There is a compatibility layer for transforming relative urls in maps, although I believe that relative urls pointing to other domains should be deprecated.
  * Added a `docker-compose.single-domain.yaml` which deploys WA in a way that it's accessible under `localhost`. `docker-compose.yaml` still works as before.

I have tested it enough to be confident that it works in general, but I can't say that I've discovered every possible case.