### PR TITLE
Fixing compatibility issue with Safari 14-

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -42,7 +42,7 @@
     "buffer": "^6.0.3",
     "cancelable-promise": "^4.2.1",
     "cross-env": "^7.0.3",
-    "deep-copy-ts": "^0.5.0",
+    "deep-copy-ts": "^0.5.4",
     "easystarjs": "^0.4.4",
     "fast-deep-equal": "^3.1.3",
     "google-protobuf": "^3.13.0",

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -806,10 +806,10 @@ debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-deep-copy-ts@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/deep-copy-ts/-/deep-copy-ts-0.5.0.tgz#b9493d8e2bae85ef7d659c16eb707c13efb84499"
-  integrity sha512-/3cgBcMkznRf5BM8wu6YWz3SQUkHzgh/v1TZFjevztLj9sMjFvNFBtpN4uUtPzw/rA/TldyD6c6LRL1zno4+YA==
+deep-copy-ts@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/deep-copy-ts/-/deep-copy-ts-0.5.4.tgz#e81b15797e4075cb3a690a1a7ac30179f2d72562"
+  integrity sha512-YJbPjw0YqdosorpCsa6copy1p/gJsFT9Q6Zq0tLi7D0nXh6Y/usjeIQZfkzV3HVuqY0Hl/5gM7TwgIbIWvEjlA==
 
 deep-equal@^1.0.1:
   version "1.1.1"


### PR DESCRIPTION
By upgrading ts-deep-copy, we are fixing an issue introduced that made iOS 14- devices incompatible with WA.