### PR TITLE
fix desktop app releasing

### DIFF
--- a/.github/workflows/build-and-release-desktop.yml
+++ b/.github/workflows/build-and-release-desktop.yml
@@ -60,6 +60,21 @@ jobs:
         run: yarn build
         working-directory: "desktop/local-app"
 
+      - name: "Set preview desktop version"
+        run: |
+          sed -i "s/managedbyci/0.0.0/g" package.json
+          cat package.json
+        working-directory: "desktop/electron"
+        if: ${{ github.event_name != 'release' }}
+
+      - name: "Set stable desktop version"
+        run: |
+          echo "Version: ${GITHUB_REF##*/v}"
+          sed -i "s/managedbyci/${GITHUB_REF##*/v}/g" package.json
+          cat package.json
+        working-directory: "desktop/electron"
+        if: ${{ github.event_name == 'release' }}
+
       - name: "Install dependencies"
         run: yarn install --froze-lockfile
         working-directory: "desktop/electron"
@@ -68,15 +83,19 @@ jobs:
         run: yarn build
         working-directory: "desktop/electron"
 
-      - name: "Build app"
-        run: yarn bundle --publish never
+      - name: "Install electron tools"
+        run: yarn electron-builder install-app-deps
+        working-directory: "desktop/electron"
+
+      - name: "Build app for testing"
+        run: yarn electron-builder --publish never
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: "desktop/electron"
         if: ${{ github.event_name != 'release' }}
 
-      - name: "Build & publish App"
-        run: yarn release
+      - name: "Build & release app"
+        run: yarn electron-builder --publish always
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: "desktop/electron"

--- a/.github/workflows/build-and-release-desktop.yml
+++ b/.github/workflows/build-and-release-desktop.yml
@@ -60,18 +60,9 @@ jobs:
         run: yarn build
         working-directory: "desktop/local-app"
 
-      - name: "Set preview desktop version"
-        run: |
-          sed -i.bak "s/managedbyci/0.0.0/g" package.json
+      - name: "Set desktop app version"
+        run: node helpers/set-version.js
         working-directory: "desktop/electron"
-        if: ${{ github.event_name != 'release' }}
-
-      - name: "Set stable desktop version"
-        run: |
-          echo "Version: ${GITHUB_REF##*/v}"
-          sed -i.bak "s/managedbyci/${GITHUB_REF##*/v}/g" package.json
-        working-directory: "desktop/electron"
-        if: ${{ github.event_name == 'release' }}
 
       - name: "Install dependencies"
         run: yarn install --froze-lockfile

--- a/.github/workflows/build-and-release-desktop.yml
+++ b/.github/workflows/build-and-release-desktop.yml
@@ -62,16 +62,14 @@ jobs:
 
       - name: "Set preview desktop version"
         run: |
-          sed -i "s/managedbyci/0.0.0/g" package.json
-          cat package.json
+          sed -i.bak "s/managedbyci/0.0.0/g" package.json
         working-directory: "desktop/electron"
         if: ${{ github.event_name != 'release' }}
 
       - name: "Set stable desktop version"
         run: |
           echo "Version: ${GITHUB_REF##*/v}"
-          sed -i "s/managedbyci/${GITHUB_REF##*/v}/g" package.json
-          cat package.json
+          sed -i.bak "s/managedbyci/${GITHUB_REF##*/v}/g" package.json
         working-directory: "desktop/electron"
         if: ${{ github.event_name == 'release' }}
 

--- a/desktop/electron/electron-builder.yml
+++ b/desktop/electron/electron-builder.yml
@@ -28,5 +28,4 @@ publish:
     provider: github
     owner: thecodingmachine
     repo: workadventure
-    vPrefixedTagName: false
-    releaseType: draft
+    releaseType: release

--- a/desktop/electron/helpers/set-version.js
+++ b/desktop/electron/helpers/set-version.js
@@ -1,0 +1,18 @@
+const path = require('path');
+const fs = require('fs');
+
+let version = '0.0.0';
+
+if (process.env.GITHUB_REF.startsWith('refs/tags/v')) {
+  version = process.env.GITHUB_REF.replace('refs/tags/v', '');
+}
+
+console.log('Version:', version);
+
+const packageJsonPath = path.resolve(__dirname, '..', 'package.json');
+
+let data = fs.readFileSync(packageJsonPath, 'utf8');
+
+data = data.replace('managedbyci', version);
+
+fs.writeFileSync(packageJsonPath, data);

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "workadventure-desktop",
-    "version": "1.0.0",
+    "version": "managedbyci",
     "description": "Desktop application for WorkAdventure",
     "author": "thecodingmachine",
     "main": "dist/main.js",
@@ -11,7 +11,6 @@
         "dev": "yarn build --watch --onSuccess 'yarn electron dist/main.js'",
         "dev:local-app": "cd ../local-app && yarn && yarn dev",
         "bundle": "yarn build:local-app && yarn build && electron-builder install-app-deps && electron-builder",
-        "release": "yarn bundle",
         "typecheck": "tsc --noEmit",
         "test": "exit 0",
         "lint": "yarn eslint src/ . --ext .ts",


### PR DESCRIPTION
There was an error in the way the releasing of the electron app was configured. It should be fixed now, so electron-builder will add its files to the release next time a release in Github is created. Those files can be manually be downloaded and will be used by the auto-updater as well.