### PR TITLE
Turn off audio on exit

### DIFF
--- a/front/src/Phaser/Game/GameMap.ts
+++ b/front/src/Phaser/Game/GameMap.ts
@@ -286,4 +286,15 @@ export class GameMap {
 
         this.triggerAll();
     }
+
+    /**
+     * Trigger all the callbacks (used when exiting a map)
+     */
+    public triggerExitCallbacks(): void {
+        const emptyProps = new Map<string, string | boolean | number>();
+        for (const [oldPropName, oldPropValue] of this.lastProperties.entries()) {
+            // We found a property that disappeared
+            this.trigger(oldPropName, oldPropValue, undefined, emptyProps);
+        }
+    }
 }

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -1236,6 +1236,8 @@ ${escapedMessage}
         if (this.mapTransitioning) return;
         this.mapTransitioning = true;
 
+        this.gameMap.triggerExitCallbacks();
+
         let targetRoom: Room;
         try {
             targetRoom = await Room.createRoom(roomUrl);

--- a/maps/tests/audio.json
+++ b/maps/tests/audio.json
@@ -50,12 +50,30 @@
          "y":0
         }, 
         {
+         "data":[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+         "height":10,
+         "id":6,
+         "name":"exit",
+         "opacity":1,
+         "properties":[
+                {
+                 "name":"exitUrl",
+                 "type":"string",
+                 "value":"Properties\/jitsi_next_to_silent.json"
+                }],
+         "type":"tilelayer",
+         "visible":true,
+         "width":10,
+         "x":0,
+         "y":0
+        }, 
+        {
          "draworder":"topdown",
          "id":3,
          "name":"floorLayer",
          "objects":[
                 {
-                 "height":119.194025905366,
+                 "height":308.584234177831,
                  "id":1,
                  "name":"",
                  "rotation":0,
@@ -63,14 +81,14 @@
                     {
                      "fontfamily":"Sans Serif",
                      "pixelsize":13,
-                     "text":"Test:\nWalk on the carpet\nResult:\nA sound is played in loop.\nControls at the top of the screen allow you to control the sound.",
+                     "text":"Test:\nWalk on the carpet\n\nResult:\nA sound is played in loop.\nControls at the top of the screen allow you to control the sound.\n\nTest:\nWalk on the white spot in the carpet\n\nResult:\nThe user is redirected to another map AND sound is shut down",
                      "wrap":true
                     },
                  "type":"",
                  "visible":true,
                  "width":315.4375,
-                 "x":2.28125,
-                 "y":198.837938422583
+                 "x":1.74700399641053,
+                 "y":1.43404009627554
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -78,7 +96,7 @@
          "x":0,
          "y":0
         }],
- "nextlayerid":6,
+ "nextlayerid":7,
  "nextobjectid":2,
  "orientation":"orthogonal",
  "renderorder":"right-down",


### PR DESCRIPTION
If an exit zone is overlapping an audio zone, when exiting, the audio is stopped.
We do this by actually triggering the fact that a user should "leave" all active zones when exiting.

Closes #1440 