### PR TITLE
Fine-tuning the @typescript-eslint/no-unused-vars rule

### DIFF
--- a/back/.eslintrc.json
+++ b/back/.eslintrc.json
@@ -27,7 +27,7 @@
         "no-unused-vars": "off",
         "@typescript-eslint/no-explicit-any": "error",
         "@typescript-eslint/no-unused-vars": [
-            "error"
+            "error", { "args": "none", "caughtErrors": "all", "varsIgnorePattern": "_exhaustiveCheck" }
         ],
         "no-throw-literal": "error"
     }

--- a/back/src/Model/Zone.ts
+++ b/back/src/Model/Zone.ts
@@ -71,7 +71,6 @@ export class Zone {
     /**
      * Notify listeners of this zone that this user entered
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     private notifyEnter(thing: Movable, oldZone: Zone | null, position: PositionInterface) {
         for (const listener of this.listeners) {
             this.onEnters(thing, oldZone, listener);

--- a/back/src/Services/Repository/VoidVariablesRepository.ts
+++ b/back/src/Services/Repository/VoidVariablesRepository.ts
@@ -4,12 +4,10 @@ import { VariablesRepositoryInterface } from "./VariablesRepositoryInterface";
  * Mock class in charge of NOT saving/loading variables from the data store
  */
 export class VoidVariablesRepository implements VariablesRepositoryInterface {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     loadVariables(roomUrl: string): Promise<{ [key: string]: string }> {
         return Promise.resolve({});
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     saveVariable(roomUrl: string, key: string, value: string): Promise<number> {
         return Promise.resolve(0);
     }

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
         "eol-last": ["error", "always"],
         "@typescript-eslint/no-explicit-any": "error",
         "no-throw-literal": "error",
-        "@typescript-eslint/no-unused-vars": ["error"],
+        "@typescript-eslint/no-unused-vars": ["error", { "args": "none", "caughtErrors": "all", "varsIgnorePattern": "_exhaustiveCheck" }],
         // TODO: remove those ignored rules and write a stronger code!
         "@typescript-eslint/no-unsafe-call": "off",
         "@typescript-eslint/restrict-plus-operands": "off",

--- a/front/src/Api/IframeListener.ts
+++ b/front/src/Api/IframeListener.ts
@@ -294,7 +294,6 @@ class IframeListener {
                         handleMenuUnregisterEvent(iframeEvent.data.name);
                     } else {
                         // Keep the line below. It will throw an error if we forget to handle one of the possible values.
-                        // eslint-disable-next-line @typescript-eslint/no-unused-vars
                         const _exhaustiveCheck: never = iframeEvent;
                     }
                 }

--- a/front/src/Api/iframe/state.ts
+++ b/front/src/Api/iframe/state.ts
@@ -88,7 +88,6 @@ export function createState(target: "global" | "player"): WorkadventureStateComm
             }
             return target.loadVariable(p.toString());
         },
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         set(target: WorkadventureStateCommands, p: PropertyKey, value: unknown, receiver: unknown): boolean {
             // Note: when using "set", there is no way to wait, so we ignore the return of the promise.
             // User must use WA.state.saveVariable to have error message.

--- a/front/src/Connexion/RoomConnection.ts
+++ b/front/src/Connexion/RoomConnection.ts
@@ -303,8 +303,7 @@ export class RoomConnection implements RoomConnection {
                             }
                             default: {
                                 // Security check: if we forget a "case", the line below will catch the error at compile-time.
-                                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                                const tmp: never = subMessage;
+                                const _exhaustiveCheck: never = subMessage;
                             }
                         }
                     }
@@ -491,8 +490,7 @@ export class RoomConnection implements RoomConnection {
                 }
                 default: {
                     // Security check: if we forget a "case", the line below will catch the error at compile-time.
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                    const tmp: never = message;
+                    const _exhaustiveCheck: never = message;
                 }
             }
         };

--- a/front/src/Phaser/Game/CameraManager.ts
+++ b/front/src/Phaser/Game/CameraManager.ts
@@ -97,7 +97,6 @@ export class CameraManager extends Phaser.Events.EventEmitter {
             });
             return;
         }
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         this.camera.pan(setTo.x, setTo.y, duration, Easing.SineEaseOut, true, (camera, progress, x, y) => {
             if (this.cameraMode === CameraMode.Positioned) {
                 this.waScaleManager.zoomModifier = currentZoomModifier + progress * zoomModifierChange;
@@ -139,7 +138,6 @@ export class CameraManager extends Phaser.Events.EventEmitter {
             this.emit(CameraManagerEvent.CameraUpdate, this.getCameraUpdateEventData());
             return;
         }
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         this.camera.pan(focusOn.x, focusOn.y, duration, Easing.SineEaseOut, true, (camera, progress, x, y) => {
             this.waScaleManager.zoomModifier = currentZoomModifier + progress * zoomModifierChange;
             if (progress === 1) {

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -1695,7 +1695,6 @@ ${escapedMessage}
     private createCollisionWithPlayer() {
         //add collision layer
         for (const phaserLayer of this.gameMap.phaserLayers) {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             this.physics.add.collider(this.CurrentPlayer, phaserLayer, (object1: GameObject, object2: GameObject) => {
                 //this.CurrentPlayer.say("Collision with layer : "+ (object2 as Tile).layer.name)
             });
@@ -1746,11 +1745,9 @@ ${escapedMessage}
                     emoteMenuStore.openEmoteMenu();
                 }
             });
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             this.CurrentPlayer.on(Phaser.Input.Events.POINTER_OVER, (pointer: Phaser.Input.Pointer) => {
                 this.CurrentPlayer.pointerOverOutline(0x365dff);
             });
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             this.CurrentPlayer.on(Phaser.Input.Events.POINTER_OUT, (pointer: Phaser.Input.Pointer) => {
                 this.CurrentPlayer.pointerOutOutline();
             });
@@ -1852,8 +1849,7 @@ ${escapedMessage}
                     break;
                 }
                 default: {
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                    const tmp: never = event;
+                    const _exhaustiveCheck: never = event;
                 }
             }
         }

--- a/front/src/Phaser/Helpers/TexturesHelper.ts
+++ b/front/src/Phaser/Helpers/TexturesHelper.ts
@@ -28,7 +28,7 @@ export class TexturesHelper {
             });
         } catch (error) {
             rt.destroy();
-            throw new Error("Could not get the snapshot");
+            throw new Error("Could not get the snapshot: " + error);
         }
     }
 

--- a/front/src/Phaser/Login/CustomizeScene.ts
+++ b/front/src/Phaser/Login/CustomizeScene.ts
@@ -112,7 +112,6 @@ export class CustomizeScene extends AbstractCharacterScene {
         this.onResize();
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public update(time: number, dt: number): void {
         this.customWokaPreviewer.update();
     }

--- a/front/src/Phaser/Login/EmptyScene.ts
+++ b/front/src/Phaser/Login/EmptyScene.ts
@@ -13,6 +13,5 @@ export class EmptyScene extends Scene {
 
     create() {}
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     update(time: number, delta: number): void {}
 }

--- a/front/src/Phaser/Login/EnableCameraScene.ts
+++ b/front/src/Phaser/Login/EnableCameraScene.ts
@@ -24,7 +24,6 @@ export class EnableCameraScene extends ResizableScene {
 
     public onResize(): void {}
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     update(time: number, delta: number): void {}
 
     public login(): void {

--- a/front/src/Phaser/Login/LoginScene.ts
+++ b/front/src/Phaser/Login/LoginScene.ts
@@ -49,7 +49,6 @@ export class LoginScene extends ResizableScene {
         loginSceneVisibleStore.set(false);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     update(time: number, delta: number): void {}
 
     public onResize(): void {}

--- a/front/src/Phaser/UserInput/GameSceneUserInputHandler.ts
+++ b/front/src/Phaser/UserInput/GameSceneUserInputHandler.ts
@@ -16,7 +16,6 @@ export class GameSceneUserInputHandler implements UserInputHandlerInterface {
         gameObjects: Phaser.GameObjects.GameObject[],
         deltaX: number,
         deltaY: number,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         deltaZ: number
     ): void {
         this.gameScene.zoomByFactor(1 - (deltaY / 53) * 0.1);
@@ -51,7 +50,6 @@ export class GameSceneUserInputHandler implements UserInputHandlerInterface {
             });
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public handlePointerDownEvent(pointer: Phaser.Input.Pointer, gameObjects: Phaser.GameObjects.GameObject[]): void {}
 
     public handleSpaceKeyUpEvent(event: Event): Event {

--- a/front/src/WebRtc/ColorGenerator.ts
+++ b/front/src/WebRtc/ColorGenerator.ts
@@ -14,15 +14,6 @@ export function getColorRgbFromHue(hue: number): { r: number; g: number; b: numb
     return hsv_to_rgb(hue, 0.5, 0.95);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function stringToDouble(string: string): number {
-    let num = 1;
-    for (const char of string.split("")) {
-        num *= char.charCodeAt(0);
-    }
-    return (num % 255) / 255;
-}
-
 //todo: test this.
 function hsv_to_rgb(hue: number, saturation: number, brightness: number): { r: number; g: number; b: number } {
     const h_i = Math.floor(hue * 6);

--- a/pusher/.eslintrc.json
+++ b/pusher/.eslintrc.json
@@ -27,7 +27,7 @@
         "no-unused-vars": "off",
         "@typescript-eslint/no-explicit-any": "error",
         "@typescript-eslint/no-unused-vars": [
-            "error"
+            "error", { "args": "none", "caughtErrors": "all", "varsIgnorePattern": "_exhaustiveCheck" }
         ],
         "no-throw-literal": "error"
     }

--- a/pusher/src/Services/AdminApi.ts
+++ b/pusher/src/Services/AdminApi.ts
@@ -40,12 +40,13 @@ class AdminApi implements AdminInterface {
             try {
                 authTokenData = jwtTokenManager.verifyJWTToken(authToken);
                 userId = authTokenData.identifier;
+                //eslint-disable-next-line @typescript-eslint/no-unused-vars
             } catch (e) {
                 try {
                     // Decode token, in this case we don't need to create new token.
                     authTokenData = jwtTokenManager.verifyJWTToken(authToken, true);
                     userId = authTokenData.identifier;
-                    console.info("JWT expire, but decoded", userId);
+                    console.info("JWT expire, but decoded:", userId);
                 } catch (e) {
                     if (e instanceof InvalidTokenError) {
                         throw new Error("Token decrypted error");

--- a/pusher/src/Services/LocalAdmin.ts
+++ b/pusher/src/Services/LocalAdmin.ts
@@ -12,13 +12,9 @@ import { AdminApiData } from "../Messages/JsonMessages/AdminApiData";
 class LocalAdmin implements AdminInterface {
     fetchMemberDataByUuid(
         userIdentifier: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         playUri: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ipAddress: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         characterLayers: string[],
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         locale?: string
     ): Promise<FetchMemberDataByUuidResponse> {
         return Promise.resolve({
@@ -32,13 +28,7 @@ class LocalAdmin implements AdminInterface {
         });
     }
 
-    fetchMapDetails(
-        playUri: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        authToken?: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        locale?: string
-    ): Promise<MapDetailsData | RoomRedirect> {
+    fetchMapDetails(playUri: string, authToken?: string, locale?: string): Promise<MapDetailsData | RoomRedirect> {
         const roomUrl = new URL(playUri);
 
         const match = /\/_\/[^/]+\/(.+)/.exec(roomUrl.pathname);
@@ -63,65 +53,42 @@ class LocalAdmin implements AdminInterface {
     }
 
     async fetchMemberDataByToken(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         organizationMemberToken: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         playUri: string | null,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         locale?: string
     ): Promise<AdminApiData> {
         return Promise.reject(new Error("No admin backoffice set!"));
     }
 
     reportPlayer(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         reportedUserUuid: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         reportedUserComment: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         reporterUserUuid: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         reportWorldSlug: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         locale?: string
     ) {
         return Promise.reject(new Error("No admin backoffice set!"));
     }
 
     async verifyBanUser(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         userUuid: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ipAddress: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         roomUrl: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         locale?: string
     ): Promise<AdminBannedData> {
         return Promise.reject(new Error("No admin backoffice set!"));
     }
 
-    async getUrlRoomsFromSameWorld(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        roomUrl: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        locale?: string
-    ): Promise<string[]> {
+    async getUrlRoomsFromSameWorld(roomUrl: string, locale?: string): Promise<string[]> {
         return Promise.reject(new Error("No admin backoffice set!"));
     }
 
-    getProfileUrl(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        accessToken: string
-    ): string {
+    getProfileUrl(accessToken: string): string {
         new Error("No admin backoffice set!");
         return "";
     }
 
-    async logoutOauth(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        token: string
-    ): Promise<void> {
+    async logoutOauth(token: string): Promise<void> {
         return Promise.reject(new Error("No admin backoffice set!"));
     }
 }

--- a/pusher/src/Services/LocalWokaService.ts
+++ b/pusher/src/Services/LocalWokaService.ts
@@ -5,7 +5,6 @@ class LocalWokaService implements WokaServiceInterface {
     /**
      * Returns the list of all available Wokas & Woka Parts for the current user.
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async getWokaList(roomId: string, token: string): Promise<WokaList | undefined> {
         const wokaData: WokaList = await require("../../data/woka.json");
         if (!wokaData) {


### PR DESCRIPTION
We now allow parameters to be unused. This is quite common in inherited methods.
This allows removing a bunch of: //eslint-disable-next-line @typescript-eslint/no-unused-vars
Also, "err" variables in catch MUST now be used and the special _exhaustiveCheck variable used in ":never" assigns can be unused.