### PR TITLE
Changing default options when saving player variables

### DIFF
--- a/docs/maps/api-player.md
+++ b/docs/maps/api-player.md
@@ -228,8 +228,10 @@ A player variable can be set simply by assigning a value.
 
 Example:
 ```javascript
-WA.player.state.foo = "value" //will set the "foo" key to "value". By default, variable is transient and private.
+WA.player.state.foo = "value"
 ```
+
+By **default**, variables saved are **persisted** and **private** in the **world** scope.
 
 If you want to set some options, you will need to use the `saveVariable` function:
 

--- a/front/src/Api/Iframe/playerState.ts
+++ b/front/src/Api/Iframe/playerState.ts
@@ -39,10 +39,10 @@ export class WorkadventurePlayerStateCommands extends AbstractWorkadventureState
             data: {
                 key,
                 value,
-                public: options?.public ?? true,
+                public: options?.public ?? false,
                 ttl: options?.ttl ?? undefined,
-                persist: options?.persist ?? false,
-                scope: options?.scope ?? "room",
+                persist: options?.persist ?? true,
+                scope: options?.scope ?? "world",
             },
         });
     }

--- a/front/src/Api/Iframe/players.ts
+++ b/front/src/Api/Iframe/players.ts
@@ -107,8 +107,13 @@ export class WorkadventurePlayersCommands extends IframeApiContribution<Workadve
      * @param options
      */
     public async configureTracking(options?: { players?: boolean; movement?: boolean }): Promise<void> {
-        this.trackingPlayers = options?.players ?? true;
-        this.trackingMovement = options?.movement ?? true;
+        const trackingPlayers = options?.players ?? true;
+        const trackingMovement = options?.movement ?? true;
+        if (trackingPlayers === this.trackingPlayers && trackingMovement === this.trackingMovement) {
+            return;
+        }
+        this.trackingPlayers = trackingPlayers;
+        this.trackingMovement = trackingMovement;
         const remotePlayersData = await queryWorkadventure({
             type: "enablePlayersTracking",
             data: {
@@ -117,8 +122,10 @@ export class WorkadventurePlayersCommands extends IframeApiContribution<Workadve
             },
         });
 
-        for (const remotePlayerEvent of remotePlayersData) {
-            this.registerRemotePlayer(remotePlayerEvent);
+        if (trackingPlayers) {
+            for (const remotePlayerEvent of remotePlayersData) {
+                this.registerRemotePlayer(remotePlayerEvent);
+            }
         }
     }
 


### PR DESCRIPTION
We now default to "private/persisted/world" which is the closest we have to the old WorkAdventure release (which was storing variables in localstorage and never sharing them with other players)