### PR TITLE
Adding an expire header on most resources

### DIFF
--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -37,12 +37,24 @@ server {
         add_header Cache-Control "public";
     }
 
+    # serve other static assets (images) with less aggressive cache policy
+    location /resources {
+        root   /usr/share/nginx/html;
+        expires 1d;
+        add_header Cache-Control "public";
+    }
+    location /static {
+        root   /usr/share/nginx/html;
+        expires 1d;
+        add_header Cache-Control "public";
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html;
         rewrite ^/register/ /index.html break;
-        rewrite ^/login /index.html break; 
-        rewrite ^/jwt /index.html break; 
+        rewrite ^/login /index.html break;
+        rewrite ^/jwt /index.html break;
     }
 
     location ~ ^/[@_*]/ {


### PR DESCRIPTION
Expire headers are already added on JS files (and anything generated by Vite)
We are here also adding expire headers to images (like default Wokas), applying a shorter "expire" header: 1 day.