### PR TITLE
fix mixed protocol configuration for ejabberd

### DIFF
--- a/contrib/docker/.env.prod.template
+++ b/contrib/docker/.env.prod.template
@@ -111,8 +111,10 @@ ACME_EMAIL=
 EJABBERD_DOMAIN=ejabberd.workadventure.localhost
 
 # MUST MATCH THE EJABBERD_HOST ENV
-EJABBERD_WS_URI=wss://ejabberd.workadventure.localhost:5443/ws
-EJABBERD_API_URI=http://ejabberd:5443/api
+# Protocols have to match -> wss:// is WebSocket over SSL (default) - Change to ws:// (WebSocket) if you defined EJABBERD_API_URI with http://
+EJABBERD_WS_URI=wss://ejabberd.workadventure.localhost/ws
+# Protocols have to match -> https:// is HTTP over SSL (default) - Change to http:// if you defined EJABBERD_WS_URI with ws://
+EJABBERD_API_URI=https://ejabberd.workadventure.localhost/api
 EJABBERD_USER=admin
 EJABBERD_PASSWORD=mySecretPassword
 


### PR DESCRIPTION
Fix protocol mix (wss:// / http://) for ejabberd container and change default configuration to SSL based settings. Remove port-settings for ejabberd URI (EJABBERD_WS_URI & EJABBERD_API_URI) as they are not required anymore.

Changes are based on findings in issue #2805