### PR TITLE
disable corner cutting

### DIFF
--- a/front/src/Utils/PathfindingManager.ts
+++ b/front/src/Utils/PathfindingManager.ts
@@ -18,6 +18,7 @@ export class PathfindingManager {
 
         this.easyStar = new EasyStar.js();
         this.easyStar.enableDiagonals();
+        this.easyStar.disableCornerCutting();
 
         this.grid = collisionsGrid;
         this.tileDimensions = tileDimensions;


### PR DESCRIPTION
Fix for wrong pathfinding behaviour if confronted with diagonal walls