### PR TITLE
[WIP] Disabling running end to end tests for forks

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -12,6 +12,7 @@ on:
 jobs:
 
   start-runner:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
     outputs:
@@ -109,12 +110,14 @@ jobs:
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Stop EC2 runner
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
         uses: machulav/ec2-github-runner@v2
         with:
           mode: stop


### PR DESCRIPTION
Github Actions does not provide big enough VMs for E2E tests.
So we need to spin our own instances on AWS. But we cannot share the credentials with the forks for obvious security reasons.
We therefore need to completely disable E2E tests for forks :(