### PR TITLE
Removing the 'search' parameters from the room URL sent to pusher

### DIFF
--- a/front/src/Connexion/Room.ts
+++ b/front/src/Connexion/Room.ts
@@ -169,6 +169,7 @@ export class Room {
      */
     public get key(): string {
         const newUrl = new URL(this.roomUrl.toString());
+        newUrl.search = "";
         newUrl.hash = "";
         return newUrl.toString();
     }


### PR DESCRIPTION
The room ID was replaced by the room full URL internally, but the search params should not be part of the ID.