### PR TITLE
Fixing buttons design

### DIFF
--- a/front/src/Components/CameraControls.svelte
+++ b/front/src/Components/CameraControls.svelte
@@ -35,21 +35,21 @@
 </script>
 
 <div class="btn-cam-action">
-    <div class="btn-monitor" on:click={screenSharingClick} class:hide={!$screenSharingAvailableStore}>
+    <div class="btn-monitor" on:click={screenSharingClick} class:hide={!$screenSharingAvailableStore} class:enabled={$requestedScreenSharingState}>
         {#if $requestedScreenSharingState}
             <img src={monitorImg} alt="Start screen sharing">
         {:else}
             <img src={monitorCloseImg} alt="Stop screen sharing">
         {/if}
     </div>
-    <div class="btn-video" on:click={cameraClick}>
+    <div class="btn-video" on:click={cameraClick} class:disabled={!$requestedCameraState}>
         {#if $requestedCameraState}
             <img src={cinemaImg} alt="Turn on webcam">
         {:else}
             <img src={cinemaCloseImg} alt="Turn off webcam">
         {/if}
     </div>
-    <div class="btn-micro" on:click={microphoneClick}>
+    <div class="btn-micro" on:click={microphoneClick} class:disabled={!$requestedMicrophoneState}>
         {#if $requestedMicrophoneState}
             <img src={microphoneImg} alt="Turn on microphone">
         {:else}


### PR DESCRIPTION
Fixing the color of camera/microphone/screen sharing buttons that was broken following the migration to Svelte