### PR TITLE
Fixing loop when setting variables

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -327,6 +327,11 @@ export class GameRoom {
 
         const readableBy = variableManager.setVariable(name, value, user);
 
+        // If the variable was not changed, let's not dispatch anything.
+        if (readableBy === false) {
+            return;
+        }
+
         // TODO: should we batch those every 100ms?
         const variableMessage = new VariableWithTagMessage();
         variableMessage.setName(name);

--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -77,7 +77,11 @@ const roomManager: IRoomManagerServer = {
                         } else if (message.hasSilentmessage()) {
                             socketManager.handleSilentMessage(room, user, message.getSilentmessage() as SilentMessage);
                         } else if (message.hasItemeventmessage()) {
-                            socketManager.handleItemEvent(room, user, message.getItemeventmessage() as ItemEventMessage);
+                            socketManager.handleItemEvent(
+                                room,
+                                user,
+                                message.getItemeventmessage() as ItemEventMessage
+                            );
                         } else if (message.hasVariablemessage()) {
                             await socketManager.handleVariableEvent(
                                 room,
@@ -97,7 +101,10 @@ const roomManager: IRoomManagerServer = {
                                 message.getWebrtcscreensharingsignaltoservermessage() as WebRtcSignalToServerMessage
                             );
                         } else if (message.hasPlayglobalmessage()) {
-                            socketManager.emitPlayGlobalMessage(room, message.getPlayglobalmessage() as PlayGlobalMessage);
+                            socketManager.emitPlayGlobalMessage(
+                                room,
+                                message.getPlayglobalmessage() as PlayGlobalMessage
+                            );
                         } else if (message.hasQueryjitsijwtmessage()) {
                             socketManager.handleQueryJitsiJwtMessage(
                                 user,
@@ -128,7 +135,7 @@ const roomManager: IRoomManagerServer = {
                     emitError(call, e);
                     call.end();
                 }
-            })().catch(e => console.error(e));
+            })().catch((e) => console.error(e));
         });
 
         call.on("end", () => {

--- a/back/src/Services/VariablesManager.ts
+++ b/back/src/Services/VariablesManager.ts
@@ -134,7 +134,17 @@ export class VariablesManager {
         return variable;
     }
 
-    setVariable(name: string, value: string, user: User): string | undefined {
+    /**
+     * Sets the variable.
+     *
+     * Returns who is allowed to read the variable (the readableby property) or "undefined" if anyone can read it.
+     * Also, returns "false" if the variable was not modified (because we set it to the value it already has)
+     *
+     * @param name
+     * @param value
+     * @param user
+     */
+    setVariable(name: string, value: string, user: User): string | undefined | false {
         let readableBy: string | undefined;
         if (this.variableObjects) {
             const variableObject = this.variableObjects.get(name);
@@ -157,6 +167,11 @@ export class VariablesManager {
             }
 
             readableBy = variableObject.readableBy;
+        }
+
+        // If the value is not modified, return false
+        if (this._variables.get(name) === value) {
+            return false;
         }
 
         this._variables.set(name, value);

--- a/front/src/Api/iframe/state.ts
+++ b/front/src/Api/iframe/state.ts
@@ -23,11 +23,11 @@ export const initVariables = (_variables: Map<string, unknown>): void => {
 
 setVariableResolvers.subscribe((event) => {
     const oldValue = variables.get(event.key);
-
     // If we are setting the same value, no need to do anything.
-    if (oldValue === event.value) {
+    // No need to do this check since it is already performed in SharedVariablesManager
+    /*if (JSON.stringify(oldValue) === JSON.stringify(event.value)) {
         return;
-    }
+    }*/
 
     variables.set(event.key, event.value);
     const subject = variableSubscribers.get(event.key);


### PR DESCRIPTION
Setting a variable would makes the application enter in an infinite loop of events (between all the scripts and the back)
This fix makes sure a variable does not emit any event if it is changed to a value it already has.