### PR TITLE
use OIDC without admin api, option to disable anonymous login

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,6 +22,7 @@ MAX_USERNAME_LENGTH=8
 OPID_CLIENT_ID=
 OPID_CLIENT_SECRET=
 OPID_CLIENT_ISSUER=
+DISABLE_ANONYMOUS=
 
 # If you want to have a contact page in your menu, you MUST set CONTACT_URL to the URL of the page that you want
 CONTACT_URL=

--- a/docker-compose.single-domain.yaml
+++ b/docker-compose.single-domain.yaml
@@ -70,6 +70,7 @@ services:
       OPID_CLIENT_ID: $OPID_CLIENT_ID
       OPID_CLIENT_SECRET: $OPID_CLIENT_SECRET
       OPID_CLIENT_ISSUER: $OPID_CLIENT_ISSUER
+      DISABLE_ANONYMOUS: $DISABLE_ANONYMOUS
     volumes:
       - ./pusher:/usr/src/app
     labels:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,6 +70,7 @@ services:
       OPID_CLIENT_ID: $OPID_CLIENT_ID
       OPID_CLIENT_SECRET: $OPID_CLIENT_SECRET
       OPID_CLIENT_ISSUER: $OPID_CLIENT_ISSUER
+      DISABLE_ANONYMOUS: $DISABLE_ANONYMOUS
     volumes:
       - ./pusher:/usr/src/app
     labels:

--- a/front/src/Connexion/ConnectionManager.ts
+++ b/front/src/Connexion/ConnectionManager.ts
@@ -215,18 +215,13 @@ class ConnectionManager {
     }
 
     public async anonymousLogin(isBenchmark: boolean = false): Promise<void> {
-        try {
-            const data = await Axios.post(`${PUSHER_URL}/anonymLogin`).then((res) => res.data);
-            this.localUser = new LocalUser(data.userUuid, []);
-            this.authToken = data.authToken;
-            if (!isBenchmark) {
-                // In benchmark, we don't have a local storage.
-                localUserStore.saveUser(this.localUser);
-                localUserStore.setAuthToken(this.authToken);
-            }
-        } catch (error) {
-            // anonymous login failed (through 403 DISABLE_ANONYMOUS)
-            this.loadOpenIDScreen();
+        const data = await Axios.post(`${PUSHER_URL}/anonymLogin`).then((res) => res.data);
+        this.localUser = new LocalUser(data.userUuid, []);
+        this.authToken = data.authToken;
+        if (!isBenchmark) {
+            // In benchmark, we don't have a local storage.
+            localUserStore.saveUser(this.localUser);
+            localUserStore.setAuthToken(this.authToken);
         }
     }
 

--- a/pusher/src/Controller/AuthenticateController.ts
+++ b/pusher/src/Controller/AuthenticateController.ts
@@ -5,6 +5,7 @@ import { adminApi } from "../Services/AdminApi";
 import { AuthTokenData, jwtTokenManager } from "../Services/JWTTokenManager";
 import { parse } from "query-string";
 import { openIDClient } from "../Services/OpenIDClient";
+import { DISABLE_ANONYMOUS } from "../Enum/EnvironmentVariable";
 
 export interface TokenInterface {
     userUuid: string;
@@ -175,16 +176,21 @@ export class AuthenticateController extends BaseController {
                 console.warn("Login request was aborted");
             });
 
-            const userUuid = v4();
-            const authToken = jwtTokenManager.createAuthToken(userUuid);
-            res.writeStatus("200 OK");
-            this.addCorsHeaders(res);
-            res.end(
-                JSON.stringify({
-                    authToken,
-                    userUuid,
-                })
-            );
+            if (DISABLE_ANONYMOUS) {
+                res.writeStatus("403 FORBIDDEN");
+                res.end();
+            } else {
+                const userUuid = v4();
+                const authToken = jwtTokenManager.createAuthToken(userUuid);
+                res.writeStatus("200 OK");
+                this.addCorsHeaders(res);
+                res.end(
+                    JSON.stringify({
+                        authToken,
+                        userUuid,
+                    })
+                );
+            }
         });
     }
 

--- a/pusher/src/Controller/IoSocketController.ts
+++ b/pusher/src/Controller/IoSocketController.ts
@@ -26,7 +26,7 @@ import { jwtTokenManager, tokenInvalidException } from "../Services/JWTTokenMana
 import { adminApi, FetchMemberDataByUuidResponse } from "../Services/AdminApi";
 import { SocketManager, socketManager } from "../Services/SocketManager";
 import { emitInBatch } from "../Services/IoSocketHelpers";
-import { ADMIN_API_TOKEN, ADMIN_API_URL, SOCKET_IDLE_TIMER } from "../Enum/EnvironmentVariable";
+import { ADMIN_API_TOKEN, ADMIN_API_URL, SOCKET_IDLE_TIMER, DISABLE_ANONYMOUS } from "../Enum/EnvironmentVariable";
 import { Zone } from "_Model/Zone";
 import { ExAdminSocketInterface } from "_Model/Websocket/ExAdminSocketInterface";
 import { v4 } from "uuid";
@@ -175,6 +175,11 @@ export class IoSocketController {
 
                         const tokenData =
                             token && typeof token === "string" ? jwtTokenManager.verifyJWTToken(token) : null;
+
+                        if (DISABLE_ANONYMOUS && !tokenData) {
+                            throw new Error("Expecting token");
+                        }
+
                         const userIdentifier = tokenData ? tokenData.identifier : "";
 
                         let memberTags: string[] = [];

--- a/pusher/src/Controller/MapController.ts
+++ b/pusher/src/Controller/MapController.ts
@@ -2,9 +2,9 @@ import { HttpRequest, HttpResponse, TemplatedApp } from "uWebSockets.js";
 import { BaseController } from "./BaseController";
 import { parse } from "query-string";
 import { adminApi } from "../Services/AdminApi";
-import { ADMIN_API_URL } from "../Enum/EnvironmentVariable";
+import { ADMIN_API_URL, DISABLE_ANONYMOUS } from "../Enum/EnvironmentVariable";
 import { GameRoomPolicyTypes } from "../Model/PusherRoom";
-import { MapDetailsData } from "../Services/AdminApi/MapDetailsData";
+import { isMapDetailsData, MapDetailsData } from "../Services/AdminApi/MapDetailsData";
 import { socketManager } from "../Services/SocketManager";
 import { AuthTokenData, jwtTokenManager } from "../Services/JWTTokenManager";
 import { v4 } from "uuid";
@@ -64,6 +64,7 @@ export class MapController extends BaseController {
                         tags: [],
                         textures: [],
                         contactPage: undefined,
+                        authenticationMandatory: DISABLE_ANONYMOUS,
                     } as MapDetailsData)
                 );
 
@@ -86,6 +87,10 @@ export class MapController extends BaseController {
                         }
                     }
                     const mapDetails = await adminApi.fetchMapDetails(query.playUri as string, userId);
+
+                    if (isMapDetailsData(mapDetails) && DISABLE_ANONYMOUS) {
+                        (mapDetails as MapDetailsData).authenticationMandatory = true;
+                    }
 
                     res.writeStatus("200 OK");
                     this.addCorsHeaders(res);

--- a/pusher/src/Controller/MapController.ts
+++ b/pusher/src/Controller/MapController.ts
@@ -89,7 +89,7 @@ export class MapController extends BaseController {
                     const mapDetails = await adminApi.fetchMapDetails(query.playUri as string, userId);
 
                     if (isMapDetailsData(mapDetails) && DISABLE_ANONYMOUS) {
-                        (mapDetails as MapDetailsData).authenticationMandatory = true;
+                        mapDetails.authenticationMandatory = true;
                     }
 
                     res.writeStatus("200 OK");

--- a/pusher/src/Enum/EnvironmentVariable.ts
+++ b/pusher/src/Enum/EnvironmentVariable.ts
@@ -15,6 +15,7 @@ export const FRONT_URL = process.env.FRONT_URL || "http://localhost";
 export const OPID_CLIENT_ID = process.env.OPID_CLIENT_ID || "";
 export const OPID_CLIENT_SECRET = process.env.OPID_CLIENT_SECRET || "";
 export const OPID_CLIENT_ISSUER = process.env.OPID_CLIENT_ISSUER || "";
+export const DISABLE_ANONYMOUS = process.env.DISABLE_ANONYMOUS ? process.env.DISABLE_ANONYMOUS == "true" : false;
 
 export {
     SECRET_KEY,

--- a/pusher/src/Services/AdminApi/MapDetailsData.ts
+++ b/pusher/src/Services/AdminApi/MapDetailsData.ts
@@ -16,6 +16,7 @@ export const isMapDetailsData = new tg.IsInterface()
         tags: tg.isArray(tg.isString),
         textures: tg.isArray(isCharacterTexture),
         contactPage: tg.isUnion(tg.isString, tg.isUndefined),
+        authenticationMandatory: tg.isUnion(tg.isBoolean, tg.isUndefined),
     })
     .get();
 


### PR DESCRIPTION
This PR as two main focuses:

- First of all it makes OpenID usable without Admin API by using the Pusher instead of `iframeAuthentication` when not set (which can normally only be set with Admin API). 
- Seconds it adds an `DISABLE_ANONYMOUS` option, which of course only makes sense with usage of OpenID with following things happening if disabled
    -  "/anonymLogin" returns 403 instead of a token
    - all rooms gets `authenticationMandatory` set to true
    - "/room" needs a valid token (this is necessary to avoid hacks, if OpenID redirect is omitted somehow, it would be possible to set username etc and to proceed to map without an authToken set!!!)

This is both in a single PR, because using OpenID without Admin API does not really make sense without `DISABLE_ANONYMOUS`. So I think this belongs together!
