### PR TITLE
Fix: Use specified type in admin message

### DIFF
--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -251,7 +251,7 @@ const roomManager: IRoomManagerServer = {
     },
     sendAdminMessage(call: ServerUnaryCall<AdminMessage>, callback: sendUnaryData<EmptyMessage>): void {
         socketManager
-            .sendAdminMessage(call.request.getRoomid(), call.request.getRecipientuuid(), call.request.getMessage())
+            .sendAdminMessage(call.request.getRoomid(), call.request.getRecipientuuid(), call.request.getMessage(), call.request.getType())
             .catch((e) => console.error(e));
 
         callback(null, new EmptyMessage());

--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -251,7 +251,12 @@ const roomManager: IRoomManagerServer = {
     },
     sendAdminMessage(call: ServerUnaryCall<AdminMessage>, callback: sendUnaryData<EmptyMessage>): void {
         socketManager
-            .sendAdminMessage(call.request.getRoomid(), call.request.getRecipientuuid(), call.request.getMessage(), call.request.getType())
+            .sendAdminMessage(
+                call.request.getRoomid(),
+                call.request.getRecipientuuid(),
+                call.request.getMessage(),
+                call.request.getType()
+            )
             .catch((e) => console.error(e));
 
         callback(null, new EmptyMessage());

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -691,7 +691,7 @@ export class SocketManager {
         }
     }
 
-    public async sendAdminMessage(roomId: string, recipientUuid: string, message: string): Promise<void> {
+    public async sendAdminMessage(roomId: string, recipientUuid: string, message: string, type: string): Promise<void> {
         const room = await this.roomsPromises.get(roomId);
         if (!room) {
             console.error(
@@ -715,7 +715,7 @@ export class SocketManager {
         for (const recipient of recipients) {
             const sendUserMessage = new SendUserMessage();
             sendUserMessage.setMessage(message);
-            sendUserMessage.setType("ban"); //todo: is the type correct?
+            sendUserMessage.setType(type);
 
             const serverToClientMessage = new ServerToClientMessage();
             serverToClientMessage.setSendusermessage(sendUserMessage);


### PR DESCRIPTION
The backend currently ignores the specified message type and uses "ban" instead. This fix passes `call.request.getType()` through to the `SocketManager.sendAdminMessage` function.