### PR TITLE
Fix jitsi URLs growing indefinitely in length

### DIFF
--- a/front/src/WebRtc/JitsiFactory.ts
+++ b/front/src/WebRtc/JitsiFactory.ts
@@ -59,6 +59,14 @@ class JitsiFactory {
 
     public start(roomName: string, playerName:string, jwt?: string, config?: object, interfaceConfig?: object): void {
         coWebsiteManager.insertCoWebsite((cowebsiteDiv => {
+            // Jitsi meet external API maintains some data in local storage
+            // which is sent via the appData URL parameter when joining a
+            // conference. Problem is that this data grows indefinitely. Thus
+            // after some time the URLs get so huge that loading the iframe
+            // becomes slow and eventually breaks completely. Thus lets just
+            // clear jitsi local storage before starting a new conference.
+            window.localStorage.removeItem("jitsiLocalStorage");
+
             const domain = JITSI_URL;
             const options: any = { // eslint-disable-line @typescript-eslint/no-explicit-any
                 roomName: roomName,


### PR DESCRIPTION
Jitsi meet external API maintains some data in local storage which is sent via the appData URL parameter when joining a conference. Problem is that this data grows indefinitely. Thus after some time the URLs get so huge that loading the iframe becomes slow and eventually breaks completely. Thus lets just clear jitsi local storage before starting a new conference.

The problematic code resides in [Jitsi External API](https://github.com/jitsi/jitsi-meet/blob/684d12115974a65b48f36c7d4fe74d8f17da6ff6/modules/API/external/external_api.js#L269-L281).

Interestingly this problem does not occur on TCM wa infrastructure. E.g., when walking through [floor0](https://play.workadventu.re/_/global/gparant.github.io/tcm-client/TCM/Floor0/floor0.json) in TCM wa, then `appData.localStorageContent` URL parameter in jitsi iframes remain `null`. When using other instances (relying on different jitsi infra), then that URL parameter grows in size every time a conference was joined.

In order to make wa work reliably in combination with most jitsies I propose to just clear the problematic local storage before an attempt is made to join a conference.