### PR TITLE
Fixing issue with local/unreachable maps and BBB/Jiti meetings

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -42,6 +42,7 @@ import { emitErrorOnRoomSocket } from "../Services/MessageHelpers";
 import { VariableError } from "../Services/VariableError";
 import { ModeratorTagFinder } from "../Services/ModeratorTagFinder";
 import { MapBbbData, MapJitsiData } from "../Messages/JsonMessages/MapDetailsData";
+import Axios from "axios";
 
 export type ConnectCallback = (user: User, group: Group) => void;
 export type DisconnectCallback = (user: User, group: Group) => void;
@@ -207,7 +208,7 @@ export class GameRoom {
     }
 
     public isEmpty(): boolean {
-        return this.users.size === 0 && this.admins.size === 0;
+        return this.users.size === 0 && this.admins.size === 0 && this.roomListeners.size === 0;
     }
 
     public updatePosition(user: User, userPosition: PointInterface): void {
@@ -671,32 +672,102 @@ export class GameRoom {
         return this.groups.get(id);
     }
 
-    private jitsiModeratorTagFinder: ModeratorTagFinder | undefined;
+    private jitsiModeratorTagFinderPromise: Promise<ModeratorTagFinder> | undefined;
 
     /**
      * Returns the moderator tag associated with jitsiRoom
      */
     public async getModeratorTagForJitsiRoom(jitsiRoom: string): Promise<string | undefined> {
-        if (this.jitsiModeratorTagFinder === undefined) {
-            const map = await this.getMap();
-            this.jitsiModeratorTagFinder = new ModeratorTagFinder(map, "jitsiRoom", "jitsiRoomAdminTag");
+        if (this.jitsiModeratorTagFinderPromise === undefined) {
+            this.jitsiModeratorTagFinderPromise = this.getMap()
+                .then((map) => {
+                    return new ModeratorTagFinder(map, "jitsiRoom", "jitsiRoomAdminTag");
+                })
+                .catch((e) => {
+                    if (e instanceof LocalUrlError) {
+                        // If we are trying to load a local URL, we are probably in test mode.
+                        // In this case, let's bypass the server-side checks completely.
+
+                        for (const roomListener of this.roomListeners) {
+                            emitErrorOnRoomSocket(
+                                roomListener,
+                                "You are loading a local map. The 'jitsiRoomAdminTag' property cannot be read from local maps."
+                            );
+                        }
+                    } else {
+                        // An error occurred while loading the map
+                        // Right now, let's bypass the error. In the future, we should make sure the user is aware of that
+                        // and that he/she will act on it to fix the problem.
+
+                        for (const roomListener of this.roomListeners) {
+                            emitErrorOnRoomSocket(
+                                roomListener,
+                                "Your map does not seem accessible from the WorkAdventure servers. Is it behind a firewall or a proxy? Your map should be accessible from the WorkAdventure servers. The 'jitsiRoomAdminTag' property cannot be read from local maps."
+                            );
+                        }
+                    }
+                    throw e;
+                });
         }
 
-        return this.jitsiModeratorTagFinder.getModeratorTag(jitsiRoom);
+        try {
+            const jitsiModeratorTagFinder = await this.jitsiModeratorTagFinderPromise;
+            return jitsiModeratorTagFinder.getModeratorTag(jitsiRoom);
+        } catch (e) {
+            if (e instanceof LocalUrlError || Axios.isAxiosError(e)) {
+                return undefined;
+            }
+            throw e;
+        }
     }
 
-    private bbbModeratorTagFinder: ModeratorTagFinder | undefined;
+    private bbbModeratorTagFinderPromise: Promise<ModeratorTagFinder> | undefined;
 
     /**
      * Returns the moderator tag associated with bbbMeeting
      */
-    public async getModeratorTagForBbbMeeting(bbbMeeting: string): Promise<string | undefined> {
-        if (this.bbbModeratorTagFinder === undefined) {
-            const map = await this.getMap();
-            this.bbbModeratorTagFinder = new ModeratorTagFinder(map, "bbbMeeting", "bbbMeetingAdminTag");
+    public async getModeratorTagForBbbMeeting(bbbRoom: string): Promise<string | undefined> {
+        if (this.bbbModeratorTagFinderPromise === undefined) {
+            this.bbbModeratorTagFinderPromise = this.getMap()
+                .then((map) => {
+                    return new ModeratorTagFinder(map, "bbbMeeting", "bbbMeetingAdminTag");
+                })
+                .catch((e) => {
+                    if (e instanceof LocalUrlError) {
+                        // If we are trying to load a local URL, we are probably in test mode.
+                        // In this case, let's bypass the server-side checks completely.
+
+                        for (const roomListener of this.roomListeners) {
+                            emitErrorOnRoomSocket(
+                                roomListener,
+                                "You are loading a local map. The 'bbbMeetingAdminTag' property cannot be read from local maps."
+                            );
+                        }
+                    } else {
+                        // An error occurred while loading the map
+                        // Right now, let's bypass the error. In the future, we should make sure the user is aware of that
+                        // and that he/she will act on it to fix the problem.
+
+                        for (const roomListener of this.roomListeners) {
+                            emitErrorOnRoomSocket(
+                                roomListener,
+                                "Your map does not seem accessible from the WorkAdventure servers. Is it behind a firewall or a proxy? Your map should be accessible from the WorkAdventure servers. The 'bbbMeetingAdminTag' property cannot be read from local maps."
+                            );
+                        }
+                    }
+                    throw e;
+                });
         }
 
-        return this.bbbModeratorTagFinder.getModeratorTag(bbbMeeting);
+        try {
+            const bbbModeratorTagFinder = await this.bbbModeratorTagFinderPromise;
+            return bbbModeratorTagFinder.getModeratorTag(bbbRoom);
+        } catch (e) {
+            if (e instanceof LocalUrlError || Axios.isAxiosError(e)) {
+                return undefined;
+            }
+            throw e;
+        }
     }
 
     public getJitsiSettings(): MapJitsiData | undefined {

--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -165,7 +165,11 @@ const roomManager: IRoomManagerServer = {
                         }
                     }
                 } catch (e) {
-                    console.error(e);
+                    console.error(
+                        "An error occurred while managing a message of type PusherToBackMessage:" +
+                            message.getMessageCase().toString(),
+                        e
+                    );
                     emitError(call, e);
                     call.end();
                 }

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -39,7 +39,6 @@ import {
     PlayerDetailsUpdatedMessage,
     GroupUsersUpdateMessage,
     LockGroupPromptMessage,
-    ErrorMessage,
     RoomsList,
     RoomDescription,
 } from "../Messages/generated/messages_pb";
@@ -59,6 +58,7 @@ import { Zone } from "../Model/Zone";
 import Debug from "debug";
 import { Admin } from "../Model/Admin";
 import crypto from "crypto";
+import { emitError } from "./MessageHelpers";
 
 const debug = Debug("sockermanager");
 
@@ -247,12 +247,7 @@ export class SocketManager {
         try {
             //user leave previous world
             room.leave(user);
-            if (room.isEmpty()) {
-                this.roomsPromises.delete(room.roomUrl);
-                this.resolvedRooms.delete(room.roomUrl);
-                gaugeManager.decNbRoomGauge();
-                debug('Room is empty. Deleting room "%s"', room.roomUrl);
-            }
+            this.cleanupRoomIfEmpty(room);
         } finally {
             clientEventsEmitter.emitClientLeave(user.uuid, room.roomUrl);
             console.log("A user left");
@@ -642,12 +637,7 @@ export class SocketManager {
 
             console.error(errorStr);
 
-            const errorMessage = new ErrorMessage();
-            errorMessage.setMessage(errorStr);
-
-            const serverToClientMessage = new ServerToClientMessage();
-            serverToClientMessage.setErrormessage(errorMessage);
-            user.socket.write(serverToClientMessage);
+            emitError(user.socket, errorStr);
 
             return;
         }
@@ -781,10 +771,12 @@ export class SocketManager {
     async removeZoneListener(call: ZoneSocket, roomId: string, x: number, y: number): Promise<void> {
         const room = await this.roomsPromises.get(roomId);
         if (!room) {
-            throw new Error("In removeZoneListener, could not find room with id '" + roomId + "'");
+            console.warn("In removeZoneListener, could not find room with id '" + roomId + "'");
+            return;
         }
 
         room.removeZoneListener(call, x, y);
+        this.cleanupRoomIfEmpty(room);
     }
 
     async addRoomListener(call: RoomSocket, roomId: string) {
@@ -819,6 +811,10 @@ export class SocketManager {
 
     public leaveAdminRoom(room: GameRoom, admin: Admin) {
         room.adminLeave(admin);
+        this.cleanupRoomIfEmpty(room);
+    }
+
+    private cleanupRoomIfEmpty(room: GameRoom): void {
         if (room.isEmpty()) {
             this.roomsPromises.delete(room.roomUrl);
             this.resolvedRooms.delete(room.roomUrl);


### PR DESCRIPTION
In v1.11, we are now correctly handling the reading of the jitsiRoomAdminTag property (or bbbMeetingAdminTag respectively).
We read this from the back server (because reading it from the front could have allowed hackers to lie in the tag).

However, there is an issue with maps that are not readable from the back (like "localhost" or any map behind a firewall).
This issue fixes the problem by bypassing reading the jitsiRoomAdminTag or bbbMeetingAdminTag instead of crashing.