### PR TITLE
I18n actions

### DIFF
--- a/front/src/Components/LayoutManager/LayoutManager.svelte
+++ b/front/src/Components/LayoutManager/LayoutManager.svelte
@@ -1,15 +1,36 @@
 <script lang="ts">
     import { layoutManagerActionStore } from "../../Stores/LayoutManagerStore";
+    import { locale } from "../../i18n/i18n-svelte";
 
     function onClick(callback: () => void) {
         callback();
+    }
+
+    function i18n(text: string | number | boolean | undefined): string {
+        if (typeof text === "string") {
+            if (text.trim().startsWith("{")) {
+                try {
+                    let textObject = JSON.parse(text);
+                    if (textObject[$locale]) {
+                        return textObject[$locale];
+                    } else if (Object.keys(textObject).length > 0) {
+                        // fallback to first value
+                        return textObject[Object.keys(textObject)[0]];
+                    }
+                } catch (err) {
+                    //
+                }
+            }
+            return text;
+        }
+        return "";
     }
 </script>
 
 <div class="layout-manager-list">
     {#each $layoutManagerActionStore as action}
         <div class="nes-container is-rounded {action.type}" on:click={() => onClick(action.callback)}>
-            <p>{action.message}</p>
+            <p>{i18n(action.message)}</p>
         </div>
     {/each}
 </div>


### PR DESCRIPTION
As always I am unsure if this is best way to do it. But I wanted a quick solution for using the locale feature for the trigger messages. This is now done, by accepting JSON in the triggerMessage property with an easy object like:
`{ "en-US" : "This text is for english locale.", "fr-FR" : "Ce texte concerne les paramètres régionaux français."}` (Pardon my french, it's auto translation) Maybe it's better to put this part into the actionStore, but as said, Q'n'D solution and may just provide a good idea on how to achieve this.