### PR TITLE
Properly bypassing validation of name for OpenID connections

### DIFF
--- a/front/src/Connexion/LocalUser.ts
+++ b/front/src/Connexion/LocalUser.ts
@@ -1,5 +1,4 @@
 import { MAX_USERNAME_LENGTH } from "../Enum/EnvironmentVariable";
-import { localUserStore } from "./LocalUserStore";
 
 export type LayerNames = "woka" | "body" | "eyes" | "hair" | "clothes" | "hat" | "accessory";
 
@@ -12,22 +11,11 @@ export interface CharacterTexture {
 export const maxUserNameLength: number = MAX_USERNAME_LENGTH;
 
 export function isUserNameValid(value: unknown): boolean {
-    return (
-        typeof value === "string" &&
-        value.length > 0 &&
-        !localUserStore.isUsernameInJwt() &&
-        value.length <= maxUserNameLength &&
-        /\S/.test(value)
-    );
+    return typeof value === "string" && value.length > 0 && value.length <= maxUserNameLength && /\S/.test(value);
 }
 
 export function isUserNameTooLong(value: unknown): boolean {
-    return (
-        typeof value === "string" &&
-        value.length > 0 &&
-        !localUserStore.isUsernameInJwt() &&
-        value.length > maxUserNameLength
-    );
+    return typeof value === "string" && value.length > 0 && value.length > maxUserNameLength;
 }
 
 export function areCharacterLayersValid(value: string[] | null): boolean {

--- a/front/src/Connexion/LocalUserStore.ts
+++ b/front/src/Connexion/LocalUserStore.ts
@@ -31,7 +31,6 @@ const emojiFavorite = "emojiFavorite";
 const JwtAuthToken = z
     .object({
         accessToken: z.string().optional().nullable(),
-        username: z.string().optional().nullable(),
     })
     .partial();
 
@@ -44,6 +43,7 @@ interface PlayerVariable {
 
 class LocalUserStore {
     private jwt: JwtAuthToken | undefined;
+    private name: string | undefined;
 
     saveUser(localUser: LocalUser) {
         localStorage.setItem("localUser", JSON.stringify(localUser));
@@ -55,10 +55,14 @@ class LocalUserStore {
     }
 
     setName(name: string): void {
+        this.name = name;
         localStorage.setItem(playerNameKey, name);
     }
 
     getName(): string | null {
+        if (this.name) {
+            return this.name;
+        }
         const value = localStorage.getItem(playerNameKey) || "";
         return isUserNameValid(value) ? value : null;
     }
@@ -245,10 +249,6 @@ class LocalUserStore {
         );
 
         return JSON.parse(jsonPayload);
-    }
-
-    isUsernameInJwt() {
-        return !!this.jwt?.username;
     }
 
     setNotification(value: boolean): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,34 @@
 {
+  "name": "workadventure",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "husky": "^7.0.1"
+      }
+    },
+    "node_modules/husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    }
+  },
   "dependencies": {
     "husky": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-6.0.0.tgz",
-      "integrity": "sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
       "dev": true
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-husky@^7.0.1:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
-  integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
+"husky@^7.0.1":
+  "integrity" "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ=="
+  "resolved" "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz"
+  "version" "7.0.4"


### PR DESCRIPTION
When reading the name from OpenID claims, we are now completely bypassing validation (previous attempt was reading "name" from JWT... but there is no "name" in JWT! It comes from /me )