### PR TITLE
[Draft] Attempt to not remove cookies in OpenID connect callback

### DIFF
--- a/pusher/src/Controller/AuthenticateController.ts
+++ b/pusher/src/Controller/AuthenticateController.ts
@@ -347,7 +347,7 @@ export class AuthenticateController extends BaseHttpController {
                         userInfo?.locale
                     );
 
-                    res.clearCookie("playUri");
+                    //res.clearCookie("playUri");
                     // FIXME: possibly redirect to Admin instead.
                     res.redirect(playUri + "?token=" + encodeURIComponent(authToken));
                     return;

--- a/pusher/src/Services/OpenIDClient.ts
+++ b/pusher/src/Services/OpenIDClient.ts
@@ -121,8 +121,8 @@ class OpenIDClient {
             }
 
             return client.callback(OPID_CLIENT_REDIRECT_URL, params, checks).then((tokenSet) => {
-                res.clearCookie("code_verifier");
-                res.clearCookie("oidc_state");
+                //res.clearCookie("code_verifier");
+                //res.clearCookie("oidc_state");
 
                 return client.userinfo(tokenSet).then((res) => {
                     return {


### PR DESCRIPTION
For some reasons, some OpenID connect provider MIGHT call the redirect URI twice (I've seen than happen with failed CSP) This is an attempt to be able to call the redirect URI several times in a row.