### PR TITLE
base front production image on official nginx image

### DIFF
--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -48,7 +48,7 @@ services:
     labels:
       - "traefik.http.routers.front.rule=Host(`${FRONT_HOST}`)"
       - "traefik.http.routers.front.entryPoints=web"
-      - "traefik.http.services.front.loadbalancer.server.port=80"
+      - "traefik.http.services.front.loadbalancer.server.port=8080"
       - "traefik.http.routers.front-ssl.rule=Host(`${FRONT_HOST}`)"
       - "traefik.http.routers.front-ssl.entryPoints=websecure"
       - "traefik.http.routers.front-ssl.service=front"

--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -48,7 +48,7 @@ services:
     labels:
       - "traefik.http.routers.front.rule=Host(`${FRONT_HOST}`)"
       - "traefik.http.routers.front.entryPoints=web"
-      - "traefik.http.services.front.loadbalancer.server.port=8080"
+      - "traefik.http.services.front.loadbalancer.server.port=80"
       - "traefik.http.routers.front-ssl.rule=Host(`${FRONT_HOST}`)"
       - "traefik.http.routers.front-ssl.entryPoints=websecure"
       - "traefik.http.routers.front-ssl.service=front"

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -11,6 +11,15 @@ services:
       dockerfile: front/Dockerfile
     command: /bin/sh -c "/templater.sh && envsubst < /usr/share/nginx/html/env-config.template.js > /usr/share/nginx/html/env-config.js && exec nginx -g 'daemon off;'"
     volumes: []
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.front.rule=Host(`play.workadventure.localhost`)"
+      - "traefik.http.routers.front.entryPoints=web"
+      - "traefik.http.services.front.loadbalancer.server.port=80"
+      - "traefik.http.routers.front-ssl.rule=Host(`play.workadventure.localhost`)"
+      - "traefik.http.routers.front-ssl.entryPoints=websecure"
+      - "traefik.http.routers.front-ssl.tls=true"
+      - "traefik.http.routers.front-ssl.service=front"
 
   pusher:
     image: 'wa-pusher-e2e'

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -9,29 +9,14 @@ services:
     build:
       context: ./
       dockerfile: front/Dockerfile
-    environment:
-      STARTUP_COMMAND_1: 'envsubst < dist/env-config.template.js > dist/env-config.js'
-      STARTUP_COMMAND_2: ''
-    command: apache2-foreground
+    command: /bin/sh -c "/templater.sh && envsubst < /usr/share/nginx/html/env-config.template.js > /usr/share/nginx/html/env-config.js && exec nginx -g 'daemon off;'"
     volumes: []
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.front.rule=Host(`play.workadventure.localhost`)"
-      - "traefik.http.routers.front.entryPoints=web"
-      - "traefik.http.services.front.loadbalancer.server.port=80"
-      - "traefik.http.routers.front-ssl.rule=Host(`play.workadventure.localhost`)"
-      - "traefik.http.routers.front-ssl.entryPoints=websecure"
-      - "traefik.http.routers.front-ssl.tls=true"
-      - "traefik.http.routers.front-ssl.service=front"
 
   pusher:
     image: 'wa-pusher-e2e'
     build:
       context: ./
       dockerfile: pusher/Dockerfile
-    environment:
-      STARTUP_COMMAND_1: ''
-      STARTUP_COMMAND_2: ''
     command: yarn run runprod
     volumes: []
 
@@ -40,8 +25,5 @@ services:
     build:
       context: ./
       dockerfile: back/Dockerfile
-    environment:
-      STARTUP_COMMAND_1: ''
-      STARTUP_COMMAND_2: ''
     command: yarn run runprod
     volumes: []

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -24,5 +24,5 @@ COPY front/nginx.conf /etc/nginx/conf.d/default.conf
 COPY front/templater.sh /
 COPY --from=builder2 /usr/src/dist /usr/share/nginx/html
 
-EXPOSE 8080
+EXPOSE 80
 CMD ["/bin/sh", "-c", "/templater.sh && envsubst < /usr/share/nginx/html/env-config.template.js > /usr/share/nginx/html/env-config.js && exec nginx -g 'daemon off;'"]

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -14,18 +14,12 @@ RUN cp -r ../messages/JsonMessages/* src/Messages/JsonMessages
 
 RUN yarn install && yarn run typesafe-i18n && yarn run build-iframe-api && yarn build
 
-FROM thecodingmachine/nodejs:14-apache
+# final production image
+FROM nginx:1.21.6-alpine
 
-COPY --from=builder --chown=docker:docker /usr/src/front/dist dist
-COPY front/templater.sh .
+COPY front/nginx.conf /etc/nginx/conf.d/default.conf
+COPY front/templater.sh /
+COPY --from=builder /usr/src/front/dist /usr/share/nginx/html
 
-USER root
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && apt-get install -y \
-    gettext-base \
-    && rm -rf /var/lib/apt/lists/*
-USER docker
-
-ENV STARTUP_COMMAND_0="./templater.sh"
-ENV STARTUP_COMMAND_1="envsubst < dist/env-config.template.js > dist/env-config.js"
-ENV APACHE_DOCUMENT_ROOT=dist/
+EXPOSE 8080
+CMD ["/bin/sh", "-c", "/templater.sh && envsubst < /usr/share/nginx/html/env-config.template.js > /usr/share/nginx/html/env-config.js && exec nginx -g 'daemon off;'"]

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -1,0 +1,48 @@
+server {
+    listen       8080;
+    listen  [::]:8080;
+    server_name  localhost;
+    access_log  off;
+
+    gzip on;
+    gzip_comp_level 6;
+    gzip_min_length 1000;
+    gzip_proxied any;
+    gzip_disable "msie6";
+    gzip_types
+        application/atom+xml
+        application/geo+json
+        application/javascript
+        application/x-javascript
+        application/json
+        application/ld+json
+        application/manifest+json
+        application/rdf+xml
+        application/rss+xml
+        application/xhtml+xml
+        application/xml
+        font/eot
+        font/otf
+        font/ttf
+        image/svg+xml
+        text/css
+        text/javascript
+        text/plain
+        text/xml;
+
+    # serve static assets (that have a cache busting hash) with an efficient cache policy
+    location /assets {
+        root   /usr/share/nginx/html;
+        expires 1y;
+        add_header Cache-Control "public";
+    }
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html;
+    }
+
+    location ~ ^/[@_]/ {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -1,6 +1,6 @@
 server {
-    listen       8080;
-    listen  [::]:8080;
+    listen       80;
+    listen  [::]:80;
     server_name  localhost;
     access_log  off;
 

--- a/front/templater.sh
+++ b/front/templater.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -x
 set -o nounset errexit
-index_file=dist/index.html
+index_file=/usr/share/nginx/html/index.html
 tmp_trackcodefile=/tmp/trackcode
 
 # To inject tracking code, you have two choices:
@@ -10,12 +10,12 @@ tmp_trackcodefile=/tmp/trackcode
 # The ANALYTICS_CODE_PATH is the location of a file inside the container
 ANALYTICS_CODE_PATH="${ANALYTICS_CODE_PATH:-dist/ga.html.tmpl}"
 
-if [[ "${INSERT_ANALYTICS:-NO}" == "NO" ]]; then
+if [ "${INSERT_ANALYTICS:-NO}" = "NO" ]; then
     echo "" > "${tmp_trackcodefile}"
 fi
 
 # Automatically insert analytics if GA_TRACKING_ID is set
-if [[ "${GA_TRACKING_ID:-}" != ""  || "${INSERT_ANALYTICS:-NO}" != "NO" ]]; then
+if [ "${GA_TRACKING_ID:-}" != "" ] || [ "${INSERT_ANALYTICS:-NO}" != "NO" ]; then
     echo "Templating code from ${ANALYTICS_CODE_PATH}"
     sed "s#<!-- TRACKING NUMBER -->#${GA_TRACKING_ID:-}#g" "${ANALYTICS_CODE_PATH}" > "$tmp_trackcodefile"
 fi


### PR DESCRIPTION
Since #594 the nodejs distribution in the custom base image is no longer needed for the front production image.

This PR changes to nginx as the base image for the front production image.

- 10x smaller image (`376MB` -> `33.6MB`)
- nginx is available as multi-platform image and will ease building multi-platform images for workadventure (see #800)
- nginx image already includes `envsubst`
- additionally adds an [efficient cache policy](https://web.dev/uses-long-cache-ttl/) for /assets

I took some inspiration from https://github.com/workadventure-xce/workadventure-xce/commit/c58d39990a45600042fcbb992550bd8b88748a64

:jack_o_lantern: Please squash this :jack_o_lantern: 