### PR TITLE
fixed Traefik Middleware CORS Headers on Pusher

### DIFF
--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -34,6 +34,7 @@ services:
       dockerfile: front/Dockerfile
     #image: thecodingmachine/workadventure-front:master
     environment:
+      ADMIN_URL: //${Domain}
       DEBUG_MODE: "$DEBUG_MODE"
       JITSI_URL: $JITSI_URL
       JITSI_PRIVATE_MODE: "$JITSI_PRIVATE_MODE"
@@ -67,6 +68,9 @@ services:
       JITSI_URL: $JITSI_URL
       JITSI_ISS: $JITSI_ISS
     labels:
+      - "traefik.http.middlewares.cors-headers.headers.accesscontrolallowmethods=GET,OPTIONS,POST"
+      - "traefik.http.middlewares.cors-headers.headers.accesscontrolalloworiginlist=https://play.${DOMAIN}"
+      - "traefik.http.routers.pusher-ssl.middlewares=cors-headers"
       - "traefik.http.routers.pusher.rule=Host(`pusher.${DOMAIN}`)"
       - "traefik.http.routers.pusher.entryPoints=web,traefik"
       - "traefik.http.services.pusher.loadbalancer.server.port=8080"


### PR DESCRIPTION
# Traefik does not correctly set CORS Headers for the Pusher Container

- set Headers middleware with [`accessControlAllowOriginList`](https://doc.traefik.io/traefik/v2.3/middlewares/headers/#accesscontrolalloworiginlist)
- set `ADMIN_URL` on "front" (unrelated to CORS caused an issue on starting the container)

related to: #1596 