### PR TITLE
Feature: Following WOKAs

### DIFF
--- a/front/src/Connexion/ConnectionManager.ts
+++ b/front/src/Connexion/ConnectionManager.ts
@@ -1,5 +1,5 @@
 import Axios from "axios";
-import { PUSHER_URL, START_ROOM_URL } from "../Enum/EnvironmentVariable";
+import { PUSHER_URL } from "../Enum/EnvironmentVariable";
 import { RoomConnection } from "./RoomConnection";
 import type { OnConnectInterface, PositionInterface, ViewportInterface } from "./ConnexionModels";
 import { GameConnexionTypes, urlManager } from "../Url/UrlManager";

--- a/front/src/Phaser/Game/PlayerMovement.ts
+++ b/front/src/Phaser/Game/PlayerMovement.ts
@@ -41,7 +41,7 @@ export class PlayerMovement {
             oldX: this.startPosition.x,
             oldY: this.startPosition.y,
             direction: this.endPosition.direction,
-            moving: true,
+            moving: this.endPosition.moving,
         };
     }
 }

--- a/front/src/Phaser/Player/Player.ts
+++ b/front/src/Phaser/Player/Player.ts
@@ -157,22 +157,26 @@ export class Player extends Character {
 
         if (activeEvents.get(UserInputEvent.Interact)) {
             const sortedPlayers = Array.from(this.scene.MapPlayersByKey.values()).sort((p1, p2) => {
-                const distToP1 = Math.pow(p1.x - this.x, 2) + Math.pow(p1.y - this.y, 2);
-                const distToP2 = Math.pow(p2.x - this.x, 2) + Math.pow(p2.y - this.y, 2);
-                if (distToP1 > distToP2) {
+                const sdistToP1 = Math.pow(p1.x - this.x, 2) + Math.pow(p1.y - this.y, 2);
+                const sdistToP2 = Math.pow(p2.x - this.x, 2) + Math.pow(p2.y - this.y, 2);
+                if (sdistToP1 > sdistToP2) {
                     return 1;
-                } else if (distToP1 < distToP2) {
+                } else if (sdistToP1 < sdistToP2) {
                     return -1;
                 } else {
                     return 0;
                 }
             });
 
+            const minFollowDist = 10000;
             if (typeof sortedPlayers !== "undefined" && sortedPlayers.length > 0) {
-                this.follow = {
-                    followPlayer: sortedPlayers[0],
-                    direction: this.previousDirection,
-                };
+                const sdist = Math.pow(sortedPlayers[0].x - this.x, 2) + Math.pow(sortedPlayers[0].y - this.y, 2);
+                if (sdist < minFollowDist) {
+                    this.follow = {
+                        followPlayer: sortedPlayers[0],
+                        direction: this.previousDirection,
+                    };
+                }
             }
         }
 

--- a/front/src/Phaser/Player/Player.ts
+++ b/front/src/Phaser/Player/Player.ts
@@ -117,7 +117,7 @@ export class Player extends Character {
 
         const distance = Math.pow(xDist, 2) + Math.pow(yDist, 2);
 
-        if (distance < 650) {
+        if (distance < 2000) {
             this.stop();
         } else {
             const moveAmount = 9 * 20;

--- a/front/src/Phaser/Player/Player.ts
+++ b/front/src/Phaser/Player/Player.ts
@@ -100,6 +100,8 @@ export class Player extends Character {
     }
 
     private followStep(activeEvents: ActiveEventList, delta: number) {
+        let moving = false;
+
         if (this.follow === null) {
             return;
         }
@@ -137,10 +139,12 @@ export class Player extends Character {
                     this.follow.direction = PlayerAnimationDirections.Down;
                 }
             }
+
+            moving = true;
         }
 
         this.emit(hasMovedEventName, {
-            moving: true,
+            moving: moving,
             direction: this.follow.direction,
             x: this.x,
             y: this.y,
@@ -148,8 +152,8 @@ export class Player extends Character {
 
         this.previousDirection = this.follow.direction;
 
-        this.wasMoving = true;
-        userMovingStore.set(true);
+        this.wasMoving = moving;
+        userMovingStore.set(moving);
     }
 
     moveUser(delta: number): void {

--- a/front/tests/Phaser/Game/PlayerMovementTest.ts
+++ b/front/tests/Phaser/Game/PlayerMovementTest.ts
@@ -74,7 +74,7 @@ describe("Interpolation / Extrapolation", () => {
         });
     });
 
-    it("should should keep moving until it stops", () => {
+    it("should keep moving until it stops", () => {
         const playerMovement = new PlayerMovement({
                 x: 100, y: 200
             }, 42000,
@@ -95,7 +95,7 @@ describe("Interpolation / Extrapolation", () => {
             oldX: 100,
             oldY: 200,
             direction: 'up',
-            moving: true
+            moving: false
         });
     });
 })


### PR DESCRIPTION
This is a "preview" of a WIP feature we are implementing: You can now press the interact button (`[space]`) to start following the nearest WOKA. It is still quite rough but usable.

So far we only collected the low-hanging fruits: It runs completely without client/server communication but improving it further will probably require changes to the `front <-> pusher` protocol, so before we start digging into that I would appreciate some feedback:
* Is such a feature of interest to anyone?
* Would maintainers be willing to merge it? The last thing we want is a "hostile" fork.

Things that definitely could be better:
* Ongoing conversations should be protected when following. Currently, conversations are closed if the "leading" WOKA moves too fast.
* The frontend should clearly display that follow mode is enabled - preferably on both sides (following / followed).
* (not sure if this is necessary:) The player being followed should be asked if it is OK and have the opportunity to deny the request.
* Conversations should persist beyond the edges of a map (=> `exitUrl`).