### PR TITLE
Upgrade to workadventure/tiled-map-type-guard:2.0.4

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/thecodingmachine/workadventure#readme",
   "dependencies": {
     "@anatine/zod-openapi": "^1.3.0",
-    "@workadventure/tiled-map-type-guard": "^2.0.3",
+    "@workadventure/tiled-map-type-guard": "^2.0.4",
     "axios": "^0.21.2",
     "busboy": "^0.3.1",
     "bigbluebutton-js": "^0.1.1",

--- a/back/yarn.lock
+++ b/back/yarn.lock
@@ -283,10 +283,10 @@
     "@typescript-eslint/types" "5.8.0"
     eslint-visitor-keys "^3.0.0"
 
-"@workadventure/tiled-map-type-guard@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.0.3.tgz#21299cc8791bd8236d97d53b1612a97401b6c657"
-  integrity sha512-D3r7OlKCs05dmhlzx4iFdBMAHboA0WqDjgEE+BYsTXM8hC5KU9b+Q2bIGs/py9BDIEjMPPYKkMs4Z2DgipetCg==
+"@workadventure/tiled-map-type-guard@^2.0.4":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.0.5.tgz#e4158770fd1b046cb211343da4e7bb7926112e6d"
+  integrity sha512-6qQ5B224nVwfZEwUT2jMFY1uR4czg4wvHB6FU6UEA9TmE7qK0MCph7aqedWifLRkq/Q+9ntAKFmvV6rqfweBcA==
   dependencies:
     zod "^3.17.3"
 

--- a/front/package.json
+++ b/front/package.json
@@ -47,7 +47,7 @@
     "@types/xmpp__jid": "^1.3.3",
     "@types/xmpp__xml": "^0.13.1",
     "@ungap/structured-clone": "^1.0.1",
-    "@workadventure/tiled-map-type-guard": "^2.0.3",
+    "@workadventure/tiled-map-type-guard": "^2.0.4",
     "@xmpp/component": "^0.13.1",
     "@xmpp/jid": "^0.13.1",
     "@xmpp/xml": "^0.13.1",

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -669,10 +669,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.0.1.tgz#549ce746c163d0869a61cfdabafe625a13ab5d0f"
   integrity sha512-zKVyTt6rELvPXYwcVPTJcPFtY0AckN5A7xWuc7owBqR0FdtuDYhE9MZZUi6IY1kZUQFSXV1B3UOOIyLkVHYd2w==
 
-"@workadventure/tiled-map-type-guard@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.0.3.tgz#21299cc8791bd8236d97d53b1612a97401b6c657"
-  integrity sha512-D3r7OlKCs05dmhlzx4iFdBMAHboA0WqDjgEE+BYsTXM8hC5KU9b+Q2bIGs/py9BDIEjMPPYKkMs4Z2DgipetCg==
+"@workadventure/tiled-map-type-guard@^2.0.4":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.0.5.tgz#e4158770fd1b046cb211343da4e7bb7926112e6d"
+  integrity sha512-6qQ5B224nVwfZEwUT2jMFY1uR4czg4wvHB6FU6UEA9TmE7qK0MCph7aqedWifLRkq/Q+9ntAKFmvV6rqfweBcA==
   dependencies:
     zod "^3.17.3"
 


### PR DESCRIPTION
This version does "in-place" upgrade of the maps, which is faster for really big maps.