### PR TITLE
Fixing the depth of players relative to ceiling in big maps

### DIFF
--- a/front/src/Phaser/Game/DepthIndexes.ts
+++ b/front/src/Phaser/Game/DepthIndexes.ts
@@ -3,7 +3,7 @@
 export const DEPTH_TILE_INDEX = 0;
 //Note: Player characters use their y coordinate as their depth to simulate a perspective.
 //See the Character class.
-export const DEPTH_OVERLAY_INDEX = 10000;
-export const DEPTH_BUBBLE_CHAT_SPRITE = 99999;
-export const DEPTH_INGAME_TEXT_INDEX = 100000;
-export const DEPTH_UI_INDEX = 1000000;
+export const DEPTH_OVERLAY_INDEX = 1_000_000;
+export const DEPTH_BUBBLE_CHAT_SPRITE = 999_9999;
+export const DEPTH_INGAME_TEXT_INDEX = 1_100_000;
+export const DEPTH_UI_INDEX = 1_200_000;


### PR DESCRIPTION
Previously, the overlay depth was 10000.
And the player depth was equal to the y coordinate of the player.

As a result, if the player moved 10000 pixels down (so 312.5 tiles down), it would go ON TOP of the overlay. That's bad.

So this commit is increasing the height of the overlay to 1.000.000. That should be enough (at least, Tiled does not support maps that big in current browser memory)