### PR TITLE
Trying to find iframe_api.js URL script dynamically

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -199,4 +199,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: Environment deployed at https://play-${{ env.GITHUB_HEAD_REF_SLUG }}.test.workadventu.re
+          msg: "Environment deployed at https://play-${{ env.GITHUB_HEAD_REF_SLUG }}.test.workadventu.re \nTests available at https://maps-${{ env.GITHUB_HEAD_REF_SLUG }}.test.workadventu.re/tests"

--- a/maps/tests/iframe.html
+++ b/maps/tests/iframe.html
@@ -1,22 +1,31 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script src="http://play.workadventure.localhost/iframe_api.js"></script>
+
+        <script>
+            var script = document.createElement('script');
+            script.setAttribute('src', document.referrer + 'iframe_api.js');
+            script.defer = false;
+            script.async = false;
+            document.head.appendChild(script);
+        </script>
     </head>
     <body>
         <button id="sendchat">Send chat message</button>
         <script>
             document.getElementById('sendchat').onclick = () => {
-                WA.sendChatMessage('Hello world!', 'Mr ROBOT');
+                WA.chat.sendChatMessage('Hello world!', 'Mr ROBOT');
             }
         </script>
         <div id="chatSent"></div>
         <script>
-            WA.onChatMessage((message => {
-                const chatDiv = document.createElement('p');
-                chatDiv.innerText = message;
-                document.getElementById('chatSent').append(chatDiv);
-            }));
+            window.addEventListener('load', () => {
+                WA.chat.onChatMessage((message => {
+                    const chatDiv = document.createElement('p');
+                    chatDiv.innerText = message;
+                    document.getElementById('chatSent').append(chatDiv);
+                }));
+            })
         </script>
     </body>
 </html>

--- a/maps/tests/iframe.html
+++ b/maps/tests/iframe.html
@@ -1,12 +1,11 @@
 <!doctype html>
 <html lang="en">
     <head>
-
         <script>
             var script = document.createElement('script');
+            // Don't do this at home kids! The "document.referrer" part is actually inserting a XSS security.
+            // We are OK in this precise case because the HTML page is hosted on the "maps" domain that contains only static files.
             script.setAttribute('src', document.referrer + 'iframe_api.js');
-            script.defer = false;
-            script.async = false;
             document.head.appendChild(script);
         </script>
     </head>

--- a/maps/tests/index.html
+++ b/maps/tests/index.html
@@ -4,7 +4,7 @@
     </head>
     <body>
         <label>Base test URL:</label>
-        <input id="baseurl" type="text" value="http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/" />
+        <input id="baseurl" type="text" value="" />
         <table>
             <tr>
                 <th>Result</th>
@@ -166,6 +166,21 @@
 
         <script>
             const baseInput = document.getElementById('baseurl');
+
+            let host = window.location.host;
+            let playHost;
+            if (host.startsWith('maps-')) {
+                playHost = 'play-'+host.substr(5);
+            } else if (host.startsWith('maps.')) {
+                playHost = 'play.'+host.substr(5);
+            } else {
+                playHost = 'localhost';
+            }
+
+            let completeUrl = window.location.protocol + '//' + playHost + '/_/global/' + host + window.location.pathname;
+
+            baseInput.value = completeUrl;
+
             baseInput.addEventListener('change', init);
 
             function init() {


### PR DESCRIPTION
This would allow us to have tests that don't rely on the iframe_api.js from prod, and would allow scripts that target the correct iframe API, no matter if they are running on workadventu.re or on self-hosted maps.