### PR TITLE
Remove explicit definition of prettier-plugin-svelte

### DIFF
--- a/front/.prettierrc.json
+++ b/front/.prettierrc.json
@@ -1,5 +1,4 @@
 {
   "printWidth": 120,
-  "tabWidth": 4,
-  "plugins": ["prettier-plugin-svelte"]
+  "tabWidth": 4
 }


### PR DESCRIPTION
This fixes prettier in vscode.

The vscode prettier extension reported an error: `Error: Cannot find module 'prettier-plugin-svelte'`.
Simply removing this definition seems to have fixed the error.
Formatting of svelte files still works as expected.
The [prettier docs](https://prettier.io/docs/en/plugins.html#using-plugins) also state that
> Plugins are automatically loaded if you have them installed in the same node_modules directory where prettier is located.