### PR TITLE
Reading the new "class" property instead of "type"

### DIFF
--- a/back/src/Services/ModeratorTagFinder.ts
+++ b/back/src/Services/ModeratorTagFinder.ts
@@ -15,7 +15,7 @@ export class ModeratorTagFinder {
     private findModeratorTagInLayer(layer: ITiledMapLayer, mainProperty: string, tagProperty: string) {
         if (layer.type === "objectgroup") {
             for (const object of layer.objects) {
-                if (object.type === "area") {
+                if (object.class === "area" || object.type === "area") {
                     this.registerProperties(layer.properties ?? [], mainProperty, tagProperty);
                 }
             }

--- a/back/src/Services/VariablesManager.ts
+++ b/back/src/Services/VariablesManager.ts
@@ -92,7 +92,7 @@ export class VariablesManager {
     private static recursiveFindVariablesInLayer(layer: ITiledMapLayer, objects: Map<string, Variable>): void {
         if (layer.type === "objectgroup") {
             for (const object of layer.objects) {
-                if (object.type === "variable") {
+                if (object.class === "variable" || object.type === "variable") {
                     if (object.template) {
                         console.warn(
                             'Warning, a variable object is using a Tiled "template". WorkAdventure does not support objects generated from Tiled templates.'

--- a/front/src/Api/iframe/Area/Area.ts
+++ b/front/src/Api/iframe/Area/Area.ts
@@ -23,8 +23,6 @@ export class Area implements IArea {
         this._y = config.y;
         this._width = config.width;
         this._height = config.height;
-
-        this.type;
     }
 
     public setProperty(propertyName: string, propertyValue: string | number | boolean | undefined): void {

--- a/front/src/Phaser/Game/GameMap.ts
+++ b/front/src/Phaser/Game/GameMap.ts
@@ -87,7 +87,7 @@ export class GameMap {
         this.tiledObjects = GameMap.getObjectsFromLayers(this.flatLayers);
         // NOTE: We leave "zone" for legacy reasons
         this.tiledObjects
-            .filter((object) => ["zone", "area"].includes(object.type ?? ""))
+            .filter((object) => ["zone", "area"].includes(object.class ?? ""))
             .forEach((area) => {
                 let name = area.name;
                 if (!name) {
@@ -292,9 +292,9 @@ export class GameMap {
         return this.flatLayers.find((layer) => layer.name === layerName);
     }
 
-    public findObject(objectName: string, objectType?: string): ITiledMapObject | undefined {
+    public findObject(objectName: string, objectClass?: string): ITiledMapObject | undefined {
         const object = this.getObjectWithName(objectName);
-        return !objectType ? object : objectType === object?.type ? object : undefined;
+        return !objectClass ? object : objectClass === object?.class ? object : undefined;
     }
 
     public findPhaserLayer(layerName: string): TilemapLayer | undefined {

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -399,17 +399,17 @@ export class GameScene extends DirtyScene {
             if (layer.type === "objectgroup") {
                 for (const object of layer.objects) {
                     let objectsOfType: ITiledMapObject[] | undefined;
-                    if (object.type) {
-                        if (!this.objectsByType.has(object.type)) {
+                    if (object.class) {
+                        if (!this.objectsByType.has(object.class)) {
                             objectsOfType = new Array<ITiledMapObject>();
                         } else {
-                            objectsOfType = this.objectsByType.get(object.type);
+                            objectsOfType = this.objectsByType.get(object.class);
                             if (objectsOfType === undefined) {
                                 throw new Error("Unexpected object type not found");
                             }
                         }
                         objectsOfType.push(object);
-                        this.objectsByType.set(object.type, objectsOfType);
+                        this.objectsByType.set(object.class, objectsOfType);
                     }
                 }
             }
@@ -534,7 +534,7 @@ export class GameScene extends DirtyScene {
                     if (object.text) {
                         TextUtils.createTextFromITiledMapObject(this, object);
                     }
-                    if (object.type === "website") {
+                    if (object.class === "website") {
                         // Let's load iframes in the map
                         const url = PropertyUtils.mustFindStringProperty(
                             GameMapProperties.URL,

--- a/front/src/Phaser/Game/SharedVariablesManager.ts
+++ b/front/src/Phaser/Game/SharedVariablesManager.ts
@@ -107,7 +107,7 @@ export class SharedVariablesManager {
     private static recursiveFindVariablesInLayer(layer: ITiledMapLayer, objects: Map<string, Variable>): void {
         if (layer.type === "objectgroup") {
             for (const object of layer.objects) {
-                if (object.type === "variable") {
+                if (object.class === "variable") {
                     if (object.template) {
                         console.warn(
                             'Warning, a variable object is using a Tiled "template". WorkAdventure does not support objects generated from Tiled templates.'


### PR DESCRIPTION
Tiled 1.9 replaced "type" properties with "class".
This commit reads the new "class" property where we previously read "type".

Because the maps are already upgraded to Tiled 1.9 format, we should not see any backward compatiblity impact.

See #2352