### PR TITLE
Refreshing map URL

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -520,7 +520,16 @@ export class GameRoom {
         this.admins.delete(admin);
     }
 
-    public incrementVersion(): number {
+    public async incrementVersion(): Promise<number> {
+        // Let's check if the mapUrl has changed
+        const mapDetails = await GameRoom.getMapDetails(this.roomUrl);
+        if (this.mapUrl !== mapDetails.mapUrl) {
+            this.mapUrl = mapDetails.mapUrl;
+            this.mapPromise = undefined;
+            // Reset the variable manager
+            this.variableManagerPromise = undefined;
+        }
+
         this.versionNumber++;
         return this.versionNumber;
     }

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -852,14 +852,14 @@ export class SocketManager {
             return;
         }
 
-        const versionNumber = room.incrementVersion();
+        const versionNumber = await room.incrementVersion();
         room.getUsers().forEach((recipient) => {
-            const worldFullMessage = new RefreshRoomMessage();
-            worldFullMessage.setRoomid(roomId);
-            worldFullMessage.setVersionnumber(versionNumber);
+            const refreshRoomMessage = new RefreshRoomMessage();
+            refreshRoomMessage.setRoomid(roomId);
+            refreshRoomMessage.setVersionnumber(versionNumber);
 
             const clientMessage = new ServerToClientMessage();
-            clientMessage.setRefreshroommessage(worldFullMessage);
+            clientMessage.setRefreshroommessage(refreshRoomMessage);
 
             recipient.socket.write(clientMessage);
         });

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@playwright/test": "~1.21.1",
+    "@playwright/test": "~1.21.0",
     "@types/dockerode": "^3.3.0",
     "axios": "^0.24.0",
     "dockerode": "^3.3.1",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@playwright/test": "~1.21.0",
+    "@playwright/test": "~1.21.1",
     "@types/dockerode": "^3.3.0",
     "axios": "^0.24.0",
     "dockerode": "^3.3.1",


### PR DESCRIPTION
When a "refresh" message is sent from the admin to the pusher, the map details endpoint is now called again.
If the Map URL is changed, the variable manager is refreshed.

This will fix the bug that happened when the map of a room was changed to a map containing variables and those variables were not working (because the GameRoom object in the back still referred to the old map URL)