### PR TITLE
Fix Jitsi integration

### DIFF
--- a/front/src/WebRtc/CoWebsiteManager.ts
+++ b/front/src/WebRtc/CoWebsiteManager.ts
@@ -150,7 +150,8 @@ class CoWebsiteManager {
      */
     public insertCoWebsite(callback: (cowebsite: HTMLDivElement) => Promise<void>): void {
         this.load();
-        this.currentOperationPromise = this.currentOperationPromise.then(() => callback(this.cowebsiteDiv)).then(() => {
+        this.cowebsiteMainDom.innerHTML = ``;
+        this.currentOperationPromise = this.currentOperationPromise.then(() => callback(this.cowebsiteMainDom)).then(() => {
             this.open();
             setTimeout(() => {
                 this.fire();


### PR DESCRIPTION
Jitsi iframes are rendered directly in the cowebsite div next to the
cowebsite > main element. This patch fixes the situation.