### PR TITLE
enable sound stop API call

### DIFF
--- a/front/src/Api/Events/IframeEvent.ts
+++ b/front/src/Api/Events/IframeEvent.ts
@@ -71,7 +71,7 @@ export type IframeEventMap = {
     setProperty: SetPropertyEvent;
     loadSound: LoadSoundEvent;
     playSound: PlaySoundEvent;
-    stopSound: null;
+    stopSound: StopSoundEvent;
     getState: undefined;
     loadTileset: LoadTilesetEvent;
     registerMenu: MenuRegisterEvent;

--- a/front/src/Api/Events/IframeEvent.ts
+++ b/front/src/Api/Events/IframeEvent.ts
@@ -13,6 +13,7 @@ import type { LayerEvent } from "./LayerEvent";
 import type { SetPropertyEvent } from "./setPropertyEvent";
 import type { LoadSoundEvent } from "./LoadSoundEvent";
 import type { PlaySoundEvent } from "./PlaySoundEvent";
+import type { StopSoundEvent } from "./StopSoundEvent";
 import type { MenuItemClickedEvent } from "./ui/MenuItemClickedEvent";
 import type { HasPlayerMovedEvent } from "./HasPlayerMovedEvent";
 import type { SetTilesEvent } from "./SetTilesEvent";


### PR DESCRIPTION
this link was missing, so "sound.stop()" does not do anything in the JS api

compare
https://play-new-select-woka-scene.test.workadventu.re/_/global/maps-new-select-woka-scene.test.workadventu.re/tests/SoundTest.json

with

https://party.tabascoeye.de/_/global/party.tabascoeye.de/maps/tests/SoundTest.json

PS: why have the tests when nobody executes them? This bug has been in there for months...