### PR TITLE
Switching API to use type="module" scripts

### DIFF
--- a/front/dist/iframe.html
+++ b/front/dist/iframe.html
@@ -11,6 +11,7 @@
         const scriptUrl = urlParams.get('script');
         const script = document.createElement('script');
         script.src = scriptUrl;
+        script.type = "module";
         document.head.append(script);
     </script>
     </head>

--- a/front/src/Api/IframeListener.ts
+++ b/front/src/Api/IframeListener.ts
@@ -326,7 +326,7 @@ class IframeListener {
                     "//" +
                     window.location.host +
                     '/iframe_api.js" ></script>\n' +
-                    '<script src="' +
+                    '<script type="module" src="' +
                     scriptUrl +
                     '" ></script>\n' +
                     "<title></title>\n" +


### PR DESCRIPTION
This allows using imports inside scripts imported by WorkAdventure out of the box (and therefore easily importing the scripting-api-extra without resorting to using a bundler)

Change suggested by @Lurkars

Note: switching to `<script type="module">` imports has some consequences documented in the MDN.

Quoting [the MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#other_differences_between_modules_and_standard_scripts): 


>    You need to pay attention to local testing — if you try to load the HTML file locally (i.e. with a file:// URL), you'll run into CORS errors due to JavaScript module security requirements. You need to do your testing through a server.
>    Also, note that you might get different behavior from sections of script defined inside modules as opposed to in standard scripts. This is because modules use strict mode automatically.
>    There is no need to use the defer attribute (see <script> attributes) when loading a module script; modules are deferred automatically.
>    Modules are only executed once, even if they have been referenced in multiple <script> tags.
>    Last but not least, let's make this clear — module features are imported into the scope of a single script — they aren't available in the global scope. Therefore, you will only be able to access imported features in the script they are imported into, and you won't be able to access them from the JavaScript console, for example. You'll still get syntax errors shown in the DevTools, but you'll not be able to use some of the debugging techniques you might have expected to use.

I don't expect this to cause a lot of troubles except for `modules use strict mode automatically`.
This could potentially break some scripts.

Still, the move is really interesting for most users, so I'd be :+1: for applying this patch.

Anybody has an objection?