### PR TITLE
WIP: Add support for BigBlueButton

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/thecodingmachine/workadventure#readme",
   "dependencies": {
     "axios": "^0.21.1",
+    "bigbluebutton-js": "^0.1.1",
     "body-parser": "^1.19.0",
     "busboy": "^0.3.1",
     "circular-json": "^0.5.9",

--- a/back/src/Enum/EnvironmentVariable.ts
+++ b/back/src/Enum/EnvironmentVariable.ts
@@ -10,6 +10,8 @@ const CPU_OVERHEAT_THRESHOLD = Number(process.env.CPU_OVERHEAT_THRESHOLD) || 80;
 const JITSI_URL : string|undefined = (process.env.JITSI_URL === '') ? undefined : process.env.JITSI_URL;
 const JITSI_ISS = process.env.JITSI_ISS || '';
 const SECRET_JITSI_KEY = process.env.SECRET_JITSI_KEY || '';
+const BBB_URL: string|undefined = (process.env.BBB_URL === '') ? undefined : process.env.BBB_URL;
+const BBB_SECRET = process.env.BBB_SECRET || '';
 const HTTP_PORT = parseInt(process.env.HTTP_PORT || '8080') || 8080;
 const GRPC_PORT = parseInt(process.env.GRPC_PORT || '50051') || 50051;
 export const SOCKET_IDLE_TIMER = parseInt(process.env.SOCKET_IDLE_TIMER as string) || 30; // maximum time (in second) without activity before a socket is closed
@@ -28,5 +30,7 @@ export {
     CPU_OVERHEAT_THRESHOLD,
     JITSI_URL,
     JITSI_ISS,
-    SECRET_JITSI_KEY
+    SECRET_JITSI_KEY,
+    BBB_URL,
+    BBB_SECRET
 }

--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -9,6 +9,7 @@ import {
     PlayGlobalMessage,
     PusherToBackMessage,
     QueryJitsiJwtMessage,
+    JoinBBBMeetingMessage,
     ReportPlayerMessage,
     RoomJoinedMessage,
     ServerToAdminClientMessage,
@@ -74,6 +75,8 @@ const roomManager: IRoomManagerServer = {
                         socketManager.handleReportMessage(client, message.getReportplayermessage() as ReportPlayerMessage);*/
                     } else if (message.hasQueryjitsijwtmessage()){
                         socketManager.handleQueryJitsiJwtMessage(user, message.getQueryjitsijwtmessage() as QueryJitsiJwtMessage);
+                    } else if (message.hasJoinbbbmeetingmessage()) {
+                        socketManager.handleJoinBBBMeetingMessage(user, message.getJoinbbbmeetingmessage() as JoinBBBMeetingMessage);
                     } else {
                         throw new Error('Unhandled message type');
                     }

--- a/back/yarn.lock
+++ b/back/yarn.lock
@@ -335,6 +335,13 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
@@ -359,6 +366,15 @@ base@^0.11.1:
     isobject "^3.0.1"
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
+
+bigbluebutton-js@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/bigbluebutton-js/-/bigbluebutton-js-0.1.1.tgz#b19ad54f4bd5a9b6ae0f69d895babea0f3e91769"
+  integrity sha512-4P9wmMhLV+3ZGIgs0NKgn02rovcT39hJeRG24/z5bTmUSxgPdRxMyFoZEekr1Ii+Dlu7bT3j04RdqUOay7rFvw==
+  dependencies:
+    axios "^0.19.2"
+    fast-xml-parser "^3.17.2"
+    hash.js "^1.1.7"
 
 binary-extensions@^2.0.0:
   version "2.1.0"
@@ -682,6 +698,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
@@ -1022,6 +1045,11 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-xml-parser@^3.17.2:
+  version "3.17.6"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.17.6.tgz#4f5df8cf927c3e59a10362abcfb7335c34bc5c5f"
+  integrity sha512-40WHI/5d2MOzf1sD2bSaTXlPn1lueJLAX6j1xH5dSAr6tNeut8B9ktEL6sjAK9yVON4uNj9//axOdBJUuruCzw==
+
 figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -1074,6 +1102,13 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 follow-redirects@^1.10.0:
   version "1.13.0"
@@ -1249,6 +1284,14 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+hash.js@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
 
 hosted-git-info@^2.1.4:
   version "2.8.8"
@@ -1804,6 +1847,11 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimatch@^3.0.4:
   version "3.0.4"

--- a/front/src/Connexion/ConnexionModels.ts
+++ b/front/src/Connexion/ConnexionModels.ts
@@ -33,6 +33,7 @@ export enum EventMessage{
     TELEPORT = "teleport",
     USER_MESSAGE = "user-message",
     START_JITSI_ROOM = "start-jitsi-room",
+    BBB_MEETING_CLIENT_URL = "bbb-meeting-client-url",
 }
 
 export interface PointInterface {

--- a/front/src/WebRtc/CoWebsiteManager.ts
+++ b/front/src/WebRtc/CoWebsiteManager.ts
@@ -42,7 +42,7 @@ class CoWebsiteManager {
         this.opened = iframeStates.opened;
     }
 
-    public loadCoWebsite(url: string): void {
+    public loadCoWebsite(url: string, tweakIframeCallback?: (iframe: HTMLIFrameElement) => void): void {
         this.load();
         this.cowebsiteDiv.innerHTML = `<button class="close-btn" id="cowebsite-close">
                     <img src="resources/logos/close.svg">
@@ -56,6 +56,9 @@ class CoWebsiteManager {
         const iframe = document.createElement('iframe');
         iframe.id = 'cowebsite-iframe';
         iframe.src = url;
+        if (tweakIframeCallback) {
+            tweakIframeCallback(iframe);
+        }
         const onloadPromise = new Promise((resolve) => {
             iframe.onload = () => resolve();
         });

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -67,6 +67,11 @@ message QueryJitsiJwtMessage {
   string tag = 2; // FIXME: rather than reading the tag from the query, we should read it from the current map!
 }
 
+message JoinBBBMeetingMessage {
+  string meetingId = 1;
+  map<string, string> userdata = 2;
+}
+
 message ClientToServerMessage {
   oneof message {
     UserMovesMessage userMovesMessage = 2;
@@ -80,6 +85,7 @@ message ClientToServerMessage {
     StopGlobalMessage stopGlobalMessage = 10;
     ReportPlayerMessage reportPlayerMessage = 11;
     QueryJitsiJwtMessage queryJitsiJwtMessage = 12;
+    JoinBBBMeetingMessage joinBBBMeetingMessage = 13;
   }
 }
 
@@ -193,6 +199,11 @@ message SendUserMessage{
   string message = 2;
 }
 
+message BBBMeetingClientURLMessage {
+  string meetingId = 1;
+  string clientURL = 2;
+}
+
 message ServerToClientMessage {
   oneof message {
     BatchMessage batchMessage = 1;
@@ -207,6 +218,7 @@ message ServerToClientMessage {
     TeleportMessageMessage teleportMessageMessage = 10;
     SendJitsiJwtMessage sendJitsiJwtMessage = 11;
     SendUserMessage sendUserMessage = 12;
+    BBBMeetingClientURLMessage bbbMeetingClientURLMessage = 13;
   }
 }
 
@@ -272,6 +284,7 @@ message PusherToBackMessage {
     StopGlobalMessage stopGlobalMessage = 9;
     ReportPlayerMessage reportPlayerMessage = 10;
     QueryJitsiJwtMessage queryJitsiJwtMessage = 11;
+    JoinBBBMeetingMessage joinBBBMeetingMessage = 12;
   }
 }
 

--- a/pusher/src/Controller/IoSocketController.ts
+++ b/pusher/src/Controller/IoSocketController.ts
@@ -12,7 +12,10 @@ import {
     WebRtcSignalToServerMessage,
     PlayGlobalMessage,
     ReportPlayerMessage,
-    QueryJitsiJwtMessage, SendUserMessage, ServerToClientMessage
+    QueryJitsiJwtMessage,
+    JoinBBBMeetingMessage,
+    SendUserMessage,
+    ServerToClientMessage
 } from "../Messages/generated/messages_pb";
 import {UserMovesMessage} from "../Messages/generated/messages_pb";
 import {TemplatedApp} from "uWebSockets.js"
@@ -308,7 +311,10 @@ export class IoSocketController {
                     socketManager.handleReportMessage(client, message.getReportplayermessage() as ReportPlayerMessage);
                 } else if (message.hasQueryjitsijwtmessage()){
                     socketManager.handleQueryJitsiJwtMessage(client, message.getQueryjitsijwtmessage() as QueryJitsiJwtMessage);
-                }
+                } else if (message.hasJoinbbbmeetingmessage()){
+                    socketManager.handleJoinBBBMeetingMessage(client, message.getJoinbbbmeetingmessage() as JoinBBBMeetingMessage);
+		}
+
 
                     /* Ok is false if backpressure was built up, wait for drain */
                 //let ok = ws.send(message, isBinary);

--- a/pusher/src/Services/SocketManager.ts
+++ b/pusher/src/Services/SocketManager.ts
@@ -25,6 +25,7 @@ import {
     WebRtcStartMessage,
     QueryJitsiJwtMessage,
     SendJitsiJwtMessage,
+    JoinBBBMeetingMessage,
     SendUserMessage,
     JoinRoomMessage,
     CharacterLayerMessage,
@@ -538,6 +539,13 @@ export class SocketManager implements ZoneEventListener {
         serverToClientMessage.setSendjitsijwtmessage(sendJitsiJwtMessage);
 
         client.send(serverToClientMessage.serializeBinary().buffer, true);
+    }
+
+    public handleJoinBBBMeetingMessage(client: ExSocketInterface, joinBBBMeetingMessage: JoinBBBMeetingMessage) {
+        const pusherToBackMessage = new PusherToBackMessage();
+        pusherToBackMessage.setJoinbbbmeetingmessage(joinBBBMeetingMessage);
+
+        client.backConnection.write(pusherToBackMessage);
     }
 
     public async emitSendUserMessage(userUuid: string, message: string, roomId: string): Promise<void> {


### PR DESCRIPTION
This is still a work in progress. If something breaks, you are free to keep the pieces. Co-authored with @znerol. 

Fixes #465.

What this does:

* Add `BBB_URL` and `BBB_SECRET` as environment variable to configure the backend.
* Add support for the `bbbMeeting` string property to tiles. This will start a meeting with the specified identifier.
* Add support for extra string properties starting with `userdata-bbb_` to [configure the behavior of BBB HTML5 client](https://docs.bigbluebutton.org/2.2/customize.html#passing-custom-parameters-to-the-client-on-join). This should allow to map a theater with a stage and an audience having different settings for camera/microphone.

Left to be done:

* [x] Build a map to test the "theater" settings mentioned above.
* [ ] Figure out how to make admins join the meeting as moderators.
* [ ] Have the client send microphone and camera state when joining to the server so we can join with matching settings.
* [ ] Clean up. Some of the behavior is common with Jitsi and should probably be factored out. The code might not be at the right place server-side as well.