### PR TITLE
New setting: Always ask before opening cowebsites / Jitsi meetings

### DIFF
--- a/front/src/Components/Menu/SettingsSubMenu.svelte
+++ b/front/src/Components/Menu/SettingsSubMenu.svelte
@@ -7,6 +7,7 @@
 
     let fullscreen: boolean = localUserStore.getFullscreen();
     let notification: boolean = localUserStore.getNotification() === "granted";
+    let forceCowebsiteTrigger: boolean = localUserStore.getForceCowebsiteTrigger();
     let valueGame: number = localUserStore.getGameQualityValue();
     let valueVideo: number = localUserStore.getVideoQualityValue();
     let previewValueGame = valueGame;
@@ -52,6 +53,10 @@
                 }
             });
         }
+    }
+
+    function changeForceCowebsiteTrigger() {
+        localUserStore.setForceCowebsiteTrigger(forceCowebsiteTrigger);
     }
 
     function closeMenu() {
@@ -108,6 +113,15 @@
                 on:change={changeNotification}
             />
             <span>Notifications</span>
+        </label>
+        <label>
+            <input
+                type="checkbox"
+                class="nes-checkbox is-dark"
+                bind:checked={forceCowebsiteTrigger}
+                on:change={changeForceCowebsiteTrigger}
+            />
+            <span>Always ask before opening websites and Jitsi Meet rooms</span>
         </label>
     </section>
 </div>

--- a/front/src/Connexion/LocalUserStore.ts
+++ b/front/src/Connexion/LocalUserStore.ts
@@ -13,6 +13,7 @@ const audioPlayerVolumeKey = "audioVolume";
 const audioPlayerMuteKey = "audioMute";
 const helpCameraSettingsShown = "helpCameraSettingsShown";
 const fullscreenKey = "fullscreen";
+const forceCowebsiteTriggerKey = "forceCowebsiteTrigger";
 const lastRoomUrl = "lastRoomUrl";
 const authToken = "authToken";
 const state = "state";
@@ -118,6 +119,13 @@ class LocalUserStore {
     }
     getFullscreen(): boolean {
         return localStorage.getItem(fullscreenKey) === "true";
+    }
+
+    setForceCowebsiteTrigger(value: boolean): void {
+        localStorage.setItem(forceCowebsiteTriggerKey, value.toString());
+    }
+    getForceCowebsiteTrigger(): boolean {
+        return localStorage.getItem(forceCowebsiteTriggerKey) === "true";
     }
 
     setLastRoomUrl(roomUrl: string): void {

--- a/front/src/Phaser/Game/GameMapPropertiesListener.ts
+++ b/front/src/Phaser/Game/GameMapPropertiesListener.ts
@@ -4,6 +4,7 @@ import { scriptUtils } from "../../Api/ScriptUtils";
 import type { CoWebsite } from "../../WebRtc/CoWebsiteManager";
 import { coWebsiteManager } from "../../WebRtc/CoWebsiteManager";
 import { layoutManagerActionStore } from "../../Stores/LayoutManagerStore";
+import { localUserStore } from "../../Connexion/LocalUserStore";
 import { get } from "svelte/store";
 import { ON_ACTION_TRIGGER_BUTTON } from "../../WebRtc/LayoutManager";
 import type { ITiledMapLayer } from "../Map/ITiledMap";
@@ -33,7 +34,8 @@ export class GameMapPropertiesListener {
             }
             if (typeof newValue == "string" && newValue.length) {
                 const openWebsiteTriggerValue = allProps.get(GameMapProperties.OPEN_WEBSITE_TRIGGER);
-                if (openWebsiteTriggerValue && openWebsiteTriggerValue === ON_ACTION_TRIGGER_BUTTON) {
+                const forceTrigger = localUserStore.getForceCowebsiteTrigger();
+                if (forceTrigger || openWebsiteTriggerValue === ON_ACTION_TRIGGER_BUTTON) {
                     let message = allProps.get(GameMapProperties.OPEN_WEBSITE_TRIGGER_MESSAGE);
                     if (message === undefined) {
                         message = "Press SPACE or touch here to open web site in new tab";
@@ -135,7 +137,8 @@ export class GameMapPropertiesListener {
                         layoutManagerActionStore.removeAction(actionUuid);
                     };
 
-                    if (websiteTriggerProperty && websiteTriggerProperty === ON_ACTION_TRIGGER_BUTTON) {
+                    const forceTrigger = localUserStore.getForceCowebsiteTrigger();
+                    if (forceTrigger || websiteTriggerProperty === ON_ACTION_TRIGGER_BUTTON) {
                         if (!websiteTriggerMessageProperty) {
                             websiteTriggerMessageProperty = "Press SPACE or touch here to open web site";
                         }

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -868,7 +868,8 @@ export class GameScene extends DirtyScene {
                 };
 
                 const jitsiTriggerValue = allProps.get(GameMapProperties.JITSI_TRIGGER);
-                if (jitsiTriggerValue && jitsiTriggerValue === ON_ACTION_TRIGGER_BUTTON) {
+                const forceTrigger = localUserStore.getForceCowebsiteTrigger();
+                if (forceTrigger || jitsiTriggerValue === ON_ACTION_TRIGGER_BUTTON) {
                     let message = allProps.get(GameMapProperties.JITSI_TRIGGER_MESSAGE);
                     if (message === undefined) {
                         message = "Press SPACE or touch here to enter Jitsi Meet room";


### PR DESCRIPTION
User can now enable a local setting that always asks for confirmation before opening websites or entering Jitsi rooms, regardless of the `jitsiTrigger` / `openWebsiteTrigger` layer properties.