### PR TITLE
remove redundant environment variable

### DIFF
--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -86,7 +86,6 @@ services:
       - PUBLIC_MAP_STORAGE_URL=https://${MAP_STORAGE_HOST}
       - DISABLE_ANONYMOUS
       - START_ROOM_URL
-      - EJABBERD_DOMAIN=ejabberd
       - OPID_PROMPT=login
       # Only used if you set up a JWT authentication mechanism in Ejabberd
       - EJABBERD_JWT_SECRET


### PR DESCRIPTION
EJABBERD_DOMAIN was specified twice in the pusher container