### PR TITLE
Fixing WA crashing in Firefox private mode

### DIFF
--- a/front/src/Connexion/ConnectionManager.ts
+++ b/front/src/Connexion/ConnectionManager.ts
@@ -168,6 +168,9 @@ class ConnectionManager {
                     }
                 } catch (err) {
                     console.error(err);
+                    if (err instanceof Error) {
+                        console.error(err.stack);
+                    }
                 }
             } else {
                 const query = urlParams.toString();

--- a/front/src/Connexion/LocalUserStore.ts
+++ b/front/src/Connexion/LocalUserStore.ts
@@ -139,9 +139,13 @@ class LocalUserStore {
     async setLastRoomUrl(roomUrl: string): Promise<void> {
         localStorage.setItem(lastRoomUrl, roomUrl.toString());
         if ("caches" in window) {
-            const cache = await caches.open(cacheAPIIndex);
-            const stringResponse = new Response(JSON.stringify({ roomUrl }));
-            await cache.put(`/${lastRoomUrl}`, stringResponse);
+            try {
+                const cache = await caches.open(cacheAPIIndex);
+                const stringResponse = new Response(JSON.stringify({ roomUrl }));
+                await cache.put(`/${lastRoomUrl}`, stringResponse);
+            } catch (e) {
+                console.error("Could not store last room url in Browser cache. Are you using private browser mode?", e);
+            }
         }
     }
     getLastRoomUrl(): string {

--- a/front/src/Phaser/Reconnecting/ErrorScene.ts
+++ b/front/src/Phaser/Reconnecting/ErrorScene.ts
@@ -78,6 +78,9 @@ export class ErrorScene extends Phaser.Scene {
      */
     public static showError(error: unknown, scene: ScenePlugin): void {
         console.error(error);
+        if (error instanceof Error) {
+            console.error("Stacktrace: ", error.stack);
+        }
         console.trace();
 
         if (typeof error === "string" || error instanceof String) {


### PR DESCRIPTION
Due to the way we now handle the browser cache, previously ignored errors in the Cache API were now explicitly thrown, preventing the loading of Firefox in private mode.
This commit fixes the issue and improves the stacktrace display of errors at the same time.