### PR TITLE
Making more stable end-to-end tests

### DIFF
--- a/tests/tests/variables.spec.ts
+++ b/tests/tests/variables.spec.ts
@@ -168,7 +168,10 @@ test.describe('Variables', () => {
 
     // Let's check the pusher getRooms endpoint returns 2 users on the map
     let rooms = await getPusherRooms();
-    if (rooms['http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json'] !== 2) {
+    for (let i = 0; i < 5; i++) {
+      if (rooms['http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json'] === 2) {
+        break;
+      }
       // If we don't have the result right away, let's wait 3 seconds, just in case pusher is slow.
       await timeout(3000);
       rooms = await getPusherRooms();


### PR DESCRIPTION
Tests tend to fail in CI env because of a too fast check on the pusher.
Adding a loop to test that correctly.