### PR TITLE
Redirect with a 302 from Pusher when possible

### DIFF
--- a/map-storage/yarn.lock
+++ b/map-storage/yarn.lock
@@ -1031,11 +1031,6 @@
   dependencies:
     "@types/superagent" "*"
 
-"@types/uuid@^8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
-
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -1132,23 +1127,12 @@
   version "0.0.0"
   uid ""
 
-"@workadventure/math-utils@link:../libs/math-utils":
-  version "0.0.0"
-  uid ""
-
 "@workadventure/tiled-map-type-guard@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-1.0.3.tgz#62c2061cacbe1360b84162af0b7e4639ed8bfa7e"
   integrity sha512-pUMxBBZHYAFkpnGWZAVAE8+M+Wn9UtzqZhXvBBBbB1gEakHIka7ahdTGfh0DgRaWrVszVXOP3tf49Dhdmn9pDg==
   dependencies:
     generic-type-guard "^3.4.1"
-
-"@workadventure/tiled-map-type-guard@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@workadventure/tiled-map-type-guard/-/tiled-map-type-guard-2.0.6.tgz#792bf242720c4bc5ab2f7d2d2c1bd2e647bca151"
-  integrity sha512-DujJlMxHx3Vd3icjIxf/eVbaOrnHR0A8GaYgQOLyhsmhY+Uz3j86NO95eS4I+GkkB4xFUR4K6xWQb1wBtVwt4w==
-  dependencies:
-    zod "^3.17.3"
 
 abbrev@1:
   version "1.1.1"
@@ -5366,11 +5350,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
-
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
@@ -5563,8 +5542,3 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-zod@^3.17.3:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.19.1.tgz#112f074a97b50bfc4772d4ad1576814bd8ac4473"
-  integrity sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==

--- a/play/src/i18n/fr-FR/login.ts
+++ b/play/src/i18n/fr-FR/login.ts
@@ -10,7 +10,7 @@ const login: DeepPartial<Translation["login"]> = {
             notValidError: "Le nom n'est pas valide",
         },
     },
-    terms: "En continuant, vous acceptez nos {links}.",
+    terms: "En continuant, vous acceptez {links}.",
     termsOfUse: "nos conditions d'utilisation",
     privacyPolicy: "notre politique de confidentialité",
     cookiePolicy: "notre politique relative aux cookies",

--- a/play/src/pusher/controllers/FrontController.ts
+++ b/play/src/pusher/controllers/FrontController.ts
@@ -143,6 +143,11 @@ export class FrontController extends BaseHttpController {
     private async displayFront(req: Request, res: Response, url: string) {
         const builder = new MetaTagsBuilder(url);
 
+        const redirectUrl = await builder.getRedirectUrl();
+        if (redirectUrl) {
+            return res.redirect(redirectUrl);
+        }
+
         const metaTagsData = await builder.getMeta(req.header("User-Agent"));
 
         const html = Mustache.render(this.indexFile, {


### PR DESCRIPTION
If the AdminAPI is sending a "RoomRedirect" response (on /api/map), on page load, we can deal with the redirect directly in the pusher (rather than in the front). As a bonus, this makes the whitelabeling working on redirected pages.