### PR TITLE
Adding a "ingame console message" feature

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -675,6 +675,13 @@ export class GameScene extends ResizableScene implements CenterListener {
                 }
             }
         });
+        this.gameMap.onPropertyChange('inGameConsoleMessage', (newValue, oldValue, allProps) => {
+            if (newValue !== undefined) {
+                layoutManager.addInGameConsoleMessage('inGameConsoleMessage', newValue.toString(), "font-size: 30px;max-width: 100%; margin-left: auto;");
+            } else {
+                layoutManager.removeInGameConsoleMessage('inGameConsoleMessage');
+            }
+        });
         this.gameMap.onPropertyChange('jitsiRoom', (newValue, oldValue, allProps) => {
             if (newValue === undefined) {
                 layoutManager.removeActionButton('jitsiRoom', this.userInputManager);

--- a/front/src/WebRtc/LayoutManager.ts
+++ b/front/src/WebRtc/LayoutManager.ts
@@ -45,6 +45,8 @@ class LayoutManager {
     private actionButtonTrigger: Map<string, Function> = new Map<string, Function>();
     private actionButtonInformation: Map<string, HTMLDivElement> = new Map<string, HTMLDivElement>();
 
+    private inGameConsoleMessage: Map<string, HTMLDivElement> = new Map<string, HTMLDivElement>();
+
     public setListener(centerListener: CenterListener|null) {
         this.listener = centerListener;
     }
@@ -357,6 +359,35 @@ class LayoutManager {
         const previousEventCallback = this.actionButtonTrigger.get(id);
         if(previousEventCallback){
             userInputManager.removeSpaceEventListner(previousEventCallback);
+        }
+    }
+
+    public addInGameConsoleMessage(id: string, text: string, customStyle: string){
+        //delete previous element
+        this.removeInGameConsoleMessage(id);
+
+        //create div and text html component
+        const p = document.createElement('p');
+        p.classList.add('action-body');
+        p.innerText = text;
+        p.setAttribute("style", customStyle);
+        const div = document.createElement('div');
+        div.classList.add('action');
+        div.id = id;
+        div.appendChild(p);
+
+        this.inGameConsoleMessage.set(id, div);
+
+        const mainContainer = HtmlUtils.getElementByIdOrFail<HTMLDivElement>('main-container');
+        mainContainer.appendChild(div);
+
+    }
+    public removeInGameConsoleMessage(id: string) {
+        //delete previous element
+        const previousDiv = this.inGameConsoleMessage.get(id);
+        if(previousDiv){
+            previousDiv.remove();
+            this.inGameConsoleMessage.delete(id);
         }
     }
 }


### PR DESCRIPTION
Roughly inspired from the code used to notify the user when a website can be opened.

Here is an example of usage:

![Screenshot from 2021-02-28 14-53-25](https://user-images.githubusercontent.com/594335/109420867-faa3d280-79d4-11eb-804f-3bc6f07941eb.png)

This can be done the same way as the "open website" feature, e.g. adding a layer with some tiles, having the property "inGameConsoleMessage" with the string to display on screen.

Note: The CSS style used for the message could probably go somewhere else, but I thought it could be interesting to be able to override it. I could not manage to find the same font as the one used for the avatar name, but I expect it to be drawn into the canvas and don't get through the CSS rendering system anyway.
