### PR TITLE
Allow URLs relative to map base in iframe / openWebsite

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -653,7 +653,7 @@ export class GameScene extends ResizableScene implements CenterListener {
                 coWebsiteManager.closeCoWebsite();
             }else{
                 const openWebsiteFunction = () => {
-                    coWebsiteManager.loadCoWebsite(newValue as string, allProps.get('openWebsitePolicy') as string | undefined);
+                    coWebsiteManager.loadCoWebsite(newValue as string, this.MapUrlFile, allProps.get('openWebsitePolicy') as string | undefined);
                     layoutManager.removeActionButton('openWebsite', this.userInputManager);
                 };
 

--- a/front/src/WebRtc/CoWebsiteManager.ts
+++ b/front/src/WebRtc/CoWebsiteManager.ts
@@ -42,7 +42,7 @@ class CoWebsiteManager {
         this.opened = iframeStates.opened;
     }
 
-    public loadCoWebsite(url: string, allowPolicy?: string): void {
+    public loadCoWebsite(url: string, base: string, allowPolicy?: string): void {
         this.load();
         this.cowebsiteDiv.innerHTML = `<button class="close-btn" id="cowebsite-close">
                     <img src="resources/logos/close.svg">
@@ -55,7 +55,7 @@ class CoWebsiteManager {
 
         const iframe = document.createElement('iframe');
         iframe.id = 'cowebsite-iframe';
-        iframe.src = url;
+        iframe.src = (new URL(url, base)).toString();
         if (allowPolicy) {
             iframe.allow = allowPolicy; 
         }


### PR DESCRIPTION
This PR adds support for specifying URLs relative to the map in the `openWebsite` custom property. This makes it easy to maintain simple HTML pages along with the rest of the map code in the same repository.

Before this PR, when specifying a relative URL, the `iframe` uses the current `location` as the base URL. However, the location points to the `play` submdomain and as a result, an attempt is made to start a new game instance pointing to an invalid map *inside* the `iframe`.

With this PR, the map URL is used as the base, and as a result the correct resource is loaded inside the `iframe`.