### PR TITLE
Fix the bbb moderator tag not to being found

### DIFF
--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -707,6 +707,7 @@ export class SocketManager {
         joinBBBMeetingQuery: JoinBBBMeetingQuery
     ): Promise<JoinBBBMeetingAnswer> {
         const meetingId = joinBBBMeetingQuery.getMeetingid();
+        const localMeetingId = joinBBBMeetingQuery.getLocalmeetingid();
         const meetingName = joinBBBMeetingQuery.getMeetingname();
         const bbbSettings = gameRoom.getBbbSettings();
 
@@ -722,7 +723,7 @@ export class SocketManager {
         if (user.tags.includes("admin")) {
             isAdmin = true;
         } else {
-            const moderatorTag = await gameRoom.getModeratorTagForBbbMeeting(meetingId);
+            const moderatorTag = await gameRoom.getModeratorTagForBbbMeeting(localMeetingId);
             if (moderatorTag && user.tags.includes(moderatorTag)) {
                 isAdmin = true;
             } else if (moderatorTag === undefined) {
@@ -759,6 +760,11 @@ export class SocketManager {
             userID: user.id,
             joinViaHtml5: true,
         });
+        console.log(
+            `User "${user.name}" (${user.uuid}) joined the BBB meeting "${meetingName}" as ${
+                isAdmin ? "Admin" : "Participant"
+            }.`
+        );
 
         const bbbMeetingAnswer = new JoinBBBMeetingAnswer();
         bbbMeetingAnswer.setMeetingid(meetingId);

--- a/front/src/Connexion/RoomConnection.ts
+++ b/front/src/Connexion/RoomConnection.ts
@@ -1083,11 +1083,13 @@ export class RoomConnection implements RoomConnection {
         props: Map<string, string | number | boolean>
     ): Promise<JoinBBBMeetingAnswer> {
         const meetingName = props.get("meetingName") as string;
+        const localMeetingId = props.get("bbbMeeting") as string;
 
         const answer = await this.query({
             $case: "joinBBBMeetingQuery",
             joinBBBMeetingQuery: {
                 meetingId,
+                localMeetingId,
                 meetingName,
             },
         });

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -213,8 +213,9 @@ message JitsiJwtQuery {
 }
 
 message JoinBBBMeetingQuery {
-  string meetingId = 1;
-  string meetingName = 2;
+  string meetingId = 1; /* a hash of domain, instance and localMeetingId */
+  string localMeetingId = 2; /* bbbMeeting field from the map  */
+  string meetingName = 3;
   // Fix me Pusher linter fails because eslint-plugin version < 3.0
   // map<string, string> userdata = 3;
 }


### PR DESCRIPTION
The `ModeratorTagFinder` constructs an object with the meetingId that is defined on the map in the `bbbMeeting` field. But the meetingId being passed was not the same as the one configured on the map because it was hashed before on the front side.

So we need to pass the original meetingId (called `localMeetingId` here) along with the hashed one (called just `meetingId`) so that we can look for the tags in the ModeratorTagFinder.