### PR TITLE
use map tilewidth to calculate starting position instead of hardcoded value

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -817,7 +817,7 @@ export class GameScene extends ResizableScene implements CenterListener {
             const y = Math.floor(key / layer.width);
             const x = key % layer.width;
 
-            possibleStartPositions.push({x: x*32, y: y*32});
+            possibleStartPositions.push({x: x * this.mapFile.tilewidth, y: y * this.mapFile.tilewidth});
         });
         // Get a value at random amongst allowed values
         if (possibleStartPositions.length === 0) {


### PR DESCRIPTION
Calculating the starting position of a user should be using the tile width provided by the map data instead of using a hardcoded value. Otherwise the starting position in maps with another tile width (eg. 16) is offset.