### PR TITLE
Making sure yarn.lock is up to date

### DIFF
--- a/.github/workflows/build-and-release-desktop.yml
+++ b/.github/workflows/build-and-release-desktop.yml
@@ -57,7 +57,7 @@ jobs:
             ${{ runner.OS }}-yarn-
 
       - name: "local-app: Install dependencies"
-        run: yarn install --froze-lockfile
+        run: yarn install  --immutable
         working-directory: "desktop/local-app"
 
       - name: "local-app: Build"
@@ -69,7 +69,7 @@ jobs:
         working-directory: "desktop/electron"
 
       - name: "Install dependencies"
-        run: yarn install --froze-lockfile
+        run: yarn install  --immutable
         working-directory: "desktop/electron"
 
       - name: "Build typescript"

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -34,23 +34,23 @@ jobs:
           version: '3.x'
 
       - name: "Install libs/tailwind dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/tailwind"
 
       - name: "Install libs/map-editor dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/map-editor"
 
       - name: "Install dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "play"
 
       - name: "Install messages dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "messages"
 
       - name: "Install libs dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/messages"
 
       - name: "Build proto messages"
@@ -118,19 +118,19 @@ jobs:
       #   working-directory: "libs"
 
       - name: "Install libs/tailwind dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/tailwind"
 
       - name: "Install libs/messages dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/messages"
 
       - name: "Install dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "chat"
 
       - name: "Install messages dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "messages"
 
       - name: "Build proto messages"
@@ -192,15 +192,15 @@ jobs:
           version: '3.x'
 
       - name: "Install dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "back"
 
       - name: "Install messages dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "messages"
 
       - name: "Install libs dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/messages"
 
       - name: "Build proto messages"
@@ -238,7 +238,7 @@ jobs:
           node-version: 16
 
       - name: "Install dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "uploader"
 
       - name: "Lint"
@@ -270,11 +270,11 @@ jobs:
           version: '3.x'
 
       - name: "Install dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "map-storage"
 
       - name: "Install messages dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "messages"
 
       - name: "Build proto messages"
@@ -282,11 +282,11 @@ jobs:
         working-directory: "messages"
 
       - name: "Install libs/map-editor dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/map-editor"
 
       - name: "Install libs/messages dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/messages"
 
       - name: "Build"
@@ -320,7 +320,7 @@ jobs:
           node-version: 16
 
       - name: "Install dependencies"
-        run: yarn install --froze-lockfile
+        run: yarn install  --immutable
         working-directory: "desktop/electron"
 
       - name: "Build"
@@ -358,7 +358,7 @@ jobs:
           node-version: 16
 
       - name: "Install dependencies"
-        run: yarn install --froze-lockfile
+        run: yarn install  --immutable
         working-directory: "desktop/local-app"
 
       - name: "Build"
@@ -401,19 +401,19 @@ jobs:
         working-directory: "tests"
 
       - name: "Install libs/map-editor dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/map-editor"
 
       - name: "Install libs/messages dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/messages"
 
       - name: "Install play dependencies"
-        run: yarn install --froze-lockfile
+        run: yarn install  --immutable
         working-directory: "play"
 
       - name: "Install messages dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "messages"
 
       - name: "Build proto messages"

--- a/.github/workflows/push-to-npm.yml
+++ b/.github/workflows/push-to-npm.yml
@@ -33,23 +33,23 @@ jobs:
           version: '3.x'
 
       - name: "Install tailwind dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/tailwind"
 
       - name: "Install map-editor dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/map-editor"
 
       - name: "Install libs/messages dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "libs/messages"
 
       - name: "Install dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "play"
 
       - name: "Install messages dependencies"
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "messages"
 
       - name: "Build proto messages"
@@ -68,7 +68,7 @@ jobs:
         working-directory: "play"
 
       - name: Install dependencies in package
-        run: yarn install
+        run: yarn install  --immutable
         working-directory: "play/packages/iframe-api-typings"
 
       - name: Publish package


### PR DESCRIPTION
By adding the --immutable parameter to yarn install, we make sure the package.json and yarn.lock are in sync.