### PR TITLE
Fix first login with empty local storage

### DIFF
--- a/front/src/Connexion/LocalUser.ts
+++ b/front/src/Connexion/LocalUser.ts
@@ -14,8 +14,8 @@ export function isUserNameValid(value: string): boolean {
     return regexp.test(value);
 }
 
-export function areCharacterLayersValid(value: string[]): boolean {
-    if (!value.length) return false;
+export function areCharacterLayersValid(value: string[] | null): boolean {
+    if (!value || !value.length) return false;
     for (let i = 0; i < value.length; i++) {
         if (/^\w+$/.exec(value[i]) === null) {
             return false;


### PR DESCRIPTION
During first login on a new domain the local storage is empty. This led
to a TypeError and hence blank black screen.