### PR TITLE
Improve display of websites not specifying background color

### DIFF
--- a/front/dist/resources/style/style.css
+++ b/front/dist/resources/style/style.css
@@ -352,6 +352,7 @@ body {
 #cowebsite {
     position: fixed;
     transition: transform 0.5s;
+    background-color: white;
 }
 #cowebsite.loading {
     background-color: gray;


### PR DESCRIPTION
The `index.html` of the front-end specifies `#000` as background color, however, it seems like various websites found 'in the wild' don't specify their own background color and thus default to `transparent`. As a result of this, they tend to become mostly unreadable when displayed using `openWebsite` since they often assume that they get displayed on a white background. Setting white as background color on the container element of the `<iframe>` works around this issue.

I've put together a small [sample map](https://play.workadventu.re/_/global/mstock.github.io/workadventure-iframe-background/map.json) to demonstrate this issue - it contains three `openWebsite` tile layers on the screens:

1. A website found 'in the wild' which does not specify a `background-color` and which becomes mostly unreadable.
2. A sample website which *does not* specify a `background-color`.
3. A sample website which *does* specify a `background-color`.