### PR TITLE
use flex-start and flex-end instead of start and end

### DIFF
--- a/front/src/Components/EmbedScreens/Layouts/PresentationLayout.svelte
+++ b/front/src/Components/EmbedScreens/Layouts/PresentationLayout.svelte
@@ -142,7 +142,7 @@
                     top: 0;
                     display: flex;
                     flex-direction: row;
-                    justify-content: end;
+                    justify-content: flex-end;
                     gap: 2%;
 
                     button {

--- a/front/style/cowebsite/_global.scss
+++ b/front/style/cowebsite/_global.scss
@@ -45,7 +45,7 @@
       flex-direction: column;
       margin-bottom: auto;
       flex: 1;
-      justify-content: start;
+      justify-content: flex-start;
 
       #cowebsite-swipe {
         display: none;
@@ -65,7 +65,7 @@
       display: flex;
       margin-top: auto;
       visibility: hidden;
-      justify-content: end;
+      justify-content: flex-end;
       flex: 1;
     }
   }

--- a/front/style/cowebsite/_short-screens.scss
+++ b/front/style/cowebsite/_short-screens.scss
@@ -57,7 +57,7 @@
         flex-direction: row-reverse;
         margin-left: auto;
         margin-bottom: 0;
-        justify-content: end;
+        justify-content: flex-end;
       }
 
       #cowebsite-fullscreen {


### PR DESCRIPTION
Vite showed some warnings like:

```
[vite:css] start value has mixed support, consider using flex-start instead
42 |    margin-bottom: auto;
43 |    flex: 1;
44 |    justify-content: start;
   |     ^
45 |  }
46 |  #cowebsite aside #cowebsite-aside-buttons #cowebsite-swipe {
[vite:css] end value has mixed support, consider using flex-end instead
59 |    margin-top: auto;
60 |    visibility: hidden;
61 |    justify-content: end;
   |     ^
62 |    flex: 1;
63 |  }
```

Reading https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content#values this should not break anything.