### PR TITLE
feat: Jitsi config properties

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -631,6 +631,15 @@ export class GameScene extends ResizableScene implements CenterListener {
         }
     }
 
+    private safeParseJSONstring(jsonString: string|undefined) {
+        try {
+            return jsonString ? JSON.parse(jsonString) : {};
+        } catch(e) {
+            console.warn(jsonString, e);
+            return {}
+        }
+    }
+
     private triggerOnMapLayerPropertyChange(){
         this.gameMap.onPropertyChange('exitSceneUrl', (newValue, oldValue) => {
             if (newValue) this.onMapExit(newValue as string);
@@ -669,13 +678,10 @@ export class GameScene extends ResizableScene implements CenterListener {
 
                         this.connection.emitQueryJitsiJwtMessage(this.instance.replace('/', '-') + "-" + newValue, adminTag);
                     } else {
-                        const jitsiConfig = allProps.get("jitsiConfig") as string|undefined;
-                        jitsiFactory.setJitsiConfig(jitsiConfig || undefined);
-
-                        const jitsiInterfaceConfig = allProps.get("jitsiInterfaceConfig") as string|undefined;
-                        jitsiFactory.setJitsiInterfaceConfig(jitsiInterfaceConfig || undefined);
-
-                        this.startJitsi(newValue as string);
+                        const jitsiConfig = this.safeParseJSONstring(allProps.get("jitsiConfig") as string|undefined);
+                        const jitsiInterfaceConfig = this.safeParseJSONstring(allProps.get("jitsiInterfaceConfig") as string|undefined);
+  
+                        this.startJitsi(newValue as string, undefined, jitsiConfig, jitsiInterfaceConfig);
                     }
                     layoutManager.removeActionButton('jitsiRoom', this.userInputManager);
                 }
@@ -1234,8 +1240,8 @@ export class GameScene extends ResizableScene implements CenterListener {
         this.updateCameraOffset();
     }
 
-    public startJitsi(roomName: string, jwt?: string): void {
-        jitsiFactory.start(roomName, this.playerName, jwt);
+    public startJitsi(roomName: string, jwt?: string, config: object = {}, interfaceConfig: object = {}): void {
+        jitsiFactory.start(roomName, this.playerName, jwt, config, interfaceConfig);
         this.connection.setSilent(true);
         mediaManager.hideGameOverlay();
 

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -669,11 +669,17 @@ export class GameScene extends ResizableScene implements CenterListener {
 
                         this.connection.emitQueryJitsiJwtMessage(this.instance.replace('/', '-') + "-" + newValue, adminTag);
                     } else {
+                        const jitsiConfig = allProps.get("jitsiConfig") as string|undefined;
+                        jitsiFactory.setJitsiConfig(jitsiConfig || undefined);
+
+                        const jitsiInterfaceConfig = allProps.get("jitsiInterfaceConfig") as string|undefined;
+                        jitsiFactory.setJitsiInterfaceConfig(jitsiInterfaceConfig || undefined);
+
                         this.startJitsi(newValue as string);
                     }
                     layoutManager.removeActionButton('jitsiRoom', this.userInputManager);
                 }
-
+                                       
                 const jitsiTriggerValue = allProps.get(TRIGGER_JITSI_PROPERTIES);
                 if(jitsiTriggerValue && jitsiTriggerValue === ON_ACTION_TRIGGER_BUTTON) {
                     layoutManager.addActionButton('jitsiRoom', 'Click on SPACE to enter in jitsi meet room', () => {

--- a/front/src/WebRtc/JitsiFactory.ts
+++ b/front/src/WebRtc/JitsiFactory.ts
@@ -3,6 +3,12 @@ import {mediaManager} from "./MediaManager";
 import {coWebsiteManager} from "./CoWebsiteManager";
 declare const window:any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
+const config = {               
+    startWithAudioMuted: !mediaManager.constraintsMedia.audio,
+    startWithVideoMuted: mediaManager.constraintsMedia.video === false,
+    prejoinPageEnabled: false
+}
+
 const interfaceConfig = {
     SHOW_CHROME_EXTENSION_BANNER: false,
     MOBILE_APP_PROMO: false,
@@ -26,6 +32,8 @@ const interfaceConfig = {
 };
 
 class JitsiFactory {
+    public jitsiConfig: object = config;
+    public jitsiInterfaceConfig: object = interfaceConfig;
     private jitsiApi: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     private audioCallback = this.onAudioChange.bind(this);
     private videoCallback = this.onVideoChange.bind(this);
@@ -39,12 +47,8 @@ class JitsiFactory {
                 width: "100%",
                 height: "100%",
                 parentNode: cowebsiteDiv,
-                configOverwrite: {
-                    startWithAudioMuted: !mediaManager.constraintsMedia.audio,
-                    startWithVideoMuted: mediaManager.constraintsMedia.video === false,
-                    prejoinPageEnabled: false
-                },
-                interfaceConfigOverwrite: interfaceConfig,
+                configOverwrite: this.jitsiConfig,
+                interfaceConfigOverwrite: this.jitsiInterfaceConfig
             };
             if (!options.jwt) {
                 delete options.jwt;
@@ -88,6 +92,33 @@ class JitsiFactory {
         }
     }
 
+    public setJitsiConfig(jitsiConfig: string|undefined): void {
+        if(jitsiConfig) {
+            try {
+                const parsedConfig = JSON.parse(jitsiConfig);
+                this.jitsiConfig = {...config, ...parsedConfig};
+            } catch (e) {
+                console.warn('jitsiConfig', e);
+                this.jitsiConfig = config;
+            }
+        } else {
+            this.jitsiConfig = config;
+        }
+    }
+
+    public setJitsiInterfaceConfig(jitsiInterfaceConfig: string|undefined): void {
+        if(jitsiInterfaceConfig) {
+            try {
+                const parsedInterfaceConfig = JSON.parse(jitsiInterfaceConfig);
+                this.jitsiInterfaceConfig = {...interfaceConfig, ...parsedInterfaceConfig};
+            } catch (e) {
+                console.warn('jitsiInterfaceConfig', e);
+                this.jitsiInterfaceConfig = interfaceConfig;
+            }
+        } else {
+            this.jitsiInterfaceConfig = interfaceConfig;
+        }
+    }
 }
 
 export const jitsiFactory = new JitsiFactory();

--- a/front/src/WebRtc/JitsiFactory.ts
+++ b/front/src/WebRtc/JitsiFactory.ts
@@ -3,13 +3,13 @@ import {mediaManager} from "./MediaManager";
 import {coWebsiteManager} from "./CoWebsiteManager";
 declare const window:any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
-const config = {               
+const defaultConfig = {               
     startWithAudioMuted: !mediaManager.constraintsMedia.audio,
     startWithVideoMuted: mediaManager.constraintsMedia.video === false,
     prejoinPageEnabled: false
 }
 
-const interfaceConfig = {
+const defaultInterfaceConfig = {
     SHOW_CHROME_EXTENSION_BANNER: false,
     MOBILE_APP_PROMO: false,
 
@@ -32,13 +32,11 @@ const interfaceConfig = {
 };
 
 class JitsiFactory {
-    public jitsiConfig: object = config;
-    public jitsiInterfaceConfig: object = interfaceConfig;
     private jitsiApi: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     private audioCallback = this.onAudioChange.bind(this);
     private videoCallback = this.onVideoChange.bind(this);
     
-    public start(roomName: string, playerName:string, jwt?: string): void {
+    public start(roomName: string, playerName:string, jwt?: string, config?: object, interfaceConfig?: object): void {
         coWebsiteManager.insertCoWebsite((cowebsiteDiv => {
             const domain = JITSI_URL;
             const options: any = { // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -47,8 +45,8 @@ class JitsiFactory {
                 width: "100%",
                 height: "100%",
                 parentNode: cowebsiteDiv,
-                configOverwrite: this.jitsiConfig,
-                interfaceConfigOverwrite: this.jitsiInterfaceConfig
+                configOverwrite: {...defaultConfig, ...config},
+                interfaceConfigOverwrite: {...defaultInterfaceConfig, ...interfaceConfig}
             };
             if (!options.jwt) {
                 delete options.jwt;
@@ -89,34 +87,6 @@ class JitsiFactory {
             mediaManager.disableCamera();
         } else if(!muted && mediaManager.constraintsMedia.video === false) {
             mediaManager.enableCamera();
-        }
-    }
-
-    public setJitsiConfig(jitsiConfig: string|undefined): void {
-        if(jitsiConfig) {
-            try {
-                const parsedConfig = JSON.parse(jitsiConfig);
-                this.jitsiConfig = {...config, ...parsedConfig};
-            } catch (e) {
-                console.warn('jitsiConfig', e);
-                this.jitsiConfig = config;
-            }
-        } else {
-            this.jitsiConfig = config;
-        }
-    }
-
-    public setJitsiInterfaceConfig(jitsiInterfaceConfig: string|undefined): void {
-        if(jitsiInterfaceConfig) {
-            try {
-                const parsedInterfaceConfig = JSON.parse(jitsiInterfaceConfig);
-                this.jitsiInterfaceConfig = {...interfaceConfig, ...parsedInterfaceConfig};
-            } catch (e) {
-                console.warn('jitsiInterfaceConfig', e);
-                this.jitsiInterfaceConfig = interfaceConfig;
-            }
-        } else {
-            this.jitsiInterfaceConfig = interfaceConfig;
         }
     }
 }


### PR DESCRIPTION
Given Jitsi is quite intensive on client CPU usage, being able set custom settings for each room would be very useful. 
Added 2 properties accepting JSON string format to customize Jitsi config:

- `jitsiConfig`
- `jitsiInterfaceConfig`

To disable the video background for exemple:
`jitsiInterfaceConfig` : `{"DISABLE_VIDEO_BACKGROUND":true}`
