### PR TITLE
Adding missing environment variable in docker-compose.prod.yml

### DIFF
--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -66,6 +66,7 @@ services:
       API_URL: back:50051
       JITSI_URL: $JITSI_URL
       JITSI_ISS: $JITSI_ISS
+      FRONT_URL: https://play.${DOMAIN}
     labels:
       - "traefik.http.routers.pusher.rule=Host(`pusher.${DOMAIN}`)"
       - "traefik.http.routers.pusher.entryPoints=web,traefik"


### PR DESCRIPTION
In the new version, a new FRONT_URL environment variable is now compulsory in the Pusher.
This is done to setup CORS security in the pusher.

This commit adds this environment variable in the sample docker-compose.prod.yml file.

Closes #1596