### PR TITLE
Allowing "*" as a valid value for FRONT_URL in pusher

### DIFF
--- a/pusher/src/Middleware/Cors.ts
+++ b/pusher/src/Middleware/Cors.ts
@@ -9,7 +9,11 @@ export function cors(req: Request, res: Response, next?: MiddlewareNext): Middle
         "Origin, X-Requested-With, Content-Type, Accept, Authorization, Pragma, Cache-Control"
     );
     res.setHeader("access-control-allow-methods", "GET, POST, OPTIONS, PUT, PATCH, DELETE");
-    res.setHeader("access-control-allow-origin", FRONT_URL);
+    if (FRONT_URL === "*") {
+        res.setHeader("access-control-allow-origin", req.header("Origin"));
+    } else {
+        res.setHeader("access-control-allow-origin", FRONT_URL);
+    }
     res.setHeader("access-control-allow-credentials", "true");
 
     if (next) {


### PR DESCRIPTION
The FRONT_URL environment variable is used to verify the CORS domains allowed to access the API.
We are here explicitly allowing the "*" value to allow ALL domains to make a request on the pusher.
Use with care (will be used to allow custom domains in production)