### PR TITLE
Resize cowebsites when main slot is loaded

### DIFF
--- a/front/src/WebRtc/CoWebsiteManager.ts
+++ b/front/src/WebRtc/CoWebsiteManager.ts
@@ -234,6 +234,9 @@ class CoWebsiteManager {
         this.openedMain = iframeStates.loading;
     }
     private openMain(): void {
+        this.cowebsiteDom.addEventListener("transitionend", () => {
+            this.resizeAllIframes();
+        });
         this.cowebsiteDom.classList.remove("loading", "hidden"); //edit the css class to trigger the transition
         this.openedMain = iframeStates.opened;
         this.resetStyleMain();


### PR DESCRIPTION
Sometime the main cowebsite is resize before the slot translation was finished.
In this fix we wait the transition end event to resize.