### PR TITLE
Better e2e tests

### DIFF
--- a/back/src/Services/MapFetcher.ts
+++ b/back/src/Services/MapFetcher.ts
@@ -43,6 +43,15 @@ class MapFetcher {
      * @private
      */
     async isLocalUrl(url: string): Promise<boolean> {
+        if (
+            url ===
+            "http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/shared_variables.json"
+        ) {
+            // This is an ugly exception case needed for the E2E test at "tests/tests/variables.spec.ts"
+            // Otherwise, we cannot test locally maps that are... not local.
+            return false;
+        }
+
         const urlObj = new URL(url);
         if (urlObj.hostname === "localhost" || urlObj.hostname.endsWith(".localhost")) {
             return true;

--- a/tests/tests/variables.spec.ts
+++ b/tests/tests/variables.spec.ts
@@ -142,6 +142,9 @@ test.describe('Variables', () => {
 
     await login(page, 'Alice', 2);
 
+    // Wait for page to load before copying file (it seems the await above does not 100% fills its role otherwise).
+    await timeout(3000);
+
     // Let's REPLACE the map by a map that has a new variable
     // At this point, the back server contains a cache of the old map (with no variables)
     fs.copyFileSync(
@@ -162,3 +165,8 @@ test.describe('Variables', () => {
     await assertLogMessage(page2, 'SUCCESS!');
   });
 });
+
+
+function timeout(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Adding a timeout to wait for old map to be correctly loaded.
This makes the E2E test regarding variables and cache actually test something ;)