### PR TITLE
Fixing base URL of manifest file

### DIFF
--- a/play/index.html
+++ b/play/index.html
@@ -35,13 +35,13 @@
         <meta property="twitter:description" content="{{ description }}">
         <meta property="twitter:image" content="{{ cardImage }}">
 
+        <base href="/" />
+
         <!-- Icons -->
         {{#favIcons}}
         <link rel="{{ rel }}" type="image/png" sizes="{{ sizes }}" href="{{ src }}" />
         {{/favIcons}}
-        <link rel="manifest" href="static/images/favicons/manifest.json?url={{ url }}" />
-
-        <base href="/" />
+        <link rel="manifest" href="/static/images/favicons/manifest.json?url={{ url }}" />
 
         <style>
             /*hide cowebsite container before scss is loaded*/

--- a/play/src/pusher/services/MetaTagsBuilder.ts
+++ b/play/src/pusher/services/MetaTagsBuilder.ts
@@ -47,7 +47,7 @@ export const MetaTagsDefaultValue: RequiredMetaTagsData = {
         {
             rel: "apple-touch-icon",
             sizes: "114x114",
-            src: "static/images/favicons/apple-icon-114x114.png",
+            src: "/static/images/favicons/apple-icon-114x114.png",
         },
         {
             rel: "apple-touch-icon",


### PR DESCRIPTION
The manifest.json file could be loaded from a relative file (on Firefox, which is not a big deal since is does not support PWAs) Also fixing a relative URL on a favicon.