### PR TITLE
startLayer as default one if no # parameters were provided

### DIFF
--- a/play/src/front/Phaser/Game/StartPositionCalculator.ts
+++ b/play/src/front/Phaser/Game/StartPositionCalculator.ts
@@ -93,9 +93,11 @@ export class StartPositionCalculator {
     }
 
     private initPositionFromLayerName(startPositionName?: string): boolean {
+        let foundLayer: ITiledMapLayer | undefined = undefined;
+
         const tileLayers = this.gameMapFrontWrapper.getFlatLayers().filter((layer) => layer.type === "tilelayer");
 
-        if (startPositionName !== undefined) {
+        if (startPositionName) {
             for (const layer of tileLayers) {
                 //we want to prioritize the selectedLayer rather than "start" layer
                 if (
@@ -115,24 +117,29 @@ export class StartPositionCalculator {
                 }
             }
         } else {
-            for (const layer of tileLayers) {
-                if (
-                    layer.name === this.DEFAULT_START_NAME ||
-                    layer.name.endsWith("/" + this.DEFAULT_START_NAME) ||
-                    this.isStartObject(layer)
-                ) {
-                    try {
-                        const startPosition = this.gameMapFrontWrapper.getRandomPositionFromLayer(layer.name);
-                        this.startPosition = {
-                            x: startPosition.x * (this.mapFile.tilewidth ?? 0) + (this.mapFile.tilewidth ?? 0) / 2,
-                            y: startPosition.y * (this.mapFile.tileheight ?? 0) + (this.mapFile.tileheight ?? 0) / 2,
-                        };
-                        return true;
-                    } catch (e: unknown) {
-                        console.error("Error while finding start position: ", e);
+            foundLayer = tileLayers.find(
+                (layer) => layer.name === this.DEFAULT_START_NAME || layer.name.endsWith("/" + this.DEFAULT_START_NAME)
+            );
+            if (!foundLayer) {
+                for (const layer of tileLayers) {
+                    if (this.isStartObject(layer)) {
+                        foundLayer = layer;
+                        break;
                     }
                 }
             }
+        }
+        if (foundLayer) {
+            try {
+                const startPosition = this.gameMapFrontWrapper.getRandomPositionFromLayer(foundLayer.name);
+                this.startPosition = {
+                    x: startPosition.x * (this.mapFile.tilewidth ?? 0) + (this.mapFile.tilewidth ?? 0) / 2,
+                    y: startPosition.y * (this.mapFile.tileheight ?? 0) + (this.mapFile.tileheight ?? 0) / 2,
+                };
+            } catch (e: unknown) {
+                console.error("Error while finding start position: ", e);
+            }
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
closes #2631 

Will still prioritize Area objects but in case of none, "start" layer will be selected as default spawn in case of no # parameter provided