### PR TITLE
Template google analytics data

### DIFF
--- a/front/.gitignore
+++ b/front/.gitignore
@@ -6,3 +6,4 @@
 /dist/webpack.config.js.map
 /dist/src
 *.sh
+!templater.sh

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -11,5 +11,6 @@ COPY --from=builder --chown=docker:docker /var/www/messages/generated /var/www/h
 RUN yarn install
 
 ENV NODE_ENV=production
+ENV STARTUP_COMMAND_0="./templater.sh"
 ENV STARTUP_COMMAND_1="yarn run build"
 ENV APACHE_DOCUMENT_ROOT=dist/

--- a/front/dist/ga.html.tmpl
+++ b/front/dist/ga.html.tmpl
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=<!-- TRACKING NUMBER -->"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '<!-- TRACKING NUMBER -->');
+</script>

--- a/front/dist/index.html.tmpl
+++ b/front/dist/index.html.tmpl
@@ -6,15 +6,8 @@
               content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
 
-        <!-- Global site tag (gtag.js) - Google Analytics -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-10196481-11"></script>
-        <script>
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-
-            gtag('config', 'UA-10196481-11');
-        </script>
+        <!-- TRACK CODE -->
+        <!-- END TRACK CODE -->
 
         <link rel="apple-touch-icon" sizes="57x57" href="static/images/favicons/apple-icon-57x57.png">
         <link rel="apple-touch-icon" sizes="60x60" href="static/images/favicons/apple-icon-60x60.png">

--- a/front/templater.sh
+++ b/front/templater.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -x
+set -o nounset errexit
+template_file_index=dist/index.html.tmpl
+generated_file_index=dist/index.html
+tmp_trackcodefile=/tmp/trackcode
+
+# To inject tracking code, you have two choices:
+# 1) Template using the provided google analytics
+# 2) Insert with your own provided code, by overriding the ANALYTICS_CODE_PATH
+# The ANALYTICS_CODE_PATH is the location of a file inside the container
+ANALYTICS_CODE_PATH="${ANALYTICS_CODE_PATH:-dist/ga.html.tmpl}"
+
+if [[ "${INSERT_ANALYTICS:-NO}" == "NO" ]]; then
+    echo "" > "${tmp_trackcodefile}"
+fi
+
+# Automatically insert analytics if TRACKING_NUMBER is set
+if [[ "${TRACKING_NUMBER:-}" != ""  || "${INSERT_ANALYTICS:-NO}" != "NO" ]]; then
+    echo "Templating code from ${ANALYTICS_CODE_PATH}"
+    sed "s#<!-- TRACKING NUMBER -->#${TRACKING_NUMBER:-}#g" "${ANALYTICS_CODE_PATH}" > "$tmp_trackcodefile"
+fi
+
+echo "Templating ${generated_file_index} from ${template_file_index}"
+sed "/<!-- TRACK CODE -->/r ${tmp_trackcodefile}" "${template_file_index}" > "${generated_file_index}"
+rm "${tmp_trackcodefile}"


### PR DESCRIPTION
Without this patch, the index.html contains google analytics at
all times, including for people self-hosting it.

This is a problem for privacy reasons, and only people wanting
to have analytics on their instances should be able to enable
them.

This fixes it by making sure the index.html page is templated
to sideload content from ANALYTICS_CODE_PATH (which itself is
also templated, for convenience).
