### PR TITLE
Making the ADMIN_URL parameter optionnal in front

### DIFF
--- a/docker-compose.single-domain.yaml
+++ b/docker-compose.single-domain.yaml
@@ -28,7 +28,7 @@ services:
       NODE_ENV: development
       PUSHER_URL: /pusher
       UPLOADER_URL: /uploader
-      ADMIN_URL: /admin
+      #ADMIN_URL: /admin
       MAPS_URL: /maps
       ICON_URL: /icon
       STARTUP_COMMAND_1: ./templater.sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       NODE_ENV: development
       PUSHER_URL: //pusher.workadventure.localhost
       UPLOADER_URL: //uploader.workadventure.localhost
-      ADMIN_URL: //workadventure.localhost
+      #ADMIN_URL: //workadventure.localhost
       ICON_URL: //icon.workadventure.localhost
       STARTUP_COMMAND_1: ./templater.sh
       STARTUP_COMMAND_2: yarn install

--- a/front/webpack.config.ts
+++ b/front/webpack.config.ts
@@ -189,7 +189,7 @@ module.exports = {
             DISABLE_NOTIFICATIONS: false,
             PUSHER_URL: undefined,
             UPLOADER_URL: null,
-            ADMIN_URL: undefined,
+            ADMIN_URL: null,
             CONTACT_URL: null,
             PROFILE_URL: null,
             ICON_URL: null,


### PR DESCRIPTION
This parameter is only used in the SAAS version (and ideally, should disappear completely).
The warning message that uses the ADMIN_URL should originate from the admin itself.