### PR TITLE
Add a parameter to allow changing phaser renderer

### DIFF
--- a/front/src/index.ts
+++ b/front/src/index.ts
@@ -53,8 +53,28 @@ const fps : Phaser.Types.Core.FPSConfig = {
     smoothStep: false
 }
 
+// the ?phaserMode=canvas parameter can be used to force Canvas usage
+let params = new URLSearchParams(document.location.search.substring(1));
+let phaserMode = params.get("phaserMode");
+let mode: number;
+switch (phaserMode) {
+    case 'auto':
+    case null:
+        mode = Phaser.AUTO;
+        break;
+    case 'canvas':
+        mode = Phaser.CANVAS;
+        break;
+    case 'webgl':
+        mode = Phaser.WEBGL;
+        break;
+    default:
+        throw new Error('phaserMode parameter must be one of "auto", "canvas" or "webgl"');
+}
+
+
 const config: GameConfig = {
-    type: Phaser.AUTO,
+    type: mode,
     title: "WorkAdventure",
     width: width / RESOLUTION,
     height: height / RESOLUTION,

--- a/front/src/index.ts
+++ b/front/src/index.ts
@@ -54,8 +54,8 @@ const fps : Phaser.Types.Core.FPSConfig = {
 }
 
 // the ?phaserMode=canvas parameter can be used to force Canvas usage
-let params = new URLSearchParams(document.location.search.substring(1));
-let phaserMode = params.get("phaserMode");
+const params = new URLSearchParams(document.location.search.substring(1));
+const phaserMode = params.get("phaserMode");
 let mode: number;
 switch (phaserMode) {
     case 'auto':


### PR DESCRIPTION
Recently, some Macs have been crashing running WorkAdventure.
Hard to say if this is related to Phaser 3.50 upgrade or to the new MacOS version.

It happens mostly on Mac Air and might be related to WebGL rendering.

This commit allows to switch to CANVAS renderer by adding `?phaserMode=canvas` in the URL