### PR TITLE
Fixing docker-compose startup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,8 @@ services:
       API_URL: pusher.workadventure.localhost
       UPLOADER_URL: uploader.workadventure.localhost
       ADMIN_URL: workadventure.localhost
-      STARTUP_COMMAND_1: yarn install
+      STARTUP_COMMAND_1: ./templater.sh
+      STARTUP_COMMAND_2: yarn install
       TURN_SERVER: "turn:coturn.workadventu.re:443,turns:coturn.workadventu.re:443"
       TURN_USER: workadventure
       TURN_PASSWORD: WorkAdventure123


### PR DESCRIPTION
With the addition of ./template.sh in #623, we now need to call the templater on each container startup, even in development environments.

Closes #630 