### PR TITLE
Making sure Physics is not enabled several times

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -186,6 +186,7 @@ export class GameScene extends DirtyScene implements CenterListener {
     private popUpElements : Map<number, DOMElement> = new Map<number, Phaser.GameObjects.DOMElement>();
     private originalMapUrl: string|undefined;
     private pinchManager: PinchManager|undefined;
+    private physicsEnabled: boolean = true;
     private mapTransitioning: boolean = false; //used to prevent transitions happenning at the same time.
     private onVisibilityChangeCallback: () => void;
 
@@ -1088,6 +1089,7 @@ ${escapedMessage}
 
     createCollisionWithPlayer() {
         this.physics.disableUpdate();
+        this.physicsEnabled = false;
         //add collision layer
         this.Layers.forEach((Layer: Phaser.Tilemaps.TilemapLayer) => {
             this.physics.add.collider(this.CurrentPlayer, Layer, (object1: GameObject, object2: GameObject) => {
@@ -1227,11 +1229,14 @@ ${escapedMessage}
         this.CurrentPlayer.moveUser(delta);
         if (this.CurrentPlayer.isMoving()) {
             this.dirty = true;
-            this.physics.enableUpdate();
-        } else {
+            if (!this.physicsEnabled) {
+                this.physics.enableUpdate();
+                this.physicsEnabled = true;
+            }
+        } else if (this.physicsEnabled) {
             this.physics.disableUpdate();
+            this.physicsEnabled = false;
         }
-
 
         // Let's handle all events
         while (this.pendingEvents.length !== 0) {


### PR DESCRIPTION
As part of an energy saving measure, we started disabling physics when the character is not moving and enabling physics again only when the character moves.
However, we enabled Physics on each frame the characeter was moving.
As a result, the Physics system would run several times, slowly slowing the computer down.

This fixes this issue by adding a flag to only enable Physics once.