### PR TITLE
apply textures on openid login, fix pusher errors on woka list

### DIFF
--- a/front/src/Connexion/ConnectionManager.ts
+++ b/front/src/Connexion/ConnectionManager.ts
@@ -364,8 +364,6 @@ class ConnectionManager {
             }
         }
 
-        console.log("textures", textures);
-
         if (textures) {
             const layers: string[] = [];
             for (const texture of textures) {

--- a/front/src/Connexion/ConnectionManager.ts
+++ b/front/src/Connexion/ConnectionManager.ts
@@ -330,9 +330,12 @@ class ConnectionManager {
                 throw new Error("No Auth code provided");
             }
         }
-        const { authToken, userUuid, email, username, locale } = await Axios.get(`${PUSHER_URL}/login-callback`, {
-            params: { code, nonce, token, playUri: this.currentRoom?.key },
-        }).then((res) => {
+        const { authToken, userUuid, email, username, locale, textures } = await Axios.get(
+            `${PUSHER_URL}/login-callback`,
+            {
+                params: { code, nonce, token, playUri: this.currentRoom?.key },
+            }
+        ).then((res) => {
             return res.data;
         });
         localUserStore.setAuthToken(authToken);
@@ -358,6 +361,20 @@ class ConnectionManager {
                 }
             } catch (err) {
                 console.warn("Could not set locale", err);
+            }
+        }
+
+        console.log("textures", textures);
+
+        if (textures) {
+            const layers: string[] = [];
+            for (const texture of textures) {
+                if (texture !== undefined) {
+                    layers.push(texture.id);
+                }
+            }
+            if (layers.length > 0) {
+                gameManager.setCharacterLayers(layers);
             }
         }
 

--- a/front/src/Phaser/Login/CustomizeScene.ts
+++ b/front/src/Phaser/Login/CustomizeScene.ts
@@ -46,7 +46,7 @@ export class CustomizeScene extends AbstractCharacterScene {
         // FIXME: window.location.href is wrong. We need the URL of the main room (so we need to apply any redirect before!)
         this.load.json(
             wokaMetadataKey,
-            `${PUSHER_URL}/woka/list/` + encodeURIComponent(window.location.href),
+            `${PUSHER_URL}/woka/list?roomUrl=` + encodeURIComponent(window.location.href),
             undefined,
             {
                 responseType: "text",

--- a/front/src/Phaser/Login/SelectCharacterScene.ts
+++ b/front/src/Phaser/Login/SelectCharacterScene.ts
@@ -50,7 +50,7 @@ export class SelectCharacterScene extends AbstractCharacterScene {
         // FIXME: window.location.href is wrong. We need the URL of the main room (so we need to apply any redirect before!)
         this.load.json(
             wokaMetadataKey,
-            `${PUSHER_URL}/woka/list/` + encodeURIComponent(window.location.href),
+            `${PUSHER_URL}/woka/list?roomUrl=` + encodeURIComponent(window.location.href),
             undefined,
             {
                 responseType: "text",

--- a/pusher/src/Controller/WokaListController.ts
+++ b/pusher/src/Controller/WokaListController.ts
@@ -32,7 +32,7 @@ export class WokaListController extends BaseHttpController {
             let { roomUrl } = parse(req.path_query);
 
             if (typeof roomUrl !== "string") {
-                throw new Error("missing roomUrl URL parameter");
+                return res.status(400).send("missing roomUrl URL parameter");
             }
 
             roomUrl = decodeURIComponent(roomUrl);

--- a/pusher/src/Controller/WokaListController.ts
+++ b/pusher/src/Controller/WokaListController.ts
@@ -1,17 +1,17 @@
 import { BaseHttpController } from "./BaseHttpController";
+import { parse } from "query-string";
 import { wokaService } from "../Services/WokaService";
-import * as tg from "generic-type-guard";
 import { jwtTokenManager } from "../Services/JWTTokenManager";
 
 export class WokaListController extends BaseHttpController {
     routes() {
-        this.app.options("/woka/list/:roomUrl", {}, (req, res) => {
+        this.app.options("/woka/list", {}, (req, res) => {
             res.status(200).send("");
             return;
         });
 
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        this.app.get("/woka/list/:roomUrl", {}, async (req, res) => {
+        this.app.get("/woka/list", {}, async (req, res) => {
             const token = req.header("Authorization");
 
             if (!token) {
@@ -29,17 +29,13 @@ export class WokaListController extends BaseHttpController {
                 return;
             }
 
-            const isParameters = new tg.IsInterface()
-                .withProperties({
-                    roomUrl: tg.isString,
-                })
-                .get();
+            let { roomUrl } = parse(req.path_query);
 
-            if (!isParameters(req.path_parameters)) {
-                return res.status(400).send("Unknown parameters");
+            if (typeof roomUrl !== "string") {
+                throw new Error("missing roomUrl URL parameter");
             }
 
-            const roomUrl = decodeURIComponent(req.path_parameters.roomUrl);
+            roomUrl = decodeURIComponent(roomUrl);
             const wokaList = await wokaService.getWokaList(roomUrl, req.params["uuid"]);
 
             if (!wokaList) {


### PR DESCRIPTION
This PR should only set textures on OpenID Connect login, if applied. But I got several 500 errors on pusher the the `/woka/list/{roomUrl}` path, so this also switches to query parameter instead of path variable.