### PR TITLE
Replaced the hard-coded URLs by variables

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,12 @@
+# Domains
+DOMAIN=workadventure.localhost
+UPLOADER_SUBDOMAIN=pusher
+UPLOADER_SUBDOMAIN=uploader
+TURN_SUBDOMAIN=coturn
+FRONT_SUBDOMAIN=play
+MAPS_SUBDOMAIN=maps
+API_SUBDOMAIN=api
+
 DEBUG_MODE=false
 JITSI_URL=meet.jit.si
 # If your Jitsi environment has authentication set up, you MUST set JITSI_PRIVATE_MODE to "true" and you MUST pass a SECRET_JITSI_KEY to generate the JWT secret

--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 # Domains
 DOMAIN=workadventure.localhost
-UPLOADER_SUBDOMAIN=pusher
+PUSHER_SUBDOMAIN=pusher
 UPLOADER_SUBDOMAIN=uploader
 TURN_SUBDOMAIN=coturn
 FRONT_SUBDOMAIN=play

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ triggered when you move next to a colleague).
 
 Install Docker.
 
+Make a copy of the `.env.template` file and name it `.env`
+
 Run:
 
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,13 +26,13 @@ services:
       JITSI_PRIVATE_MODE: "$JITSI_PRIVATE_MODE"
       HOST: "0.0.0.0"
       NODE_ENV: development
-      API_URL: pusher.workadventure.localhost
-      UPLOADER_URL: uploader.workadventure.localhost
-      ADMIN_URL: workadventure.localhost
+      API_URL: $UPLOADER_SUBDOMAIN.$DOMAIN
+      UPLOADER_URL: $UPLOADER_SUBDOMAIN.$DOMAIN
+      ADMIN_URL: $DOMAIN
       STARTUP_COMMAND_1: ./templater.sh
       STARTUP_COMMAND_2: yarn install
       STUN_SERVER: "stun:stun.l.google.com:19302"
-      TURN_SERVER: "turn:coturn.workadventure.localhost:3478,turns:coturn.workadventure.localhost:5349"
+      TURN_SERVER: "turn:$TURN_SUBDOMAIN.$DOMAIN:3478,turns:$TURN_SUBDOMAIN.$DOMAIN:5349"
       # Use TURN_USER/TURN_PASSWORD if your Coturn server is secured via hard coded credentials.
       # Advice: you should instead use Coturn REST API along the TURN_STATIC_AUTH_SECRET in the Back container
       TURN_USER: ""
@@ -42,10 +42,10 @@ services:
     volumes:
       - ./front:/usr/src/app
     labels:
-      - "traefik.http.routers.front.rule=Host(`play.workadventure.localhost`)"
+      - "traefik.http.routers.front.rule=Host(`$FRONT_SUBDOMAIN.$DOMAIN`)"
       - "traefik.http.routers.front.entryPoints=web,traefik"
       - "traefik.http.services.front.loadbalancer.server.port=8080"
-      - "traefik.http.routers.front-ssl.rule=Host(`play.workadventure.localhost`)"
+      - "traefik.http.routers.front-ssl.rule=Host(`$FRONT_SUBDOMAIN.$DOMAIN`)"
       - "traefik.http.routers.front-ssl.entryPoints=websecure"
       - "traefik.http.routers.front-ssl.tls=true"
       - "traefik.http.routers.front-ssl.service=front"
@@ -67,10 +67,10 @@ services:
     volumes:
       - ./pusher:/usr/src/app
     labels:
-      - "traefik.http.routers.pusher.rule=Host(`pusher.workadventure.localhost`)"
+      - "traefik.http.routers.pusher.rule=Host(`$UPLOADER_SUBDOMAIN.$DOMAIN`)"
       - "traefik.http.routers.pusher.entryPoints=web"
       - "traefik.http.services.pusher.loadbalancer.server.port=8080"
-      - "traefik.http.routers.pusher-ssl.rule=Host(`pusher.workadventure.localhost`)"
+      - "traefik.http.routers.pusher-ssl.rule=Host(`$UPLOADER_SUBDOMAIN.$DOMAIN`)"
       - "traefik.http.routers.pusher-ssl.entryPoints=websecure"
       - "traefik.http.routers.pusher-ssl.tls=true"
       - "traefik.http.routers.pusher-ssl.service=pusher"
@@ -90,10 +90,10 @@ services:
     volumes:
       - ./maps:/var/www/html
     labels:
-      - "traefik.http.routers.maps.rule=Host(`maps.workadventure.localhost`)"
+      - "traefik.http.routers.maps.rule=Host(`$MAPS_SUBDOMAIN.$DOMAIN`)"
       - "traefik.http.routers.maps.entryPoints=web,traefik"
       - "traefik.http.services.maps.loadbalancer.server.port=80"
-      - "traefik.http.routers.maps-ssl.rule=Host(`maps.workadventure.localhost`)"
+      - "traefik.http.routers.maps-ssl.rule=Host(`$MAPS_SUBDOMAIN.$DOMAIN`)"
       - "traefik.http.routers.maps-ssl.entryPoints=websecure"
       - "traefik.http.routers.maps-ssl.tls=true"
       - "traefik.http.routers.maps-ssl.service=maps"
@@ -115,10 +115,10 @@ services:
     volumes:
       - ./back:/usr/src/app
     labels:
-      - "traefik.http.routers.back.rule=Host(`api.workadventure.localhost`)"
+      - "traefik.http.routers.back.rule=Host(`$API_SUBDOMAIN.$DOMAIN`)"
       - "traefik.http.routers.back.entryPoints=web"
       - "traefik.http.services.back.loadbalancer.server.port=8080"
-      - "traefik.http.routers.back-ssl.rule=Host(`api.workadventure.localhost`)"
+      - "traefik.http.routers.back-ssl.rule=Host(`$API_SUBDOMAIN.$DOMAIN`)"
       - "traefik.http.routers.back-ssl.entryPoints=websecure"
       - "traefik.http.routers.back-ssl.tls=true"
       - "traefik.http.routers.back-ssl.service=back"
@@ -133,10 +133,10 @@ services:
     volumes:
       - ./uploader:/usr/src/app
     labels:
-      - "traefik.http.routers.uploader.rule=Host(`uploader.workadventure.localhost`)"
+      - "traefik.http.routers.uploader.rule=Host(`$UPLOADER_SUBDOMAIN.$DOMAIN`)"
       - "traefik.http.routers.uploader.entryPoints=web"
       - "traefik.http.services.uploader.loadbalancer.server.port=8080"
-      - "traefik.http.routers.uploader-ssl.rule=Host(`uploader.workadventure.localhost`)"
+      - "traefik.http.routers.uploader-ssl.rule=Host(`$UPLOADER_SUBDOMAIN.$DOMAIN`)"
       - "traefik.http.routers.uploader-ssl.entryPoints=websecure"
       - "traefik.http.routers.uploader-ssl.tls=true"
       - "traefik.http.routers.uploader-ssl.service=uploader"
@@ -166,8 +166,8 @@ services:
 #      - --max-port=10010
 #      - --tls-listening-port=5349
 #      - --listening-ip=0.0.0.0
-#      - --realm=coturn.workadventure.localhost
-#      - --server-name=coturn.workadventure.localhost
+#      - --realm=$TURN_SUBDOMAIN.$DOMAIN
+#      - --server-name=$TURN_SUBDOMAIN.$DOMAIN
 #      - --lt-cred-mech
 #      # Enable Coturn "REST API" to validate temporary passwords.
 #      #- --use-auth-secret

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       JITSI_PRIVATE_MODE: "$JITSI_PRIVATE_MODE"
       HOST: "0.0.0.0"
       NODE_ENV: development
-      API_URL: $UPLOADER_SUBDOMAIN.$DOMAIN
+      API_URL: $PUSHER_SUBDOMAIN.$DOMAIN
       UPLOADER_URL: $UPLOADER_SUBDOMAIN.$DOMAIN
       ADMIN_URL: $DOMAIN
       STARTUP_COMMAND_1: ./templater.sh
@@ -67,10 +67,10 @@ services:
     volumes:
       - ./pusher:/usr/src/app
     labels:
-      - "traefik.http.routers.pusher.rule=Host(`$UPLOADER_SUBDOMAIN.$DOMAIN`)"
+      - "traefik.http.routers.pusher.rule=Host(`$PUSHER_SUBDOMAIN.$DOMAIN`)"
       - "traefik.http.routers.pusher.entryPoints=web"
       - "traefik.http.services.pusher.loadbalancer.server.port=8080"
-      - "traefik.http.routers.pusher-ssl.rule=Host(`$UPLOADER_SUBDOMAIN.$DOMAIN`)"
+      - "traefik.http.routers.pusher-ssl.rule=Host(`$PUSHER_SUBDOMAIN.$DOMAIN`)"
       - "traefik.http.routers.pusher-ssl.entryPoints=websecure"
       - "traefik.http.routers.pusher-ssl.tls=true"
       - "traefik.http.routers.pusher-ssl.service=pusher"


### PR DESCRIPTION
Replace all the hard-coded URLs from the docker-compose file with env variables.
Add also one doc instruction about creating the env file needed by docker-compose.