### PR TITLE
Fixing bug when no WebGL is available

### DIFF
--- a/front/src/Phaser/Items/ActionableItem.ts
+++ b/front/src/Phaser/Items/ActionableItem.ts
@@ -42,8 +42,10 @@ export class ActionableItem {
             return;
         }
         this.isSelectable = true;
-        this.sprite.setPipeline(OutlinePipeline.KEY);
-        this.sprite.pipeline.set2f('uTextureSize', this.sprite.texture.getSourceImage().width, this.sprite.texture.getSourceImage().height);
+        if (this.sprite.pipeline) {
+            this.sprite.setPipeline(OutlinePipeline.KEY);
+            this.sprite.pipeline.set2f('uTextureSize', this.sprite.texture.getSourceImage().width, this.sprite.texture.getSourceImage().height);
+        }
     }
 
     /**

--- a/front/src/index.ts
+++ b/front/src/index.ts
@@ -73,9 +73,10 @@ const config: GameConfig = {
     },
     callbacks: {
         postBoot: game => {
-            // FIXME: we should fore WebGL in the config.
-            const renderer = game.renderer as WebGLRenderer;
-            renderer.pipelines.add(OutlinePipeline.KEY, new OutlinePipeline(game));
+            const renderer = game.renderer;
+            if (renderer instanceof WebGLRenderer) {
+                renderer.pipelines.add(OutlinePipeline.KEY, new OutlinePipeline(game));
+            }
         }
     }
 };


### PR DESCRIPTION
The switch to Phaser 3.50 introduced a bug when WebGL is not available in a browser.
The changes in this commit prevent calls to the WebGL pipeline if the pipeline is not available.

Closes #587 