### PR TITLE
Change character depth to 0

### DIFF
--- a/front/src/Phaser/Entity/Character.ts
+++ b/front/src/Phaser/Entity/Character.ts
@@ -107,7 +107,7 @@ export abstract class Character extends Container {
         this.setSize(16, 16);
         this.getBody().setSize(16, 16); //edit the hitbox to better match the character model
         this.getBody().setOffset(0, 8);
-        this.setDepth(-1);
+        this.setDepth(0);
 
         this.playAnimation(direction, moving);
 


### PR DESCRIPTION
Currently the characters can be display under a text or something object with a depth of -1.

WARNING : Test your maps to abort deviant behaviors.