### PR TITLE
Implement disable/restore proximity meeting in api

### DIFF
--- a/docs/maps/api-controls.md
+++ b/docs/maps/api-controls.md
@@ -14,7 +14,7 @@ When controls are disabled, the user cannot move anymore using keyboard input. T
 
 Example:
 
-```javascript
+```ts
 WA.room.onEnterLayer('myZone').subscribe(() => {
     WA.controls.disablePlayerControls();
     WA.ui.openPopup("popupRectangle", 'This is an imporant message!', [{
@@ -25,5 +25,28 @@ WA.room.onEnterLayer('myZone').subscribe(() => {
             popup.close();
         }
     }]);
-})
+});
+```
+
+### Disabling / restoring proximity meeting
+
+```
+WA.controls.disablePlayerProximityMeeting(): void
+WA.controls.restorePlayerProximityMeeting(): void
+```
+
+These 2 methods can be used to completely disable player proximity meeting and to enable them again.
+
+When proximity meeting are disabled, the user cannot speak with anyone.
+
+Example:
+
+```ts
+WA.room.onEnterLayer('myZone').subscribe(() => {
+    WA.controls.disablePlayerProximityMeeting();
+});
+
+WA.room.onLeaveLayer('myZone').subscribe(() => {
+    WA.controls.restorePlayerProximityMeeting();
+});
 ```

--- a/front/src/Api/Events/IframeEvent.ts
+++ b/front/src/Api/Events/IframeEvent.ts
@@ -98,6 +98,14 @@ export const isIframeEventWrapper = z.union([
         data: z.undefined(),
     }),
     z.object({
+        type: z.literal("disablePlayerProximityMeeting"),
+        data: z.undefined(),
+    }),
+    z.object({
+        type: z.literal("restorePlayerProximityMeeting"),
+        data: z.undefined(),
+    }),
+    z.object({
         type: z.literal("displayBubble"),
         data: z.undefined(),
     }),

--- a/front/src/Api/IframeListener.ts
+++ b/front/src/Api/IframeListener.ts
@@ -59,6 +59,15 @@ class IframeListener {
     private readonly _disablePlayerControlStream: Subject<void> = new Subject();
     public readonly disablePlayerControlStream = this._disablePlayerControlStream.asObservable();
 
+    private readonly _enablePlayerControlStream: Subject<void> = new Subject();
+    public readonly enablePlayerControlStream = this._enablePlayerControlStream.asObservable();
+
+    private readonly _disablePlayerProximityMeetingStream: Subject<void> = new Subject();
+    public readonly disablePlayerProximityMeetingStream = this._disablePlayerProximityMeetingStream.asObservable();
+
+    private readonly _enablePlayerProximityMeetingStream: Subject<void> = new Subject();
+    public readonly enablePlayerProximityMeetingStream = this._enablePlayerProximityMeetingStream.asObservable();
+
     private readonly _cameraSetStream: Subject<CameraSetEvent> = new Subject();
     public readonly cameraSetStream = this._cameraSetStream.asObservable();
 
@@ -73,9 +82,6 @@ class IframeListener {
         new Subject();
     public readonly removeActionsMenuKeyFromRemotePlayerEvent =
         this._removeActionsMenuKeyFromRemotePlayerEvent.asObservable();
-
-    private readonly _enablePlayerControlStream: Subject<void> = new Subject();
-    public readonly enablePlayerControlStream = this._enablePlayerControlStream.asObservable();
 
     private readonly _closePopupStream: Subject<ClosePopupEvent> = new Subject();
     public readonly closePopupStream = this._closePopupStream.asObservable();
@@ -264,6 +270,10 @@ class IframeListener {
                         this._disablePlayerControlStream.next();
                     } else if (iframeEvent.type === "restorePlayerControls") {
                         this._enablePlayerControlStream.next();
+                    } else if (iframeEvent.type === "disablePlayerProximityMeeting") {
+                        this._disablePlayerProximityMeetingStream.next();
+                    } else if (iframeEvent.type === "restorePlayerProximityMeeting") {
+                        this._enablePlayerProximityMeetingStream.next();
                     } else if (iframeEvent.type === "displayBubble") {
                         this._displayBubbleStream.next();
                     } else if (iframeEvent.type === "removeBubble") {

--- a/front/src/Api/iframe/controls.ts
+++ b/front/src/Api/iframe/controls.ts
@@ -10,6 +10,14 @@ export class WorkadventureControlsCommands extends IframeApiContribution<Workadv
     restorePlayerControls(): void {
         sendToWorkadventure({ type: "restorePlayerControls", data: undefined });
     }
+
+    disablePlayerProximityMeeting(): void {
+        sendToWorkadventure({ type: "disablePlayerProximityMeeting", data: undefined });
+    }
+
+    restorePlayerProximityMeeting(): void {
+        sendToWorkadventure({ type: "restorePlayerProximityMeeting", data: undefined });
+    }
 }
 
 export default new WorkadventureControlsCommands();

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -1103,6 +1103,24 @@ ${escapedMessage}
         );
 
         this.iframeSubscriptionList.push(
+            iframeListener.enablePlayerControlStream.subscribe(() => {
+                this.userInputManager.restoreControls();
+            })
+        );
+
+        this.iframeSubscriptionList.push(
+            iframeListener.disablePlayerProximityMeetingStream.subscribe(() => {
+                this.disableMediaBehaviors();
+            })
+        );
+
+        this.iframeSubscriptionList.push(
+            iframeListener.enablePlayerProximityMeetingStream.subscribe(() => {
+                this.enableMediaBehaviors();
+            })
+        );
+
+        this.iframeSubscriptionList.push(
             iframeListener.cameraSetStream.subscribe((cameraSetEvent) => {
                 const duration = cameraSetEvent.smooth ? 1000 : 0;
                 cameraSetEvent.lock
@@ -1189,11 +1207,6 @@ ${escapedMessage}
             })
         );
 
-        this.iframeSubscriptionList.push(
-            iframeListener.enablePlayerControlStream.subscribe(() => {
-                this.userInputManager.restoreControls();
-            })
-        );
         this.iframeSubscriptionList.push(
             iframeListener.loadPageStream.subscribe((url: string) => {
                 this.loadNextGameFromExitUrl(url)


### PR DESCRIPTION
You can disable or enable proximity meeting on the current player (like when you are in a Jitsi meeting).
There are two new methods on the API : 
- WA.controls.disablePlayerProximityMeeting()
- WA.controls.restorePlayerProximityMeeting()