### PR TITLE
Set the public url for the front server in webpack

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
       JITSI_PRIVATE_MODE: "$JITSI_PRIVATE_MODE"
       HOST: "0.0.0.0"
       NODE_ENV: development
+      FRONT_URL: play.workadventure.localhost
       API_URL: pusher.workadventure.localhost
       UPLOADER_URL: uploader.workadventure.localhost
       ADMIN_URL: workadventure.localhost

--- a/front/package.json
+++ b/front/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "start": "webpack-dev-server --open",
-    "build": "webpack --config webpack.prod.js",
+    "build": "webpack --env.FRONT_URL=$FRONT_URL --config webpack.prod.js",
     "test": "ts-node node_modules/jasmine/bin/jasmine --config=jasmine.json",
     "lint": "node_modules/.bin/eslint src/ . --ext .ts",
     "fix": "node_modules/.bin/eslint --fix src/ . --ext .ts"

--- a/front/webpack.prod.js
+++ b/front/webpack.prod.js
@@ -1,7 +1,11 @@
 const merge = require('webpack-merge');
 const common = require('./webpack.config.js');
 
-module.exports = merge(common, {
-  mode: 'production',
-  devtool: 'source-map'
-});
+module.exports = env => {
+  console.log('FRONT_URL is: ' + env.FRONT_URL);
+  return merge(common, {
+      mode: 'production',
+      devtool: 'source-map',
+      devServer: {'public': env.FRONT_URL}
+    });
+};


### PR DESCRIPTION
Fix #574 

This adds the environment variable `FRONT_URL` to `docker-compose.yml`.