### PR TITLE
Adding templater call to single domain startup

### DIFF
--- a/docker-compose.single-domain.yaml
+++ b/docker-compose.single-domain.yaml
@@ -30,7 +30,8 @@ services:
       UPLOADER_URL: /uploader
       ADMIN_URL: /admin
       MAPS_URL: /maps
-      STARTUP_COMMAND_1: yarn install
+      STARTUP_COMMAND_1: ./templater.sh
+      STARTUP_COMMAND_2: yarn install
       TURN_SERVER: "turn:localhost:3478,turns:localhost:5349"
       # Use TURN_USER/TURN_PASSWORD if your Coturn server is secured via hard coded credentials.
       # Advice: you should instead use Coturn REST API along the TURN_STATIC_AUTH_SECRET in the Back container


### PR DESCRIPTION
The docker-compose.single-domain.yaml was missing a call to the templater script.
As a result, the first run would fail unless docker-compose.yaml was started before.

Closes #947
Closes #957