### PR TITLE
Fixing sound stop function in scripting API

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -1107,6 +1107,13 @@ ${escapedMessage}
         );
 
         this.iframeSubscriptionList.push(
+            iframeListener.stopSoundStream.subscribe((stopSoundEvent) => {
+                const url = new URL(stopSoundEvent.url, this.MapUrlFile);
+                soundManager.stopSound(this.sound, url.toString());
+            })
+        );
+
+        this.iframeSubscriptionList.push(
             iframeListener.addActionsMenuKeyToRemotePlayerStream.subscribe((data) => {
                 this.MapPlayersByKey.get(data.id)?.registerActionsMenuAction({
                     actionName: data.actionKey,


### PR DESCRIPTION
The sound "stop()" method was broken in scripting API.
This commit adds the missing listener in GameScene