### PR TITLE
reapply properties after tp, finish following path if any

### DIFF
--- a/front/src/Phaser/Game/GameMap.ts
+++ b/front/src/Phaser/Game/GameMap.ts
@@ -190,6 +190,10 @@ export class GameMap {
         return this.lastProperties;
     }
 
+    public clearCurrentProperties(): void {
+        return this.lastProperties.clear();
+    }
+
     public getMap(): ITiledMap {
         return this.map;
     }

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -1644,6 +1644,10 @@ ${escapedMessage}
             this.startPositionCalculator.initPositionFromLayerName(roomUrl.hash, roomUrl.hash);
             this.CurrentPlayer.x = this.startPositionCalculator.startPosition.x;
             this.CurrentPlayer.y = this.startPositionCalculator.startPosition.y;
+            this.CurrentPlayer.finishFollowingPath(true);
+            // clear properties in case we are moved on the same layer / area in order to trigger them
+            this.gameMap.clearCurrentProperties();
+            this.gameMap.setPosition(this.CurrentPlayer.x, this.CurrentPlayer.y);
             setTimeout(() => (this.mapTransitioning = false), 500);
         }
     }

--- a/front/src/Phaser/Player/Player.ts
+++ b/front/src/Phaser/Player/Player.ts
@@ -84,6 +84,12 @@ export class Player extends Character {
         });
     }
 
+    public finishFollowingPath(cancelled: boolean = false): void {
+        this.pathToFollow = undefined;
+        this.pathWalkingSpeed = undefined;
+        this.followingPathPromiseResolve?.call(this, { x: this.x, y: this.y, cancelled });
+    }
+
     private deduceSpeed(speedUp: boolean, followMode: boolean): number {
         return this.pathWalkingSpeed ? this.pathWalkingSpeed : speedUp && !followMode ? 25 : 9;
     }
@@ -179,12 +185,6 @@ export class Player extends Character {
             this.pathToFollow.shift();
         }
         return this.getMovementDirection(xDistance, yDistance, distance);
-    }
-
-    private finishFollowingPath(cancelled: boolean = false): void {
-        this.pathToFollow = undefined;
-        this.pathWalkingSpeed = undefined;
-        this.followingPathPromiseResolve?.call(this, { x: this.x, y: this.y, cancelled });
     }
 
     private getMovementDirection(xDistance: number, yDistance: number, distance: number): [number, number] {


### PR DESCRIPTION
Fixing issues when using exitUrl pointing on the same map:

- [ ] Player lands on the same layer / area, thus not triggering properties change
- [ ] Player is still moving to the previous path-follow destination after TP