### PR TITLE
prevent game from crashing if there is no scene available for animation

### DIFF
--- a/front/src/Phaser/Components/PlayerStatusDot.ts
+++ b/front/src/Phaser/Components/PlayerStatusDot.ts
@@ -48,6 +48,10 @@ export class PlayerStatusDot extends Phaser.GameObjects.Container {
     }
 
     private playStatusChangeAnimation(): void {
+        if (!this.scene) {
+            this.redraw();
+            return;
+        }
         this.scale = 1;
         this.animationTween?.stop();
         this.animationTween = this.scene.tweens.add({


### PR DESCRIPTION
Not really fixing cause of the problem, but will prevent game from crashing unexpectedly