### PR TITLE
clear hashParams after moving player with moveTo param

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -1598,6 +1598,8 @@ ${escapedMessage}
                         }
                     })
                     .catch((reason) => console.warn(reason));
+
+                urlManager.clearHashParameter();
             } catch (err) {
                 console.warn(`Cannot proceed with moveTo command:\n\t-> ${err}`);
             }

--- a/front/src/Url/UrlManager.ts
+++ b/front/src/Url/UrlManager.ts
@@ -58,6 +58,10 @@ class UrlManager {
         return this.getHashParameters()[name];
     }
 
+    public clearHashParameter(): void {
+        window.location.hash = "";
+    }
+
     private getHashParameters(): Record<string, string> {
         return window.location.hash
             .substring(1)


### PR DESCRIPTION
This is needed so player won't move again after returning from machine's standby mode. Will leave '#' at the end of the url.