### PR TITLE
New settings: Silent mode and ignoring audio files

### DIFF
--- a/front/src/Components/Menu/SettingsSubMenu.svelte
+++ b/front/src/Components/Menu/SettingsSubMenu.svelte
@@ -1,14 +1,16 @@
 <script lang="typescript">
     import { localUserStore } from "../../Connexion/LocalUserStore";
-    import { videoConstraintStore } from "../../Stores/MediaStore";
+    import { isSilentStore, videoConstraintStore } from "../../Stores/MediaStore";
     import { HtmlUtils } from "../../WebRtc/HtmlUtils";
     import { isMobile } from "../../Enum/EnvironmentVariable";
     import { menuVisiblilityStore } from "../../Stores/MenuStore";
+    import { gameManager } from "../../Phaser/Game/GameManager";
 
     let fullscreen: boolean = localUserStore.getFullscreen();
     let notification: boolean = localUserStore.getNotification() === "granted";
     let forceCowebsiteTrigger: boolean = localUserStore.getForceCowebsiteTrigger();
     let ignoreFollowRequests: boolean = localUserStore.getIgnoreFollowRequests();
+    let alwaysSilent: boolean = localUserStore.getAlwaysSilent();
     let valueGame: number = localUserStore.getGameQualityValue();
     let valueVideo: number = localUserStore.getVideoQualityValue();
     let previewValueGame = valueGame;
@@ -62,6 +64,14 @@
 
     function changeIgnoreFollowRequests() {
         localUserStore.setIgnoreFollowRequests(ignoreFollowRequests);
+    }
+
+    function changeAlwaysSilent() {
+        localUserStore.setAlwaysSilent(alwaysSilent);
+        const scene = gameManager.getCurrentGameScene();
+        const silentZone = scene.isSilentZone();
+        scene.connection?.setSilent(alwaysSilent || silentZone);
+        isSilentStore.set(alwaysSilent || silentZone);
     }
 
     function closeMenu() {
@@ -136,6 +146,15 @@
                 on:change={changeIgnoreFollowRequests}
             />
             <span>Ignore requests to follow other users</span>
+        </label>
+        <label>
+            <input
+                type="checkbox"
+                class="nes-checkbox is-dark"
+                bind:checked={alwaysSilent}
+                on:change={changeAlwaysSilent}
+            />
+            <span>Silent mode (disable proximity chat)</span>
         </label>
     </section>
 </div>

--- a/front/src/Components/Menu/SettingsSubMenu.svelte
+++ b/front/src/Components/Menu/SettingsSubMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="typescript">
     import { localUserStore } from "../../Connexion/LocalUserStore";
     import { isSilentStore, videoConstraintStore } from "../../Stores/MediaStore";
+    import { audioManagerFileStore, audioManagerVisibilityStore } from "../../Stores/AudioManagerStore";
     import { HtmlUtils } from "../../WebRtc/HtmlUtils";
     import { isMobile } from "../../Enum/EnvironmentVariable";
     import { menuVisiblilityStore } from "../../Stores/MenuStore";
@@ -8,6 +9,7 @@
 
     let fullscreen: boolean = localUserStore.getFullscreen();
     let notification: boolean = localUserStore.getNotification() === "granted";
+    let blockAudio: boolean = localUserStore.getBlockAudio();
     let forceCowebsiteTrigger: boolean = localUserStore.getForceCowebsiteTrigger();
     let ignoreFollowRequests: boolean = localUserStore.getIgnoreFollowRequests();
     let alwaysSilent: boolean = localUserStore.getAlwaysSilent();
@@ -56,6 +58,14 @@
                 }
             });
         }
+    }
+
+    function changeBlockAudio() {
+        if (blockAudio) {
+            audioManagerFileStore.unloadAudio();
+            audioManagerVisibilityStore.set(false);
+        }
+        localUserStore.setBlockAudio(blockAudio);
     }
 
     function changeForceCowebsiteTrigger() {
@@ -128,6 +138,15 @@
                 on:change={changeNotification}
             />
             <span>Notifications</span>
+        </label>
+        <label>
+            <input
+                type="checkbox"
+                class="nes-checkbox is-dark"
+                bind:checked={blockAudio}
+                on:change={changeBlockAudio}
+            />
+            <span>Block ambient sounds and music</span>
         </label>
         <label>
             <input

--- a/front/src/Components/MyCamera.svelte
+++ b/front/src/Components/MyCamera.svelte
@@ -1,4 +1,5 @@
 <script lang="typescript">
+    import { localUserStore } from "../Connexion/LocalUserStore";
     import { obtainedMediaConstraintStore } from "../Stores/MediaStore";
     import { localStreamStore, isSilentStore } from "../Stores/MediaStore";
     import SoundMeterWidget from "./SoundMeterWidget.svelte";
@@ -32,5 +33,6 @@
             <SoundMeterWidget {stream} />
         {/if}
     </div>
-    <div class="is-silent" class:hide={isSilent}>Silent zone</div>
+    <div class="is-silent" class:hide={isSilent && localUserStore.getAlwaysSilent()}>Silent mode</div>
+    <div class="is-silent" class:hide={isSilent && !localUserStore.getAlwaysSilent()}>Silent zone</div>
 </div>

--- a/front/src/Connexion/LocalUserStore.ts
+++ b/front/src/Connexion/LocalUserStore.ts
@@ -15,6 +15,7 @@ const helpCameraSettingsShown = "helpCameraSettingsShown";
 const fullscreenKey = "fullscreen";
 const forceCowebsiteTriggerKey = "forceCowebsiteTrigger";
 const ignoreFollowRequests = "ignoreFollowRequests";
+const alwaysSilent = "alwaysSilent";
 const lastRoomUrl = "lastRoomUrl";
 const authToken = "authToken";
 const state = "state";
@@ -134,6 +135,13 @@ class LocalUserStore {
     }
     getIgnoreFollowRequests(): boolean {
         return localStorage.getItem(ignoreFollowRequests) === "true";
+    }
+
+    setAlwaysSilent(value: boolean): void {
+        localStorage.setItem(alwaysSilent, value.toString());
+    }
+    getAlwaysSilent(): boolean {
+        return localStorage.getItem(alwaysSilent) === "true";
     }
 
     setLastRoomUrl(roomUrl: string): void {

--- a/front/src/Connexion/LocalUserStore.ts
+++ b/front/src/Connexion/LocalUserStore.ts
@@ -13,6 +13,7 @@ const audioPlayerVolumeKey = "audioVolume";
 const audioPlayerMuteKey = "audioMute";
 const helpCameraSettingsShown = "helpCameraSettingsShown";
 const fullscreenKey = "fullscreen";
+const blockAudio = "blockAudio";
 const forceCowebsiteTriggerKey = "forceCowebsiteTrigger";
 const ignoreFollowRequests = "ignoreFollowRequests";
 const alwaysSilent = "alwaysSilent";
@@ -121,6 +122,13 @@ class LocalUserStore {
     }
     getFullscreen(): boolean {
         return localStorage.getItem(fullscreenKey) === "true";
+    }
+
+    setBlockAudio(value: boolean): void {
+        localStorage.setItem(blockAudio, value.toString());
+    }
+    getBlockAudio(): boolean {
+        return localStorage.getItem(blockAudio) === "true";
     }
 
     setForceCowebsiteTrigger(value: boolean): void {

--- a/front/src/Connexion/RoomConnection.ts
+++ b/front/src/Connexion/RoomConnection.ts
@@ -220,6 +220,7 @@ export class RoomConnection implements RoomConnection {
                         );
                     }
                 }
+                this.setSilent(localUserStore.getAlwaysSilent());
 
                 this.userId = roomJoinedMessage.getCurrentuserid();
                 this.tags = roomJoinedMessage.getTagList();

--- a/front/src/Phaser/Entity/Character.ts
+++ b/front/src/Phaser/Entity/Character.ts
@@ -326,11 +326,8 @@ export abstract class Character extends Container {
         super.destroy();
     }
 
-    isSilent() {
-        isSilentStore.set(true);
-    }
-    noSilent() {
-        isSilentStore.set(false);
+    setSilent(silent: boolean) {
+        isSilentStore.set(silent);
     }
 
     playEmote(emote: string) {

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -78,6 +78,7 @@ import { emoteStore, emoteMenuStore } from "../../Stores/EmoteStore";
 import { userIsAdminStore } from "../../Stores/GameStore";
 import { contactPageStore } from "../../Stores/MenuStore";
 import { audioManagerFileStore, audioManagerVisibilityStore } from "../../Stores/AudioManagerStore";
+import { isSilentStore } from "../../Stores/MediaStore";
 
 import EVENT_TYPE = Phaser.Scenes.Events;
 import Texture = Phaser.Textures.Texture;
@@ -555,6 +556,9 @@ export class GameScene extends DirtyScene {
             document.querySelector("body")?.requestFullscreen();
         }
 
+        // Force silent state if requested
+        isSilentStore.set(localUserStore.getAlwaysSilent());
+
         //notify game manager can to create currentUser in map
         this.createCurrentPlayer();
         this.removeAllRemotePlayers(); //cleanup the list  of remote players in case the scene was rebooted
@@ -955,13 +959,9 @@ export class GameScene extends DirtyScene {
             }
         });
         this.gameMap.onPropertyChange(GameMapProperties.SILENT, (newValue, oldValue) => {
-            if (newValue === undefined || newValue === false || newValue === "") {
-                this.connection?.setSilent(false);
-                this.CurrentPlayer.noSilent();
-            } else {
-                this.connection?.setSilent(true);
-                this.CurrentPlayer.isSilent();
-            }
+            const silent = !!newValue || localUserStore.getAlwaysSilent();
+            this.connection?.setSilent(silent);
+            this.CurrentPlayer.setSilent(silent);
         });
         this.gameMap.onPropertyChange(GameMapProperties.PLAY_AUDIO, (newValue, oldValue, allProps) => {
             const volume = allProps.get(GameMapProperties.AUDIO_VOLUME) as number | undefined;
@@ -1987,12 +1987,15 @@ ${escapedMessage}
     }
 
     public stopJitsi(): void {
-        const silent = this.gameMap.getCurrentProperties().get(GameMapProperties.SILENT);
-        this.connection?.setSilent(!!silent);
+        this.connection?.setSilent(this.isSilentZone() || localUserStore.getAlwaysSilent());
         jitsiFactory.stop();
         mediaManager.showGameOverlay();
 
         mediaManager.removeTriggerCloseJitsiFrameButton("close-jitsi");
+    }
+
+    public isSilentZone(): boolean {
+        return !!this.gameMap.getCurrentProperties().get(GameMapProperties.SILENT);
     }
 
     //todo: put this into an 'orchestrator' scene (EntryScene?)

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -964,6 +964,9 @@ export class GameScene extends DirtyScene {
             this.CurrentPlayer.setSilent(silent);
         });
         this.gameMap.onPropertyChange(GameMapProperties.PLAY_AUDIO, (newValue, oldValue, allProps) => {
+            if (localUserStore.getBlockAudio()) {
+                return;
+            }
             const volume = allProps.get(GameMapProperties.AUDIO_VOLUME) as number | undefined;
             const loop = allProps.get(GameMapProperties.AUDIO_LOOP) as boolean | undefined;
             newValue === undefined

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -971,13 +971,6 @@ export class GameScene extends DirtyScene {
                 : audioManagerFileStore.playAudio(newValue, this.getMapDirUrl(), volume, loop);
             audioManagerVisibilityStore.set(!(newValue === undefined));
         });
-        // TODO: This legacy property should be removed at some point
-        this.gameMap.onPropertyChange(GameMapProperties.PLAY_AUDIO_LOOP, (newValue, oldValue) => {
-            newValue === undefined
-                ? audioManagerFileStore.unloadAudio()
-                : audioManagerFileStore.playAudio(newValue, this.getMapDirUrl(), undefined, true);
-            audioManagerVisibilityStore.set(!(newValue === undefined));
-        });
 
         // TODO: Legacy functionnality replace by layer change
         this.gameMap.onPropertyChange(GameMapProperties.ZONE, (newValue, oldValue) => {


### PR DESCRIPTION
Another setting that disables stuff: This one enables a silent mode that makes the frontend behave as if the player were moving in a silent zone all the time.

I'm going to add the last "deactivate $feature" setting to this draft PR too: It will make the frontend ignore `playAudio` properties.
I'd appreciate some input on UI, though: I think it's come to a point where we should probably consider combining or at least sorting all these "disable" settings. There are (or will be):
* Disabling groups (aka silent mode)
* Disabling follow invites
* Disabling audio files
* Forcing Jitsi- and Cowebsite triggers

For example, silent mode could (should?) automagically disable audio files and follow invites as well. The latter is effectively done anyway, because following is built on groups.