### PR TITLE
Using parallel build in end to end tests

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -23,8 +23,10 @@ jobs:
         run: npx playwright install --with-deps
       - name: 'Setup .env file'
         run: cp .env.template .env
+      - name: Build WorkAdventure
+        run: docker-compose -f docker-compose.yaml -f docker-compose.e2e.yml build --parallel
       - name: Start WorkAdventure
-        run: docker-compose -f docker-compose.yaml -f docker-compose.e2e.yml up -d --build
+        run: docker-compose -f docker-compose.yaml -f docker-compose.e2e.yml up -d
       - name: Wait for environment to Start
         run: sleep 60
       - name: Run Playwright tests


### PR DESCRIPTION
The docker-compose build used in E2E tests was running builds sequentially.
This is an attempt to run the builds in parallel to optimize the E2E startup time.
Before this commit, the "Start WorkAdventure" step takes 7m11 on GitHub