### PR TITLE
Track generate_request directory to fix play dev-startup

### DIFF
--- a/play/src/messages/.gitignore
+++ b/play/src/messages/.gitignore
@@ -1,2 +1,1 @@
 /generated/
-/generate_request/need_regenerate

--- a/play/src/messages/generate_request/.gitignore
+++ b/play/src/messages/generate_request/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Fixes `workadventure-play-1  | touch: cannot touch '/usr/src/app/src/messages/generate_request/need_regenerate': No such file or directory`