### PR TITLE
Fix admin message update in frontend

### DIFF
--- a/front/src/Components/TypeMessage/BanMessage.svelte
+++ b/front/src/Components/TypeMessage/BanMessage.svelte
@@ -3,7 +3,10 @@
     import { banMessageVisibleStore, banMessageContentStore } from "../../Stores/TypeMessageStore/BanMessageStore";
     import { onMount } from "svelte";
 
-    const text = $banMessageContentStore;
+    let text: string;
+    $: {
+        text = $banMessageContentStore;
+    }
     const NAME_BUTTON = "Ok";
     let nbSeconds = 10;
     let nameButton = "";

--- a/front/src/Components/TypeMessage/TextMessage.svelte
+++ b/front/src/Components/TypeMessage/TextMessage.svelte
@@ -3,8 +3,11 @@
     import { textMessageContentStore, textMessageVisibleStore } from "../../Stores/TypeMessageStore/TextMessageStore";
     import { QuillDeltaToHtmlConverter } from "quill-delta-to-html";
 
-    const content = JSON.parse($textMessageContentStore);
-    const converter = new QuillDeltaToHtmlConverter(content.ops, { inlineStyles: true });
+    let converter: QuillDeltaToHtmlConverter;
+    $: {
+        const content = JSON.parse($textMessageContentStore);
+        converter = new QuillDeltaToHtmlConverter(content.ops, { inlineStyles: true });
+    }
     const NAME_BUTTON = "Ok";
 
     function closeTextMessage() {


### PR DESCRIPTION
Currently if a user receives multiple admin messages only the first one is displayed. The existing code indicates that if a new message arrives the old one should be overwritten. The problem with the existing svelte message components is that the message content is computed in the script tag, which gets evaluated only once. My solution uses [reactive statements](https://svelte.dev/docs#component-format-script-3-$-marks-a-statement-as-reactive) to solve this issue.