### PR TITLE
Fix disconnects after 5 minutes in Chrome

### DIFF
--- a/back/src/Enum/EnvironmentVariable.ts
+++ b/back/src/Enum/EnvironmentVariable.ts
@@ -9,7 +9,6 @@ const JITSI_ISS = process.env.JITSI_ISS || "";
 const SECRET_JITSI_KEY = process.env.SECRET_JITSI_KEY || "";
 const HTTP_PORT = parseInt(process.env.HTTP_PORT || "8080") || 8080;
 const GRPC_PORT = parseInt(process.env.GRPC_PORT || "50051") || 50051;
-export const SOCKET_IDLE_TIMER = parseInt(process.env.SOCKET_IDLE_TIMER as string) || 30; // maximum time (in second) without activity before a socket is closed
 export const TURN_STATIC_AUTH_SECRET = process.env.TURN_STATIC_AUTH_SECRET || "";
 export const MAX_PER_GROUP = parseInt(process.env.MAX_PER_GROUP || "4");
 export const REDIS_HOST = process.env.REDIS_HOST || undefined;

--- a/pusher/src/Enum/EnvironmentVariable.ts
+++ b/pusher/src/Enum/EnvironmentVariable.ts
@@ -9,7 +9,7 @@ const JITSI_URL: string | undefined = process.env.JITSI_URL === "" ? undefined :
 const JITSI_ISS = process.env.JITSI_ISS || "";
 const SECRET_JITSI_KEY = process.env.SECRET_JITSI_KEY || "";
 const PUSHER_HTTP_PORT = parseInt(process.env.PUSHER_HTTP_PORT || "8080") || 8080;
-export const SOCKET_IDLE_TIMER = parseInt(process.env.SOCKET_IDLE_TIMER as string) || 30; // maximum time (in second) without activity before a socket is closed
+export const SOCKET_IDLE_TIMER = parseInt(process.env.SOCKET_IDLE_TIMER as string) || 120; // maximum time (in second) without activity before a socket is closed. Should be greater than 60 seconds in order to cope for Chrome intensive throttling (https://developer.chrome.com/blog/timer-throttling-in-chrome-88/#intensive-throttling)
 
 export const FRONT_URL = process.env.FRONT_URL || "http://localhost";
 export const OPID_CLIENT_ID = process.env.OPID_CLIENT_ID || "";


### PR DESCRIPTION
This commit increases idle timeout for websocket connection

Issue: after 5 minutes of inactive tab (hidden tab) in Chrome, WorkAdventure was disconnected.

I believe Google was going in "intensive throttling" mode (see  https://developer.chrome.com/blog/timer-throttling-in-chrome-88/#intensive-throttling)
This means setTimeouts are run only once per minute.

And I believe the "keep alive" must be implemented with a "setTimeout" (one way or another even if I can't find a trace of this in the code). This would mean that the browser would send keep alive requests only once per minute.
But the pusher is configured to shut the connection after 30 seconds of idle activity.

Therefore, the pusher disconnects inactive Chrome tabs. By raising the Pusher idle timer to 2 minutes, we give a chance to Chrome to send a ping to the server in time (since Chrome won't send more than 1 ping per minute).

The fix is not perfect, because it means that if the connexion is broken when Chrome is in "intensive throttling" mode, it won't resume the connection. So we still need to investigate this part.

- [ ] Resume connection, even when browser is hidden after 5 minutes of inactivity
- [ ] Write a test about "Resume connection, even when browser is hidden after 5 minutes of inactivity"