### PR TITLE
Improving cleanup of peers

### DIFF
--- a/front/src/Connexion/RoomConnection.ts
+++ b/front/src/Connexion/RoomConnection.ts
@@ -534,28 +534,24 @@ export class RoomConnection implements RoomConnection {
         const message = SetPlayerDetailsMessageTsProto.fromPartial({
             showVoiceIndicator: show,
         });
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "setPlayerDetailsMessage",
                 setPlayerDetailsMessage: message,
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public emitPlayerStatusChange(availabilityStatus: AvailabilityStatus): void {
         const message = SetPlayerDetailsMessageTsProto.fromPartial({
             availabilityStatus,
         });
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "setPlayerDetailsMessage",
                 setPlayerDetailsMessage: message,
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public emitPlayerOutlineColor(color: number | null) {
@@ -569,14 +565,12 @@ export class RoomConnection implements RoomConnection {
                 outlineColor: color,
             });
         }
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "setPlayerDetailsMessage",
                 setPlayerDetailsMessage: message,
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public closeConnection(): void {
@@ -624,7 +618,7 @@ export class RoomConnection implements RoomConnection {
 
         const viewportMessage = this.toViewportMessage(viewport);
 
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "userMovesMessage",
                 userMovesMessage: {
@@ -632,20 +626,16 @@ export class RoomConnection implements RoomConnection {
                     viewport: viewportMessage,
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public setViewport(viewport: ViewportInterface): void {
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "viewportMessage",
                 viewportMessage: this.toViewportMessage(viewport),
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     /*    public onUserJoins(callback: (message: MessageUserJoined) => void): void {
@@ -718,7 +708,7 @@ export class RoomConnection implements RoomConnection {
     }
 
     public sendWebrtcSignal(signal: unknown, receiverId: number) {
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "webRtcSignalToServerMessage",
                 webRtcSignalToServerMessage: {
@@ -726,13 +716,11 @@ export class RoomConnection implements RoomConnection {
                     signal: JSON.stringify(signal),
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public sendWebrtcScreenSharingSignal(signal: unknown, receiverId: number) {
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "webRtcScreenSharingSignalToServerMessage",
                 webRtcScreenSharingSignalToServerMessage: {
@@ -740,9 +728,7 @@ export class RoomConnection implements RoomConnection {
                     signal: JSON.stringify(signal),
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public onServerDisconnected(callback: () => void): void {
@@ -765,7 +751,7 @@ export class RoomConnection implements RoomConnection {
     }
 
     emitActionableEvent(itemId: number, event: string, state: unknown, parameters: unknown): void {
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "itemEventMessage",
                 itemEventMessage: {
@@ -775,13 +761,11 @@ export class RoomConnection implements RoomConnection {
                     parametersJson: JSON.stringify(parameters),
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     emitSetVariableEvent(name: string, value: unknown): void {
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "variableMessage",
                 variableMessage: {
@@ -789,9 +773,7 @@ export class RoomConnection implements RoomConnection {
                     value: JSON.stringify(value),
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public uploadAudio(file: FormData) {
@@ -806,7 +788,7 @@ export class RoomConnection implements RoomConnection {
     }
 
     public emitGlobalMessage(message: PlayGlobalMessageInterface): void {
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "playGlobalMessage",
                 playGlobalMessage: {
@@ -815,13 +797,11 @@ export class RoomConnection implements RoomConnection {
                     broadcastToWorld: message.broadcastToWorld,
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public emitReportPlayerMessage(reportedUserUuid: string, reportComment: string): void {
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "reportPlayerMessage",
                 reportPlayerMessage: {
@@ -829,13 +809,11 @@ export class RoomConnection implements RoomConnection {
                     reportComment,
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public emitQueryJitsiJwtMessage(jitsiRoom: string, tag: string | undefined): void {
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "queryJitsiJwtMessage",
                 queryJitsiJwtMessage: {
@@ -844,9 +822,7 @@ export class RoomConnection implements RoomConnection {
                     // TODO: when we migrated "pusher" to ts-proto, migrate this to a StringValue
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public hasTag(tag: string): boolean {
@@ -858,16 +834,14 @@ export class RoomConnection implements RoomConnection {
     }
 
     public emitEmoteEvent(emoteName: string): void {
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "emotePromptMessage",
                 emotePromptMessage: {
                     emote: emoteName,
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public emitFollowRequest(): void {
@@ -875,16 +849,14 @@ export class RoomConnection implements RoomConnection {
             return;
         }
 
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "followRequestMessage",
                 followRequestMessage: {
                     leader: this.userId,
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public emitFollowConfirmation(): void {
@@ -892,7 +864,7 @@ export class RoomConnection implements RoomConnection {
             return;
         }
 
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "followConfirmationMessage",
                 followConfirmationMessage: {
@@ -900,9 +872,7 @@ export class RoomConnection implements RoomConnection {
                     follower: this.userId,
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public emitFollowAbort(): void {
@@ -912,7 +882,7 @@ export class RoomConnection implements RoomConnection {
             return;
         }
 
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "followAbortMessage",
                 followAbortMessage: {
@@ -920,22 +890,18 @@ export class RoomConnection implements RoomConnection {
                     follower: isLeader ? 0 : this.userId,
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public emitLockGroup(lock: boolean = true): void {
-        const bytes = ClientToServerMessageTsProto.encode({
+        this.send({
             message: {
                 $case: "lockGroupPromptMessage",
                 lockGroupPromptMessage: {
                     lock,
                 },
             },
-        }).finish();
-
-        this.socket.send(bytes);
+        });
     }
 
     public getAllTags(): string[] {
@@ -951,5 +917,16 @@ export class RoomConnection implements RoomConnection {
         menuIconVisiblilityStore.set(false);
         selectCharacterSceneVisibleStore.set(true);
         gameManager.leaveGame(SelectCharacterSceneName, new SelectCharacterScene());
+    }
+
+    private send(message: ClientToServerMessageTsProto): void {
+        const bytes = ClientToServerMessageTsProto.encode(message).finish();
+
+        if (this.socket.readyState === WebSocket.CLOSING || this.socket.readyState === WebSocket.CLOSED) {
+            console.warn("Trying to send a message to the server, but the connection is closed. Message: ", message);
+            return;
+        }
+
+        this.socket.send(bytes);
     }
 }


### PR DESCRIPTION
Built on top of #2224
Related to #2222 

This actually tries to remove the elements in SimplePeer.PeerConnectionArray and SimplePeer.PeerScreenSharingConnectionArray. Something we surprisingly did not do before!