### PR TITLE
Fixing a freeze in MapStore on several unsubscribes

### DIFF
--- a/front/src/Stores/Utils/MapStore.ts
+++ b/front/src/Stores/Utils/MapStore.ts
@@ -96,6 +96,7 @@ export class MapStore<K, V> extends Map<K, V> implements Readable<Map<K, V>> {
             const unsubscribe = storeByKey.subscribe((newMapValue) => {
                 if (unsubscribeDeepStore) {
                     unsubscribeDeepStore();
+                    unsubscribeDeepStore = undefined;
                 }
                 if (newMapValue === undefined) {
                     set(undefined);
@@ -115,6 +116,7 @@ export class MapStore<K, V> extends Map<K, V> implements Readable<Map<K, V>> {
                 unsubscribe();
                 if (unsubscribeDeepStore) {
                     unsubscribeDeepStore();
+                    unsubscribeDeepStore = undefined;
                 }
             };
         });


### PR DESCRIPTION
For some reason (I could not reproduce this in unit tests alas), the unsubscribe function
could be called several times in a row, leading to a complete map freeze.

Closes #1736