### PR TITLE
Update design for mobile

### DIFF
--- a/front/src/Components/EnableCamera/EnableCameraScene.svelte
+++ b/front/src/Components/EnableCamera/EnableCameraScene.svelte
@@ -219,15 +219,14 @@
             margin-top: 2vh;
             margin-left: auto;
             margin-right: auto;
-            max-height: 50vh;
+            max-height: 28vh;
             width: 50vw;
-            border: white 6px solid;
-            -webkit-transform: scaleX(-1);
             transform: scaleX(-1);
-
             display: flex;
             align-items: center;
             justify-content: center;
+            border-radius: 0.5rem;
+            object-fit: cover;
         }
     }
 </style>


### PR DESCRIPTION
# Issue
With mobile, on the camera and microphone configuration page, the camera preview is too high and the "let's go" button is masked. This means that the user is unable to click on it to enter the room.

# Fix
Reduce camera preview to maximum height.