### PR TITLE
Adding back playUri to the OpenID authenticate request

### DIFF
--- a/pusher/src/Controller/AuthenticateController.ts
+++ b/pusher/src/Controller/AuthenticateController.ts
@@ -91,7 +91,7 @@ export class AuthenticateController extends BaseHttpController {
                     throw new Error("Expecting playUri");
                 }
 
-                const loginUri = await openIDClient.authorizationUrl(res, redirect as string | undefined);
+                const loginUri = await openIDClient.authorizationUrl(res, redirect as string | undefined, playUri);
                 res.cookie("playUri", playUri, undefined, {
                     httpOnly: true,
                 });

--- a/pusher/src/Services/OpenIDClient.ts
+++ b/pusher/src/Services/OpenIDClient.ts
@@ -56,7 +56,7 @@ class OpenIDClient {
         return this.issuerPromise;
     }
 
-    public authorizationUrl(res: Response, redirect?: string): Promise<string> {
+    public authorizationUrl(res: Response, redirect: string | undefined, playUri: string): Promise<string> {
         return this.initClient().then((client) => {
             if (!OPID_SCOPE.includes("email") || !OPID_SCOPE.includes("openid")) {
                 throw new Error("Invalid scope, 'email' and 'openid' are required in OPID_SCOPE.");
@@ -83,6 +83,7 @@ class OpenIDClient {
                 prompt: OPID_PROMPT,
                 state: state,
                 //nonce: nonce,
+                playUri,
                 redirect: redirect,
 
                 code_challenge,


### PR DESCRIPTION
While this parameter is completely custom to WorkAdventure, custom implementations of an OpenID provider could use it to customize the login experience of the user.