### PR TITLE
Adding RXJS as a dependency in iframe-api-typings

### DIFF
--- a/front/packages/iframe-api-typings/package.json
+++ b/front/packages/iframe-api-typings/package.json
@@ -9,5 +9,8 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "rxjs": "^6.6.3"
   }
 }


### PR DESCRIPTION
Because some methods are returning Subjects, we need to import rxjs as a dependency of the package to have full typing available.