### PR TITLE
Enable right click on overlay

### DIFF
--- a/front/src/index.ts
+++ b/front/src/index.ts
@@ -104,7 +104,6 @@ const config: GameConfig = {
     dom: {
         createContainer: true,
     },
-    disableContextMenu: true,
     render: {
         pixelArt: true,
         roundPixels: true,
@@ -141,6 +140,14 @@ const config: GameConfig = {
 const game = new Game(config);
 
 waScaleManager.setGame(game);
+
+/*
+TODO: replace with disableContextMenu when Phaser does not disable context menu on document.body
+see https://github.com/photonstorm/phaser/issues/6064
+*/
+HtmlUtils.querySelectorOrFail("#game canvas").addEventListener("contextmenu", function (e) {
+    e.preventDefault();
+});
 
 window.addEventListener("resize", function (event) {
     coWebsiteManager.resetStyleMain();


### PR DESCRIPTION
Disables the context menu only on the Phaser canvas to allow opening the context menu on the overlay and moving by right click simultaneously.

This is somewhat of a workaround for #1980.