### PR TITLE
Fixing Safari on MacOS compatibility

### DIFF
--- a/front/src/Components/EnableCamera/HorizontalSoundMeterWidget.svelte
+++ b/front/src/Components/EnableCamera/HorizontalSoundMeterWidget.svelte
@@ -10,9 +10,11 @@
 
     let timeout;
     const soundMeter = new SoundMeter();
+    let display = false;
 
     $: {
         if (stream && stream.getAudioTracks().length > 0) {
+            display = true;
             soundMeter.connectToSource(stream, new AudioContext());
 
             if (timeout) {
@@ -28,6 +30,8 @@
                 }
             }, 100);
 
+        } else {
+            display = false;
         }
     }
 
@@ -53,7 +57,7 @@
 </script>
 
 
-<div class="horizontal-sound-meter" class:active={stream?.getAudioTracks().length > 0}>
+<div class="horizontal-sound-meter" class:active={display}>
     {#each [...Array(NB_BARS).keys()] as i}
         <div style={color(i, volume)}></div>
     {/each}

--- a/front/src/Components/SoundMeterWidget.svelte
+++ b/front/src/Components/SoundMeterWidget.svelte
@@ -10,9 +10,11 @@
 
     let timeout;
     const soundMeter = new SoundMeter();
+    let display = false;
 
     $: {
         if (stream && stream.getAudioTracks().length > 0) {
+            display = true;
             soundMeter.connectToSource(stream, new AudioContext());
 
             if (timeout) {
@@ -28,6 +30,8 @@
                 }
             }, 100);
 
+        } else {
+            display = false;
         }
     }
 
@@ -40,7 +44,7 @@
 </script>
 
 
-<div class="sound-progress" class:active={stream?.getAudioTracks().length > 0}>
+<div class="sound-progress" class:active={display}>
     <span class:active={volume > 1}></span>
     <span class:active={volume > 2}></span>
     <span class:active={volume > 3}></span>

--- a/front/src/Stores/MediaStore.ts
+++ b/front/src/Stores/MediaStore.ts
@@ -423,7 +423,7 @@ export const localStreamStore = derived<Readable<MediaStreamConstraints>, LocalS
             //throw new Error('Unable to access your camera or microphone. Your browser is too old.');
             set({
                 type: 'error',
-                error: new Error('Unable to access your camera or microphone. Your browser is too old.'),
+                error: new Error('Unable to access your camera or microphone. Your browser is too old. Please consider upgrading your browser or try using a recent version of Chrome.'),
                 constraints
             });
             return;

--- a/front/src/Stores/MediaStore.ts
+++ b/front/src/Stores/MediaStore.ts
@@ -418,6 +418,7 @@ export const localStreamStore = derived<Readable<MediaStreamConstraints>, LocalS
                 error: new Error('Unable to access your camera or microphone. You need to use a HTTPS connection.'),
                 constraints
             });
+            return;
         } else {
             //throw new Error('Unable to access your camera or microphone. Your browser is too old.');
             set({
@@ -425,6 +426,7 @@ export const localStreamStore = derived<Readable<MediaStreamConstraints>, LocalS
                 error: new Error('Unable to access your camera or microphone. Your browser is too old.'),
                 constraints
             });
+            return;
         }
     }
 

--- a/front/src/WebRtc/MediaManager.ts
+++ b/front/src/WebRtc/MediaManager.ts
@@ -440,10 +440,30 @@ export class MediaManager {
     public getNotification(){
         //Get notification
         if (!DISABLE_NOTIFICATIONS && window.Notification && Notification.permission !== "granted") {
-            Notification.requestPermission().catch((err) => {
-                console.error(`Notification permission error`, err);
-            });
+            if (this.checkNotificationPromise()) {
+                Notification.requestPermission().catch((err) => {
+                    console.error(`Notification permission error`, err);
+                });
+            } else {
+                Notification.requestPermission();
+            }
         }
+    }
+
+    /**
+     * Return true if the browser supports the modern version of the Notification API (which is Promise based) or false
+     * if we are on Safari...
+     *
+     * See https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API
+     */
+    private checkNotificationPromise(): boolean {
+        try {
+            Notification.requestPermission().then();
+        } catch(e) {
+            return false;
+        }
+
+        return true;
     }
 
     public createNotification(userName: string){


### PR DESCRIPTION
The null safe operator is not recognized and was not encoded by Webpack in Svelte expressions (inside {})

+ The Notification API of Safari is old and broken and we need to account for that.