### PR TITLE
Fix circular serialization in pusher dump endpoint

### DIFF
--- a/pusher/src/Controller/DebugController.ts
+++ b/pusher/src/Controller/DebugController.ts
@@ -19,11 +19,13 @@ export class DebugController {
                 return res.writeStatus("401 Unauthorized").end("Invalid token sent!");
             }
 
+            const worlds = Object.fromEntries(socketManager.getWorlds().entries());
+
             return res
                 .writeStatus("200 OK")
                 .writeHeader("Content-Type", "application/json")
                 .end(
-                    stringify(socketManager.getWorlds(), (key: unknown, value: unknown) => {
+                    stringify(worlds, (key: unknown, value: unknown) => {
                         if (value instanceof Map) {
                             const obj: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
                             for (const [mapKey, mapValue] of value.entries()) {


### PR DESCRIPTION
The debug/dump endpoint in the pusher has a bug where nested referenced objects miss the root path (the roomId).

e.g. `~listeners~0~listenedZones~0~positionDispatcher~zones~0~1~listeners~1` should be `~http://workadventure.local/@/org/world/room~listeners~0~listenedZones~0~positionDispatcher~zones~0~1~listeners~1`.

This happens because worlds are passed as Map objects to the CircularJSON.stringify function. The debug/dump endpoint in the back already handles this correctly by converting the map to an object.

This PR implements the same approach for the pusher.