### PR TITLE
Updating i18n-typesafe version to 5.4.0

### DIFF
--- a/front/.typesafe-i18n.json
+++ b/front/.typesafe-i18n.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "https://unpkg.com/typesafe-i18n@5.3.5/schema/typesafe-i18n.json",
+   "$schema": "https://unpkg.com/typesafe-i18n@5.4.0/schema/typesafe-i18n.json",
    "baseLocale": "en-US",
    "adapter": "svelte"
 }

--- a/front/package.json
+++ b/front/package.json
@@ -60,7 +60,7 @@
     "standardized-audio-context": "^25.2.4",
     "ts-deferred": "^1.0.4",
     "ts-proto": "^1.96.0",
-    "typesafe-i18n": "^5.3.5",
+    "typesafe-i18n": "^5.4.0",
     "uuidv4": "^6.2.10",
     "zod": "^3.14.3"
   },

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -2991,10 +2991,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typesafe-i18n@^5.3.5:
-  version "5.3.5"
-  resolved "https://registry.yarnpkg.com/typesafe-i18n/-/typesafe-i18n-5.3.5.tgz#8561648a2be0df660404aa087993f3eee584cb87"
-  integrity sha512-ZjCCQ2lCyyvUThtxJblXoxwpr62paOjMRi/Kia1PSEh3gRfwPvEorABS0zTdF6lZ75MQXoz0WqtobChVjkO5mQ==
+typesafe-i18n@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/typesafe-i18n/-/typesafe-i18n-5.4.0.tgz#cab696160bb144c387d7cbd13f7a728aa8371777"
+  integrity sha512-htewpld3FzZQv3Y1G31w54bofaaKR11MCkDK0FIYuXCpX72y1G6fkXUDslqzZCyVkZWRnIhY8leviNDxLwEzRw==
 
 typescript@*:
   version "4.3.2"


### PR DESCRIPTION
This should help us fix issues with watcher compiling files in a loop in dev mode.