### PR TITLE
ScaleManager: do not apply new size if width is zero

### DIFF
--- a/front/src/Phaser/Services/WaScaleManager.ts
+++ b/front/src/Phaser/Services/WaScaleManager.ts
@@ -31,6 +31,10 @@ export class WaScaleManager {
             height: height * devicePixelRatio,
         });
 
+        if (gameSize.width == 0) {
+            return;
+        }
+
         this.actualZoom = realSize.width / gameSize.width / devicePixelRatio;
 
         this.scaleManager.setZoom(realSize.width / gameSize.width / devicePixelRatio);


### PR DESCRIPTION
If the game width reaches zero (e.g by resizing a cowebsite manually),
a division by zero happens when calculating the new zoom.
This results in NaN, which causes phaser to reach an invalid state when rezooming.