### PR TITLE
FIX: fixed a circular dependancy in stores 

### DIFF
--- a/front/src/Components/Video/PresentationLayout.svelte
+++ b/front/src/Components/Video/PresentationLayout.svelte
@@ -12,7 +12,9 @@
 
 <div class="main-section">
     {#if $videoFocusStore }
-        <MediaBox streamable={$videoFocusStore}></MediaBox>
+        {#key $videoFocusStore.uniqueId}
+            <MediaBox streamable={$videoFocusStore}></MediaBox>
+        {/key}
     {/if}
 </div>
 <aside class="sidebar">

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -715,24 +715,7 @@ export class GameScene extends DirtyScene {
 
                 // When connection is performed, let's connect SimplePeer
                 this.simplePeer = new SimplePeer(this.connection);
-                peerStore.connectToSimplePeer(this.simplePeer);
-                screenSharingPeerStore.connectToSimplePeer(this.simplePeer);
-                videoFocusStore.connectToSimplePeer(this.simplePeer);
                 userMessageManager.setReceiveBanListener(this.bannedUser.bind(this));
-
-                const self = this;
-                this.simplePeer.registerPeerConnectionListener({
-                    onConnect(peer) {
-                        //self.openChatIcon.setVisible(true);
-                        audioManagerVolumeStore.setTalking(true);
-                    },
-                    onDisconnect(userId: number) {
-                        if (self.simplePeer.getNbConnections() === 0) {
-                            //self.openChatIcon.setVisible(false);
-                            audioManagerVolumeStore.setTalking(false);
-                        }
-                    },
-                });
 
                 //listen event to share position of user
                 this.CurrentPlayer.on(hasMovedEventName, this.pushPlayerPosition.bind(this));

--- a/front/src/Stores/AudioManagerStore.ts
+++ b/front/src/Stores/AudioManagerStore.ts
@@ -1,4 +1,5 @@
 import { get, writable } from "svelte/store";
+import { peerStore } from "./PeerStore";
 
 export interface audioManagerVolume {
     muted: boolean;
@@ -103,3 +104,7 @@ export const audioManagerVisibilityStore = writable(false);
 export const audioManagerVolumeStore = createAudioManagerVolumeStore();
 
 export const audioManagerFileStore = createAudioManagerFileStore();
+
+peerStore.subscribe((peers) => {
+    audioManagerVolumeStore.setTalking(peers.size > 0);
+});

--- a/front/src/Stores/MediaStore.ts
+++ b/front/src/Stores/MediaStore.ts
@@ -1,4 +1,4 @@
-import { derived, get, Readable, readable, writable, Writable } from "svelte/store";
+import { derived, get, Readable, readable, writable } from "svelte/store";
 import { localUserStore } from "../Connexion/LocalUserStore";
 import { userMovingStore } from "./GameStore";
 import { HtmlUtils } from "../WebRtc/HtmlUtils";

--- a/front/src/Stores/PeerStore.ts
+++ b/front/src/Stores/PeerStore.ts
@@ -1,37 +1,29 @@
 import { readable, writable } from "svelte/store";
-import type { RemotePeer, SimplePeer } from "../WebRtc/SimplePeer";
-import { VideoPeer } from "../WebRtc/VideoPeer";
-import { ScreenSharingPeer } from "../WebRtc/ScreenSharingPeer";
+import type { VideoPeer } from "../WebRtc/VideoPeer";
+import type { ScreenSharingPeer } from "../WebRtc/ScreenSharingPeer";
 
 /**
  * A store that contains the list of (video) peers we are connected to.
  */
 function createPeerStore() {
-    let peers = new Map<number, VideoPeer>();
-
-    const { subscribe, set, update } = writable(peers);
+    const { subscribe, set, update } = writable(new Map<number, VideoPeer>());
 
     return {
         subscribe,
-        connectToSimplePeer: (simplePeer: SimplePeer) => {
-            peers = new Map<number, VideoPeer>();
-            set(peers);
-            simplePeer.registerPeerConnectionListener({
-                onConnect(peer: RemotePeer) {
-                    if (peer instanceof VideoPeer) {
-                        update((users) => {
-                            users.set(peer.userId, peer);
-                            return users;
-                        });
-                    }
-                },
-                onDisconnect(userId: number) {
-                    update((users) => {
-                        users.delete(userId);
-                        return users;
-                    });
-                },
+        pushNewPeer(peer: VideoPeer) {
+            update((users) => {
+                users.set(peer.userId, peer);
+                return users;
             });
+        },
+        removePeer(userId: number) {
+            update((users) => {
+                users.delete(userId);
+                return users;
+            });
+        },
+        cleanupStore() {
+            set(new Map<number, VideoPeer>());
         },
     };
 }
@@ -40,31 +32,24 @@ function createPeerStore() {
  * A store that contains the list of screen sharing peers we are connected to.
  */
 function createScreenSharingPeerStore() {
-    let peers = new Map<number, ScreenSharingPeer>();
-
-    const { subscribe, set, update } = writable(peers);
+    const { subscribe, set, update } = writable(new Map<number, ScreenSharingPeer>());
 
     return {
         subscribe,
-        connectToSimplePeer: (simplePeer: SimplePeer) => {
-            peers = new Map<number, ScreenSharingPeer>();
-            set(peers);
-            simplePeer.registerPeerConnectionListener({
-                onConnect(peer: RemotePeer) {
-                    if (peer instanceof ScreenSharingPeer) {
-                        update((users) => {
-                            users.set(peer.userId, peer);
-                            return users;
-                        });
-                    }
-                },
-                onDisconnect(userId: number) {
-                    update((users) => {
-                        users.delete(userId);
-                        return users;
-                    });
-                },
+        pushNewPeer(peer: ScreenSharingPeer) {
+            update((users) => {
+                users.set(peer.userId, peer);
+                return users;
             });
+        },
+        removePeer(userId: number) {
+            update((users) => {
+                users.delete(userId);
+                return users;
+            });
+        },
+        cleanupStore() {
+            set(new Map<number, ScreenSharingPeer>());
         },
     };
 }

--- a/front/src/Stores/ScreenSharingStore.ts
+++ b/front/src/Stores/ScreenSharingStore.ts
@@ -175,6 +175,7 @@ export const screenSharingAvailableStore = derived(peerStore, ($peerStore, set) 
 export interface ScreenSharingLocalMedia {
     uniqueId: string;
     stream: MediaStream | null;
+    userId?: undefined;
 }
 
 /**

--- a/front/src/Stores/VideoFocusStore.ts
+++ b/front/src/Stores/VideoFocusStore.ts
@@ -1,14 +1,12 @@
-import { writable } from "svelte/store";
-import type { RemotePeer, SimplePeer } from "../WebRtc/SimplePeer";
-import { VideoPeer } from "../WebRtc/VideoPeer";
-import { ScreenSharingPeer } from "../WebRtc/ScreenSharingPeer";
+import { get, writable } from "svelte/store";
 import type { Streamable } from "./StreamableCollectionStore";
+import { peerStore } from "./PeerStore";
 
 /**
  * A store that contains the peer / media that has currently the "importance" focus.
  */
 function createVideoFocusStore() {
-    const { subscribe, set, update } = writable<Streamable | null>(null);
+    const { subscribe, set } = writable<Streamable | null>(null);
 
     let focusedMedia: Streamable | null = null;
 
@@ -23,27 +21,17 @@ function createVideoFocusStore() {
             set(null);
         },
         toggleFocus: (media: Streamable) => {
-            if (media !== focusedMedia) {
-                focusedMedia = media;
-            } else {
-                focusedMedia = null;
-            }
+            focusedMedia = media !== focusedMedia ? media : null;
             set(focusedMedia);
-        },
-        connectToSimplePeer: (simplePeer: SimplePeer) => {
-            simplePeer.registerPeerConnectionListener({
-                onConnect(peer: RemotePeer) {},
-                onDisconnect(userId: number) {
-                    if (
-                        (focusedMedia instanceof VideoPeer || focusedMedia instanceof ScreenSharingPeer) &&
-                        focusedMedia.userId === userId
-                    ) {
-                        set(null);
-                    }
-                },
-            });
         },
     };
 }
 
 export const videoFocusStore = createVideoFocusStore();
+
+peerStore.subscribe((peers) => {
+    const focusedMedia: Streamable | null = get(videoFocusStore);
+    if (focusedMedia && focusedMedia.userId !== undefined && !peers.get(focusedMedia.userId)) {
+        videoFocusStore.removeFocus();
+    }
+});

--- a/front/src/WebRtc/VideoPeer.ts
+++ b/front/src/WebRtc/VideoPeer.ts
@@ -4,7 +4,7 @@ import type { RoomConnection } from "../Connexion/RoomConnection";
 import { blackListManager } from "./BlackListManager";
 import type { Subscription } from "rxjs";
 import type { UserSimplePeerInterface } from "./SimplePeer";
-import { get, readable, Readable, Unsubscriber } from "svelte/store";
+import { readable, Readable, Unsubscriber } from "svelte/store";
 import {
     localStreamStore,
     obtainedMediaConstraintIsMobileStore,
@@ -12,7 +12,7 @@ import {
     ObtainedMediaStreamConstraints,
 } from "../Stores/MediaStore";
 import { playersStore } from "../Stores/PlayersStore";
-import { chatMessagesStore, chatVisibilityStore, newChatMessageStore } from "../Stores/ChatStore";
+import { chatMessagesStore, newChatMessageStore } from "../Stores/ChatStore";
 import { getIceServersConfig } from "../Components/Video/utils";
 import { isMobile } from "../Enum/EnvironmentVariable";
 


### PR DESCRIPTION
Removed the dependacy of PeerStore.ts over SimplePeer, VideoPeer (now a type) and ScreenSharinPeer (now a type) by rewriting createPeerStore() and createScreenSharingPeerStore()