### PR TITLE
Optimize collision grid generation

### DIFF
--- a/front/src/Phaser/Game/GameMap.ts
+++ b/front/src/Phaser/Game/GameMap.ts
@@ -139,6 +139,8 @@ export class GameMap {
     }
 
     public getCollisionGrid(): number[][] {
+        console.log("START getCollisionGrid()");
+        const start = new Date().getTime();
         const grid: number[][] = [];
         for (let y = 0; y < this.map.height; y += 1) {
             const row: number[] = [];
@@ -147,6 +149,7 @@ export class GameMap {
             }
             grid.push(row);
         }
+        console.log(`getCollisionGrid() elapsed time: ${new Date().getTime() - start}ms`);
         return grid;
     }
 

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -480,7 +480,9 @@ export class GameScene extends DirtyScene {
         this.companion = gameManager.getCompanion();
 
         //initialise map
-        this.Map = this.add.tilemap(this.MapUrlFile);
+        const start = new Date().getTime();
+        this.Map = this.add.tilemap(this.MapUrlFile); // this is lagging too!
+        console.log(`this.add.tilemap(...) elapsed time: ${new Date().getTime() - start}ms`);
         const mapDirUrl = this.MapUrlFile.substr(0, this.MapUrlFile.lastIndexOf("/"));
         this.mapFile.tilesets.forEach((tileset: ITiledTileSet) => {
             this.Terrains.push(

--- a/maps/tests/BigMap/script.php
+++ b/maps/tests/BigMap/script.php
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script src="<?php echo $_SERVER["FRONT_URL"] ?>/iframe_api.js"></script>
+        <script>
+            window.addEventListener('load', () => {
+                document.getElementById('show/hideLayer').onclick = () => {
+                    if (document.getElementById('show/hideLayer').checked) {
+                        WA.room.showLayer('wall');
+                    }
+                    else {
+                        WA.room.hideLayer('wall');
+                    }
+                }
+            })
+        </script>
+    </head>
+    <body style="color: #ffffff">
+    	<div>
+            <label for="show/hideLayer">Hide Layer: </label><input type="checkbox" id="show/hideLayer" name="visible" value="show" checked>
+        </div>
+    </body>
+</html>

--- a/maps/tests/index.html
+++ b/maps/tests/index.html
@@ -500,6 +500,14 @@
             <table class="table">
                 <tr>
                     <td>
+                        <input type="radio" name="test-big-map"> Success <input type="radio" name="test-big-map"> Failure <input type="radio" name="test-big-map" checked> Pending
+                    </td>
+                    <td>
+                        <a href="#" class="testLink" data-testmap="BigMap/map.json" target="_blank">Test Big Map</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         <input type="radio" name="test-reconnection"> Success <input type="radio" name="test-reconnection"> Failure <input type="radio" name="test-reconnection" checked> Pending
                     </td>
                     <td>


### PR DESCRIPTION
Lower `getCollisionGrid` execution time from ~550ms to ~80ms for first generation and to ~13ms with cache.