### PR TITLE
Updating E2E tests output

### DIFF
--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -28,7 +28,10 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [
+    ['html'],
+    [process.env.CI ? 'github' : 'list']
+  ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */


### PR DESCRIPTION
For Playwright tests, using a "line" reporter in dev, and GitHub annotations in CI, in addition to the HTML reporter already used.