### PR TITLE
Change pusher host in readme from .testing to .localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Note: on some OSes, you will need to add this line to your `/etc/hosts` file:
 ```
 
 Note: If on the first run you get a page with "network error". Try to ``docker-compose stop`` , then ``docker-compose start``.
-Note 2: If you are still getting "network error". Make sure you are authorizing the self-signed certificate by entering https://pusher.workadventure.testing and accepting them.
+Note 2: If you are still getting "network error". Make sure you are authorizing the self-signed certificate by entering https://pusher.workadventure.localhost and accepting them.
 
 ### MacOS developers, your environment with Vagrant
 


### PR DESCRIPTION
Change pusher host in readme from .testing to .localhost to match workadventure.localhost added in /etc/hosts