### PR TITLE
Allowing variables nested in group layers

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/thecodingmachine/workadventure#readme",
   "dependencies": {
-    "@workadventure/tiled-map-type-guard": "^1.0.0",
+    "@workadventure/tiled-map-type-guard": "^1.0.2",
     "axios": "^0.21.1",
     "busboy": "^0.3.1",
     "circular-json": "^0.5.9",

--- a/back/yarn.lock
+++ b/back/yarn.lock
@@ -194,10 +194,10 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@workadventure/tiled-map-type-guard@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-1.0.0.tgz#02524602ee8b2688429a1f56df1d04da3fc171ba"
-  integrity sha512-Mc0SE128otQnYlScQWVaQVyu1+CkailU/FTBh09UTrVnBAhyMO+jIn9vT9+Dv244xq+uzgQDpXmiVdjgrYFQ+A==
+"@workadventure/tiled-map-type-guard@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-1.0.2.tgz#4171550f6cd71be19791faef48360d65d698bcb0"
+  integrity sha512-RCtygGV5y9cb7QoyGMINBE9arM5pyXjkxvXgA5uXEv4GDbXKorhFim/rHgwbVR+eFnVF3rDgWbRnk3DIaHt+lQ==
   dependencies:
     generic-type-guard "^3.4.1"
 


### PR DESCRIPTION
Up until this commit, variables nested in object layers inside group layers where not found by the front nor the back.
This PR changes analysis so that variables can be detected.