### PR TITLE
Fixing error thrown by VirtualJoystick when changing rooms

### DIFF
--- a/front/src/Phaser/Components/MobileJoystick.ts
+++ b/front/src/Phaser/Components/MobileJoystick.ts
@@ -69,7 +69,7 @@ export class MobileJoystick extends VirtualJoystick {
     }
 
     public destroy() {
-        super.destroy();
         this.scene.scale.removeListener(Phaser.Scale.Events.RESIZE, this.resizeCallback);
+        super.destroy();
     }
 }

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -1864,7 +1864,7 @@ ${escapedMessage}
         if (!targetRoom.isEqual(this.room)) {
             if (this.scene.get(targetRoom.key) === null) {
                 console.error("next room not loaded", targetRoom.key);
-                // Try to load next dame room from exit URL
+                // Try to load next game room from exit URL
                 // The policy of room can to be updated during a session and not load before
                 await this.loadNextGameFromExitUrl(targetRoom.key);
             }


### PR DESCRIPTION
Was due to an update in the MobileJoystick: we are now cleaning the resize listener before the mobile joystick looses the reference to the game scene on cleanup.

Closes #2567 