### PR TITLE
Fix tab index on embedded iframes

### DIFF
--- a/front/src/Phaser/Game/EmbeddedWebsiteManager.ts
+++ b/front/src/Phaser/Game/EmbeddedWebsiteManager.ts
@@ -162,6 +162,7 @@ export class EmbeddedWebsiteManager {
 
         const iframe = document.createElement("iframe");
         iframe.src = absoluteUrl;
+        iframe.tabIndex = -1;
         iframe.style.width = embeddedWebsiteEvent.position.width + "px";
         iframe.style.height = embeddedWebsiteEvent.position.height + "px";
         iframe.style.margin = "0";


### PR DESCRIPTION
When you press the tab key many times the embedded iframes move front of the player screen regardless you have placed them.