### PR TITLE
Allowing pusher to forward redirect calls

### DIFF
--- a/pusher/src/Controller/MapController.ts
+++ b/pusher/src/Controller/MapController.ts
@@ -106,15 +106,17 @@ export class MapController extends BaseHttpController {
 
             (async () => {
                 try {
-                    const mapDetails = isMapDetailsData.parse(
-                        await adminService.fetchMapDetails(
-                            query.playUri as string,
-                            query.authToken as string,
-                            req.header("accept-language")
-                        )
+                    let mapDetails = await adminService.fetchMapDetails(
+                        query.playUri as string,
+                        query.authToken as string,
+                        req.header("accept-language")
                     );
 
-                    if (DISABLE_ANONYMOUS) mapDetails.authenticationMandatory = true;
+                    const mapDetailsParsed = isMapDetailsData.safeParse(mapDetails);
+                    if (DISABLE_ANONYMOUS && mapDetailsParsed.success) {
+                        mapDetails = mapDetailsParsed.data;
+                        mapDetails.authenticationMandatory = true;
+                    }
 
                     res.json(mapDetails);
                     return;

--- a/pusher/src/Services/AdminApi.ts
+++ b/pusher/src/Services/AdminApi.ts
@@ -139,11 +139,12 @@ class AdminApi implements AdminInterface {
         });
 
         const mapDetailData = isMapDetailsData.safeParse(res.data);
-        const roomRedirect = isRoomRedirect.safeParse(res.data);
 
         if (mapDetailData.success) {
             return mapDetailData.data;
         }
+
+        const roomRedirect = isRoomRedirect.safeParse(res.data);
 
         if (roomRedirect.success) {
             return roomRedirect.data;


### PR DESCRIPTION
For some reason, the /map endpoint was not more allowed to forward "redirect" calls coming from the admin API.
This commit fixes this issue.