### PR TITLE
Preventing crash on iOS

### DIFF
--- a/front/src/WebRtc/MediaManager.ts
+++ b/front/src/WebRtc/MediaManager.ts
@@ -129,7 +129,11 @@ export class MediaManager {
     }
 
     addActiveVideo(user: UserSimplePeerInterface, userName: string = ""){
-        this.webrtcInAudio.play();
+        try {
+            this.webrtcInAudio.play();
+        } catch(e) {
+            console.error(e);
+        }
         const userId = ''+user.userId
 
         userName = userName.toUpperCase();
@@ -278,7 +282,11 @@ export class MediaManager {
     }
 
     playWebrtcOutSound(): void {
-        this.webrtcOutAudio.play();
+        try {
+            this.webrtcOutAudio.play();
+        } catch(e) {
+            console.error(e);
+        }
     }
 
     isConnecting(userId: string): void {


### PR DESCRIPTION
On iOS, audio elements must be triggered by a user gesture.
We are catching exceptions thrown in order not to crash.

In the future, we need to find another way to play sounds.

Closes #1104 