### PR TITLE
Modifying logs to be less verbose

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -885,17 +885,6 @@ export class GameScene extends DirtyScene {
     }
 
     private subscribeToStores(): void {
-        console.error(
-            "subscribeToStores => Check all subscriber undefined ",
-            this.userIsJitsiDominantSpeakerStoreUnsubscriber,
-            this.jitsiParticipantsCountStoreUnsubscriber,
-            this.availabilityStatusStoreUnsubscriber,
-            this.emoteUnsubscriber,
-            this.emoteMenuUnsubscriber,
-            this.followUsersColorStoreUnsubscriber,
-            this.biggestAvailableAreaStoreUnsubscriber,
-            this.peerStoreUnsubscriber
-        );
         if (
             this.userIsJitsiDominantSpeakerStoreUnsubscriber != undefined ||
             this.jitsiParticipantsCountStoreUnsubscriber != undefined ||
@@ -905,8 +894,21 @@ export class GameScene extends DirtyScene {
             this.followUsersColorStoreUnsubscriber != undefined ||
             this.biggestAvailableAreaStoreUnsubscriber != undefined ||
             this.peerStoreUnsubscriber != undefined
-        )
-            throw new Error("subscribeToStores => Check subscriber");
+        ) {
+            console.error(
+                "subscribeToStores => Check all subscriber undefined ",
+                this.userIsJitsiDominantSpeakerStoreUnsubscriber,
+                this.jitsiParticipantsCountStoreUnsubscriber,
+                this.availabilityStatusStoreUnsubscriber,
+                this.emoteUnsubscriber,
+                this.emoteMenuUnsubscriber,
+                this.followUsersColorStoreUnsubscriber,
+                this.biggestAvailableAreaStoreUnsubscriber,
+                this.peerStoreUnsubscriber
+            );
+
+            throw new Error("One store is already subscribed.");
+        }
 
         this.userIsJitsiDominantSpeakerStoreUnsubscriber = userIsJitsiDominantSpeakerStore.subscribe(
             (dominantSpeaker) => {

--- a/pusher/src/Services/SocketManager.ts
+++ b/pusher/src/Services/SocketManager.ts
@@ -122,18 +122,17 @@ export class SocketManager implements ZoneEventListener {
                 }
             })
             .on("end", () => {
-                console.warn(
-                    "Admin connection lost to back server '" +
-                        apiClient.getChannel().getTarget() +
-                        "' for room '" +
-                        roomId +
-                        "'"
-                );
                 // Let's close the front connection if the back connection is closed. This way, we can retry connecting from the start.
                 if (!client.disconnecting) {
+                    console.warn(
+                        "Admin connection lost to back server '" +
+                            apiClient.getChannel().getTarget() +
+                            "' for room '" +
+                            roomId +
+                            "'"
+                    );
                     this.closeWebsocketConnection(client, 1011, "Admin Connection lost to back server");
                 }
-                console.log("A user left");
             })
             .on("error", (err: Error) => {
                 console.error(
@@ -201,7 +200,7 @@ export class SocketManager implements ZoneEventListener {
                 joinRoomMessage.addCharacterlayer(characterLayerMessage);
             }
 
-            console.log("Calling joinRoom '" + client.roomId + "'");
+            debug("Calling joinRoom '" + client.roomId + "'");
             const apiClient = await apiClientRepository.getClient(client.roomId);
             const streamToPusher = apiClient.joinRoom();
             clientEventsEmitter.emitClientJoin(client.userUuid, client.roomId);
@@ -229,18 +228,17 @@ export class SocketManager implements ZoneEventListener {
                     }
                 })
                 .on("end", () => {
-                    console.warn(
-                        "Connection lost to back server '" +
-                            apiClient.getChannel().getTarget() +
-                            "' for room '" +
-                            client.roomId +
-                            "'"
-                    );
                     // Let's close the front connection if the back connection is closed. This way, we can retry connecting from the start.
                     if (!client.disconnecting) {
+                        console.warn(
+                            "Connection lost to back server '" +
+                                apiClient.getChannel().getTarget() +
+                                "' for room '" +
+                                client.roomId +
+                                "'"
+                        );
                         this.closeWebsocketConnection(client, 1011, "Connection lost to back server");
                     }
-                    console.log("A user left");
                 })
                 .on("error", (err: Error) => {
                     console.error(
@@ -425,7 +423,7 @@ export class SocketManager implements ZoneEventListener {
                 } finally {
                     //delete Client.roomId;
                     clientEventsEmitter.emitClientLeave(socket.userUuid, socket.roomId);
-                    console.log("A user left");
+                    debug("User ", socket.name, " left: ", socket.userUuid);
                 }
             }
         } finally {


### PR DESCRIPTION
In particular, a frightening warning issued each time someone was leaving the room in the Pusher is now only issued if the connection was broken between pusher and back

Also, removing an error message that is supposed to be displayed only if things go wrong.