### PR TITLE
save "mute" state in localStore

### DIFF
--- a/front/src/Connexion/LocalUserStore.ts
+++ b/front/src/Connexion/LocalUserStore.ts
@@ -1,60 +1,83 @@
 import {LocalUser} from "./LocalUser";
 
-const characterLayersKey = 'characterLayers';
-const gameQualityKey = 'gameQuality';
-const videoQualityKey = 'videoQuality';
+const playerNameKey =           'playerName';
+const selectedPlayerKey =       'selectedPlayer';
+const customCursorPositionKey = 'customCursorPosition';
+const characterLayersKey =      'characterLayers';
+const gameQualityKey =          'gameQuality';
+const videoQualityKey =         'videoQuality';
+const joystickKey =             'showJoystick';
+const audioPlayerVolumeKey =    'audioplayer_volume';
+const audioPlayerMuteKey =      'audioplayer_mute';
+
+const storage = window.localStorage;
 
 //todo: add localstorage fallback
 class LocalUserStore {
-    
+
     saveUser(localUser: LocalUser) {
-        localStorage.setItem('localUser', JSON.stringify(localUser));
+        storage.setItem('localUser', JSON.stringify(localUser));
     }
     getLocalUser(): LocalUser|null {
-        const data = localStorage.getItem('localUser');
+        const data = storage.getItem('localUser');
         return data ? JSON.parse(data) : null;
     }
-    
+
     setName(name:string): void {
-        window.localStorage.setItem('playerName', name);
+        storage.setItem(playerNameKey, name);
     }
     getName(): string {
-        return window.localStorage.getItem('playerName') ?? '';
+        return storage.getItem(playerNameKey) ?? '';
     }
 
     setPlayerCharacterIndex(playerCharacterIndex: number): void {
-        window.localStorage.setItem('selectedPlayer', ''+playerCharacterIndex);
+        storage.setItem(selectedPlayerKey, ''+playerCharacterIndex);
     }
     getPlayerCharacterIndex(): number {
-        return parseInt(window.localStorage.getItem('selectedPlayer') || '');
+        return parseInt(storage.getItem(selectedPlayerKey) || '');
     }
 
     setCustomCursorPosition(activeRow:number, selectedLayers: number[]): void {
-        window.localStorage.setItem('customCursorPosition', JSON.stringify({activeRow, selectedLayers}));
+        storage.setItem(customCursorPositionKey, JSON.stringify({activeRow, selectedLayers}));
     }
     getCustomCursorPosition(): {activeRow:number, selectedLayers:number[]}|null  {
-        return JSON.parse(window.localStorage.getItem('customCursorPosition') || "null");
+        return JSON.parse(storage.getItem(customCursorPositionKey) || "null");
     }
 
     setCharacterLayers(layers: string[]): void {
-        window.localStorage.setItem(characterLayersKey, JSON.stringify(layers));
+        storage.setItem(characterLayersKey, JSON.stringify(layers));
     }
     getCharacterLayers(): string[]|null {
-        return JSON.parse(window.localStorage.getItem(characterLayersKey) || "null");
-    }
-    
-    getGameQualityValue(): number {
-        return parseInt(window.localStorage.getItem(gameQualityKey) || '') || 60;
-    }
-    setGameQualityValue(value: number): void {
-        localStorage.setItem(gameQualityKey, '' + value);
+        return JSON.parse(storage.getItem(characterLayersKey) || "null");
     }
 
-    getVideoQualityValue(): number {
-        return parseInt(window.localStorage.getItem(videoQualityKey) || '') || 20;
+    setGameQualityValue(value: number): void {
+        storage.setItem(gameQualityKey, '' + value);
     }
+    getGameQualityValue(): number {
+        return parseInt(storage.getItem(gameQualityKey) || '') || 60;
+    }
+
     setVideoQualityValue(value: number): void {
-        localStorage.setItem(videoQualityKey, '' + value);
+        storage.setItem(videoQualityKey, '' + value);
+    }
+    getVideoQualityValue(): number {
+        return parseInt(storage.getItem(videoQualityKey) || '') || 20;
+    }
+
+    setAudioPlayerVolume(value: number): void {
+        storage.setItem(audioPlayerVolumeKey, '' + value);
+    }
+    getAudioPlayerVolume(): number {
+        return parseFloat(storage.getItem(audioPlayerVolumeKey) || '') || 1;
+    }
+
+    setAudioPlayerMuted(value: boolean): void {
+        storage.setItem(audioPlayerMuteKey, value.toString());
+    }
+    getAudioPlayerMuted(): boolean {
+        const value = storage.getItem(audioPlayerMuteKey);
+        return (value === 'true') ? true : false;
     }
 }
 

--- a/front/src/WebRtc/AudioManager.ts
+++ b/front/src/WebRtc/AudioManager.ts
@@ -28,11 +28,11 @@ class AudioManager {
         this.audioPlayerDiv = HtmlUtils.getElementByIdOrFail<HTMLDivElement>(audioPlayerDivId);
         this.audioPlayerCtrl = HtmlUtils.getElementByIdOrFail<HTMLDivElement>(audioPlayerCtrlId);
         this.volume = localUserStore.getAudioPlayerVolume();
-        HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume').value = '' + localUser
+        HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume').value = '' + localUserStore.getAudioPlayerVolume();
 
         this.muted = localUserStore.getAudioPlayerMuted();
         if (this.muted) {
-            HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume_icon_playing').class
+            HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume_icon_playing').classList.add('muted');
         }
     }
 
@@ -76,7 +76,7 @@ class AudioManager {
         this.load();
 
         /* Solution 1, remove whole audio player */
-        this.audioPlayerDiv.innerHTML = ''; // necessary, if switching from one audio context to anot
+        this.audioPlayerDiv.innerHTML = ''; // necessary, if switching from one audio context to another! (else both streams would play simultaneously)
 
         this.audioPlayerElem = document.createElement('audio');
         this.audioPlayerElem.id = 'audioplayerelem';
@@ -101,10 +101,10 @@ class AudioManager {
 
             if (this.muted) {
                 localStorage.setItem('audioplayer_muted', 'true');
-                HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume_icon_playing').c
+                HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume_icon_playing').classList.add('muted');
             } else {
                 localStorage.setItem('audioplayer_muted', 'false');
-                HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume_icon_playing').c
+                HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume_icon_playing').classList.remove('muted');
             }
         }
 
@@ -116,7 +116,7 @@ class AudioManager {
             (<HTMLInputElement>ev.currentTarget).blur();
         }
 
-        const decreaseElem = HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_decrease_w
+        const decreaseElem = HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_decrease_while_talking');
         decreaseElem.oninput = (ev: Event)=> {
             this.decreaseWhileTalking = (<HTMLInputElement>ev.currentTarget).checked;
             this.changeVolume();

--- a/front/src/WebRtc/AudioManager.ts
+++ b/front/src/WebRtc/AudioManager.ts
@@ -1,5 +1,6 @@
 import {HtmlUtils} from "./HtmlUtils";
 import {isUndefined} from "generic-type-guard";
+import {localUserStore} from "../Connexion/LocalUserStore";
 
 enum audioStates {
     closed = 0,
@@ -26,16 +27,13 @@ class AudioManager {
     constructor() {
         this.audioPlayerDiv = HtmlUtils.getElementByIdOrFail<HTMLDivElement>(audioPlayerDivId);
         this.audioPlayerCtrl = HtmlUtils.getElementByIdOrFail<HTMLDivElement>(audioPlayerCtrlId);
+        this.volume = localUserStore.getAudioPlayerVolume();
+        HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume').value = '' + localUser
 
-        const storedVolume = localStorage.getItem('volume')
-        if (storedVolume === null) {
-            this.setVolume(1);
-        } else {
-            this.volume = parseFloat(storedVolume);
-            HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume').value = storedVolume;
+        this.muted = localUserStore.getAudioPlayerMuted();
+        if (this.muted) {
+            HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume_icon_playing').class
         }
-
-        HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume').value = '' + this.volume;
     }
 
     private close(): void {
@@ -71,15 +69,14 @@ class AudioManager {
 
     private setVolume(volume: number): void {
         this.volume = volume;
-        localStorage.setItem('volume', '' + volume);
+        localUserStore.setAudioPlayerVolume(volume);
     }
-
 
     public loadAudio(url: string): void {
         this.load();
 
         /* Solution 1, remove whole audio player */
-        this.audioPlayerDiv.innerHTML = ''; // necessary, if switching from one audio context to another! (else both streams would play simultaneously)
+        this.audioPlayerDiv.innerHTML = ''; // necessary, if switching from one audio context to anot
 
         this.audioPlayerElem = document.createElement('audio');
         this.audioPlayerElem.id = 'audioplayerelem';
@@ -100,11 +97,14 @@ class AudioManager {
         muteElem.onclick = (ev: Event)=> {
             this.muted = !this.muted;
             this.changeVolume();
+            localUserStore.setAudioPlayerMuted(this.muted);
 
             if (this.muted) {
-                HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume_icon_playing').classList.add('muted');
+                localStorage.setItem('audioplayer_muted', 'true');
+                HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume_icon_playing').c
             } else {
-                HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume_icon_playing').classList.remove('muted');
+                localStorage.setItem('audioplayer_muted', 'false');
+                HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_volume_icon_playing').c
             }
         }
 
@@ -116,7 +116,7 @@ class AudioManager {
             (<HTMLInputElement>ev.currentTarget).blur();
         }
 
-        const decreaseElem = HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_decrease_while_talking');
+        const decreaseElem = HtmlUtils.getElementByIdOrFail<HTMLInputElement>('audioplayer_decrease_w
         decreaseElem.oninput = (ev: Event)=> {
             this.decreaseWhileTalking = (<HTMLInputElement>ev.currentTarget).checked;
             this.changeVolume();


### PR DESCRIPTION
When the "background" audio player is being muted, this state was not save in LocalStore of the browser.
This PR add that and refactors the use of localStore so that also the volume is stored and received via getter/setter functions from the central class