### PR TITLE
Fix offsets of SpeechBubble.ts

### DIFF
--- a/front/src/Phaser/Entity/SpeechBubble.ts
+++ b/front/src/Phaser/Entity/SpeechBubble.ts
@@ -14,7 +14,7 @@ export class SpeechBubble {
         const bubbleWidth = bubblePadding * 2 + text.length * 10;
         const arrowHeight = bubbleHeight / 4;
 
-        this.bubble = scene.add.graphics({ x: player.x + 16, y: player.y - 80 });
+        this.bubble = scene.add.graphics({ x: 16, y: -80 });
         player.add(this.bubble);
 
         //  Bubble shadow


### PR DESCRIPTION
Since some recent optimizations, they are being added on top of the player, which makes the offset redundant.

(Also they appear to be unused - but I wanted to play around with them.)