### PR TITLE
Fixing "has/in" on variables proxy object

### DIFF
--- a/docs/maps/api-state.md
+++ b/docs/maps/api-state.md
@@ -9,6 +9,7 @@ Moreover, `WA.state` functions can be used to persist this state across reloads.
 ```
 WA.state.saveVariable(key : string, data : unknown): void
 WA.state.loadVariable(key : string) : unknown
+WA.state.hasVariable(key : string) : boolean
 WA.state.onVariableChange(key : string).subscribe((data: unknown) => {}) : Subscription
 WA.state.[any property]: unknown
 ```

--- a/front/src/Api/iframe/state.ts
+++ b/front/src/Api/iframe/state.ts
@@ -62,6 +62,10 @@ export class WorkadventureStateCommands extends IframeApiContribution<Workadvent
         return variables.get(key);
     }
 
+    hasVariable(key: string): boolean {
+        return variables.has(key);
+    }
+
     onVariableChange(key: string): Observable<unknown> {
         let subject = variableSubscribers.get(key);
         if (subject === undefined) {
@@ -84,6 +88,12 @@ const proxyCommand = new Proxy(new WorkadventureStateCommands(), {
         // User must use WA.state.saveVariable to have error message.
         target.saveVariable(p.toString(), value);
         return true;
+    },
+    has(target: WorkadventureStateCommands, p: PropertyKey): boolean {
+        if (p in target) {
+            return true;
+        }
+        return target.hasVariable(p.toString());
     },
 }) as WorkadventureStateCommands & { [key: string]: unknown };
 


### PR DESCRIPTION
When using WA.state, using `"myVariable" in WA.state` would always return false.
This is now fixed by adding a "has" method on the Proxy class.

Also, added a `WA.state.hasVariable` method.