### PR TITLE
Fixing bubble + Jitsi issue

### DIFF
--- a/front/src/Phaser/Game/GameMapPropertiesListener.ts
+++ b/front/src/Phaser/Game/GameMapPropertiesListener.ts
@@ -103,6 +103,8 @@ export class GameMapPropertiesListener {
                         domain = `${location.protocol}//${domain}`;
                     }
 
+                    inJitsiStore.set(true);
+
                     const closable = allProps.get(GameMapProperties.OPEN_WEBSITE_CLOSABLE) as boolean | undefined;
 
                     const coWebsite = new JitsiCoWebsite(new URL(domain), false, undefined, undefined, closable);


### PR DESCRIPTION
The new query / answer system implementation introduced a bug where bubbles could be opened inside Jitsi areas.
This commit fixes the issue.