### PR TITLE
Adding an endpoint to list the rooms

### DIFF
--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -29,6 +29,7 @@ import {
     WorldFullWarningToRoomMessage,
     ZoneMessage,
     LockGroupPromptMessage,
+    RoomsList,
 } from "./Messages/generated/messages_pb";
 import { sendUnaryData, ServerDuplexStream, ServerUnaryCall, ServerWritableStream } from "grpc";
 import { socketManager } from "./Services/SocketManager";
@@ -329,6 +330,9 @@ const roomManager: IRoomManagerServer = {
         // FIXME: we could improve return message by returning a Success|ErrorMessage message
         socketManager.dispatchRoomRefresh(call.request.getRoomid()).catch((e) => console.error(e));
         callback(null, new EmptyMessage());
+    },
+    getRooms(call: ServerUnaryCall<EmptyMessage>, callback: sendUnaryData<RoomsList>): void {
+        callback(null, socketManager.getAllRooms());
     },
 };
 

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -40,6 +40,8 @@ import {
     GroupUsersUpdateMessage,
     LockGroupPromptMessage,
     ErrorMessage,
+    RoomsList,
+    RoomDescription,
 } from "../Messages/generated/messages_pb";
 import { User, UserSocket } from "../Model/User";
 import { ProtobufUtils } from "../Model/Websocket/ProtobufUtils";
@@ -68,8 +70,13 @@ function emitZoneMessage(subMessage: SubToPusherMessage, socket: ZoneSocket): vo
 }
 
 export class SocketManager {
-    //private rooms = new Map<string, GameRoom>();
-    // List of rooms in process of loading.
+    /**
+     * List of rooms already loaded (note: never use this directly).
+     * It is only here for the very specific getAllRooms case that needs to return all available rooms
+     * without waiting for pending rooms.
+     */
+    private resolvedRooms = new Map<string, GameRoom>();
+    // List of rooms (or rooms in process of loading).
     private roomsPromises = new Map<string, PromiseLike<GameRoom>>();
 
     constructor() {
@@ -242,6 +249,7 @@ export class SocketManager {
             room.leave(user);
             if (room.isEmpty()) {
                 this.roomsPromises.delete(room.roomUrl);
+                this.resolvedRooms.delete(room.roomUrl);
                 gaugeManager.decNbRoomGauge();
                 debug('Room is empty. Deleting room "%s"', room.roomUrl);
             }
@@ -284,6 +292,7 @@ export class SocketManager {
             )
                 .then((gameRoom) => {
                     gaugeManager.incNbRoomGauge();
+                    this.resolvedRooms.set(roomId, gameRoom);
                     return gameRoom;
                 })
                 .catch((e) => {
@@ -812,6 +821,7 @@ export class SocketManager {
         room.adminLeave(admin);
         if (room.isEmpty()) {
             this.roomsPromises.delete(room.roomUrl);
+            this.resolvedRooms.delete(room.roomUrl);
             gaugeManager.decNbRoomGauge();
             debug('Room is empty. Deleting room "%s"', room.roomUrl);
         }
@@ -1000,6 +1010,20 @@ export class SocketManager {
         }
         group.lock(message.getLock());
         room.emitLockGroupEvent(user, group.getId());
+    }
+
+    getAllRooms(): RoomsList {
+        const roomsList = new RoomsList();
+
+        for (const room of this.resolvedRooms.values()) {
+            const roomDescription = new RoomDescription();
+            roomDescription.setRoomid(room.roomUrl);
+            roomDescription.setNbusers(room.getUsers().size);
+
+            roomsList.addRoomdescription(roomDescription);
+        }
+
+        return roomsList;
     }
 }
 

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -559,6 +559,15 @@ message BanMessage {
   string message = 4;
 }
 
+message RoomDescription {
+  string roomId = 1;
+  int32 nbUsers = 2;
+}
+
+message RoomsList {
+  repeated RoomDescription roomDescription = 1;
+}
+
 message EmptyMessage {
 
 }
@@ -577,4 +586,5 @@ service RoomManager {
   rpc sendAdminMessageToRoom(AdminRoomMessage) returns (EmptyMessage);
   rpc sendWorldFullWarningToRoom(WorldFullWarningToRoomMessage) returns (EmptyMessage);
   rpc sendRefreshRoomPrompt(RefreshRoomPromptMessage) returns (EmptyMessage);
+  rpc getRooms(EmptyMessage) returns (RoomsList);
 }

--- a/pusher/src/Controller/AdminController.ts
+++ b/pusher/src/Controller/AdminController.ts
@@ -3,14 +3,18 @@ import {
     AdminRoomMessage,
     WorldFullWarningToRoomMessage,
     RefreshRoomPromptMessage,
+    EmptyMessage,
+    RoomsList,
 } from "../Messages/generated/messages_pb";
 import { adminToken } from "../Middleware/AdminToken";
 import { BaseHttpController } from "./BaseHttpController";
+import { Metadata } from "grpc";
 
 export class AdminController extends BaseHttpController {
     routes() {
         this.receiveGlobalMessagePrompt();
         this.receiveRoomEditionPrompt();
+        this.getRoomsList();
     }
 
     /**
@@ -18,6 +22,8 @@ export class AdminController extends BaseHttpController {
      * /room/refresh:
      *   post:
      *     description: Forces anyone out of the room. The request must be authenticated with the "admin-token" header.
+     *     tags:
+     *      - Admin endpoint
      *     parameters:
      *      - name: "admin-token"
      *        in: "header"
@@ -70,6 +76,8 @@ export class AdminController extends BaseHttpController {
      * /message:
      *   post:
      *     description: Sends a message (or a world full message) to a number of rooms.
+     *     tags:
+     *      - Admin endpoint
      *     parameters:
      *      - name: "admin-token"
      *        in: "header"
@@ -148,6 +156,87 @@ export class AdminController extends BaseHttpController {
             }
 
             res.send("ok");
+        });
+    }
+
+    /**
+     * @openapi
+     * /rooms:
+     *   get:
+     *     description: Returns the list of all rooms, along the number of users in each room.
+     *     tags:
+     *      - Admin endpoint
+     *     parameters:
+     *      - name: "Authorization"
+     *        in: "header"
+     *        required: true
+     *        type: "string"
+     *        description: The token to be allowed to access this API (in ADMIN_API_TOKEN environment variable)
+     *     responses:
+     *       200:
+     *         description: Will always return "ok".
+     *         example: "{\"https://workadventu.re/@/company/world/room\": 24}"
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *               additionalProperties:
+     *                 type: integer
+     */
+    getRoomsList() {
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        this.app.get("/rooms", { middlewares: [adminToken] }, async (req, res) => {
+            try {
+                const roomClients = await apiClientRepository.getAllClients();
+
+                const emptyMessage = new EmptyMessage();
+
+                const promises: Promise<RoomsList>[] = [];
+                for (const roomClient of roomClients) {
+                    promises.push(
+                        new Promise<RoomsList>((resolve, reject) => {
+                            roomClient.getRooms(
+                                emptyMessage,
+                                new Metadata(),
+                                {
+                                    deadline: Date.now() + 1000,
+                                },
+                                (error, result) => {
+                                    if (error) {
+                                        reject(error);
+                                    } else {
+                                        resolve(result);
+                                    }
+                                }
+                            );
+                        })
+                    );
+                }
+
+                // Note: this call will take at most 1 second because we won't wait more for all the promises to resolve.
+                const roomsListsResult = await Promise.allSettled(promises);
+
+                const rooms: Record<string, number> = {};
+
+                for (const roomsListResult of roomsListsResult) {
+                    if (roomsListResult.status === "fulfilled") {
+                        for (const room of roomsListResult.value.getRoomdescriptionList()) {
+                            rooms[room.getRoomid()] = room.getNbusers();
+                        }
+                    } else {
+                        console.warn(
+                            "One back server did not respond within one second to the call to 'getRooms': ",
+                            roomsListResult.reason
+                        );
+                    }
+                }
+
+                res.setHeader("Content-Type", "application/json").send(JSON.stringify(rooms));
+                return;
+            } catch (err) {
+                this.castErrorToResponse(err, res);
+                return;
+            }
         });
     }
 }

--- a/pusher/src/Controller/SwaggerController.ts
+++ b/pusher/src/Controller/SwaggerController.ts
@@ -233,7 +233,7 @@ export class SwaggerController extends BaseHttpController {
                 }
 
                 const urls = [
-                    { url: "/openapi/pusher", name: "Front <- Pusher" },
+                    { url: "/openapi/pusher", name: "Front -> Pusher <- Admin" },
                     { url: "/openapi/admin", name: "Pusher -> Admin" },
                     { url: "/openapi/external-admin", name: "Admin -> External Admin" },
                 ];

--- a/pusher/src/Middleware/AdminToken.ts
+++ b/pusher/src/Middleware/AdminToken.ts
@@ -4,7 +4,8 @@ import { MiddlewareNext, MiddlewarePromise } from "hyper-express/types/component
 import { ADMIN_API_TOKEN } from "../Enum/EnvironmentVariable";
 
 export function adminToken(req: Request, res: Response, next?: MiddlewareNext): MiddlewarePromise {
-    const token = req.header("admin-token");
+    let token = req.header("admin-token"); // @deprecated, use the authorization header instead.
+    token = token || req.header("authorization");
 
     if (ADMIN_API_TOKEN === "") {
         res.status(401).end("No token configured!");

--- a/pusher/src/Services/ApiClientRepository.ts
+++ b/pusher/src/Services/ApiClientRepository.ts
@@ -25,14 +25,19 @@ class ApiClientRepository {
                 this.apiUrls[index],
                 grpc.credentials.createInsecure()
             );
-            debug("Mapping room %s to API server %s", roomId, this.apiUrls[index]);
         }
+        debug("Mapping room %s to API server %s", roomId, this.apiUrls[index]);
 
         return Promise.resolve(client);
     }
 
-    public async getAllClients(): Promise<RoomManagerClient[]> {
-        return [await this.getClient("")];
+    public getAllClients(): Promise<RoomManagerClient[]> {
+        for (let i = 0; i < this.apiUrls.length; i++) {
+            if (this.roomManagerClients[i] === undefined) {
+                this.roomManagerClients[i] = new RoomManagerClient(this.apiUrls[i], grpc.credentials.createInsecure());
+            }
+        }
+        return Promise.resolve(this.roomManagerClients);
     }
 }
 

--- a/tests/tests/utils/debug.ts
+++ b/tests/tests/utils/debug.ts
@@ -29,3 +29,18 @@ export async function getBackDump(): Promise<any> {
     })).data;
 }
 
+export async function getPusherRooms(): Promise<Record<string, number>> {
+    let url = 'http://pusher.workadventure.localhost/rooms';
+    if (fs.existsSync('/project')) {
+        // We are inside a container. Let's use a direct route
+        url = 'http://pusher:8080/rooms';
+    }
+
+    return (await axios({
+        url,
+        method: 'get',
+        headers: {
+            "Authorization": ADMIN_API_TOKEN
+        }
+    })).data;
+}

--- a/tests/tests/variables.spec.ts
+++ b/tests/tests/variables.spec.ts
@@ -8,7 +8,7 @@ import {
   startRedis,
   stopRedis,
 } from './utils/containers';
-import { getBackDump, getPusherDump } from './utils/debug';
+import {getBackDump, getPusherDump, getPusherRooms} from './utils/debug';
 import { assertLogMessage } from './utils/log';
 import { login } from './utils/roles';
 
@@ -165,6 +165,19 @@ test.describe('Variables', () => {
 
     // Let's check we successfully manage to save the variable value.
     await assertLogMessage(page2, 'SUCCESS!');
+
+    // Let's check the pusher getRooms endpoint returns 2 users on the map
+    let rooms = await getPusherRooms();
+    if (rooms['http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json'] !== 2) {
+      // If we don't have the result right away, let's wait 3 seconds, just in case pusher is slow.
+      await timeout(3000);
+      rooms = await getPusherRooms();
+    }
+    expect(
+        rooms[
+            'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json'
+            ]
+    ).toBe(2);
   });
 });
 


### PR DESCRIPTION
Adding an endpoint in the pusher to list all the rooms.
The pusher will contact ALL back servers and get the list of rooms from there.
It aggregates the rooms and sends it back to the caller.

The back server only has 1 second to answer, otherwise, the answer is ignored.

The end-point is protected via the Admin token.