### PR TITLE
Upgrading playwright to 1.21

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -20,7 +20,8 @@ jobs:
         run: npm ci
         working-directory: tests
       - name: Install Playwright
-        run: npx playwright@~1.21.0 install --with-deps
+        run: npx playwright install --with-deps
+        working-directory: tests
       - name: 'Setup .env file'
         run: cp .env.template .env
       - name: Install messages dependencies

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -20,7 +20,7 @@ jobs:
         run: npm ci
         working-directory: tests
       - name: Install Playwright
-        run: npx playwright install --with-deps
+        run: npx playwright@~1.21.0 install --with-deps
       - name: 'Setup .env file'
         run: cp .env.template .env
       - name: Install messages dependencies

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@playwright/test": "^1.20.0",
+        "@playwright/test": "~1.21.0",
         "@types/dockerode": "^3.3.0",
         "axios": "^0.24.0",
         "dockerode": "^3.3.1",
@@ -854,9 +854,9 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.20.0.tgz",
-      "integrity": "sha512-UpI5HTcgNLckR0kqXqwNvbcIXtRaDxk+hnO0OBwPSjfbBjRfRgAJ2ClA/b30C5E3UW5dJa17zhsy2qrk66l5cg==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.21.0.tgz",
+      "integrity": "sha512-jvgN3ZeAG6rw85z4u9Rc4uyj6qIaYlq2xrOtS7J2+CDYhzKOttab9ix9ELcvBOCHuQ6wgTfxfJYdh6DRZmQ9hg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.16.7",
@@ -882,13 +882,13 @@
         "debug": "4.3.3",
         "expect": "27.2.5",
         "jest-matcher-utils": "27.2.5",
-        "json5": "2.2.0",
+        "json5": "2.2.1",
         "mime": "3.0.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
         "open": "8.4.0",
         "pirates": "4.0.4",
-        "playwright-core": "1.20.0",
+        "playwright-core": "1.21.0",
         "rimraf": "3.0.2",
         "source-map-support": "0.4.18",
         "stack-utils": "2.0.5",
@@ -1007,9 +1007,9 @@
       "dev": true
     },
     "node_modules/@types/yauzl": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
-      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -2071,13 +2071,10 @@
       }
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -2279,9 +2276,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.20.0.tgz",
-      "integrity": "sha512-d25IRcdooS278Cijlp8J8A5fLQZ+/aY3dKRJvgX5yjXA69N0huIUdnh3xXSgn+LsQ9DCNmB7Ngof3eY630jgdA==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.21.0.tgz",
+      "integrity": "sha512-yDGVs9qaaW6WiefgR7wH1CGt9D6D/X4U3jNpIzH0FjjrrWLCOYQo78Tu3SkW8X+/kWlBpj49iWf3QNSxhYc12Q==",
       "dev": true,
       "dependencies": {
         "colors": "1.4.0",
@@ -3340,9 +3337,9 @@
       }
     },
     "@playwright/test": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.20.0.tgz",
-      "integrity": "sha512-UpI5HTcgNLckR0kqXqwNvbcIXtRaDxk+hnO0OBwPSjfbBjRfRgAJ2ClA/b30C5E3UW5dJa17zhsy2qrk66l5cg==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.21.0.tgz",
+      "integrity": "sha512-jvgN3ZeAG6rw85z4u9Rc4uyj6qIaYlq2xrOtS7J2+CDYhzKOttab9ix9ELcvBOCHuQ6wgTfxfJYdh6DRZmQ9hg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.16.7",
@@ -3368,13 +3365,13 @@
         "debug": "4.3.3",
         "expect": "27.2.5",
         "jest-matcher-utils": "27.2.5",
-        "json5": "2.2.0",
+        "json5": "2.2.1",
         "mime": "3.0.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
         "open": "8.4.0",
         "pirates": "4.0.4",
-        "playwright-core": "1.20.0",
+        "playwright-core": "1.21.0",
         "rimraf": "3.0.2",
         "source-map-support": "0.4.18",
         "stack-utils": "2.0.5",
@@ -3489,9 +3486,9 @@
       "dev": true
     },
     "@types/yauzl": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
-      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4269,13 +4266,10 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
     },
     "micromatch": {
       "version": "4.0.4",
@@ -4425,9 +4419,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.20.0.tgz",
-      "integrity": "sha512-d25IRcdooS278Cijlp8J8A5fLQZ+/aY3dKRJvgX5yjXA69N0huIUdnh3xXSgn+LsQ9DCNmB7Ngof3eY630jgdA==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.21.0.tgz",
+      "integrity": "sha512-yDGVs9qaaW6WiefgR7wH1CGt9D6D/X4U3jNpIzH0FjjrrWLCOYQo78Tu3SkW8X+/kWlBpj49iWf3QNSxhYc12Q==",
       "dev": true,
       "requires": {
         "colors": "1.4.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@playwright/test": "^1.20.0",
+    "@playwright/test": "~1.21.0",
     "@types/dockerode": "^3.3.0",
     "axios": "^0.24.0",
     "dockerode": "^3.3.1",


### PR DESCRIPTION
Also, locking CI to install 1.21 (just like package.json is using).
This way, on the next Playwright release, CI will continue working.