### PR TITLE
Fixing users walking infinitely

### DIFF
--- a/front/src/Phaser/Game/PlayerMovement.ts
+++ b/front/src/Phaser/Game/PlayerMovement.ts
@@ -41,7 +41,7 @@ export class PlayerMovement {
             oldX: this.startPosition.x,
             oldY: this.startPosition.y,
             direction: this.endPosition.direction,
-            moving: this.endPosition.moving,
+            moving: this.isOutdated(tick) ? false : this.endPosition.moving,
         };
     }
 }


### PR DESCRIPTION
Now, if no event is received from the Pusher after MAX_EXTRAPOLATION_TIME, the
moving variable of the user is set to false.

So if a client does not send an update on time (for instance if the user switched
tab while walking), on the screen of others, the woka will appear to stop.