### PR TITLE
script api can add menu commands

### DIFF
--- a/front/src/Api/Events/MenuItemClickedEvent.ts
+++ b/front/src/Api/Events/MenuItemClickedEvent.ts
@@ -1,0 +1,10 @@
+import * as tg from "generic-type-guard";
+
+export const isMenuItemClickedEvent =
+    new tg.IsInterface().withProperties({
+        menuItem: tg.isString
+    }).get();
+/**
+ * A message sent from the game to the iFrame when a user enters or leaves a zone marked with the "zone" property.
+ */
+export type MenuItemClickedEvent = tg.GuardedType<typeof isMenuItemClickedEvent>;

--- a/front/src/Api/Events/MenuItemRegisterEvent.ts
+++ b/front/src/Api/Events/MenuItemRegisterEvent.ts
@@ -1,0 +1,10 @@
+import * as tg from "generic-type-guard";
+
+export const isMenuItemRegisterEvent =
+    new tg.IsInterface().withProperties({
+        menutItem: tg.isString
+    }).get();
+/**
+ * A message sent from the game to the iFrame when a user enters or leaves a zone marked with the "zone" property.
+ */
+export type MenuItemRegisterEvent = tg.GuardedType<typeof isMenuItemRegisterEvent>;

--- a/front/src/Api/IframeListener.ts
+++ b/front/src/Api/IframeListener.ts
@@ -12,6 +12,8 @@ import {ClosePopupEvent, isClosePopupEvent} from "./Events/ClosePopupEvent";
 import {scriptUtils} from "./ScriptUtils";
 import {GoToPageEvent, isGoToPageEvent} from "./Events/GoToPageEvent";
 import {isOpenCoWebsite, OpenCoWebSiteEvent} from "./Events/OpenCoWebSiteEvent";
+import { isMenuItemRegisterEvent } from './Events/MenuItemRegisterEvent';
+import { MenuItemClickedEvent } from './Events/MenuItemClickedEvent';
 
 
 /**
@@ -52,6 +54,8 @@ class IframeListener {
     private readonly _removeBubbleStream: Subject<void> = new Subject();
     public readonly removeBubbleStream = this._removeBubbleStream.asObservable();
 
+    private readonly _registerMenuCommandStream: Subject<string> = new Subject();
+    public readonly registerMenuCommandStream = this._registerMenuCommandStream.asObservable();
     private readonly iframes = new Set<HTMLIFrameElement>();
     private readonly scripts = new Map<string, HTMLIFrameElement>();
 
@@ -103,6 +107,8 @@ class IframeListener {
                 }
                 else if (payload.type === 'removeBubble'){
                     this._removeBubbleStream.next();
+                } else if (payload.type == "registerMenuCommand" && isMenuItemRegisterEvent(payload.data)) {
+                    this._registerMenuCommandStream.next(payload.data.menutItem)
                 }
             }
 
@@ -185,6 +191,15 @@ class IframeListener {
         iframe.remove();
 
         this.scripts.delete(scriptUrl);
+    }
+
+    sendMenuClickedEvent(menuItem: string) {
+        this.postMessage({
+            'type': 'menuItemClicked',
+            'data': {
+                menuItem: menuItem,
+            } as MenuItemClickedEvent
+        });
     }
 
     sendUserInputChat(message: string) {

--- a/front/src/iframe_api.ts
+++ b/front/src/iframe_api.ts
@@ -9,6 +9,8 @@ import {ClosePopupEvent} from "./Api/Events/ClosePopupEvent";
 import {OpenTabEvent} from "./Api/Events/OpenTabEvent";
 import {GoToPageEvent} from "./Api/Events/GoToPageEvent";
 import {OpenCoWebSiteEvent} from "./Api/Events/OpenCoWebSiteEvent";
+import { isMenuItemClickedEvent } from './Api/Events/MenuItemClickedEvent';
+import { MenuItemRegisterEvent } from './Api/Events/MenuItemRegisterEvent';
 
 interface WorkAdventureApi {
     sendChatMessage(message: string, author: string): void;
@@ -24,6 +26,7 @@ interface WorkAdventureApi {
     restorePlayerControl() : void;
     displayBubble() : void;
     removeBubble() : void;
+    registerMenuCommand(commandDescriptor: string, callback: (commandDescriptor: string) => void): void
 }
 
 declare global {
@@ -40,7 +43,7 @@ const enterStreams: Map<string, Subject<EnterLeaveEvent>> = new Map<string, Subj
 const leaveStreams: Map<string, Subject<EnterLeaveEvent>> = new Map<string, Subject<EnterLeaveEvent>>();
 const popups: Map<number, Popup> = new Map<number, Popup>();
 const popupCallbacks: Map<number, Map<number, ButtonClickedCallback>> = new Map<number, Map<number, ButtonClickedCallback>>();
-
+const menuCallbacks: Map<string, (command: string) => void> = new Map()
 let popupId = 0;
 interface ButtonDescriptor {
     /**
@@ -172,6 +175,16 @@ window.WA = {
         popups.set(popupId, popup)
         return popup;
     },
+
+    registerMenuCommand(commandDescriptor: string, callback: (commandDescriptor: string) => void) {
+        menuCallbacks.set(commandDescriptor, callback);
+        window.parent.postMessage({
+            'type': 'registerMenuCommand',
+            'data': {
+                menutItem: commandDescriptor
+            } as MenuItemRegisterEvent
+        }, '*');
+    },
     /**
      * Listen to messages sent by the local user, in the chat.
      */
@@ -224,8 +237,12 @@ window.addEventListener('message', message => {
             if (callback) {
                 callback(popup);
             }
+        } else if (payload.type == "menuItemClicked" && isMenuItemClickedEvent(payload.data)) {
+            const callback = menuCallbacks.get(payload.data.menuItem);
+            if (callback) {
+                callback(payload.data.menuItem)
+            }
         }
-
     }
 
     // ...


### PR DESCRIPTION
allows user scripts to register their own menu optinos with callbacks

used for global triggers

for example you can register "help"
```
let chatbotEnabled=false
WA.registerMenuCommand('help', () => {
    chatbotEnabled=true;
    WA.onChatMessage ...
});
```
to enable a chat bot or similar