### PR TITLE
prod template: Use docker-hub images by default

### DIFF
--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -27,10 +27,7 @@ services:
 
 
   front:
-    build:
-      context: ../..
-      dockerfile: front/Dockerfile
-    #image: thecodingmachine/workadventure-front:${VERSION}
+    image: thecodingmachine/workadventure-front:${VERSION}
     environment:
       - DEBUG_MODE
       - JITSI_URL
@@ -60,10 +57,7 @@ services:
     restart: ${RESTART_POLICY}
 
   pusher:
-    build:
-      context: ../..
-      dockerfile: pusher/Dockerfile
-    #image: thecodingmachine/workadventure-pusher:${VERSION}
+    image: thecodingmachine/workadventure-pusher:${VERSION}
     command: yarn run runprod
     environment:
       - SECRET_JITSI_KEY
@@ -85,10 +79,7 @@ services:
     restart: ${RESTART_POLICY}
 
   back:
-    build:
-      context: ../..
-      dockerfile: back/Dockerfile
-    #image: thecodingmachine/workadventure-back:${VERSION}
+    image: thecodingmachine/workadventure-back:${VERSION}
     command: yarn run runprod
     environment:
       - SECRET_JITSI_KEY
@@ -119,7 +110,7 @@ services:
     image: matthiasluedtke/iconserver:v3.13.0
     labels:
       - "traefik.http.routers.icon.rule=Host(`${ICON_HOST}`)"
-      - "traefik.http.routers.icon.entryPoints=web,traefik"
+      - "traefik.http.routers.icon.entryPoints=web"
       - "traefik.http.services.icon.loadbalancer.server.port=8080"
       - "traefik.http.routers.icon-ssl.rule=Host(`${ICON_HOST}`)"
       - "traefik.http.routers.icon-ssl.entryPoints=websecure"


### PR DESCRIPTION
In production environments, it is more likely for people to use the stable versions from the docker hub.
The build parameters were thus removed and the image variables uncommented.