### PR TITLE
Improving build time for pusher and back

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -11,7 +11,7 @@ COPY messages .
 RUN yarn run tag-version && yarn proto
 
 # typescript build
-FROM node:16.15-buster-slim@sha256:9ad2f889d4a15ef94e40ac75e95c28daa34073dbc25d7b1e619caacc6b83623c as builder
+FROM --platform=$BUILDPLATFORM node:16.15-buster-slim@sha256:9ad2f889d4a15ef94e40ac75e95c28daa34073dbc25d7b1e619caacc6b83623c as builder
 WORKDIR /usr/src
 COPY back/yarn.lock back/package.json ./
 RUN yarn install

--- a/pusher/Dockerfile
+++ b/pusher/Dockerfile
@@ -11,7 +11,7 @@ COPY messages .
 RUN yarn run tag-version && yarn proto
 
 # typescript build
-FROM node:16.15-buster-slim@sha256:9ad2f889d4a15ef94e40ac75e95c28daa34073dbc25d7b1e619caacc6b83623c as builder
+FROM --platform=$BUILDPLATFORM node:16.15-buster-slim@sha256:9ad2f889d4a15ef94e40ac75e95c28daa34073dbc25d7b1e619caacc6b83623c as builder
 WORKDIR /usr/src
 COPY pusher/yarn.lock pusher/package.json ./
 RUN yarn install


### PR DESCRIPTION
We try here to build on X64 only and copy the resulting .js files (that are platform agnostic) to the ARM image.