### PR TITLE
fix nginx.conf to work with OIDC

### DIFF
--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -40,6 +40,13 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html;
+        rewrite ^/register/ /index.html break;
+        rewrite ^/login /index.html break; 
+        rewrite ^/jwt /index.html break; 
+    }
+
+    location ~ ^/[@_]/ {
         try_files $uri $uri/ /index.html;
     }
+
 }

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -40,9 +40,6 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html;
-    }
-
-    location ~ ^/[@_]/ {
         try_files $uri $uri/ /index.html;
     }
 }

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -48,5 +48,4 @@ server {
     location ~ ^/[@_]/ {
         try_files $uri $uri/ /index.html;
     }
-
 }


### PR DESCRIPTION
Is there any reason for not redirecting everything to index? Without those changes, I got 404 from nginx when accessing /jwt... for example on OIDC login!