### PR TITLE
Fix admin message and ban functionality

### DIFF
--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -204,7 +204,7 @@ const roomManager: IRoomManagerServer = {
     },
     ban(call: ServerUnaryCall<BanMessage>, callback: sendUnaryData<EmptyMessage>): void {
         // FIXME Work in progress
-        socketManager.banUser(call.request.getRoomid(), call.request.getRecipientuuid(), 'foo bar TODO change this');
+        socketManager.banUser(call.request.getRoomid(), call.request.getRecipientuuid(), 'You have been banned from the server!');
 
         callback(null, new EmptyMessage());
     },

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -809,10 +809,10 @@ export class SocketManager {
         sendUserMessage.setMessage(message);
         sendUserMessage.setType('ban');
 
-        const subToPusherMessage = new SubToPusherMessage();
-        subToPusherMessage.setSendusermessage(sendUserMessage);
 
-        recipient.socket.write(subToPusherMessage);
+        const serverToClientMessage = new ServerToClientMessage();
+        serverToClientMessage.setSendusermessage(sendUserMessage);
+        recipient.socket.write(serverToClientMessage);
     }
 
     public banUser(roomId: string, recipientUuid: string, message: string): void {
@@ -835,10 +835,9 @@ export class SocketManager {
         sendUserMessage.setMessage(message);
         sendUserMessage.setType('banned');
 
-        const subToPusherMessage = new SubToPusherMessage();
-        subToPusherMessage.setSendusermessage(sendUserMessage);
-
-        recipient.socket.write(subToPusherMessage);
+        const serverToClientMessage = new ServerToClientMessage();
+        serverToClientMessage.setSendusermessage(sendUserMessage);
+        recipient.socket.write(serverToClientMessage);
 
         // Let's close the connection when the user is banned.
         recipient.socket.end();


### PR DESCRIPTION
When trying out the ban and sendAdminMessage functions I got an error saying that GRPC expected a ServerToClientMessage. This happened on both requests. I changed from the SubToPusherMessage to a ServerToClientMessage and it seems to work nicely, so I suspect this was a bug :-) 
