### PR TITLE
fix comparison that is always false

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -1405,7 +1405,7 @@ ${escapedMessage}
             phaserLayer.setCollisionByProperty({ collides: true }, visible);
         } else {
             const phaserLayers = this.gameMap.findPhaserLayers(layerName + "/");
-            if (phaserLayers === []) {
+            if (phaserLayers.length === 0) {
                 console.warn(
                     'Could not find layer with name that contains "' +
                         layerName +


### PR DESCRIPTION
While building the frontend with vite I noticed the following warning:

```
[vite] warning: Comparison using the "===" operator here is always false
 1405|          } else {
 1406|              const phaserLayers = this.gameMap.findPhaserLayers(layerName + "/");
 1407|              if (phaserLayers === []) {
    |                               ^
 1408|                  console.warn(
 1409|                      'Could not find layer with name that contains "' +
```