### PR TITLE
Ignored .tmp files inside /dist

### DIFF
--- a/front/.gitignore
+++ b/front/.gitignore
@@ -1,4 +1,5 @@
 /node_modules/
+/dist/*.tmp
 /dist/*.js
 /dist/*.js.map
 /dist/*.js.LICENSE.txt


### PR DESCRIPTION
Sometimes we have the file in the git unstaged area: '/front/dist/index.tmpl.html.tmp' which is kind of annoying ^^