### PR TITLE
Disabling hot_reload in production

### DIFF
--- a/play/package.json
+++ b/play/package.json
@@ -113,7 +113,7 @@
     "google-protobuf": "^3.21.0",
     "hyper-express": "^6.4.11",
     "jsonwebtoken": "^8.5.1",
-    "live-directory": "^2.3.2",
+    "live-directory": "moufmouf/live-directory#hot_reload_param",
     "mustache": "^4.2.0",
     "openapi3-ts": "^3.0.2",
     "openid-client": "^5.1.10",

--- a/play/src/pusher/app.ts
+++ b/play/src/pusher/app.ts
@@ -66,6 +66,7 @@ class App {
                     ".map",
                 ],
             },
+            hot_reload: process.env.NODE_ENV !== "production",
         });
 
         liveAssets.ready().then(() => {

--- a/play/yarn.lock
+++ b/play/yarn.lock
@@ -3228,10 +3228,9 @@ listr2@^4.0.5:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-live-directory@^2.3.2:
+live-directory@moufmouf/live-directory#hot_reload_param:
   version "2.3.2"
-  resolved "https://registry.yarnpkg.com/live-directory/-/live-directory-2.3.2.tgz#17945a1386ed439af24228c802f6546c0fa85a9b"
-  integrity sha512-s/QBuRkngjzUU8kVkrklqT/2/je4GYE45HiVZ8WwFNTvswXknlsC5vdgv4ycOrL/76CBMjrG7rySFpX8nX80gg==
+  resolved "https://codeload.github.com/moufmouf/live-directory/tar.gz/cc0d9127cd8ec61ec3ed9fab161e97f7fbe0db92"
   dependencies:
     chokidar "^3.5.2"
     etag "^1.8.1"


### PR DESCRIPTION
This should allow scaling the play container without exploding servers file watcher limits. We should revert to proper live-directory package when the fix is merged and tagged. Closes https://github.com/thecodingmachine/workadventure/issues/2741