### PR TITLE
Use same ejabberd image for dev as for prod

### DIFF
--- a/contrib/docker/docker-compose.single-domain.yaml
+++ b/contrib/docker/docker-compose.single-domain.yaml
@@ -122,7 +122,7 @@ services:
       - "traefik.http.routers.pusher-ssl.service=pusher"
 
   ejabberd:
-    image: ejabberd/ecs
+    image: ghcr.io/processone/ejabberd:22.05
     volumes:
       - ./xmpp/ejabberd.yml:/home/ejabberd/conf/ejabberd.yml
     labels:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -280,7 +280,7 @@ services:
       - "traefik.http.services.icon.loadbalancer.server.port=8080"
 
   ejabberd:
-    image: ejabberd/ecs
+    image: ghcr.io/processone/ejabberd:22.05
     volumes:
       - ./xmpp/ejabberd.yml:/home/ejabberd/conf/ejabberd.yml
     labels:


### PR DESCRIPTION
Fixes `Failed to start ejabberd application: Invalid value of option ca_file: Failed to read PEM file '/opt/ejabberd/conf/cacert.pem': no such file or directory`