### PR TITLE
Fixing "camera popup" always display on resize

### DIFF
--- a/front/src/Phaser/Menu/HelpCameraSettingsScene.ts
+++ b/front/src/Phaser/Menu/HelpCameraSettingsScene.ts
@@ -109,15 +109,18 @@ export class HelpCameraSettingsScene extends DirtyScene {
 
     public onResize(ev: UIEvent): void {
         super.onResize(ev);
-        const middleX = this.getMiddleX();
-        const middleY = this.getMiddleY();
-        this.tweens.add({
-            targets: this.helpCameraSettingsElement,
-            x: middleX,
-            y: middleY,
-            duration: 1000,
-            ease: 'Power3'
-        });
+        if (this.helpCameraSettingsOpened) {
+            const middleX = this.getMiddleX();
+            const middleY = this.getMiddleY();
+            this.tweens.add({
+                targets: this.helpCameraSettingsElement,
+                x: middleX,
+                y: middleY,
+                duration: 1000,
+                ease: 'Power3'
+            });
+            this.dirty = true;
+        }
     }
 
     private getMiddleX() : number{


### PR DESCRIPTION
This fixes a bug where the "camera popup" window was always displayed when the screen was resized.