### PR TITLE
front: prevent navigation on backspace-key in LoginScene

### DIFF
--- a/front/src/Phaser/Components/TextInput.ts
+++ b/front/src/Phaser/Components/TextInput.ts
@@ -15,8 +15,10 @@ export class TextInput extends Phaser.GameObjects.BitmapText {
         this.scene.input.keyboard.on('keydown', (event: KeyboardEvent) => {
             if (event.keyCode === 8 && this.text.length > 0) {
                 this.deleteLetter();
+                event.preventDefault();
             } else if ((event.keyCode === 32 || (event.keyCode >= 48 && event.keyCode <= 90)) && this.text.length < maxLength) {
                 this.addLetter(event.key);
+                event.preventDefault();
             }
             this.underLine.text = this.getUnderLineBody(this.text.length);
             onChange(this.text);


### PR DESCRIPTION
Backspace input in LoginScene triggered navigation, because event wasn't handled in TextInput.ts. This affected only users with the classic browser feature for _navigate to previous page on backspace key_.

The problem may only occurred after phaser update.