### PR TITLE
Loosen maps script's iframe sanbox to allow-same-origin

### DIFF
--- a/front/src/Api/IframeListener.ts
+++ b/front/src/Api/IframeListener.ts
@@ -426,6 +426,7 @@ class IframeListener {
             // We are putting a sandbox on this script because it will run in the same domain as the main website.
             iframe.sandbox.add("allow-scripts");
             iframe.sandbox.add("allow-top-navigation-by-user-activation");
+            iframe.sandbox.add("allow-same-origin");
 
             //iframe.src = "data:text/html;charset=utf-8," + escape(html);
             iframe.srcdoc =

--- a/maps/.htaccess
+++ b/maps/.htaccess
@@ -1,1 +1,3 @@
-Header set Access-Control-Allow-Origin "*"
+Header add Access-Control-Allow-Origin "http://play.workadventure.localhost"
+Header add Access-Control-Allow-Methods: "GET,POST,OPTIONS,DELETE,PUT"
+Header add Access-Control-Allow-Headers: "*"


### PR DESCRIPTION
In our deployment of workadventure, maps are served from a static file host. For security reasons, we allow CORS only to our own `play` instance (i.e. `Access-Control-Allow-Origin "http://play.our-domain.org"`)

In this scenario, the script file referenced from a map cannot be loaded. The HTTP request yields a CORS error.
<img width="819" alt="image" src="https://user-images.githubusercontent.com/344781/181303537-d0d03a06-8f53-4bb6-8175-6ec0f0401f35.png">
Curiously, the script.js's request has `Origin: null` in it's headers. Upon investigating, I found that [this is the default behavior for sandboxed iframes](https://stackoverflow.com/questions/44764338/origin-header-null-for-xhr-request-made-from-iframe-with-sandbox-attribute).  

If we add `allow-same-origin` to the sandbox policy, the script.js request will have the `Origin: <play host>` header, CORS to succeeds and the script loads correctly.

The main change requested is the one in `IFrameListener.ts`. The changes to `.htaccess` are mainly for reproducing, demonstrating and testing the issue with our setup, thus don't need merging.

Happy for your thoughts and assessment if this change can be integrated into Workadventure.



