### PR TITLE
Adding required HTTP authentication to access /metrics endpoint

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -29,3 +29,11 @@ DISABLE_ANONYMOUS=
 
 # If you want to have a contact page in your menu, you MUST set CONTACT_URL to the URL of the page that you want
 CONTACT_URL=
+
+# Prometheus settings
+## Uncomment this to enable the /metrics Prometheus endpoint.
+## To hit this endpoint, you will need to configure Prometheus with:
+## authorization:
+##   type: Bearer
+##   credentials: "[The value of PROMETHEUS_AUTHORIZATION_TOKEN env variable]"
+PROMETHEUS_AUTHORIZATION_TOKEN=

--- a/back/src/Controller/PrometheusController.ts
+++ b/back/src/Controller/PrometheusController.ts
@@ -1,6 +1,7 @@
 import { App } from "../Server/sifrr.server";
-import { HttpResponse } from "uWebSockets.js";
+import { HttpRequest, HttpResponse } from "uWebSockets.js";
 import { register, collectDefaultMetrics } from "prom-client";
+import { PROMETHEUS_AUTHORIZATION_TOKEN } from "../Enum/EnvironmentVariable";
 
 export class PrometheusController {
     constructor(private App: App) {
@@ -11,7 +12,25 @@ export class PrometheusController {
         this.App.get("/metrics", this.metrics.bind(this));
     }
 
-    private metrics(res: HttpResponse): void {
+    private metrics(res: HttpResponse, req: HttpRequest): void {
+        if (!PROMETHEUS_AUTHORIZATION_TOKEN) {
+            res.writeStatus("501").end("Prometheus endpoint is disabled.");
+            return;
+        }
+        const authorizationHeader = req.getHeader("authorization");
+        if (!authorizationHeader) {
+            res.writeStatus("401").end("Undefined authorization header");
+            return;
+        }
+        if (!authorizationHeader.startsWith("Bearer ")) {
+            res.writeStatus("401").end('Authorization header should start with "Bearer"');
+            return;
+        }
+        if (authorizationHeader.substring(7) !== PROMETHEUS_AUTHORIZATION_TOKEN) {
+            res.writeStatus("401").end("Incorrect authorization header sent.");
+            return;
+        }
+
         res.writeHeader("Content-Type", register.contentType);
         res.end(register.metrics());
     }

--- a/back/src/Enum/EnvironmentVariable.ts
+++ b/back/src/Enum/EnvironmentVariable.ts
@@ -15,6 +15,7 @@ export const REDIS_HOST = process.env.REDIS_HOST || undefined;
 export const REDIS_PORT = parseInt(process.env.REDIS_PORT || "6379") || 6379;
 export const REDIS_PASSWORD = process.env.REDIS_PASSWORD || undefined;
 export const STORE_VARIABLES_FOR_LOCAL_MAPS = process.env.STORE_VARIABLES_FOR_LOCAL_MAPS === "true";
+export const PROMETHEUS_AUTHORIZATION_TOKEN = process.env.PROMETHEUS_AUTHORIZATION_TOKEN;
 
 export {
     MINIMUM_DISTANCE,

--- a/contrib/docker/.env.prod.template
+++ b/contrib/docker/.env.prod.template
@@ -108,6 +108,14 @@ DISABLE_NOTIFICATIONS=false
 SKIP_RENDER_OPTIMIZATIONS=false
 STORE_VARIABLES_FOR_LOCAL_MAPS=true
 
+# Prometheus settings
+## Uncomment this to enable the /metrics Prometheus endpoint.
+## To hit this endpoint, you will need to configure Prometheus with:
+## authorization:
+##   type: Bearer
+##   credentials: "[The value of PROMETHEUS_AUTHORIZATION_TOKEN env variable]"
+#PROMETHEUS_AUTHORIZATION_TOKEN=my_password
+
 # Debugging options
 DEBUG_MODE=false
 LOG_LEVEL=WARN

--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -96,6 +96,7 @@ services:
       - MAX_PER_GROUP
       - STORE_VARIABLES_FOR_LOCAL_MAPS
       - REDIS_HOST=redis
+      - PROMETHEUS_AUTHORIZATION_TOKEN
     labels:
       - "traefik.http.routers.back.rule=Host(`${BACK_HOST}`)"
       - "traefik.http.routers.back.entryPoints=web"

--- a/deeployer.libsonnet
+++ b/deeployer.libsonnet
@@ -22,6 +22,7 @@
          "SECRET_JITSI_KEY": env.SECRET_JITSI_KEY,
          "TURN_STATIC_AUTH_SECRET": env.TURN_STATIC_AUTH_SECRET,
          "REDIS_HOST": "redis",
+         "PROMETHEUS_AUTHORIZATION_TOKEN": "promToken",
        } + (if adminUrl != null then {
          "ADMIN_API_URL": adminUrl,
          "ADMIN_API_TOKEN": env.ADMIN_API_TOKEN,
@@ -41,6 +42,7 @@
               "SECRET_JITSI_KEY": env.SECRET_JITSI_KEY,
               "TURN_STATIC_AUTH_SECRET": env.TURN_STATIC_AUTH_SECRET,
               "REDIS_HOST": "redis",
+              "PROMETHEUS_AUTHORIZATION_TOKEN": "promToken",
             } + (if adminUrl != null then {
               "ADMIN_API_URL": adminUrl,
               "ADMIN_API_TOKEN": env.ADMIN_API_TOKEN,

--- a/deeployer.libsonnet
+++ b/deeployer.libsonnet
@@ -61,7 +61,8 @@
               "JITSI_URL": env.JITSI_URL,
               "API_URL": "back1:50051,back2:50051",
               "SECRET_JITSI_KEY": env.SECRET_JITSI_KEY,
-              "FRONT_URL": "https://play-"+url
+              "FRONT_URL": "https://play-"+url,
+              "PROMETHEUS_AUTHORIZATION_TOKEN": "promToken",
             } + (if adminUrl != null then {
               "ADMIN_API_URL": adminUrl,
               "ADMIN_API_TOKEN": env.ADMIN_API_TOKEN,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -146,6 +146,7 @@ services:
       REDIS_HOST: redis
       NODE_ENV: development
       STORE_VARIABLES_FOR_LOCAL_MAPS: "true"
+      PROMETHEUS_AUTHORIZATION_TOKEN: "$PROMETHEUS_AUTHORIZATION_TOKEN"
     volumes:
       - ./back:/usr/src/app
     labels:

--- a/pusher/src/Controller/PrometheusController.ts
+++ b/pusher/src/Controller/PrometheusController.ts
@@ -3,6 +3,7 @@ import { Server } from "hyper-express";
 import { BaseHttpController } from "./BaseHttpController";
 import Request from "hyper-express/types/components/http/Request";
 import Response from "hyper-express/types/components/http/Response";
+import { PROMETHEUS_AUTHORIZATION_TOKEN } from "../Enum/EnvironmentVariable";
 
 export class PrometheusController extends BaseHttpController {
     constructor(app: Server) {
@@ -17,6 +18,24 @@ export class PrometheusController extends BaseHttpController {
     }
 
     private metrics(req: Request, res: Response): void {
+        if (!PROMETHEUS_AUTHORIZATION_TOKEN) {
+            res.status(501).send("Prometheus endpoint is disabled.");
+            return;
+        }
+        const authorizationHeader = req.header("Authorization");
+        if (!authorizationHeader) {
+            res.status(401).send("Undefined authorization header");
+            return;
+        }
+        if (!authorizationHeader.startsWith("Bearer ")) {
+            res.status(401).send('Authorization header should start with "Bearer"');
+            return;
+        }
+        if (authorizationHeader.substring(7) !== PROMETHEUS_AUTHORIZATION_TOKEN) {
+            res.status(401).send("Incorrect authorization header sent.");
+            return;
+        }
+
         res.setHeader("Content-Type", register.contentType);
         res.end(register.metrics());
     }

--- a/pusher/src/Enum/EnvironmentVariable.ts
+++ b/pusher/src/Enum/EnvironmentVariable.ts
@@ -22,6 +22,7 @@ export const OPID_SCOPE = process.env.OPID_SCOPE || "openid email";
 export const OPID_USERNAME_CLAIM = process.env.OPID_USERNAME_CLAIM || "username";
 export const OPID_LOCALE_CLAIM = process.env.OPID_LOCALE_CLAIM || "locale";
 export const DISABLE_ANONYMOUS: boolean = process.env.DISABLE_ANONYMOUS === "true";
+export const PROMETHEUS_AUTHORIZATION_TOKEN = process.env.PROMETHEUS_AUTHORIZATION_TOKEN;
 
 // If set to the string "true", the /openapi route will return the OpenAPI definition and the swagger-ui/ route will display the documentation
 export const ENABLE_OPENAPI_ENDPOINT = process.env.ENABLE_OPENAPI_ENDPOINT === "true";


### PR DESCRIPTION
This commit adds an HTTP authentication endpoint on the back component.
HTTP Bearer Authentication is now REQUIRED. If the PROMETHEUS_AUTHORIZATION_TOKEN environment variable is not set (to configure the authentication token), the /metrics endpoint is disabled.