### PR TITLE
Adding a ping endpoint for pusher and back servers

### DIFF
--- a/back/src/App.ts
+++ b/back/src/App.ts
@@ -2,17 +2,20 @@
 import { PrometheusController } from "./Controller/PrometheusController";
 import { DebugController } from "./Controller/DebugController";
 import { App as uwsApp } from "./Server/sifrr.server";
+import { PingController } from "./Controller/PingController";
 
 class App {
     public app: uwsApp;
     public prometheusController: PrometheusController;
     private debugController: DebugController;
+    private pingController: PingController;
 
     constructor() {
         this.app = new uwsApp();
 
         this.prometheusController = new PrometheusController(this.app);
         this.debugController = new DebugController(this.app);
+        this.pingController = new PingController(this.app);
     }
 }
 

--- a/back/src/Controller/PingController.ts
+++ b/back/src/Controller/PingController.ts
@@ -1,0 +1,12 @@
+import { App } from "../Server/sifrr.server";
+import { HttpRequest, HttpResponse } from "uWebSockets.js";
+
+export class PingController {
+    constructor(private App: App) {
+        this.App.get("/ping", this.ping.bind(this));
+    }
+
+    private ping(res: HttpResponse, req: HttpRequest): void {
+        res.writeStatus("200").end("pong");
+    }
+}

--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -30,6 +30,7 @@ import {
     ZoneMessage,
     LockGroupPromptMessage,
     RoomsList,
+    PingMessage,
 } from "./Messages/generated/messages_pb";
 import { sendUnaryData, ServerDuplexStream, ServerUnaryCall, ServerWritableStream } from "grpc";
 import { socketManager } from "./Services/SocketManager";
@@ -333,6 +334,9 @@ const roomManager: IRoomManagerServer = {
     },
     getRooms(call: ServerUnaryCall<EmptyMessage>, callback: sendUnaryData<RoomsList>): void {
         callback(null, socketManager.getAllRooms());
+    },
+    ping(call: ServerUnaryCall<PingMessage>, callback: sendUnaryData<PingMessage>): void {
+        callback(null, call.request);
     },
 };
 

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -587,4 +587,5 @@ service RoomManager {
   rpc sendWorldFullWarningToRoom(WorldFullWarningToRoomMessage) returns (EmptyMessage);
   rpc sendRefreshRoomPrompt(RefreshRoomPromptMessage) returns (EmptyMessage);
   rpc getRooms(EmptyMessage) returns (RoomsList);
+  rpc ping(PingMessage) returns (PingMessage);
 }

--- a/pusher/src/App.ts
+++ b/pusher/src/App.ts
@@ -11,6 +11,7 @@ import { SwaggerController } from "./Controller/SwaggerController";
 import HyperExpress from "hyper-express";
 import { cors } from "./Middleware/Cors";
 import { ENABLE_OPENAPI_ENDPOINT } from "./Enum/EnvironmentVariable";
+import { PingController } from "./Controller/PingController";
 
 class App {
     public app: HyperExpress.compressors.TemplatedApp;
@@ -33,6 +34,7 @@ class App {
         new AdminController(webserver);
         new OpenIdProfileController(webserver);
         new WokaListController(webserver);
+        new PingController(webserver);
         if (ENABLE_OPENAPI_ENDPOINT) {
             new SwaggerController(webserver);
         }

--- a/pusher/src/Controller/PingController.ts
+++ b/pusher/src/Controller/PingController.ts
@@ -1,0 +1,28 @@
+import { BaseHttpController } from "./BaseHttpController";
+
+export class PingController extends BaseHttpController {
+    // Returns a map mapping map name to file name of the map
+    routes() {
+        /**
+         * @openapi
+         * /ping:
+         *   get:
+         *     description: Returns a "pong" message. This endpoint can be useful to check if the application is alive.
+         *     produces:
+         *      - "text/plain;charset=UTF-8"
+         *     responses:
+         *       200:
+         *         description: OK
+         *         content:
+         *           text/plain:
+         *             schema:
+         *               type: string
+         *               example: pong
+         *
+         */
+        this.app.get("/ping", (req, res) => {
+            res.status(200).send("pong");
+            return;
+        });
+    }
+}

--- a/pusher/src/Controller/PingController.ts
+++ b/pusher/src/Controller/PingController.ts
@@ -1,4 +1,7 @@
 import { BaseHttpController } from "./BaseHttpController";
+import { apiClientRepository } from "../Services/ApiClientRepository";
+import { PingMessage } from "../Messages/generated/messages_pb";
+import { Metadata } from "grpc";
 
 export class PingController extends BaseHttpController {
     // Returns a map mapping map name to file name of the map
@@ -23,6 +26,71 @@ export class PingController extends BaseHttpController {
         this.app.get("/ping", (req, res) => {
             res.status(200).send("pong");
             return;
+        });
+
+        /**
+         * @openapi
+         * /ping-back:
+         *   get:
+         *     description: Returns a "pong" message if all back servers could be reached.
+         *     produces:
+         *      - "text/plain;charset=UTF-8"
+         *     responses:
+         *       200:
+         *         description: OK
+         *         content:
+         *           text/plain:
+         *             schema:
+         *               type: string
+         *               example: pong
+         *       503:
+         *         description: One or more back servers are unreachable
+         *         content:
+         *           text/plain:
+         *             schema:
+         *               type: string
+         *               example: ko
+         *
+         */
+        this.app.get("/ping-backs", (req, res) => {
+            (async () => {
+                const clients = await apiClientRepository.getAllClients();
+
+                const promises: Promise<PingMessage>[] = [];
+                for (const client of clients) {
+                    promises.push(
+                        new Promise<PingMessage>((resolve, reject) => {
+                            client.ping(
+                                new PingMessage(),
+                                new Metadata(),
+                                {
+                                    deadline: Date.now() + 1000,
+                                },
+                                (error, result) => {
+                                    if (error) {
+                                        reject(error);
+                                    } else {
+                                        resolve(result);
+                                    }
+                                }
+                            );
+                        })
+                    );
+                }
+
+                // Note: this call will take at most 1 second because we won't wait more for all the promises to resolve.
+                const pingsResult = await Promise.allSettled(promises);
+
+                for (const pingResult of pingsResult) {
+                    if (pingResult.status === "rejected") {
+                        res.status(503).send("ko");
+                        return;
+                    }
+                }
+
+                res.status(200).send("pong");
+                return;
+            })().catch((e) => console.error(e));
         });
     }
 }


### PR DESCRIPTION
This adds a simple /ping endpoint on the pusher and back servers.
This will allow checking if the pusher is alive easily.

Furthermore, a "ping-backs" endpoint is added in the pusher that calls all pings from back servers.