### PR TITLE
Compute instance in pusher /map endpoint

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -562,13 +562,14 @@ export class GameRoom {
         if (!ADMIN_API_URL) {
             const roomUrlObj = new URL(roomUrl);
 
-            const match = /\/_\/[^/]+\/(.+)/.exec(roomUrlObj.pathname);
+            const match = /\/_\/([^/]+)\/(.+)/.exec(roomUrlObj.pathname);
             if (!match) {
                 console.error("Unexpected room URL", roomUrl);
                 throw new Error('Unexpected room URL "' + roomUrl + '"');
             }
 
-            const mapUrl = roomUrlObj.protocol + "//" + match[1];
+            const instance = match[1];
+            const mapUrl = roomUrlObj.protocol + "//" + match[2];
 
             return {
                 mapUrl,
@@ -578,6 +579,7 @@ export class GameRoom {
                 roomSlug: null,
                 contactPage: null,
                 group: null,
+                instance
             };
         }
 

--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -579,7 +579,7 @@ export class GameRoom {
                 roomSlug: null,
                 contactPage: null,
                 group: null,
-                instance
+                instance,
             };
         }
 

--- a/front/src/Connexion/Room.ts
+++ b/front/src/Connexion/Room.ts
@@ -130,6 +130,7 @@ export class Room {
                 this._canReport = data.canReport ?? false;
                 this._loadingLogo = data.loadingLogo ?? undefined;
                 this._loginSceneLogo = data.loginSceneLogo ?? undefined;
+                this.instance = data.instance;
                 return new MapDetail(data.mapUrl);
             } else {
                 console.log(data);

--- a/front/src/Connexion/Room.ts
+++ b/front/src/Connexion/Room.ts
@@ -15,10 +15,6 @@ export interface RoomRedirect {
 
 export class Room {
     public readonly id: string;
-    /**
-     * @deprecated
-     */
-    private readonly isPublic: boolean;
     private _authenticationMandatory: boolean = DISABLE_ANONYMOUS;
     private _iframeAuthentication?: string = OPID_LOGIN_SCREEN_PROVIDER;
     private _mapUrl: string | undefined;
@@ -36,13 +32,6 @@ export class Room {
 
         if (this.id.startsWith("/")) {
             this.id = this.id.substr(1);
-        }
-        if (this.id.startsWith("_/") || this.id.startsWith("*/")) {
-            this.isPublic = true;
-        } else if (this.id.startsWith("@/")) {
-            this.isPublic = false;
-        } else {
-            throw new Error("Invalid room ID");
         }
 
         this._search = new URLSearchParams(roomUrl.search);
@@ -84,7 +73,7 @@ export class Room {
 
         const currentRoom = new Room(baseUrl);
         let instance: string = "global";
-        if (currentRoom.isPublic) {
+        if (currentRoom.id.startsWith("_/") || currentRoom.id.startsWith("*/")) {
             const match = /[_*]\/([^/]+)\/.+/.exec(currentRoom.id);
             if (!match) throw new Error('Could not extract instance from "' + currentRoom.id + '"');
             instance = match[1];

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -233,7 +233,7 @@ export class GameScene extends DirtyScene {
         });
         this.Terrains = [];
         this.groups = new Map<number, Sprite>();
-        this.instance = room.getInstance();
+        this.instance = room.instance;
 
         this.MapUrlFile = MapUrlFile;
         this.roomUrl = room.key;

--- a/messages/JsonMessages/MapDetailsData.ts
+++ b/messages/JsonMessages/MapDetailsData.ts
@@ -13,6 +13,7 @@ export const isMapDetailsData = z.object({
     roomSlug: z.nullable(z.string()), // deprecated
     contactPage: z.nullable(z.string()),
     group: z.nullable(z.string()),
+    instance: z.string(),
 
     iframeAuthentication: z.optional(z.nullable(z.string())),
     // The date (in ISO 8601 format) at which the room will expire

--- a/pusher/src/Controller/MapController.ts
+++ b/pusher/src/Controller/MapController.ts
@@ -76,6 +76,10 @@ export class MapController extends BaseHttpController {
          *                   type: string|null
          *                   description: The group this room is part of (maps the notion of "world" in WorkAdventure SAAS)
          *                   example: myorg/myworld
+         *                 instance:
+         *                   type: string
+         *                   description: The instance of this map. In a public URL: the second part of the URL (_/[instance]/map.json)
+         *                   example: global
          *                 iframeAuthentication:
          *                   type: string|null
          *                   description: The URL of the authentication Iframe
@@ -111,14 +115,15 @@ export class MapController extends BaseHttpController {
             if (!ADMIN_API_URL) {
                 const roomUrl = new URL(query.playUri);
 
-                const match = /\/_\/[^/]+\/(.+)/.exec(roomUrl.pathname);
+                const match = /\/_\/([^/]+)\/(.+)/.exec(roomUrl.pathname);
                 if (!match) {
                     res.status(404);
                     res.json({});
                     return;
                 }
 
-                const mapUrl = roomUrl.protocol + "//" + match[1];
+                const instance = match[1];
+                const mapUrl = roomUrl.protocol + "//" + match[2];
 
                 res.json({
                     mapUrl,
@@ -128,6 +133,7 @@ export class MapController extends BaseHttpController {
                     tags: [],
                     contactPage: null,
                     authenticationMandatory: DISABLE_ANONYMOUS,
+                    instance,
                 } as MapDetailsData);
 
                 return;


### PR DESCRIPTION
Small PR for this https://github.com/thecodingmachine/workadventure/issues/2064 issue. 

TODO: Admin/SAAS needs to compute the instance in the /api/map endpoint.

This PR allows us to remove the last bit of "routing code" from the front. 

@moufmouf Shoud we make Room.instance "private" (Room._instance) and remove the old instance parsing code from Room.getInstance()?