### PR TITLE
Do not change rooms if scene failed to load

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -716,6 +716,10 @@ export class GameScene extends ResizableScene implements CenterListener {
         if (!roomId) throw new Error('Could not find the room from its exit key: '+exitKey);
         urlManager.pushStartLayerNameToUrl(hash);
         if (roomId !== this.scene.key) {
+            if (this.scene.get(roomId) === null) {
+                console.error("next room not loaded", exitKey);
+                return;
+            }
             this.cleanupClosingScene();
             this.scene.stop();
             this.scene.remove(this.scene.key);


### PR DESCRIPTION
Sometimes a following room fails to load (e.g., #582) and instead of fading to black (as no scene is active) when trying to enter that next room, the player will stay in the old room and an error is logged (as throwing one crashes the game).

(Also I hope making smaller separate PRs is the correct approach for helping, if not just tell me)