### PR TITLE
Fix report userId in report menu

### DIFF
--- a/front/src/Phaser/Menu/ReportMenu.ts
+++ b/front/src/Phaser/Menu/ReportMenu.ts
@@ -105,13 +105,13 @@ export class ReportMenu extends Phaser.GameObjects.DOMElement {
         gamePError.style.display = 'none';
         const gameTextArea = this.getChildByID('gameReportInput') as HTMLInputElement;
         const gameIdUserReported = this.getChildByID('idUserReported') as HTMLInputElement;
-        if(!gameTextArea || !gameTextArea.value || !gameIdUserReported || !gameIdUserReported.value){
+        if(!gameTextArea || !gameTextArea.value ){
             gamePError.innerText = 'Report message cannot to be empty.';
             gamePError.style.display = 'block';
             return;
         }
         gameManager.getCurrentGameScene(this.scene).connection.emitReportPlayerMessage(
-            parseInt(gameIdUserReported.value),
+            this.userId,
             gameTextArea.value
         );
         this.close();


### PR DESCRIPTION
This fixes #775 by correctly getting the userId instead of checking a nonexistent DOM element