### PR TITLE
Removing parsing of TSX files in "maps" container

### DIFF
--- a/maps/tsconfig.json
+++ b/maps/tsconfig.json
@@ -20,5 +20,8 @@
 
     "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
     "noFallthroughCasesInSwitch": true        /* Report errors for fallthrough cases in switch statement. */
-  }
+  },
+  "include": [
+    "**/*.ts"
+  ]
 }


### PR DESCRIPTION
The TSX extension is used by Typescript (for JSX like files) but ALSO by Tiled (for tilesets).
We don't need the Typescript TSX files so this PR is preventing Typescript from parsing those files in the "maps" container.