### PR TITLE
Feat persistent MediaStore

### DIFF
--- a/front/src/Connexion/LocalUserStore.ts
+++ b/front/src/Connexion/LocalUserStore.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 const playerNameKey = "playerName";
 const selectedPlayerKey = "selectedPlayer";
 const customCursorPositionKey = "customCursorPosition";
+const requestedCameraStateKey = "requestedCameraStateKey";
 const characterLayersKey = "characterLayers";
 const companionKey = "companion";
 const gameQualityKey = "gameQuality";
@@ -60,6 +61,14 @@ class LocalUserStore {
 
     getCustomCursorPosition(): { activeRow: number; selectedLayers: number[] } | null {
         return JSON.parse(localStorage.getItem(customCursorPositionKey) || "null");
+    }
+
+    getRequestedCameraState(): boolean {
+        return JSON.parse(localStorage.getItem(requestedCameraStateKey) || "true");
+    }
+
+    setRequestedCameraState(value: boolean): void {
+        localStorage.setItem(requestedCameraStateKey, JSON.stringify(value));
     }
 
     setCharacterLayers(layers: string[]): void {

--- a/front/src/Connexion/LocalUserStore.ts
+++ b/front/src/Connexion/LocalUserStore.ts
@@ -5,6 +5,7 @@ const playerNameKey = "playerName";
 const selectedPlayerKey = "selectedPlayer";
 const customCursorPositionKey = "customCursorPosition";
 const requestedCameraStateKey = "requestedCameraStateKey";
+const requestedMicrophoneStateKey = "requestedMicrophoneStateKey";
 const characterLayersKey = "characterLayers";
 const companionKey = "companion";
 const gameQualityKey = "gameQuality";
@@ -69,6 +70,14 @@ class LocalUserStore {
 
     setRequestedCameraState(value: boolean): void {
         localStorage.setItem(requestedCameraStateKey, JSON.stringify(value));
+    }
+
+    getRequestedMicrophoneState(): boolean {
+        return JSON.parse(localStorage.getItem(requestedMicrophoneStateKey) || "true");
+    }
+
+    setRequestedMicrophoneState(value: boolean): void {
+        localStorage.setItem(requestedMicrophoneStateKey, JSON.stringify(value));
     }
 
     setCharacterLayers(layers: string[]): void {

--- a/front/src/Stores/MediaStore.ts
+++ b/front/src/Stores/MediaStore.ts
@@ -12,18 +12,25 @@ import { privacyShutdownStore } from "./PrivacyShutdownStore";
 import { MediaStreamConstraintsError } from "./Errors/MediaStreamConstraintsError";
 import { SoundMeter } from "../Phaser/Components/SoundMeter";
 import { AvailabilityStatus } from "../Messages/ts-proto-generated/protos/messages";
+
 import deepEqual from "fast-deep-equal";
 
 /**
  * A store that contains the camera state requested by the user (on or off).
  */
 function createRequestedCameraState() {
-    const { subscribe, set } = writable(true);
+    const { subscribe, set } = writable(localUserStore.getRequestedCameraState());
 
     return {
         subscribe,
-        enableWebcam: () => set(true),
-        disableWebcam: () => set(false),
+        enableWebcam: () => {
+            set(true);
+            localUserStore.setRequestedCameraState(true);
+        },
+        disableWebcam: () => {
+            set(false);
+            localUserStore.setRequestedCameraState(false);
+        },
     };
 }
 

--- a/front/src/Stores/MediaStore.ts
+++ b/front/src/Stores/MediaStore.ts
@@ -38,12 +38,18 @@ function createRequestedCameraState() {
  * A store that contains the microphone state requested by the user (on or off).
  */
 function createRequestedMicrophoneState() {
-    const { subscribe, set } = writable(true);
+    const { subscribe, set } = writable(localUserStore.getRequestedMicrophoneState());
 
     return {
         subscribe,
-        enableMicrophone: () => set(true),
-        disableMicrophone: () => set(false),
+        enableMicrophone: () => {
+            set(true);
+            localUserStore.setRequestedMicrophoneState(true);
+        },
+        disableMicrophone: () => {
+            set(false);
+            localUserStore.setRequestedMicrophoneState(false);
+        },
     };
 }
 


### PR DESCRIPTION
This PR makes `createRequestedCameraState` and `createRequestedMicrophoneState` stores their values in localstorage, this keeps the current behavior (enabled by default), but make the user choice persistent.