### PR TITLE
Adding a "policy" property in embedded website

### DIFF
--- a/docs/maps/website-in-map.md
+++ b/docs/maps/website-in-map.md
@@ -38,3 +38,11 @@ to explicitly allow it, by setting an additional `allowApi` property to `true`.
         <figcaption class="figure-caption">A "website" object that can communicate using the Iframe API</figcaption>
     </figure>
 </div>
+
+### Setting the iFrame "allow" attribute
+
+By default, iFrames have limited rights in browsers. For instance, they cannot put their content in fullscreen, they cannot start your webcam, etc...
+
+If you want to grant additional access rights to your embedded iFrame, you should use the `policy` property. The value of this property will be directly used for the [`allow` atttribute of your iFrame](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy#the_iframe_allow_attribute).
+
+For instance, if you want an iFrame to be able to go in fullscreen, you will use the property `policy: fullscreen`

--- a/front/src/Phaser/Game/GameMapProperties.ts
+++ b/front/src/Phaser/Game/GameMapProperties.ts
@@ -29,6 +29,7 @@ export enum GameMapProperties {
     OPEN_WEBSITE_TRIGGER_MESSAGE = "openWebsiteTriggerMessage",
     PLAY_AUDIO = "playAudio",
     PLAY_AUDIO_LOOP = "playAudioLoop",
+    POLICY = "policy",
     READABLE_BY = "readableBy",
     SCRIPT = "script",
     SCRIPT_DISABLE_MODULE_SUPPORT = "scriptDisableModuleSupport",

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -521,8 +521,8 @@ export class GameScene extends DirtyScene {
                             GameMapProperties.ALLOW_API,
                             object.properties
                         );
+                        const policy = PropertyUtils.findStringProperty(GameMapProperties.POLICY, object.properties);
 
-                        // TODO: add a "allow" property to iframe
                         this.embeddedWebsiteManager.createEmbeddedWebsite(
                             object.name,
                             url,
@@ -532,7 +532,7 @@ export class GameScene extends DirtyScene {
                             object.height,
                             object.visible,
                             allowApi ?? false,
-                            "",
+                            policy ?? "",
                             "map",
                             1
                         );

--- a/front/src/Phaser/Map/PropertyUtils.ts
+++ b/front/src/Phaser/Map/PropertyUtils.ts
@@ -25,6 +25,23 @@ export class PropertyUtils {
         return property;
     }
 
+    public static findStringProperty(
+        name: string,
+        properties: ITiledMapProperty[] | undefined,
+        context?: string
+    ): string | undefined {
+        const property = PropertyUtils.findProperty(name, properties);
+        if (property === undefined) {
+            return undefined;
+        }
+        if (typeof property !== "string") {
+            throw new Error(
+                'Expected property "' + name + '" to be a string. ' + (context ? " (" + context + ")" : "")
+            );
+        }
+        return property;
+    }
+
     public static mustFindProperty(
         name: string,
         properties: ITiledMapProperty[] | undefined,


### PR DESCRIPTION
Site new property allows setting the "allow" attribute on the iframes that are embedded inside the map.

Closes #2220