### PR TITLE
Use selected video quality during webcam initialization

### DIFF
--- a/front/src/WebRtc/MediaManager.ts
+++ b/front/src/WebRtc/MediaManager.ts
@@ -2,19 +2,14 @@ import {DivImportance, layoutManager} from "./LayoutManager";
 import {HtmlUtils} from "./HtmlUtils";
 import {discussionManager, SendMessageCallback} from "./DiscussionManager";
 import {UserInputManager} from "../Phaser/UserInput/UserInputManager";
-import {VIDEO_QUALITY_SELECT} from "../Administration/ConsoleGlobalMessageManager";
+import {localUserStore} from "../Connexion/LocalUserStore";
 import {UserSimplePeerInterface} from "./SimplePeer";
 declare const navigator:any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
-const localValueVideo = localStorage.getItem(VIDEO_QUALITY_SELECT);
-let valueVideo = 20;
-if(localValueVideo){
-    valueVideo = parseInt(localValueVideo);
-}
 let videoConstraint: boolean|MediaTrackConstraints = {
     width: { min: 640, ideal: 1280, max: 1920 },
     height: { min: 400, ideal: 720 },
-    frameRate: { ideal: valueVideo },
+    frameRate: { ideal: localUserStore.getVideoQualityValue() },
     facingMode: "user",
     resizeMode: 'crop-and-scale',
     aspectRatio: 1.777777778


### PR DESCRIPTION
The video frame rate setting is currently only working directly after you change it in the settings menu. During initialization (eg. after refresh) it tries to get the frame rate from the local storage with the key "select-video-quality". But it looks like this is some administration related setting.

I changed the code, so it gets the frame rate setting via the LocalUserStore class, which happens to use 20 as a default. So we can get rid of some lines of  code.