### PR TITLE
fixed typing in chat still causes character to move

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -435,8 +435,8 @@ export class GameScene extends ResizableScene implements CenterListener {
 
 
         //create input to move
-        mediaManager.setUserInputManager(this.userInputManager);
         this.userInputManager = new UserInputManager(this);
+        mediaManager.setUserInputManager(this.userInputManager);
 
         if (localUserStore.getFullscreen()) {
             document.querySelector('body')?.requestFullscreen();


### PR DESCRIPTION
userInputManager was always undefined


🤔 there is another bug where if you click on the game canvas the **focus event of the chat input field gets called instead of the blur** ?! so you currently always have to completely clsoe chat to get back into the game