### PR TITLE
Do not cache errors when fetching openid-configuration

### DIFF
--- a/pusher/src/Services/OpenIDClient.ts
+++ b/pusher/src/Services/OpenIDClient.ts
@@ -40,16 +40,19 @@ class OpenIDClient {
                     console.log(
                         "Failed to fetch OIDC configuration for both .well-known/openid-configuration and oauth-authorization-server. Trying .well-known/openid-configuration only."
                     );
-                    this.issuerPromise = Issuer.discover(OPID_CLIENT_ISSUER + "/.well-known/openid-configuration").then(
-                        (issuer) => {
+                    this.issuerPromise = Issuer.discover(OPID_CLIENT_ISSUER + "/.well-known/openid-configuration")
+                        .then((issuer) => {
                             return new issuer.Client({
                                 client_id: OPID_CLIENT_ID,
                                 client_secret: OPID_CLIENT_SECRET,
                                 redirect_uris: [OPID_CLIENT_REDIRECT_URL],
                                 response_types: ["code"],
                             });
-                        }
-                    );
+                        })
+                        .catch((e) => {
+                            this.issuerPromise = null;
+                            throw e;
+                        });
                     return this.issuerPromise;
                 });
         }


### PR DESCRIPTION
Previously, if an error occured while fetching the OpenID configuration, the error would be cached and the request never retried. We are here reseting the promise in case of error to fix this issue.