### PR TITLE
allow start urls to be different

### DIFF
--- a/front/src/Connexion/ConnectionManager.ts
+++ b/front/src/Connexion/ConnectionManager.ts
@@ -1,11 +1,12 @@
 import Axios from "axios";
-import {PUSHER_URL, START_ROOM_URL} from "../Enum/EnvironmentVariable";
-import {RoomConnection} from "./RoomConnection";
+import { PUSHER_URL, START_ROOM_URL } from "../Enum/EnvironmentVariable";
+import { RoomConnection } from "./RoomConnection";
 import type {OnConnectInterface, PositionInterface, ViewportInterface} from "./ConnexionModels";
-import {GameConnexionTypes, urlManager} from "../Url/UrlManager";
-import {localUserStore} from "./LocalUserStore";
-import {LocalUser} from "./LocalUser";
-import {Room} from "./Room";
+import { GameConnexionTypes, urlManager } from "../Url/UrlManager";
+import { localUserStore } from "./LocalUserStore";
+import { LocalUser } from "./LocalUser";
+import { Room } from "./Room";
+import { uuidv4 } from '../utility/uuid';
 
 
 class ConnectionManager {
@@ -62,7 +63,7 @@ class ConnectionManager {
             }
             let roomId: string
             if (connexionType === GameConnexionTypes.empty) {
-                roomId = START_ROOM_URL;
+                roomId = START_ROOM_URL.replace(new RegExp(':uuid', 'g'), () => uuidv4());
             } else {
                 roomId = window.location.pathname + window.location.search + window.location.hash;
             }

--- a/front/src/utility/uuid.ts
+++ b/front/src/utility/uuid.ts
@@ -1,0 +1,6 @@
+export function uuidv4() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+        const r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+}


### PR DESCRIPTION
in tutorial maps users may be confused by other people showing up to mitigate this we should allow the startmap url to be somwhat randomized 

i also looked into being able to redirect mapurls on the backend with a simple 302 but phaser does no reemit the new url which means following requests would fail

i did start an issue at phaser to pass the responseURL back though