### PR TITLE
Adding a proper README to the production docker-compose directory

### DIFF
--- a/contrib/docker/.env.prod.template
+++ b/contrib/docker/.env.prod.template
@@ -30,7 +30,7 @@ ADMIN_API_URL=
 DATA_DIR=./wa
 
 # The URL used by default, in the form: "/_/global/map/url.json"
-START_ROOM_URL=/_/global/maps.workadventu.re/Floor0/floor0.json
+START_ROOM_URL=/_/global/thecodingmachine.github.io/workadventure-map-starter-kit/map.json
 
 # If you want to have a contact page in your menu,
 # you MUST set CONTACT_URL to the URL of the page that you want

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -1,0 +1,34 @@
+# Deploying WorkAdventure in production
+
+This directory contains a sample production deployment of WorkAdventure using docker-compose.
+
+Every production environment is different and this docker-compose file will not
+fit all use cases. But it is intended to be a good starting point for you 
+to build your own deployment.
+
+In this docker-compose file, you will find:
+
+- A reverse-proxy (Traefik) that dispatches requests to the WorkAdventure containers and handles HTTPS certificates using LetsEncrypt
+- A front container (nginx) that servers static files (HTML/JS/CSS)
+- A pusher container (NodeJS) that is the point of entry for users (you can start many if you want to increase performance)
+- A back container (NodeJS) that shares your rooms information
+- An icon container to fetch the favicon of sites imported in iframes
+- A Redis server to store values from variables originating from the Scripting API
+
+```mermaid
+graph LR
+    A[Browser] --> B(Traefik)
+    subgraph docker-compose
+    B --> C(Front)
+    B --> D(Pusher)
+    B --> E(Icon)
+    D --> F(Back)
+    F --> G(Redis)
+    end
+    A .-> H(Map)
+    F .-> H
+```
+
+**Important**: the default docker-compose file does **not** contain a container dedicated to hosting maps. The documentation and
+tutorials are relying on GitHub Pages to host the maps. If you want to self-host your maps, you will need to add a simple 
+HTTP server (nginx / Apache, ...) and properly configure the [CORS settings as explained in the documentation](../../docs/maps/hosting.md).

--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -95,6 +95,7 @@ services:
       - JITSI_ISS
       - MAX_PER_GROUP
       - STORE_VARIABLES_FOR_LOCAL_MAPS
+      - REDIS_HOST=redis
     labels:
       - "traefik.http.routers.back.rule=Host(`${BACK_HOST}`)"
       - "traefik.http.routers.back.entryPoints=web"
@@ -117,3 +118,11 @@ services:
       - "traefik.http.routers.icon-ssl.service=icon"
       - "traefik.http.routers.icon-ssl.tls=true"
       - "traefik.http.routers.icon-ssl.tls.certresolver=myresolver"
+
+  redis:
+    image: redis:6
+    volumes:
+      - redisdata:/data
+
+volumes:
+  redisdata:


### PR DESCRIPTION
This PR also adds a "Redis" server in the docker-compose from prod (required to store values of Scripting API variables)

Closes #2078