### PR TITLE
Adding missing Content-Type header for json responses in pusher code

### DIFF
--- a/pusher/src/Controller/AuthenticateController.ts
+++ b/pusher/src/Controller/AuthenticateController.ts
@@ -79,6 +79,7 @@ export class AuthenticateController extends BaseController {
                             if (!code && !nonce) {
                                 res.writeStatus("200");
                                 this.addCorsHeaders(res);
+                                res.writeHeader('Content-Type', 'application/json');
                                 return res.end(JSON.stringify({ ...resUserData, authToken: token }));
                             }
                             console.error("Token cannot to be check on OpenId provider");
@@ -91,6 +92,7 @@ export class AuthenticateController extends BaseController {
                         const resCheckTokenAuth = await openIDClient.checkTokenAuth(authTokenData.accessToken);
                         res.writeStatus("200");
                         this.addCorsHeaders(res);
+                        res.writeHeader('Content-Type', 'application/json');
                         return res.end(JSON.stringify({ ...resCheckTokenAuth, ...resUserData, authToken: token }));
                     } catch (err) {
                         console.info("User was not connected", err);
@@ -121,6 +123,7 @@ export class AuthenticateController extends BaseController {
 
                 res.writeStatus("200");
                 this.addCorsHeaders(res);
+                res.writeHeader('Content-Type', 'application/json');
                 return res.end(JSON.stringify({ ...data, authToken }));
             } catch (e) {
                 console.error("openIDCallback => ERROR", e);
@@ -183,6 +186,7 @@ export class AuthenticateController extends BaseController {
                     const authToken = jwtTokenManager.createAuthToken(email || userUuid);
                     res.writeStatus("200 OK");
                     this.addCorsHeaders(res);
+                    res.writeHeader('Content-Type', 'application/json');
                     res.end(
                         JSON.stringify({
                             authToken,
@@ -222,6 +226,7 @@ export class AuthenticateController extends BaseController {
                 const authToken = jwtTokenManager.createAuthToken(userUuid);
                 res.writeStatus("200 OK");
                 this.addCorsHeaders(res);
+                res.writeHeader('Content-Type', 'application/json');
                 res.end(
                     JSON.stringify({
                         authToken,

--- a/pusher/src/Controller/MapController.ts
+++ b/pusher/src/Controller/MapController.ts
@@ -47,6 +47,7 @@ export class MapController extends BaseController {
                 if (!match) {
                     res.writeStatus("404 Not Found");
                     this.addCorsHeaders(res);
+                    res.writeHeader('Content-Type', 'application/json');
                     res.end(JSON.stringify({}));
                     return;
                 }
@@ -55,6 +56,7 @@ export class MapController extends BaseController {
 
                 res.writeStatus("200 OK");
                 this.addCorsHeaders(res);
+                res.writeHeader('Content-Type', 'application/json');
                 res.end(
                     JSON.stringify({
                         mapUrl,
@@ -106,6 +108,7 @@ export class MapController extends BaseController {
 
                     res.writeStatus("200 OK");
                     this.addCorsHeaders(res);
+                    res.writeHeader('Content-Type', 'application/json');
                     res.end(JSON.stringify(mapDetails));
                 } catch (e) {
                     this.errorToResponse(e, res);


### PR DESCRIPTION
Removes the parser warnings in the console due to missing 'Content-Type' headers of some json responses.