### PR TITLE
Continuous Deployment: add connect to admin

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -149,6 +149,10 @@ jobs:
       # Create a slugified value of the branch
       - uses: rlespinasse/github-slug-action@3.1.0
 
+      - name: Set ADMIN_URL if "deploy-connect-to-admin" label is set
+        run: echo "ADMIN_API_URL=https://${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}.test.workadventu.re" >> $GITHUB_ENV
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy-connect-to-admin') }}
+
       - name: Write certificate
         run: echo "${CERTS_PRIVATE_KEY}" > secret.key && chmod 0600 secret.key
         env:

--- a/deeployer.libsonnet
+++ b/deeployer.libsonnet
@@ -4,7 +4,7 @@
   local tag = namespace,
   local url = namespace+".test.workadventu.re",
   // develop branch does not use admin because of issue with SSL certificate of admin as of now.
-  local adminUrl = if std.startsWith(namespace, "admin") then "https://"+url else null,
+  local adminUrl = if std.objectHas(env, 'ADMIN_API_URL') then env.ADMIN_API_URL else null,
   "$schema": "https://raw.githubusercontent.com/thecodingmachine/deeployer/master/deeployer.schema.json",
   "version": "1.0",
   "containers": {


### PR DESCRIPTION
We can now connect to a remote admin server in the CD environment by using the new "deploy-connect-to-admin" label in the PR.