### PR TITLE
Renaming reportWorldSlug to roomUrl in ADMIN_API /api/report endpoint.

### DIFF
--- a/pusher/src/Services/AdminApi.ts
+++ b/pusher/src/Services/AdminApi.ts
@@ -305,7 +305,7 @@ class AdminApi implements AdminInterface {
         reportedUserUuid: string,
         reportedUserComment: string,
         reporterUserUuid: string,
-        reportWorldSlug: string,
+        roomUrl: string,
         locale?: string
     ) {
         /**
@@ -334,9 +334,9 @@ class AdminApi implements AdminInterface {
          *        description: "The identifier of the reporter user \n It can be an uuid or an email"
          *        type: "string"
          *        example: "998ce839-3dea-4698-8b41-ebbdf7688ad8"
-         *      - name: "reportWorldSlug"
+         *      - name: "roomUrl"
          *        in: "query"
-         *        description: "The slug of the world where the report is made"
+         *        description: "The URL of the room where the report is made"
          *        type: "string"
          *        example: "/@/teamSlug/worldSlug/roomSlug"
          *     responses:
@@ -349,7 +349,7 @@ class AdminApi implements AdminInterface {
                 reportedUserUuid,
                 reportedUserComment,
                 reporterUserUuid,
-                reportWorldSlug,
+                reportWorldSlug: roomUrl,
             },
             {
                 headers: { Authorization: `${ADMIN_API_TOKEN}`, "Accept-Language": locale ?? "en" },

--- a/pusher/src/Services/AdminInterface.ts
+++ b/pusher/src/Services/AdminInterface.ts
@@ -43,13 +43,13 @@ export interface AdminInterface {
      * @param reportedUserUuid
      * @param reportedUserComment
      * @param reporterUserUuid
-     * @param reportWorldSlug
+     * @param roomUrl
      */
     reportPlayer(
         reportedUserUuid: string,
         reportedUserComment: string,
         reporterUserUuid: string,
-        reportWorldSlug: string,
+        roomUrl: string,
         locale?: string
     ): Promise<unknown>;
 

--- a/pusher/src/Services/LocalAdmin.ts
+++ b/pusher/src/Services/LocalAdmin.ts
@@ -74,7 +74,7 @@ class LocalAdmin implements AdminInterface {
         reportedUserUuid: string,
         reportedUserComment: string,
         reporterUserUuid: string,
-        reportWorldSlug: string,
+        roomUrl: string,
         locale?: string
     ) {
         return Promise.reject(new Error("No admin backoffice set!"));


### PR DESCRIPTION
The rename is made because the parameter named "reportWorldSlug" was actually supposed to be a full "roomUrl" (which was completely misleading)