### PR TITLE
Moving the START_ROOM_URL to the pusher

### DIFF
--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -39,7 +39,6 @@ services:
       - TURN_PASSWORD
       - TURN_STATIC_AUTH_SECRET
       - STUN_SERVER
-      - START_ROOM_URL
       - SKIP_RENDER_OPTIMIZATIONS
       - MAX_PER_GROUP
       - MAX_USERNAME_LENGTH
@@ -67,6 +66,7 @@ services:
       - JITSI_URL
       - JITSI_ISS
       - DISABLE_ANONYMOUS
+      - START_ROOM_URL
     labels:
       - "traefik.http.routers.pusher.rule=Host(`${PUSHER_HOST}`)"
       - "traefik.http.routers.pusher.entryPoints=web"

--- a/deeployer.libsonnet
+++ b/deeployer.libsonnet
@@ -72,6 +72,7 @@
               "OPID_CLIENT_ISSUER": "https://publichydra-"+url,
               "OPID_CLIENT_REDIRECT_URL": "https://"+url+"/oauth/hydra",
               "OPID_LOGIN_SCREEN_PROVIDER": "https://pusher-"+url+"/login-screen",
+              "START_ROOM_URL": "/_/global/maps-"+url+"/starter/map.json",
             } else {})
           },
     "front": {
@@ -91,7 +92,6 @@
         "SECRET_JITSI_KEY": env.SECRET_JITSI_KEY,
         "TURN_SERVER": "turn:coturn.workadventu.re:443,turns:coturn.workadventu.re:443",
         "JITSI_PRIVATE_MODE": if env.SECRET_JITSI_KEY != '' then "true" else "false",
-        "START_ROOM_URL": "/_/global/maps-"+url+"/starter/map.json",
         "ICON_URL": "//icon-"+url,
       }
     },

--- a/docker-compose.single-domain.yaml
+++ b/docker-compose.single-domain.yaml
@@ -41,7 +41,6 @@ services:
       # Advice: you should instead use Coturn REST API along the TURN_STATIC_AUTH_SECRET in the Back container
       TURN_USER: ""
       TURN_PASSWORD: ""
-      START_ROOM_URL: "$START_ROOM_URL"
       DISABLE_ANONYMOUS: "$DISABLE_ANONYMOUS"
     command: yarn run start
     volumes:
@@ -81,6 +80,7 @@ services:
       OPID_USERNAME_CLAIM: $OPID_USERNAME_CLAIM
       OPID_LOCALE_CLAIM: $OPID_LOCALE_CLAIM
       DISABLE_ANONYMOUS: $DISABLE_ANONYMOUS
+      START_ROOM_URL: "$START_ROOM_URL"
     volumes:
       - ./pusher:/usr/src/app
     labels:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,6 @@ services:
       # Advice: you should instead use Coturn REST API along the TURN_STATIC_AUTH_SECRET in the Back container
       TURN_USER: ""
       TURN_PASSWORD: ""
-      START_ROOM_URL: "$START_ROOM_URL"
       MAX_PER_GROUP: "$MAX_PER_GROUP"
       MAX_USERNAME_LENGTH: "$MAX_USERNAME_LENGTH"
       DISABLE_ANONYMOUS: "$DISABLE_ANONYMOUS"
@@ -91,6 +90,7 @@ services:
       OPID_LOCALE_CLAIM: $OPID_LOCALE_CLAIM
       DISABLE_ANONYMOUS: $DISABLE_ANONYMOUS
       ENABLE_OPENAPI_ENDPOINT: "true"
+      START_ROOM_URL: "$START_ROOM_URL"
     volumes:
       - ./pusher:/usr/src/app
     labels:

--- a/front/src/Connexion/LocalUserStore.ts
+++ b/front/src/Connexion/LocalUserStore.ts
@@ -1,6 +1,5 @@
 import { areCharacterLayersValid, isUserNameValid, LocalUser } from "./LocalUser";
 import { v4 as uuidv4 } from "uuid";
-import { START_ROOM_URL } from "../Enum/EnvironmentVariable";
 
 const playerNameKey = "playerName";
 const selectedPlayerKey = "selectedPlayer";
@@ -174,9 +173,7 @@ class LocalUserStore {
     }
 
     getLastRoomUrl(): string {
-        return (
-            localStorage.getItem(lastRoomUrl) ?? window.location.protocol + "//" + window.location.host + START_ROOM_URL
-        );
+        return localStorage.getItem(lastRoomUrl) ?? window.location.protocol + "//" + window.location.host + "/";
     }
 
     getLastRoomUrlCacheApi(): Promise<string | undefined> {

--- a/front/src/Enum/EnvironmentVariable.ts
+++ b/front/src/Enum/EnvironmentVariable.ts
@@ -1,8 +1,6 @@
 import { getEnvConfig } from "@geprog/vite-plugin-env-config/getEnvConfig";
 
 const DEBUG_MODE: boolean = getEnvConfig("DEBUG_MODE") == "true";
-const START_ROOM_URL: string =
-    getEnvConfig("START_ROOM_URL") || "/_/global/maps.workadventure.localhost/Floor1/floor1.json";
 const PUSHER_URL = getEnvConfig("PUSHER_URL") || "//pusher.workadventure.localhost";
 export const ADMIN_URL = getEnvConfig("ADMIN_URL") || "//workadventu.re";
 const UPLOADER_URL = getEnvConfig("UPLOADER_URL") || "//uploader.workadventure.localhost";
@@ -32,7 +30,6 @@ const FALLBACK_LOCALE = getEnvConfig("FALLBACK_LOCALE") || undefined;
 
 export {
     DEBUG_MODE,
-    START_ROOM_URL,
     SKIP_RENDER_OPTIMIZATIONS,
     DISABLE_NOTIFICATIONS,
     PUSHER_URL,

--- a/pusher/src/Enum/EnvironmentVariable.ts
+++ b/pusher/src/Enum/EnvironmentVariable.ts
@@ -27,6 +27,9 @@ export const PROMETHEUS_AUTHORIZATION_TOKEN = process.env.PROMETHEUS_AUTHORIZATI
 // If set to the string "true", the /openapi route will return the OpenAPI definition and the swagger-ui/ route will display the documentation
 export const ENABLE_OPENAPI_ENDPOINT = process.env.ENABLE_OPENAPI_ENDPOINT === "true";
 
+// The URL to use if the user is visiting the first time and hitting the "/" route.
+export const START_ROOM_URL: string = process.env.START_ROOM_URL || "/_/global/maps.workadventu.re/starter/map.json";
+
 export {
     SECRET_KEY,
     API_URL,

--- a/pusher/src/Services/LocalAdmin.ts
+++ b/pusher/src/Services/LocalAdmin.ts
@@ -3,7 +3,7 @@ import { AdminInterface } from "./AdminInterface";
 import { MapDetailsData } from "../Messages/JsonMessages/MapDetailsData";
 import { RoomRedirect } from "../Messages/JsonMessages/RoomRedirect";
 import { GameRoomPolicyTypes } from "../Model/PusherRoom";
-import { DISABLE_ANONYMOUS } from "../Enum/EnvironmentVariable";
+import { DISABLE_ANONYMOUS, START_ROOM_URL } from "../Enum/EnvironmentVariable";
 import { AdminApiData } from "../Messages/JsonMessages/AdminApiData";
 
 /**
@@ -30,6 +30,13 @@ class LocalAdmin implements AdminInterface {
 
     fetchMapDetails(playUri: string, authToken?: string, locale?: string): Promise<MapDetailsData | RoomRedirect> {
         const roomUrl = new URL(playUri);
+
+        if (roomUrl.pathname === "/") {
+            roomUrl.pathname = START_ROOM_URL;
+            return Promise.resolve({
+                redirectUrl: roomUrl.toString(),
+            });
+        }
 
         const match = /\/_\/[^/]+\/(.+)/.exec(roomUrl.pathname);
         if (!match) {


### PR DESCRIPTION
The START_ROOM_URL environment variable is now applied to the Pusher and not to the Front.
Unlike before, it is only applied when no AdminAPI is set.

This means users of AdminAPI can now decide where the "/" route will lead
without having to reconfigure the front container (and therefore
that depending on your user, you can redirect to one place or another)

WARNING! This is a breaking change in the containers configuration as
the environment variable must be moved in all production setups from the front to the pusher.