### PR TITLE
Fixing silent zone not respected when exiting Jitsi

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -1807,17 +1807,18 @@ ${escapedMessage}
         mediaManager.hideGameOverlay();
 
         //permit to stop jitsi when user close iframe
-        mediaManager.addTriggerCloseJitsiFrameButton("close-jisi", () => {
+        mediaManager.addTriggerCloseJitsiFrameButton("close-jitsi", () => {
             this.stopJitsi();
         });
     }
 
     public stopJitsi(): void {
-        this.connection?.setSilent(false);
+        const silent = this.gameMap.getCurrentProperties().get("silent");
+        this.connection?.setSilent(!!silent);
         jitsiFactory.stop();
         mediaManager.showGameOverlay();
 
-        mediaManager.removeTriggerCloseJitsiFrameButton("close-jisi");
+        mediaManager.removeTriggerCloseJitsiFrameButton("close-jitsi");
     }
 
     //todo: put this into an 'orchestrator' scene (EntryScene?)

--- a/maps/tests/index.html
+++ b/maps/tests/index.html
@@ -71,6 +71,14 @@
                         <a href="#" class="testLink" data-testmap="audio.json" target="_blank">Testing audio layer</a>
                     </td>
                 </tr>
+                <tr>
+                    <td>
+                        <input type="radio" name="test-jitsi-silent"> Success <input type="radio" name="test-jitsi-silent"> Failure <input type="radio" name="test-jitsi-silent" checked> Pending
+                    </td>
+                    <td>
+                        <a href="#" class="testLink" data-testmap="jitsi_custom_url.json" target="_blank">Testing Jitsi + silent layer</a>
+                    </td>
+                </tr>
             </table>
             <h2>Iframe API</h2>
             <table class="table">

--- a/maps/tests/jitsi_custom_url.json
+++ b/maps/tests/jitsi_custom_url.json
@@ -8,6 +8,12 @@
          "id":1,
          "name":"floor",
          "opacity":1,
+         "properties":[
+                {
+                 "name":"silent",
+                 "type":"bool",
+                 "value":true
+                }],
          "type":"tilelayer",
          "visible":true,
          "width":10,
@@ -37,11 +43,6 @@
                  "name":"jitsiRoom",
                  "type":"string",
                  "value":"myRoom"
-                }, 
-                {
-                 "name":"jitsiUrl",
-                 "type":"string",
-                 "value":"meet.jit.si"
                 }],
          "type":"tilelayer",
          "visible":true,
@@ -55,7 +56,7 @@
          "name":"floorLayer",
          "objects":[
                 {
-                 "height":94.6489098314831,
+                 "height":163.652982988579,
                  "id":1,
                  "name":"",
                  "properties":[
@@ -69,14 +70,14 @@
                     {
                      "fontfamily":"Sans Serif",
                      "pixelsize":8,
-                     "text":"Test:\nWalk on the carpet and press space\nResult:\nJitsi opens on meet.jit.si (check this in the network tab). Note: this test only makes sense if the default configured Jitsi instance is NOT meet.jit.si  (check your .env file)",
+                     "text":"Test:\nThe whole map is silent.\nConnect with 2 users\nResult:\nThe map is silent\n\nTest:\nmove on the carpet with both users\n\nResult:\nA Jitsi opens\n\nTest:\nmove out of the carpet and try to connect both users\nResult:\nThey are still silent\n",
                      "wrap":true
                     },
                  "type":"",
                  "visible":true,
                  "width":317.361946929159,
                  "x":2.32853056864467,
-                 "y":224.602707451482
+                 "y":2.25624950083909
                 }],
          "opacity":1,
          "type":"objectgroup",


### PR DESCRIPTION
Now, when a silent zone is adjacent to a Jitsi, it is enforced, even after leaving the Jitsi zone

Closes #1454 