### PR TITLE
Upgrading @workadventure/tiled-map-type-guard to 2.0.6

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/thecodingmachine/workadventure#readme",
   "dependencies": {
     "@anatine/zod-openapi": "^1.3.0",
-    "@workadventure/tiled-map-type-guard": "^2.0.4",
+    "@workadventure/tiled-map-type-guard": "^2.0.6",
     "axios": "^0.21.2",
     "bigbluebutton-js": "^0.1.1",
     "busboy": "^0.3.1",

--- a/back/yarn.lock
+++ b/back/yarn.lock
@@ -397,10 +397,10 @@
     "@typescript-eslint/types" "5.8.0"
     eslint-visitor-keys "^3.0.0"
 
-"@workadventure/tiled-map-type-guard@^2.0.4":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.0.5.tgz#e4158770fd1b046cb211343da4e7bb7926112e6d"
-  integrity sha512-6qQ5B224nVwfZEwUT2jMFY1uR4czg4wvHB6FU6UEA9TmE7qK0MCph7aqedWifLRkq/Q+9ntAKFmvV6rqfweBcA==
+"@workadventure/tiled-map-type-guard@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.0.6.tgz#792bf242720c4bc5ab2f7d2d2c1bd2e647bca151"
+  integrity sha512-DujJlMxHx3Vd3icjIxf/eVbaOrnHR0A8GaYgQOLyhsmhY+Uz3j86NO95eS4I+GkkB4xFUR4K6xWQb1wBtVwt4w==
   dependencies:
     zod "^3.17.3"
 

--- a/libs/map-editor/package.json
+++ b/libs/map-editor/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@workadventure/math-utils": "link:../math-utils",
-    "@workadventure/tiled-map-type-guard": "^2.0.4",
+    "@workadventure/tiled-map-type-guard": "^2.0.6",
     "@types/uuid": "^8.3.4",
     "uuid": "^9.0.0"
   },

--- a/libs/map-editor/yarn.lock
+++ b/libs/map-editor/yarn.lock
@@ -16,10 +16,10 @@
   version "0.0.0"
   uid ""
 
-"@workadventure/tiled-map-type-guard@^2.0.4":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.0.5.tgz#e4158770fd1b046cb211343da4e7bb7926112e6d"
-  integrity sha512-6qQ5B224nVwfZEwUT2jMFY1uR4czg4wvHB6FU6UEA9TmE7qK0MCph7aqedWifLRkq/Q+9ntAKFmvV6rqfweBcA==
+"@workadventure/tiled-map-type-guard@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.0.6.tgz#792bf242720c4bc5ab2f7d2d2c1bd2e647bca151"
+  integrity sha512-DujJlMxHx3Vd3icjIxf/eVbaOrnHR0A8GaYgQOLyhsmhY+Uz3j86NO95eS4I+GkkB4xFUR4K6xWQb1wBtVwt4w==
   dependencies:
     zod "^3.17.3"
 

--- a/play/package.json
+++ b/play/package.json
@@ -95,7 +95,7 @@
     "@workadventure/map-editor": "link:../libs/map-editor",
     "@workadventure/math-utils": "link:../libs/math-utils",
     "@workadventure/tailwind": "link:../libs/tailwind",
-    "@workadventure/tiled-map-type-guard": "^2.0.4",
+    "@workadventure/tiled-map-type-guard": "^2.0.6",
     "@xmpp/client": "^0.13.1",
     "@xmpp/component": "^0.13.1",
     "@xmpp/debug": "^0.13.0",

--- a/play/yarn.lock
+++ b/play/yarn.lock
@@ -1112,29 +1112,21 @@
   integrity sha512-zKVyTt6rELvPXYwcVPTJcPFtY0AckN5A7xWuc7owBqR0FdtuDYhE9MZZUi6IY1kZUQFSXV1B3UOOIyLkVHYd2w==
 
 "@workadventure/map-editor@link:../libs/map-editor":
-  version "1.0.0"
-  dependencies:
-    "@types/uuid" "^8.3.4"
-    "@workadventure/math-utils" "link:../libs/math-utils"
-    "@workadventure/tiled-map-type-guard" "^2.0.4"
-    uuid "^9.0.0"
+  version "0.0.0"
+  uid ""
 
 "@workadventure/math-utils@link:../libs/math-utils":
-  version "1.0.0"
+  version "0.0.0"
+  uid ""
 
 "@workadventure/tailwind@link:../libs/tailwind":
-  version "1.0.0"
-  dependencies:
-    "@16bits/nes.css" "^2.3.2"
-    "@fontsource/press-start-2p" "^4.3.0"
-    "@tailwindcss/forms" "^0.5.0"
-    postcss "^8.4.14"
-    tailwindcss "^3.1.5"
+  version "0.0.0"
+  uid ""
 
-"@workadventure/tiled-map-type-guard@^2.0.4":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.0.5.tgz#e4158770fd1b046cb211343da4e7bb7926112e6d"
-  integrity sha512-6qQ5B224nVwfZEwUT2jMFY1uR4czg4wvHB6FU6UEA9TmE7qK0MCph7aqedWifLRkq/Q+9ntAKFmvV6rqfweBcA==
+"@workadventure/tiled-map-type-guard@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.0.6.tgz#792bf242720c4bc5ab2f7d2d2c1bd2e647bca151"
+  integrity sha512-DujJlMxHx3Vd3icjIxf/eVbaOrnHR0A8GaYgQOLyhsmhY+Uz3j86NO95eS4I+GkkB4xFUR4K6xWQb1wBtVwt4w==
   dependencies:
     zod "^3.17.3"
 


### PR DESCRIPTION
This version fixes issues with Wang tilesets parsing and collisions in tiles parsing.