### PR TITLE
Allow relative redirect URLs

### DIFF
--- a/front/src/Connexion/Room.ts
+++ b/front/src/Connexion/Room.ts
@@ -58,7 +58,7 @@ export class Room {
                 return room;
             }
             redirectCount++;
-            roomUrl = new URL(result.redirectUrl);
+            roomUrl = new URL(result.redirectUrl, window.location.href);
         }
         throw new Error("Room resolving seems stuck in a redirect loop after 32 redirect attempts");
     }

--- a/messages/JsonMessages/RoomRedirect.ts
+++ b/messages/JsonMessages/RoomRedirect.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { extendApi } from "@anatine/zod-openapi";
 
 /*
  * WARNING! The original file is in /messages/JsonMessages.
@@ -6,7 +7,10 @@ import { z } from "zod";
  */
 
 export const isRoomRedirect = z.object({
-    redirectUrl: z.string(),
+    redirectUrl: extendApi(z.string(), {
+        description: "The WorkAdventure URL to redirect to.",
+        example: "/_/global/example.com/start.json",
+    }),
 });
 
 export type RoomRedirect = z.infer<typeof isRoomRedirect>;

--- a/pusher/src/Services/AdminApi.ts
+++ b/pusher/src/Services/AdminApi.ts
@@ -124,7 +124,9 @@ class AdminApi implements AdminInterface {
          *       200:
          *         description: The details of the map
          *         schema:
-         *             $ref: "#/definitions/MapDetailsData"
+         *           oneOf:
+         *            - $ref: "#/definitions/MapDetailsData"
+         *            - $ref: "#/definitions/RoomRedirect"
          *       401:
          *         description: Error while retrieving the data because you are not authorized
          *         schema:

--- a/pusher/src/Services/SwaggerGenerator.ts
+++ b/pusher/src/Services/SwaggerGenerator.ts
@@ -10,6 +10,7 @@ import { isMapDetailsData } from "../Messages/JsonMessages/MapDetailsData";
 import { isFetchMemberDataByUuidResponse } from "./AdminApi";
 import { isWokaDetail, wokaList, wokaTexture } from "../Messages/JsonMessages/PlayerTextures";
 import { SchemaObject } from "openapi3-ts";
+import { isRoomRedirect } from "../Messages/JsonMessages/RoomRedirect";
 
 class SwaggerGenerator {
     definitions(type: string | null): {
@@ -21,6 +22,7 @@ class SwaggerGenerator {
                 ErrorApiUnauthorizedData: generateSchema(isErrorApiUnauthorizedData),
                 FetchMemberDataByUuidResponse: generateSchema(isFetchMemberDataByUuidResponse),
                 MapDetailsData: generateSchema(isMapDetailsData),
+                RoomRedirect: generateSchema(isRoomRedirect),
                 WokaDetail: generateSchema(isWokaDetail),
             },
         };
@@ -38,6 +40,7 @@ class SwaggerGenerator {
                 FetchMemberDataByUuidResponse: generateSchema(isFetchMemberDataByUuidResponse),
                 //ListenRoomsMessageInterface: generateSchema(isListenRoomsMessageInterface),
                 MapDetailsData: generateSchema(isMapDetailsData),
+                RoomRedirect: generateSchema(isRoomRedirect),
                 //RegisterData: generateSchema(isRegisterData),
                 //RoomRedirect: generateSchema(isRoomRedirect),
                 //UserMessageAdminMessageInterface: generateSchema(isUserMessageAdminMessageInterface),


### PR DESCRIPTION
The AdminAPI can return a "redirectURL" property for '/map'.
This property can now contain a relative URL and not only an absolute URL.

Also, improves API doc