### PR TITLE
Trying to fix "reconnecting" screen issue

### DIFF
--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -600,20 +600,22 @@ export class GameScene extends DirtyScene {
         if (!this.room.isDisconnected()) {
             if (this.isReconnecting) {
                 setTimeout(() => {
-                    this.scene.sleep();
-                    if (get(errorScreenStore)) {
-                        // If an error message is already displayed, don't display the "connection lost" message.
-                        return;
+                    if (this.connection === undefined) {
+                        this.scene.sleep();
+                        if (get(errorScreenStore)) {
+                            // If an error message is already displayed, don't display the "connection lost" message.
+                            return;
+                        }
+                        errorScreenStore.setError(
+                            ErrorScreenMessage.fromPartial({
+                                type: "reconnecting",
+                                code: "CONNECTION_LOST",
+                                title: get(LL).warning.connectionLostTitle(),
+                                details: get(LL).warning.connectionLostSubtitle(),
+                            })
+                        );
+                        //this.scene.launch(ReconnectingSceneName);
                     }
-                    errorScreenStore.setError(
-                        ErrorScreenMessage.fromPartial({
-                            type: "reconnecting",
-                            code: "CONNECTION_LOST",
-                            title: get(LL).warning.connectionLostTitle(),
-                            details: get(LL).warning.connectionLostSubtitle(),
-                        })
-                    );
-                    //this.scene.launch(ReconnectingSceneName);
                 }, 0);
             } else if (this.connection === undefined) {
                 // Let's wait 1 second before printing the "connecting" screen to avoid blinking
@@ -627,9 +629,9 @@ export class GameScene extends DirtyScene {
                         errorScreenStore.setError(
                             ErrorScreenMessage.fromPartial({
                                 type: "reconnecting",
-                                code: "CONNECTION_LOST",
-                                title: get(LL).warning.connectionLostTitle(),
-                                details: get(LL).warning.connectionLostSubtitle(),
+                                code: "CONNECTION_PENDING",
+                                title: get(LL).warning.waitingConnectionTitle(),
+                                details: get(LL).warning.waitingConnectionSubtitle(),
                             })
                         );
                         //this.scene.launch(ReconnectingSceneName);
@@ -839,11 +841,9 @@ export class GameScene extends DirtyScene {
                 this.connectionAnswerPromiseDeferred.resolve(onConnect.room);
                 // Analyze tags to find if we are admin. If yes, show console.
 
-                if (this.scene.isSleeping()) {
-                    const error = get(errorScreenStore);
-                    if (error && error?.type === "reconnecting") errorScreenStore.delete();
-                    //this.scene.stop(ReconnectingSceneName);
-                }
+                const error = get(errorScreenStore);
+                if (error && error?.type === "reconnecting") errorScreenStore.delete();
+                //this.scene.stop(ReconnectingSceneName);
 
                 //init user position and play trigger to check layers properties
                 this.gameMap.setPosition(this.CurrentPlayer.x, this.CurrentPlayer.y);

--- a/front/src/i18n/de-DE/warning.ts
+++ b/front/src/i18n/de-DE/warning.ts
@@ -16,6 +16,8 @@ const warning: NonNullable<Translation["warning"]> = {
     connectionLost: "Verbindungen unterbrochen. Wiederverbinden...",
     connectionLostTitle: "Verbindungen unterbrochen",
     connectionLostSubtitle: "Wiederverbinden",
+    waitingConnectionTitle: "Auf Verbindung warten",
+    waitingConnectionSubtitle: "Verbinden",
 };
 
 export default warning;

--- a/front/src/i18n/en-US/warning.ts
+++ b/front/src/i18n/en-US/warning.ts
@@ -15,6 +15,8 @@ const warning: BaseTranslation = {
     connectionLost: "Connection lost. Reconnecting...",
     connectionLostTitle: "Connection lost",
     connectionLostSubtitle: "Reconnecting",
+    waitingConnectionTitle: "Waiting for connection",
+    waitingConnectionSubtitle: "Connecting",
 };
 
 export default warning;

--- a/front/src/i18n/fr-FR/warning.ts
+++ b/front/src/i18n/fr-FR/warning.ts
@@ -15,6 +15,8 @@ const warning: NonNullable<Translation["warning"]> = {
     connectionLost: "Connexion perdue. Reconnexion...",
     connectionLostTitle: "Connexion perdue",
     connectionLostSubtitle: "Reconnexion",
+    waitingConnectionTitle: "En attente du serveur",
+    waitingConnectionSubtitle: "Connexion",
 };
 
 export default warning;

--- a/front/src/i18n/zh-CN/warning.ts
+++ b/front/src/i18n/zh-CN/warning.ts
@@ -15,6 +15,8 @@ const warning: NonNullable<Translation["warning"]> = {
     connectionLost: "连接丢失。重新连接中...",
     connectionLostTitle: "连接丢失。",
     connectionLostSubtitle: "重新连接中",
+    waitingConnectionTitle: "Waiting for connection", // TODO: translate
+    waitingConnectionSubtitle: "Connecting", // TODO: translate
 };
 
 export default warning;


### PR DESCRIPTION
In rare circumstances, the "reconnect" screen stays displayed (even if behind the scene, the reconnection has successfully happened).
We try here to fix this by forcing the removal of the errorScreen (even if the scene is not sleeping).

Also, we make a difference in the user message between a "reconnection failed" and a "connection did not happen yet, even after 1 second"

Related to #2222