### PR TITLE
fix: local storage value parser

### DIFF
--- a/play/src/front/Connexion/LocalUserStore.ts
+++ b/play/src/front/Connexion/LocalUserStore.ts
@@ -347,9 +347,19 @@ class LocalUserStore {
                             }
                         }
 
+                        let valueReturned;
+                        try {
+                            valueReturned = JSON.parse(value);
+                        } catch (err) {
+                            console.info(
+                                "getAllUserProperties => value cannot be parsed to JSON, undefined returned.",
+                                err
+                            );
+                            valueReturned = undefined;
+                        }
                         result.set(userKey, {
                             isPublic,
-                            value: JSON.parse(value),
+                            value: valueReturned,
                         });
                     }
                 }


### PR DESCRIPTION
The undefined value can be defined in scripting API but cannot be parsed with the JSON parser.