### PR TITLE
Fixing GA tag not included in play domain

### DIFF
--- a/front/dist/.gitignore
+++ b/front/dist/.gitignore
@@ -1,1 +1,2 @@
 index.html
+index.tmpl.html.tmp

--- a/front/templater.sh
+++ b/front/templater.sh
@@ -2,7 +2,7 @@
 set -x
 set -o nounset errexit
 template_file_index=dist/index.tmpl.html
-generated_file_index=dist/index.html
+generated_file_index=dist/index.tmpl.html.tmp
 tmp_trackcodefile=/tmp/trackcode
 
 # To inject tracking code, you have two choices:

--- a/front/webpack.config.js
+++ b/front/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = {
     plugins: [
         new HtmlWebpackPlugin(
             {
-                template: './dist/index.tmpl.html',
+                template: './dist/index.tmpl.html.tmp',
                 minify: {
                     collapseWhitespace: true,
                     keepClosingSlash: true,


### PR DESCRIPTION
The GA tag was not properly included because the index.html file that contained it was overwritten by Webpack's HtmlWebpackPlugin.