### PR TITLE
Fixing map caching

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -45,6 +45,7 @@
     "@types/socket.io-client": "^1.4.32",
     "axios": "^0.21.2",
     "cross-env": "^7.0.3",
+    "deep-copy-ts": "^0.5.0",
     "generic-type-guard": "^3.2.0",
     "google-protobuf": "^3.13.0",
     "phaser": "^3.54.0",

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -89,6 +89,7 @@ import { get } from "svelte/store";
 import { contactPageStore } from "../../Stores/MenuStore";
 import { GameMapProperties } from "./GameMapProperties";
 import SpriteSheetFile = Phaser.Loader.FileTypes.SpriteSheetFile;
+import { deepCopy } from "deep-copy-ts";
 
 export interface GameSceneInitInterface {
     initPosition: PointInterface | null;
@@ -341,7 +342,10 @@ export class GameScene extends DirtyScene {
     private async onMapLoad(data: any): Promise<void> {
         // Triggered when the map is loaded
         // Load tiles attached to the map recursively
-        this.mapFile = data.data;
+
+        // The map file can be modified by the scripting API and we don't want to tamper the Phaser cache (in case we come back on the map after visiting other maps)
+        // So we are doing a deep copy
+        this.mapFile = deepCopy(data.data);
         const url = this.MapUrlFile.substr(0, this.MapUrlFile.lastIndexOf("/"));
         this.mapFile.tilesets.forEach((tileset) => {
             if (typeof tileset.name === "undefined" || typeof tileset.image === "undefined") {

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -1656,6 +1656,11 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
+deep-copy-ts@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/deep-copy-ts/-/deep-copy-ts-0.5.0.tgz#b9493d8e2bae85ef7d659c16eb707c13efb84499"
+  integrity sha512-/3cgBcMkznRf5BM8wu6YWz3SQUkHzgh/v1TZFjevztLj9sMjFvNFBtpN4uUtPzw/rA/TldyD6c6LRL1zno4+YA==
+
 deep-equal@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"


### PR DESCRIPTION
Maps in the GameScene can be modified by the scripting API.
If so, previously, the changes to the maps were persisted in the ITiledMap object in the GameScene because this was cached by the Phaser loader,
causing a series of problems, the most noticeable being that templating in the scripting API stopped working on a second visit of a page.

We are now deep-copying the map on load to avoid these nasty effects.

Closes https://github.com/workadventure/scripting-api-extra/issues/77