### PR TITLE
Do not upgrade websocket if response was aborted

### DIFF
--- a/pusher/src/Controller/IoSocketChatController.ts
+++ b/pusher/src/Controller/IoSocketChatController.ts
@@ -108,6 +108,10 @@ export class IoSocketChatController {
                         const uuid = query.uuid as string;
 
                         if (version !== apiVersionHash) {
+                            if (upgradeAborted.aborted) {
+                                // If the response points to nowhere, don't attempt an upgrade
+                                return;
+                            }
                             return res.upgrade(
                                 {
                                     rejected: true,
@@ -172,6 +176,10 @@ export class IoSocketChatController {
                                 if (Axios.isAxiosError(err)) {
                                     const errorType = isErrorApiData.safeParse(err?.response?.data);
                                     if (errorType.success) {
+                                        if (upgradeAborted.aborted) {
+                                            // If the response points to nowhere, don't attempt an upgrade
+                                            return;
+                                        }
                                         return res.upgrade(
                                             {
                                                 rejected: true,
@@ -185,6 +193,10 @@ export class IoSocketChatController {
                                             context
                                         );
                                     } else {
+                                        if (upgradeAborted.aborted) {
+                                            // If the response points to nowhere, don't attempt an upgrade
+                                            return;
+                                        }
                                         return res.upgrade(
                                             {
                                                 rejected: true,
@@ -237,7 +249,6 @@ export class IoSocketChatController {
                             /* You must not upgrade now */
                             return;
                         }
-
                         /* This immediately calls open handler, you must not use res after this call */
                         res.upgrade(
                             {
@@ -265,6 +276,10 @@ export class IoSocketChatController {
                             if (!(e instanceof InvalidTokenError)) {
                                 console.error(e);
                             }
+                            if (upgradeAborted.aborted) {
+                                // If the response points to nowhere, don't attempt an upgrade
+                                return;
+                            }
                             res.upgrade(
                                 {
                                     rejected: true,
@@ -278,6 +293,10 @@ export class IoSocketChatController {
                                 context
                             );
                         } else {
+                            if (upgradeAborted.aborted) {
+                                // If the response points to nowhere, don't attempt an upgrade
+                                return;
+                            }
                             res.upgrade(
                                 {
                                     rejected: true,

--- a/pusher/src/Controller/IoSocketController.ts
+++ b/pusher/src/Controller/IoSocketController.ts
@@ -285,6 +285,10 @@ export class IoSocketController {
                         const version = query.version;
 
                         if (version !== apiVersionHash) {
+                            if (upgradeAborted.aborted) {
+                                // If the response points to nowhere, don't attempt an upgrade
+                                return;
+                            }
                             return res.upgrade(
                                 {
                                     rejected: true,
@@ -379,6 +383,10 @@ export class IoSocketController {
                                 if (Axios.isAxiosError(err)) {
                                     const errorType = isErrorApiData.safeParse(err?.response?.data);
                                     if (errorType.success) {
+                                        if (upgradeAborted.aborted) {
+                                            // If the response points to nowhere, don't attempt an upgrade
+                                            return;
+                                        }
                                         return res.upgrade(
                                             {
                                                 rejected: true,
@@ -392,6 +400,10 @@ export class IoSocketController {
                                             context
                                         );
                                     } else {
+                                        if (upgradeAborted.aborted) {
+                                            // If the response points to nowhere, don't attempt an upgrade
+                                            return;
+                                        }
                                         return res.upgrade(
                                             {
                                                 rejected: true,
@@ -494,6 +506,10 @@ export class IoSocketController {
                             if (!(e instanceof InvalidTokenError)) {
                                 console.error(e);
                             }
+                            if (upgradeAborted.aborted) {
+                                // If the response points to nowhere, don't attempt an upgrade
+                                return;
+                            }
                             res.upgrade(
                                 {
                                     rejected: true,
@@ -507,6 +523,10 @@ export class IoSocketController {
                                 context
                             );
                         } else {
+                            if (upgradeAborted.aborted) {
+                                // If the response points to nowhere, don't attempt an upgrade
+                                return;
+                            }
                             res.upgrade(
                                 {
                                     rejected: true,


### PR DESCRIPTION
Attempting to upgrade a websocket if the onAborted event handler was triggered will lead to a crash of the pusher. Fixes #2681