### PR TITLE
Change default front URL to "play"

### DIFF
--- a/contrib/docker/.env.prod.template
+++ b/contrib/docker/.env.prod.template
@@ -13,7 +13,7 @@ DOMAIN=workadventure.localhost
 
 # Subdomains
 # MUST match the DOMAIN variable above
-FRONT_HOST=front.workadventure.localhost
+FRONT_HOST=play.workadventure.localhost
 PUSHER_HOST=pusher.workadventure.localhost
 BACK_HOST=api.workadventure.localhost
 MAPS_HOST=maps.workadventure.localhost


### PR DESCRIPTION
Previously, the URL was "front". However, this is not in line with the default URL of the dev environments, where it is "play.workadventure.localhost".