### PR TITLE
improve docker build caching

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,8 +1,10 @@
 # protobuf build
 FROM node:14.18.2-buster-slim@sha256:20bedf0c09de887379e59a41c04284974f5fb529cf0e13aab613473ce298da3d as builder
 WORKDIR /usr/src
+COPY messages/yarn.lock messages/package.json ./
+RUN yarn install
 COPY messages .
-RUN yarn install && yarn proto
+RUN yarn proto
 
 # typescript build
 FROM node:14.18.2-buster-slim@sha256:20bedf0c09de887379e59a41c04284974f5fb529cf0e13aab613473ce298da3d as builder2
@@ -18,9 +20,9 @@ RUN yarn run tsc
 FROM node:14.18.2-buster-slim@sha256:20bedf0c09de887379e59a41c04284974f5fb529cf0e13aab613473ce298da3d
 WORKDIR /usr/src
 COPY back/yarn.lock back/package.json ./
-COPY --from=builder2 /usr/src/dist /usr/src/dist
 ENV NODE_ENV=production
 RUN yarn install --production
+COPY --from=builder2 /usr/src/dist /usr/src/dist
 
 USER node
 CMD ["yarn", "run", "runprod"]

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,23 +1,24 @@
+# protobuf build
 FROM node:14.18.2-buster-slim@sha256:20bedf0c09de887379e59a41c04284974f5fb529cf0e13aab613473ce298da3d as builder
-
-WORKDIR /usr/src/messages
+WORKDIR /usr/src
+COPY messages/yarn.lock messages/package.json ./
+RUN yarn install
 COPY messages .
-RUN yarn install && yarn ts-proto
+RUN yarn proto
 
-WORKDIR /usr/src/front
+# typescript build
+FROM node:14.18.2-buster-slim@sha256:20bedf0c09de887379e59a41c04284974f5fb529cf0e13aab613473ce298da3d as builder2
+WORKDIR /usr/src
+COPY front/yarn.lock front/package.json ./
+RUN yarn install
 COPY front .
-
-# move messages to front
-RUN cp -r ../messages/ts-proto-generated/protos/* src/Messages/ts-proto-generated
+COPY --from=builder /usr/src/ts-proto-generated/protos src/Messages/ts-proto-generated
 RUN sed -i 's/import { Observable } from "rxjs";/import type { Observable } from "rxjs";/g' src/Messages/ts-proto-generated/messages.ts
-RUN cp -r ../messages/JsonMessages/* src/Messages/JsonMessages
+COPY --from=builder /usr/src/JsonMessages src/Messages/JsonMessages
+RUN yarn run typesafe-i18n && yarn run build-iframe-api && yarn build
 
-RUN yarn install && yarn run typesafe-i18n && yarn run build-iframe-api && yarn build
-
+# final production image
 FROM thecodingmachine/nodejs:14-apache
-
-COPY --from=builder --chown=docker:docker /usr/src/front/dist dist
-COPY front/templater.sh .
 
 USER root
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
@@ -25,6 +26,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     gettext-base \
     && rm -rf /var/lib/apt/lists/*
 USER docker
+
+COPY --from=builder2 --chown=docker:docker /usr/src/dist dist
+COPY front/templater.sh .
 
 ENV STARTUP_COMMAND_0="./templater.sh"
 ENV STARTUP_COMMAND_1="envsubst < dist/env-config.template.js > dist/env-config.js"

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src
 COPY messages/yarn.lock messages/package.json ./
 RUN yarn install
 COPY messages .
-RUN yarn proto
+RUN yarn ts-proto
 
 # typescript build
 FROM node:14.18.2-buster-slim@sha256:20bedf0c09de887379e59a41c04284974f5fb529cf0e13aab613473ce298da3d as builder2

--- a/pusher/Dockerfile
+++ b/pusher/Dockerfile
@@ -1,8 +1,10 @@
 # protobuf build
 FROM node:14.18.2-buster-slim@sha256:20bedf0c09de887379e59a41c04284974f5fb529cf0e13aab613473ce298da3d as builder
 WORKDIR /usr/src
+COPY messages/yarn.lock messages/package.json ./
+RUN yarn install
 COPY messages .
-RUN yarn install && yarn proto
+RUN yarn proto
 
 # typescript build
 FROM node:14.18.2-buster-slim@sha256:20bedf0c09de887379e59a41c04284974f5fb529cf0e13aab613473ce298da3d as builder2
@@ -19,9 +21,9 @@ RUN yarn run tsc
 FROM node:14.18.2-buster-slim@sha256:20bedf0c09de887379e59a41c04284974f5fb529cf0e13aab613473ce298da3d
 WORKDIR /usr/src
 COPY pusher/yarn.lock pusher/package.json ./
-COPY --from=builder2 /usr/src/dist /usr/src/dist
 ENV NODE_ENV=production
 RUN yarn install --production
+COPY --from=builder2 /usr/src/dist /usr/src/dist
 
 USER node
 CMD ["yarn", "run", "runprod"]

--- a/uploader/Dockerfile
+++ b/uploader/Dockerfile
@@ -11,9 +11,9 @@ RUN yarn run tsc
 FROM node:14.15.4-buster-slim@sha256:cbae886186467bbfd274b82a234a1cdfbbd31201c2a6ee63a6893eefcf3c6e76
 WORKDIR /usr/src
 COPY uploader/yarn.lock uploader/package.json ./
-COPY --from=builder2 /usr/src/dist /usr/src/dist
 ENV NODE_ENV=production
 RUN yarn install --production
+COPY --from=builder2 /usr/src/dist /usr/src/dist
 
 USER node
 CMD ["yarn", "run", "runprod"]


### PR DESCRIPTION
Install dependencies before copying source into image.
This should speed up consecutive docker builds.

:jack_o_lantern: Please squash this :jack_o_lantern: 