### PR TITLE
FIX: the deploy action now only start when the label 'deploy' is applied to the PR

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,7 +1,9 @@
 name: Build, push and deploy Docker image
 
 on:
-  - push
+  pull_request:
+    types: [ labeled, synchronize ]
+
 
 # Enables BuildKit
 env:
@@ -10,7 +12,7 @@ env:
 jobs:
 
   build-front:
-
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -34,7 +36,7 @@ jobs:
           add_git_labels: true
 
   build-back:
-
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -57,7 +59,7 @@ jobs:
           add_git_labels: true
 
   build-pusher:
-
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -80,7 +82,7 @@ jobs:
           add_git_labels: true
 
   build-uploader:
-
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -103,7 +105,7 @@ jobs:
           add_git_labels: true
 
   build-maps:
-
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,7 +1,8 @@
 name: Cleanup images and environments
 
 on:
-  - delete
+  pull_request:
+    types: [ closed ]
 
 # Enables BuildKit
 env:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -3,8 +3,11 @@
 name: "Continuous Integration"
 
 on:
-  - "pull_request"
-  - "push"
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
 
 jobs:
 


### PR DESCRIPTION
Deploying a new CD environment in every MR, on every push is wasteful and not always useful.
This PR tweaks the deploy action to only start when the label 'deploy' is applied to the PR (or when a PR with this label is synchronized).

It also improve the triggers for the CI and cleanup workflows: cleanup now trigger when the PR is closed rather than when the branch is deleted.