### PR TITLE
Fix Jitsi co-website reloading

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -2156,9 +2156,9 @@ ${escapedMessage}
         );
         const jitsiUrl = allProps.get(GameMapProperties.JITSI_URL) as string | undefined;
 
-        coWebsite.setJitsiLoadPromise(
-            jitsiFactory.start(roomName, this.playerName, jwt, jitsiConfig, jitsiInterfaceConfig, jitsiUrl)
-        );
+        coWebsite.setJitsiLoadPromise(() => {
+            return jitsiFactory.start(roomName, this.playerName, jwt, jitsiConfig, jitsiInterfaceConfig, jitsiUrl);
+        });
 
         coWebsiteManager.loadCoWebsite(coWebsite).catch((err) => {
             console.error(err);

--- a/front/src/WebRtc/CoWebsite/JitsiCoWebsite.ts
+++ b/front/src/WebRtc/CoWebsite/JitsiCoWebsite.ts
@@ -5,7 +5,7 @@ import { jitsiFactory } from "../JitsiFactory";
 import { SimpleCoWebsite } from "./SimpleCoWebsite";
 
 export class JitsiCoWebsite extends SimpleCoWebsite {
-    private jitsiLoadPromise?: CancelablePromise<HTMLIFrameElement>;
+    private jitsiLoadPromise?: () => CancelablePromise<HTMLIFrameElement>;
 
     constructor(url: URL, allowApi?: boolean, allowPolicy?: string, widthPercent?: number, closable?: boolean) {
         const coWebsite = coWebsiteManager.searchJitsi();
@@ -17,7 +17,7 @@ export class JitsiCoWebsite extends SimpleCoWebsite {
         super(url, allowApi, allowPolicy, widthPercent, closable);
     }
 
-    setJitsiLoadPromise(promise: CancelablePromise<HTMLIFrameElement>): void {
+    setJitsiLoadPromise(promise: () => CancelablePromise<HTMLIFrameElement>): void {
         this.jitsiLoadPromise = promise;
     }
 
@@ -32,7 +32,7 @@ export class JitsiCoWebsite extends SimpleCoWebsite {
                 return reject("Undefined Jitsi start callback");
             }
 
-            const jitsiLoading = this.jitsiLoadPromise
+            const jitsiLoading = this.jitsiLoadPromise()
                 .then((iframe) => {
                     this.iframe = iframe;
                     this.iframe.classList.add("pixel");


### PR DESCRIPTION
Fix Jitsi co-website reloading by isolating the promise who create the iframe on DOM.