### PR TITLE
Fixing "Query string parameters prevent WA from loading"

### DIFF
--- a/front/src/Connexion/ConnectionManager.ts
+++ b/front/src/Connexion/ConnectionManager.ts
@@ -163,12 +163,13 @@ class ConnectionManager {
                     console.error(err);
                 }
             } else {
+                const query = urlParams.toString();
                 roomPath =
                     window.location.protocol +
                     "//" +
                     window.location.host +
                     window.location.pathname +
-                    urlParams.toString() + //use urlParams because the token param must be deleted
+                    (query ? "?" + query : "") + //use urlParams because the token param must be deleted
                     window.location.hash;
             }
 

--- a/tests/tests/test.ts
+++ b/tests/tests/test.ts
@@ -4,8 +4,9 @@ const fs = require('fs')
 import { Selector } from 'testcafe';
 import {userAlice} from "./utils/roles";
 
+// Note: we are also testing that we can connect if the URL contains a random query string
 fixture `Variables`
-    .page `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json`;
+    .page `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json?somerandomparam=1`;
 
 test("Test that variables cache in the back don't prevent setting a variable in case the map changes", async (t: TestController) => {
     // Let's start by visiting a map that DOES not have the variable.


### PR DESCRIPTION
Due to a regression, query string parameters added to the URL (like: `http://play.workadventure.localhost/_/global/maps.workadventure.localhost/starter/map.json?utm_source=sendinblue&utm_campaign=WA+-+2021+Christmap+map+launch&utm_medium=email#foo`) were causing a crash in WA.

This commit fixes the issue (and adds a E2E test)