### PR TITLE
Making the room meter more robust

### DIFF
--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -882,8 +882,10 @@ export class SocketManager {
     private cleanupRoomIfEmpty(room: GameRoom): void {
         if (room.isEmpty()) {
             this.roomsPromises.delete(room.roomUrl);
-            this.resolvedRooms.delete(room.roomUrl);
-            gaugeManager.decNbRoomGauge();
+            const deleted = this.resolvedRooms.delete(room.roomUrl);
+            if (deleted) {
+                gaugeManager.decNbRoomGauge();
+            }
             debug('Room is empty. Deleting room "%s"', room.roomUrl);
         }
     }


### PR DESCRIPTION
Only decreasing the room number in the back Prometheus gauge if the room was found in the rooms list. This will avoid triggering `gaugeManager.decNbRoomGauge()` too many times for the same room.