### PR TITLE
Creating a dedicated package for iframe API typings

### DIFF
--- a/.github/workflows/push-to-npm.yml
+++ b/.github/workflows/push-to-npm.yml
@@ -42,12 +42,15 @@ jobs:
         env:
           API_URL: "localhost:8080"
         working-directory: "front"
+
       # We build the front to generate the typings of iframe_api, then we copy those typings in a separate package.
       - name: Copy typings to package dir
         run: cp front/dist/src/iframe_api.d.ts front/packages/iframe-api-typings/iframe_api.d.ts
+
       - name: Install dependencies in package
         run: yarn install
         working-directory: "front/packages/iframe-api-typings"
+
       - name: Publish package
         run: yarn publish
         working-directory: "front/packages/iframe-api-typings"

--- a/.github/workflows/push-to-npm.yml
+++ b/.github/workflows/push-to-npm.yml
@@ -1,7 +1,5 @@
 name: Push @workadventure/iframe-api-typings to NPM
 on:
-  # TODO remove action on push
-  push: ~
   release:
     types: [created]
 jobs:
@@ -14,8 +12,19 @@ jobs:
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
-      # TODO: replace version with RELEASE tag
-      # TODO: enable declaration flag in tsconfig dynamically
+
+      - name: Edit tsconfig.json to add declarations
+        run: "sed -i 's/\"declaration\": false/\"declaration\": true/g' tsconfig.json"
+        working-directory: "front"
+
+      - name: Replace version number
+        run: 'sed -i "s#VERSION_PLACEHOLDER#${GITHUB_REF/refs\/tags\//}#g" package.json'
+        working-directory: "front/packages/iframe-api-typings"
+
+      - name: Debug package.json
+        run: cat package.json
+        working-directory: "front/packages/iframe-api-typings"
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:

--- a/.github/workflows/push-to-npm.yml
+++ b/.github/workflows/push-to-npm.yml
@@ -1,0 +1,55 @@
+name: Push @workadventure/iframe-api-typings to NPM
+on:
+  # TODO remove action on push
+  push: ~
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+      # TODO: replace version with RELEASE tag
+      # TODO: enable declaration flag in tsconfig dynamically
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+
+      - name: "Install dependencies"
+        run: yarn install
+        working-directory: "front"
+
+      - name: "Install messages dependencies"
+        run: yarn install
+        working-directory: "messages"
+
+      - name: "Build proto messages"
+        run: yarn run proto && yarn run copy-to-front
+        working-directory: "messages"
+
+      - name: "Create index.html"
+        run: ./templater.sh
+        working-directory: "front"
+
+      - name: "Build"
+        run: yarn run build
+        env:
+          API_URL: "localhost:8080"
+        working-directory: "front"
+      # We build the front to generate the typings of iframe_api, then we copy those typings in a separate package.
+      - name: Copy typings to package dir
+        run: cp front/dist/src/iframe_api.d.ts front/packages/iframe-api-typings/iframe_api.d.ts
+      - name: Install dependencies in package
+        run: yarn install
+        working-directory: "front/packages/iframe-api-typings"
+      - name: Publish package
+        run: yarn publish
+        working-directory: "front/packages/iframe-api-typings"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/front/packages/iframe-api-typings/.gitignore
+++ b/front/packages/iframe-api-typings/.gitignore
@@ -1,0 +1,1 @@
+iframe_api.d.ts

--- a/front/packages/iframe-api-typings/README.md
+++ b/front/packages/iframe-api-typings/README.md
@@ -1,0 +1,27 @@
+<h1 align="center">WorkAdventure - IFrame API typings for Typescript</h1>
+
+<p align="center">This package contains Typescript typings for <a href="https://workadventu.re/map-building/scripting">WorkAdventure's map scripting API</a></p>
+
+<hr/>
+
+[WorkAdventure](https://workadventu.re) comes with a scripting API. Using this API, you can add some intelligence to your map.
+You use this API by loading an external script directly from WorkAdventure (at https://play.workadventu.re/iframe_api.js), or this script is loaded
+for you if you are using the "script" property of a map.
+
+This project contains Typescript typings for the `WA` object provided by this script.
+
+## Usage
+
+This package is only useful if you are using Typescript to script your WorkAdventure maps.
+
+## Download & Installation
+
+```shell
+$ npm install @workadventure/iframe-api-typings
+```
+
+or
+
+```shell
+$ yarn add @workadventure/iframe-api-typings
+```

--- a/front/packages/iframe-api-typings/iframe_api.js
+++ b/front/packages/iframe-api-typings/iframe_api.js
@@ -1,0 +1,1 @@
+// This file is voluntarily empty.

--- a/front/packages/iframe-api-typings/package.json
+++ b/front/packages/iframe-api-typings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workadventure/iframe-api-typings",
-  "version": "1.2.0",
+  "version": "VERSION_PLACEHOLDER",
   "description": "Typescript typings for WorkAdventure iFrame API",
   "main": "iframe_api.js",
   "types": "iframe_api.d.ts",

--- a/front/packages/iframe-api-typings/package.json
+++ b/front/packages/iframe-api-typings/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@workadventure/iframe-api-typings",
+  "version": "1.2.0",
+  "description": "Typescript typings for WorkAdventure iFrame API",
+  "main": "iframe_api.js",
+  "types": "iframe_api.d.ts",
+  "repository": "https://github.com/thecodingmachine/workadventure/",
+  "author": "David Négrier <d.negrier@thecodingmachine.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "node",
     "module": "CommonJS",
     "target": "ES2015",
-    "declaration": true,
+    "declaration": false,
     "downlevelIteration": true,
     "jsx": "react",
     "allowJs": true,

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "module": "CommonJS",
     "target": "ES2015",
+    "declaration": true,
     "downlevelIteration": true,
     "jsx": "react",
     "allowJs": true,


### PR DESCRIPTION
If users are willing to use Typescript to develop scripts for maps, they will need typings for the `WA` object.
This PR creates a new package (@workadventure/iframe-api-typings) that contains only the `iframe_api.d.ts` file.

The file is generated from the build of the front and isolated in this package.
This is necessary because the iframe_api.js file is supposed to always be loaded from WorkAdventure directly (and there is no @workadventure/iframe-api package and there will never be one)