### PR TITLE
Disable screensharing button if user refuses rights

### DIFF
--- a/front/src/Stores/ScreenSharingStore.ts
+++ b/front/src/Stores/ScreenSharingStore.ts
@@ -169,6 +169,7 @@ export const screenSharingLocalStreamStore = derived<Readable<MediaStreamConstra
             return;
         } catch (e) {
             currentStream = null;
+            requestedScreenSharingState.disableScreenSharing();
             console.info("Error. Unable to share screen.", e);
             set({
                 type: 'error',


### PR DESCRIPTION
If the user refuses the popup to screen-share, we should switch back the button to gray.

Closes #1179