### PR TITLE
Adding a "group/world" notion to Prometheus

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -74,6 +74,7 @@ export class GameRoom {
         onEmote: EmoteCallback,
         onLockGroup: LockGroupCallback,
         onPlayerDetailsUpdated: PlayerDetailsUpdatedCallback,
+        public readonly group: string | null,
         private thirdParty: MapThirdPartyData | undefined
     ) {
         // A zone is 10 sprites wide.
@@ -117,7 +118,8 @@ export class GameRoom {
             onEmote,
             onLockGroup,
             onPlayerDetailsUpdated,
-            mapDetails.thirdParty ?? undefined
+            mapDetails.group,
+            mapDetails.thirdParty ?? undefined,
         );
 
         return gameRoom;

--- a/back/src/Services/ClientEventsEmitter.ts
+++ b/back/src/Services/ClientEventsEmitter.ts
@@ -4,27 +4,27 @@ const clientJoinEvent = "clientJoin";
 const clientLeaveEvent = "clientLeave";
 
 class ClientEventsEmitter extends EventEmitter {
-    emitClientJoin(clientUUid: string, roomId: string): void {
-        this.emit(clientJoinEvent, clientUUid, roomId);
+    emitClientJoin(clientUUid: string, roomId: string, world: string | null): void {
+        this.emit(clientJoinEvent, clientUUid, roomId, world);
     }
 
-    emitClientLeave(clientUUid: string, roomId: string): void {
-        this.emit(clientLeaveEvent, clientUUid, roomId);
+    emitClientLeave(clientUUid: string, roomId: string, world: string | null): void {
+        this.emit(clientLeaveEvent, clientUUid, roomId, world);
     }
 
-    registerToClientJoin(callback: (clientUUid: string, roomId: string) => void): void {
+    registerToClientJoin(callback: (clientUUid: string, roomId: string, world: string | null) => void): void {
         this.on(clientJoinEvent, callback);
     }
 
-    registerToClientLeave(callback: (clientUUid: string, roomId: string) => void): void {
+    registerToClientLeave(callback: (clientUUid: string, roomId: string, world: string | null) => void): void {
         this.on(clientLeaveEvent, callback);
     }
 
-    unregisterFromClientJoin(callback: (clientUUid: string, roomId: string) => void): void {
+    unregisterFromClientJoin(callback: (clientUUid: string, roomId: string, world: string | null) => void): void {
         this.removeListener(clientJoinEvent, callback);
     }
 
-    unregisterFromClientLeave(callback: (clientUUid: string, roomId: string) => void): void {
+    unregisterFromClientLeave(callback: (clientUUid: string, roomId: string, world: string | null) => void): void {
         this.removeListener(clientLeaveEvent, callback);
     }
 }

--- a/back/src/Services/GaugeManager.ts
+++ b/back/src/Services/GaugeManager.ts
@@ -21,18 +21,18 @@ class GaugeManager {
         this.nbClientsPerRoomGauge = new Gauge({
             name: "workadventure_nb_clients_per_room",
             help: "Number of clients per room",
-            labelNames: ["room"],
+            labelNames: ["room", "world"],
         });
 
         this.nbGroupsPerRoomCounter = new Counter({
             name: "workadventure_counter_groups_per_room",
             help: "Counter of groups per room",
-            labelNames: ["room"],
+            labelNames: ["room", "world"],
         });
         this.nbGroupsPerRoomGauge = new Gauge({
             name: "workadventure_nb_groups_per_room",
             help: "Number of groups per room",
-            labelNames: ["room"],
+            labelNames: ["room", "world"],
         });
     }
 
@@ -43,14 +43,14 @@ class GaugeManager {
         this.nbRoomsGauge.dec();
     }
 
-    incNbClientPerRoomGauge(roomId: string): void {
+    incNbClientPerRoomGauge(roomId: string, world: string | null): void {
         this.nbClientsGauge.inc();
-        this.nbClientsPerRoomGauge.inc({ room: roomId });
+        this.nbClientsPerRoomGauge.inc({ room: roomId, world: world ?? "" });
     }
 
-    decNbClientPerRoomGauge(roomId: string): void {
+    decNbClientPerRoomGauge(roomId: string, world: string | null): void {
         this.nbClientsGauge.dec();
-        this.nbClientsPerRoomGauge.dec({ room: roomId });
+        this.nbClientsPerRoomGauge.dec({ room: roomId, world: world ?? "" });
     }
 }
 

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -73,11 +73,11 @@ export class SocketManager {
     private roomsPromises = new Map<string, PromiseLike<GameRoom>>();
 
     constructor() {
-        clientEventsEmitter.registerToClientJoin((clientUUid: string, roomId: string) => {
-            gaugeManager.incNbClientPerRoomGauge(roomId);
+        clientEventsEmitter.registerToClientJoin((clientUUid: string, roomId: string, world: string | null) => {
+            gaugeManager.incNbClientPerRoomGauge(roomId, world);
         });
-        clientEventsEmitter.registerToClientLeave((clientUUid: string, roomId: string) => {
-            gaugeManager.decNbClientPerRoomGauge(roomId);
+        clientEventsEmitter.registerToClientLeave((clientUUid: string, roomId: string, world: string | null) => {
+            gaugeManager.decNbClientPerRoomGauge(roomId, world);
         });
     }
 
@@ -246,7 +246,7 @@ export class SocketManager {
                 debug('Room is empty. Deleting room "%s"', room.roomUrl);
             }
         } finally {
-            clientEventsEmitter.emitClientLeave(user.uuid, room.roomUrl);
+            clientEventsEmitter.emitClientLeave(user.uuid, room.roomUrl, room.group);
             console.log("A user left");
         }
     }
@@ -306,7 +306,7 @@ export class SocketManager {
         //join world
         const user = room.join(socket, joinRoomMessage);
 
-        clientEventsEmitter.emitClientJoin(user.uuid, roomId);
+        clientEventsEmitter.emitClientJoin(user.uuid, roomId, room.group);
         console.log(new Date().toISOString() + " A user joined");
         return { room, user };
     }


### PR DESCRIPTION
When connected to the AdminAPI, the AdminAPI can now send a "group" notion attached to a map.
This maps the "world" notion in WorkAdventure SAAS.
This "world" notion is now exposed through the Prometheus endpoint.