### PR TITLE
Adding Discord badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/thecodingmachine/workadventure/workflows/Continuous%20Integration/badge.svg)
+![](https://github.com/thecodingmachine/workadventure/workflows/Continuous%20Integration/badge.svg) [![Discord](https://img.shields.io/discord/821338762134290432?label=Discord)](https://discord.gg/JVVhXzcE)
 
 ![WorkAdventure landscape image](README-INTRO.jpg)
 


### PR DESCRIPTION
This should be merged only when the Discord widget mode is enabled on the server (otherwise the number of current users is not displayed)