### PR TITLE
Fixing error handling for invalid token

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -81,6 +81,7 @@
   },
   "lint-staged": {
     "*.ts": [
+      "node_modules/.bin/eslint --fix",
       "prettier --write"
     ]
   }

--- a/front/package.json
+++ b/front/package.json
@@ -91,8 +91,8 @@
       "yarn run svelte-check"
     ],
     "*.{ts,svelte}": [
-      "yarn run fix",
-      "yarn run pretty"
+      "DEBUG= node_modules/.bin/eslint --fix",
+      "prettier --write"
     ]
   }
 }

--- a/front/src/Connexion/Room.ts
+++ b/front/src/Connexion/Room.ts
@@ -134,10 +134,10 @@ export class Room {
                 throw new Error("Data received by the /map endpoint of the Pusher is not in a valid format.");
             }
         } catch (e) {
-            if (axios.isAxiosError(e) && e.response?.status == 401 && e.response?.data === "Token decrypted error") {
+            if (axios.isAxiosError(e) && e.response?.status == 401 && e.response?.data === "The Token is invalid") {
                 console.warn("JWT token sent could not be decrypted. Maybe it expired?");
                 localUserStore.setAuthToken(null);
-                window.location.assign("/login");
+                window.location.reload();
             } else if (axios.isAxiosError(e)) {
                 console.error("Error => getMapDetail", e, e.response);
             } else {

--- a/front/src/Phaser/Login/EntryScene.ts
+++ b/front/src/Phaser/Login/EntryScene.ts
@@ -1,6 +1,5 @@
 import { gameManager } from "../Game/GameManager";
 import { Scene } from "phaser";
-import { ErrorScene } from "../Reconnecting/ErrorScene";
 import { waScaleManager } from "../Services/WaScaleManager";
 import { ReconnectingTextures } from "../Reconnecting/ReconnectingScene";
 import { localeDetector } from "../../i18n/locales";
@@ -51,7 +50,8 @@ export class EntryScene extends Scene {
                                 window.location.assign(errorType.data.urlToRedirect);
                             } else errorScreenStore.setError(err?.response?.data);
                         } else {
-                            ErrorScene.showError(err, this.scene);
+                            errorScreenStore.setException(err);
+                            //ErrorScene.showError(err, this.scene);
                         }
                     });
             })

--- a/front/src/Phaser/Reconnecting/ErrorScene.ts
+++ b/front/src/Phaser/Reconnecting/ErrorScene.ts
@@ -3,7 +3,6 @@ import Image = Phaser.GameObjects.Image;
 import Sprite = Phaser.GameObjects.Sprite;
 import Text = Phaser.GameObjects.Text;
 import ScenePlugin = Phaser.Scenes.ScenePlugin;
-import Axios from "axios";
 
 export const ErrorSceneName = "ErrorScene";
 enum Textures {
@@ -70,54 +69,6 @@ export class ErrorScene extends Phaser.Scene {
 
         this.cat = this.physics.add.sprite(this.game.renderer.width / 2, this.game.renderer.height / 2 - 32, "cat", 6);
         this.cat.flipY = true;
-    }
-
-    /**
-     * Displays the error page, with an error message matching the "error" parameters passed in.
-     */
-    public static showError(error: unknown, scene: ScenePlugin): void {
-        console.error(error);
-        if (error instanceof Error) {
-            console.error("Stacktrace: ", error.stack);
-        }
-        console.trace();
-
-        if (typeof error === "string" || error instanceof String) {
-            scene.start(ErrorSceneName, {
-                title: "An error occurred",
-                subTitle: error,
-            });
-        } else if (Axios.isAxiosError(error) && error.response) {
-            // Axios HTTP error
-            // client received an error response (5xx, 4xx)
-            console.error("Axios error. Request:", error.request, " - Response: ", error.response);
-            scene.start(ErrorSceneName, {
-                title:
-                    "HTTP " +
-                    error.response.status +
-                    " - " +
-                    (error.response.data ? error.response.data : error.response.statusText),
-                subTitle: "An error occurred while accessing URL:",
-                message: error.response.config.url,
-            });
-        } else if (Axios.isAxiosError(error)) {
-            // Axios HTTP error
-            // client never received a response, or request never left
-            console.error("Axios error. No full HTTP response received. Request to URL:", error.config.url);
-            scene.start(ErrorSceneName, {
-                title: "Network error",
-                subTitle: error.message,
-            });
-        } else if (error instanceof Error) {
-            // Error
-            scene.start(ErrorSceneName, {
-                title: "An error occurred",
-                subTitle: error.name,
-                message: error.message,
-            });
-        } else {
-            throw error;
-        }
     }
 
     /**

--- a/front/src/Stores/ErrorScreenStore.ts
+++ b/front/src/Stores/ErrorScreenStore.ts
@@ -1,5 +1,6 @@
 import { writable } from "svelte/store";
 import { ErrorScreenMessage } from "../Messages/ts-proto-generated/protos/messages";
+import Axios from "axios";
 
 /**
  * A store that contains one error of type WAError to be displayed.
@@ -11,6 +12,69 @@ function createErrorScreenStore() {
         subscribe,
         setError: (e: ErrorScreenMessage): void => {
             set(e);
+        },
+        /**
+         * Turns an exception into an error.
+         */
+        setException: (error: unknown): void => {
+            console.error(error);
+            if (error instanceof Error) {
+                console.error("Stacktrace: ", error.stack);
+            }
+            console.trace();
+
+            if (typeof error === "string" || error instanceof String) {
+                set(
+                    ErrorScreenMessage.fromPartial({
+                        type: "error",
+                        code: "INTERNAL_ERROR",
+                        title: "An error occurred",
+                        details: error.toString(),
+                    })
+                );
+            } else if (Axios.isAxiosError(error) && error.response) {
+                // Axios HTTP error
+                // client received an error response (5xx, 4xx)
+                console.error("Axios error. Request:", error.request, " - Response: ", error.response);
+
+                set(
+                    ErrorScreenMessage.fromPartial({
+                        type: "error",
+                        code: "HTTP_ERROR",
+                        title:
+                            "HTTP " +
+                            error.response.status +
+                            " - " +
+                            (error.response.data ? error.response.data : error.response.statusText),
+                        details: "An error occurred while accessing URL: " + error.response.config.url,
+                    })
+                );
+            } else if (Axios.isAxiosError(error)) {
+                // Axios HTTP error
+                // client never received a response, or request never left
+                console.error("Axios error. No full HTTP response received. Request to URL:", error.config.url);
+                set(
+                    ErrorScreenMessage.fromPartial({
+                        type: "error",
+                        code: "NETWORK_ERROR",
+                        title: "Network error",
+                        subtitle: error.message,
+                    })
+                );
+            } else if (error instanceof Error) {
+                // Error
+                set(
+                    ErrorScreenMessage.fromPartial({
+                        type: "error",
+                        code: "INTERNAL_ERROR",
+                        title: "An error occurred",
+                        subtitle: error.name,
+                        details: error.message,
+                    })
+                );
+            } else {
+                throw error;
+            }
         },
         delete: () => {
             set(undefined);

--- a/pusher/package.json
+++ b/pusher/package.json
@@ -81,6 +81,7 @@
   },
   "lint-staged": {
     "*.ts": [
+      "node_modules/.bin/eslint --fix",
       "prettier --write"
     ]
   }

--- a/pusher/src/Controller/MapController.ts
+++ b/pusher/src/Controller/MapController.ts
@@ -3,6 +3,7 @@ import { isMapDetailsData } from "../Messages/JsonMessages/MapDetailsData";
 import { parse } from "query-string";
 import { BaseHttpController } from "./BaseHttpController";
 import { adminService } from "../Services/AdminService";
+import { InvalidTokenError } from "./InvalidTokenError";
 
 export class MapController extends BaseHttpController {
     // Returns a map mapping map name to file name of the map
@@ -121,7 +122,14 @@ export class MapController extends BaseHttpController {
                     res.json(mapDetails);
                     return;
                 } catch (e) {
-                    this.castErrorToResponse(e, res);
+                    if (e instanceof InvalidTokenError) {
+                        console.warn("Invalid token received", e);
+                        res.status(401);
+                        res.send("The Token is invalid");
+                        return;
+                    } else {
+                        this.castErrorToResponse(e, res);
+                    }
                 }
             })();
         });

--- a/pusher/src/Services/AdminApi.ts
+++ b/pusher/src/Services/AdminApi.ts
@@ -66,24 +66,10 @@ class AdminApi implements AdminInterface {
                 userId = authTokenData.identifier;
                 //eslint-disable-next-line @typescript-eslint/no-unused-vars
             } catch (e) {
-                try {
-                    // Decode token, in this case we don't need to create new token.
-                    authTokenData = jwtTokenManager.verifyJWTToken(authToken, true);
-                    userId = authTokenData.identifier;
-                    console.info("JWT expire, but decoded:", userId);
-                } catch (e) {
-                    if (e instanceof InvalidTokenError) {
-                        throw new Error("Token decrypted error");
-                        // The token was not good, redirect user on login page
-                        //res.status(401);
-                        //res.send("Token decrypted error");
-                        //return;
-                    } else {
-                        throw new Error("Error on decryption of token :" + e);
-                        //this.castErrorToResponse(e, res);
-                        //return;
-                    }
-                }
+                // Decode token, in this case we don't need to create new token.
+                authTokenData = jwtTokenManager.verifyJWTToken(authToken, true);
+                userId = authTokenData.identifier;
+                console.info("JWT expire, but decoded:", userId);
             }
         }
 

--- a/pusher/src/Services/AdminApi.ts
+++ b/pusher/src/Services/AdminApi.ts
@@ -8,7 +8,6 @@ import { isWokaDetail } from "../Messages/JsonMessages/PlayerTextures";
 import qs from "qs";
 import { AdminInterface } from "./AdminInterface";
 import { AuthTokenData, jwtTokenManager } from "./JWTTokenManager";
-import { InvalidTokenError } from "../Controller/InvalidTokenError";
 import { extendApi } from "@anatine/zod-openapi";
 
 export interface AdminBannedData {


### PR DESCRIPTION
In case the JWT token was invalid, we would get an HTTP 500.
With these changes, the JWT token will be silently discarded and the page refreshed.
Depending on whether login is compulsory or not, the user will be logged anonymously or redirected to the login page.

Closes #2211