### PR TITLE
Attempt to switch bubble sound playing into Phaser

### DIFF
--- a/front/dist/index.tmpl.html
+++ b/front/dist/index.tmpl.html
@@ -91,12 +91,6 @@
 
         <div id="activeScreenSharing" class="active-screen-sharing active">
         </div>
-        <audio id="audio-webrtc-in">
-            <source src="/resources/objects/webrtc-in.mp3" type="audio/mp3">
-        </audio>
-        <audio id="audio-webrtc-out">
-            <source src="/resources/objects/webrtc-out.mp3" type="audio/mp3">
-        </audio>
         <audio id="report-message">
             <source src="/resources/objects/report-message.mp3" type="audio/mp3">
         </audio>

--- a/front/src/Administration/TypeMessage.ts
+++ b/front/src/Administration/TypeMessage.ts
@@ -44,7 +44,13 @@ export class TypeMessageExt implements TypeMessageInterface{
         mainSectionDiv.appendChild(div);
 
         const reportMessageAudio = HtmlUtils.getElementByIdOrFail<HTMLAudioElement>('report-message');
-        reportMessageAudio.play();
+        // FIXME: this will fail on iOS
+        // We should move the sound playing into the GameScene and listen to the event of a report using a store
+        try {
+            reportMessageAudio.play();
+        } catch (e) {
+            console.error(e);
+        }
 
         this.nbSecond = this.maxNbSecond;
         setTimeout((c) => {

--- a/front/src/WebRtc/MediaManager.ts
+++ b/front/src/WebRtc/MediaManager.ts
@@ -23,10 +23,8 @@ export type HelpCameraSettingsCallBack = () => void;
 
 export class MediaManager {
     private remoteVideo: Map<string, HTMLVideoElement> = new Map<string, HTMLVideoElement>();
-    webrtcInAudio: HTMLAudioElement;
     //FIX ME SOUNDMETER: check stalability of sound meter calculation
     //mySoundMeterElement: HTMLDivElement;
-    private webrtcOutAudio: HTMLAudioElement;
     startScreenSharingCallBacks : Set<StartScreenSharingCallback> = new Set<StartScreenSharingCallback>();
     stopScreenSharingCallBacks : Set<StopScreenSharingCallback> = new Set<StopScreenSharingCallback>();
     showReportModalCallBacks : Set<ShowReportCallBack> = new Set<ShowReportCallBack>();
@@ -43,11 +41,6 @@ export class MediaManager {
     private soundMeterElements: Map<string, HTMLDivElement> = new Map<string, HTMLDivElement>();*/
 
     constructor() {
-
-        this.webrtcInAudio = HtmlUtils.getElementByIdOrFail<HTMLAudioElement>('audio-webrtc-in');
-        this.webrtcOutAudio = HtmlUtils.getElementByIdOrFail<HTMLAudioElement>('audio-webrtc-out');
-        this.webrtcInAudio.volume = 0.2;
-        this.webrtcOutAudio.volume = 0.2;
 
         this.pingCameraStatus();
 
@@ -129,11 +122,6 @@ export class MediaManager {
     }
 
     addActiveVideo(user: UserSimplePeerInterface, userName: string = ""){
-        try {
-            this.webrtcInAudio.play();
-        } catch(e) {
-            console.error(e);
-        }
         const userId = ''+user.userId
 
         userName = userName.toUpperCase();
@@ -279,14 +267,6 @@ export class MediaManager {
     }
     removeActiveScreenSharingVideo(userId: string) {
         this.removeActiveVideo(this.getScreenSharingId(userId))
-    }
-
-    playWebrtcOutSound(): void {
-        try {
-            this.webrtcOutAudio.play();
-        } catch(e) {
-            console.error(e);
-        }
     }
 
     isConnecting(userId: string): void {

--- a/front/src/WebRtc/MediaManager.ts
+++ b/front/src/WebRtc/MediaManager.ts
@@ -129,7 +129,11 @@ export class MediaManager {
     }
 
     addActiveVideo(user: UserSimplePeerInterface, userName: string = ""){
-        this.webrtcInAudio.play();
+        try {
+            this.webrtcInAudio.play();
+        } catch(e) {
+            console.error(e);
+        }
         const userId = ''+user.userId
 
         userName = userName.toUpperCase();
@@ -278,7 +282,11 @@ export class MediaManager {
     }
 
     playWebrtcOutSound(): void {
-        this.webrtcOutAudio.play();
+        try {
+            this.webrtcOutAudio.play();
+        } catch(e) {
+            console.error(e);
+        }
     }
 
     isConnecting(userId: string): void {

--- a/front/src/WebRtc/SimplePeer.ts
+++ b/front/src/WebRtc/SimplePeer.ts
@@ -246,7 +246,6 @@ export class SimplePeer {
      * This is triggered twice. Once by the server, and once by a remote client disconnecting
      */
     private closeConnection(userId : number) {
-        mediaManager.playWebrtcOutSound();
         try {
             const peer = this.PeerConnectionArray.get(userId);
             if (peer === undefined) {


### PR DESCRIPTION
In iOS, we cannot trigger a playing sound if it does not start from a user gesture.
This is a huge bummer for a notification sound!

This is an attempt to switch sound playing to Phaser, which is using under the hood the WebAudio API.
This might solve the issue.