### PR TITLE
Fixing "Query string parameters prevent WA from loading"

### DIFF
--- a/front/src/Connexion/ConnectionManager.ts
+++ b/front/src/Connexion/ConnectionManager.ts
@@ -132,13 +132,14 @@ class ConnectionManager {
 
             const roomUrl = data.roomUrl;
 
+            const query = urlParams.toString();
             this._currentRoom = await Room.createRoom(
                 new URL(
                     window.location.protocol +
                         "//" +
                         window.location.host +
                         roomUrl +
-                        urlParams.toString() + //use urlParams because the token param must be deleted
+                        (query ? "?" + query : "") + //use urlParams because the token param must be deleted
                         window.location.hash
                 )
             );


### PR DESCRIPTION
Due to a regression, query string parameters added to the URL (like:

http://play.workadventure.localhost/_/global/maps.workadventure.localhost/starter/map.json?utm_source=sendinblue&utm_campaign=WA+-+2021+Christmap+map+launch&utm_medium=email#foo

) were causing a crash in WA.

Signed-off-by: Gregoire Parant <g.parant@thecodingmachine.com>