### PR TITLE
Add allowfullscreen and screen-wake-lock policies to BBB iframe

### DIFF
--- a/front/src/WebRtc/BBBFactory.ts
+++ b/front/src/WebRtc/BBBFactory.ts
@@ -11,7 +11,7 @@ class BBBFactory {
         }
 
         const allowPolicy =
-            "microphone *; camera *; display-capture *; clipboard-read *; clipboard-write *; screen-wake-lock *;";
+            "microphone *; camera *; display-capture *; clipboard-read *; clipboard-write *; screen-wake-lock *; fullscreen *";
         const coWebsite = new BBBCoWebsite(new URL(clientURL), false, allowPolicy, undefined, false);
         coWebsiteManager.addCoWebsiteToStore(coWebsite, 0);
         coWebsiteManager.loadCoWebsite(coWebsite).catch((e) => console.error(`Error on opening co-website: ${e}`));

--- a/front/src/WebRtc/BBBFactory.ts
+++ b/front/src/WebRtc/BBBFactory.ts
@@ -11,7 +11,7 @@ class BBBFactory {
         }
 
         const allowPolicy =
-            "microphone *; " + "camera *; " + "display-capture *; " + "clipboard-read *; " + "clipboard-write *;";
+            "microphone *; camera *; display-capture *; clipboard-read *; clipboard-write *; screen-wake-lock *;";
         const coWebsite = new BBBCoWebsite(new URL(clientURL), false, allowPolicy, undefined, false);
         coWebsiteManager.addCoWebsiteToStore(coWebsite, 0);
         coWebsiteManager.loadCoWebsite(coWebsite).catch((e) => console.error(`Error on opening co-website: ${e}`));

--- a/front/src/WebRtc/CoWebsite/BBBCoWebsite.ts
+++ b/front/src/WebRtc/CoWebsite/BBBCoWebsite.ts
@@ -17,13 +17,7 @@ export class BBBCoWebsite extends SimpleCoWebsite {
 
     load(): CancelablePromise<HTMLIFrameElement> {
         inExternalServiceStore.set(true);
-        const loadIframe = super.load();
-
-        if (this.iframe) {
-            this.iframe.allowFullscreen = true;
-        }
-
-        return loadIframe;
+        return super.load();
     }
 
     unload(): Promise<void> {

--- a/front/src/WebRtc/CoWebsite/BBBCoWebsite.ts
+++ b/front/src/WebRtc/CoWebsite/BBBCoWebsite.ts
@@ -17,7 +17,13 @@ export class BBBCoWebsite extends SimpleCoWebsite {
 
     load(): CancelablePromise<HTMLIFrameElement> {
         inExternalServiceStore.set(true);
-        return super.load();
+        const loadIframe = super.load();
+
+        if (this.iframe) {
+            this.iframe.allowFullscreen = true;
+        }
+
+        return loadIframe;
     }
 
     unload(): Promise<void> {


### PR DESCRIPTION
These changes add policies needed to play videos and presentations in full screen and to prevent the device from locking the screen after a while.