### PR TITLE
Fix timeline by adding userJid in joinRoom message

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -186,6 +186,7 @@ export class GameRoom implements BrothersFinder {
         const user = await User.create(
             this.nextUserId,
             joinRoomMessage.getUseruuid(),
+            joinRoomMessage.getUserjid(),
             joinRoomMessage.getIslogged(),
             joinRoomMessage.getIpaddress(),
             position,

--- a/back/src/Model/User.ts
+++ b/back/src/Model/User.ts
@@ -33,6 +33,7 @@ export class User implements Movable {
 
     public constructor(
         public id: number,
+        public userJid: string,
         public readonly uuid: string,
         public readonly isLogged: boolean,
         public readonly IPAddress: string,
@@ -60,6 +61,7 @@ export class User implements Movable {
     public static async create(
         id: number,
         uuid: string,
+        userJid: string,
         isLogged: boolean,
         IPAddress: string,
         position: PointInterface,
@@ -85,6 +87,7 @@ export class User implements Movable {
 
         return new User(
             id,
+            userJid,
             uuid,
             isLogged,
             IPAddress,

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -114,6 +114,7 @@ export class SocketManager {
             };
         }
         const roomJoinedMessage = new RoomJoinedMessage();
+        roomJoinedMessage.setUserjid(joinRoomMessage.getUserjid());
         roomJoinedMessage.setTagList(joinRoomMessage.getTagList());
         roomJoinedMessage.setUserroomtoken(joinRoomMessage.getUserroomtoken());
         roomJoinedMessage.setCharacterlayerList(joinRoomMessage.getCharacterlayerList());
@@ -364,6 +365,7 @@ export class SocketManager {
             throw new Error(`clientUser.userId is not an integer ${user.id}`);
         }
         userJoinedZoneMessage.setUserid(user.id);
+        userJoinedZoneMessage.setUserjid(user.userJid);
         userJoinedZoneMessage.setUseruuid(user.uuid);
         userJoinedZoneMessage.setName(user.name);
         userJoinedZoneMessage.setAvailabilitystatus(user.getAvailabilityStatus());

--- a/back/tests/PositionNotifierTest.ts
+++ b/back/tests/PositionNotifierTest.ts
@@ -41,6 +41,7 @@ describe("PositionNotifier", () => {
         const user1 = await User.create(
             1,
             "test",
+            "test",
             false,
             "10.0.0.2",
             {
@@ -63,6 +64,7 @@ describe("PositionNotifier", () => {
 
         const user2 = await User.create(
             2,
+            "test",
             "test",
             false,
             "10.0.0.2",
@@ -157,6 +159,7 @@ describe("PositionNotifier", () => {
         const user1 = await User.create(
             1,
             "test",
+            "test",
             false,
             "10.0.0.2",
             {
@@ -179,6 +182,7 @@ describe("PositionNotifier", () => {
 
         const user2 = await User.create(
             2,
+            "test",
             "test",
             false,
             "10.0.0.2",

--- a/chat/src/Components/Chat.svelte
+++ b/chat/src/Components/Chat.svelte
@@ -66,7 +66,7 @@
         );
         subscribeListeners.push(
             availabilityStatusStore.subscribe(() => {
-                mucRoomsStore.sendPresences();
+                mucRoomsStore.sendUserInfos();
             })
         );
         subscribeListeners.push(

--- a/chat/src/Components/UsersList.svelte
+++ b/chat/src/Components/UsersList.svelte
@@ -82,7 +82,7 @@
                     <span
                         class="{room !== 'disconnected'
                             ? 'tw-bg-light-blue'
-                            : 'tw-bg-gray'} tw-text-dark-purple tw-w-5 tw-h-5 tw-mr-3 tw-text-sm tw-font-semibold tw-flex tw-items-center tw-justify-center tw-rounded"
+                            : 'tw-bg-gray'} tw-text-dark-purple tw-min-w-[20px] tw-h-5 tw-mr-3 tw-text-sm tw-font-semibold tw-flex tw-items-center tw-justify-center tw-rounded"
                     >
                         {usersByMaps.get(room)?.length}
                     </span>

--- a/chat/src/IframeListener.ts
+++ b/chat/src/IframeListener.ts
@@ -50,14 +50,13 @@ class IframeListener {
                         case "userData": {
                             iframeEvent.data.name = iframeEvent.data.name.replace(emojiRegex, "");
                             userStore.set(iframeEvent.data);
-                            if (!chatConnectionManager.connection) {
-                                chatConnectionManager.initUser(
-                                    iframeEvent.data.playUri,
-                                    iframeEvent.data.uuid,
-                                    iframeEvent.data.authToken
-                                );
-                            } else {
-                                mucRoomsStore.sendPresences();
+                            chatConnectionManager.initUser(
+                                iframeEvent.data.playUri,
+                                iframeEvent.data.uuid,
+                                iframeEvent.data.authToken
+                            );
+                            if (chatConnectionManager.connection) {
+                                mucRoomsStore.sendUserInfos();
                             }
                             break;
                         }

--- a/chat/src/Stores/MucRoomsStore.ts
+++ b/chat/src/Stores/MucRoomsStore.ts
@@ -36,6 +36,9 @@ function createMucRoomsStore() {
         sendPresences() {
             [...get(this).values()].forEach((mucRoom) => mucRoom.sendPresence());
         },
+        sendUserInfos() {
+            [...get(this).values()].forEach((mucRoom) => mucRoom.sendUserInfo());
+        },
     };
 }
 export const mucRoomsStore = createMucRoomsStore();

--- a/chat/src/Xmpp/MucRoom.ts
+++ b/chat/src/Xmpp/MucRoom.ts
@@ -83,7 +83,8 @@ export class MucRoom extends AbstractRoom {
         if (first) {
             this.subscriptions.set("firstPresence", presenceId);
         }
-        this.xmppClient.socket.sendPresence({ to: this.recipient, id: presenceId });
+        //this.xmppClient.socket.sendPresence({ to: this.recipient, id: presenceId });
+        this.sendUserInfo(presenceId);
         if (_VERBOSE)
             console.warn(
                 `[XMPP][${this.name}]`,

--- a/chat/src/Xmpp/MucRoom.ts
+++ b/chat/src/Xmpp/MucRoom.ts
@@ -54,13 +54,7 @@ export class MucRoom extends AbstractRoom {
     }
 
     public getUserByJid(jid: string): User {
-        let user = undefined;
-        get(this.presenceStore).forEach((user_, key) => {
-            // WORKAROUND BECAUSE WE DON'T SEND THE JID FROM THE OTHER USERS IN THE FRONT
-            if (JID.parse(key).local == jid || JID.parse(key).local == JID.parse(jid).local) {
-                user = user_;
-            }
-        });
+        let user = get(this.presenceStore).get(jid);
         if (!user) {
             throw new Error("No user found for this JID");
         }
@@ -100,7 +94,7 @@ export class MucRoom extends AbstractRoom {
                 presenceId
             );
     }
-    private sendUserInfo(presenceId: string = uuid()) {
+    sendUserInfo(presenceId: string = uuid()) {
         this.xmppClient.socket.sendUserInfo(this.recipient, presenceId, {
             jid: this.xmppClient.getMyJID(),
             roomPlayUri: get(userStore).playUri,

--- a/chat/src/Xmpp/MucRoom.ts
+++ b/chat/src/Xmpp/MucRoom.ts
@@ -54,7 +54,7 @@ export class MucRoom extends AbstractRoom {
     }
 
     public getUserByJid(jid: string): User {
-        let user = get(this.presenceStore).get(jid);
+        const user = get(this.presenceStore).get(jid);
         if (!user) {
             throw new Error("No user found for this JID");
         }

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -338,16 +338,17 @@ message GroupDeleteMessage {
 
 message UserJoinedMessage {
   int32 userId = 1;
-  string name = 2;
-  repeated CharacterLayerMessage characterLayers = 3;
-  PositionMessage position = 4;
-  CompanionMessage companion = 5;
-  string visitCardUrl = 6;
-  string userUuid = 7;
-  uint32 outlineColor = 8;
-  bool hasOutline = 9;
-  AvailabilityStatus availabilityStatus = 10;
-  map<string, string> variables = 11;
+  string userJid = 2;
+  string name = 3;
+  repeated CharacterLayerMessage characterLayers = 4;
+  PositionMessage position = 5;
+  CompanionMessage companion = 6;
+  string visitCardUrl = 7;
+  string userUuid = 8;
+  uint32 outlineColor = 9;
+  bool hasOutline = 10;
+  AvailabilityStatus availabilityStatus = 11;
+  map<string, string> variables = 12;
 }
 
 message UserLeftMessage {
@@ -400,6 +401,7 @@ message RoomJoinedMessage {
   bool activatedInviteUser = 9;
   repeated VariableMessage playerVariable = 10;
   repeated ApplicationMessage applications = 11;
+  string userJid = 12;
 }
 
 message WebRtcStartMessage {
@@ -463,6 +465,7 @@ message AskPositionMessage{
   string playUri = 2;
 }
 
+
 /**
  * Messages going from back and pusher to the front
  */
@@ -515,21 +518,23 @@ message JoinRoomMessage {
   bool activatedInviteUser = 12;
   bool isLogged = 13;
   repeated ApplicationMessage applications = 14;
+  string userJid = 15;
 }
 
 message UserJoinedZoneMessage {
   int32 userId = 1;
-  string name = 2;
-  repeated CharacterLayerMessage characterLayers = 3;
-  PositionMessage position = 4;
-  Zone fromZone = 5;
-  CompanionMessage companion = 6;
-  string visitCardUrl = 7;
-  string userUuid = 8;
-  uint32 outlineColor = 9;
-  bool hasOutline = 10;
-  AvailabilityStatus availabilityStatus = 11;
-  map<string, string> variables = 12;
+  string userJid = 2;
+  string name = 3;
+  repeated CharacterLayerMessage characterLayers = 4;
+  PositionMessage position = 5;
+  Zone fromZone = 6;
+  CompanionMessage companion = 7;
+  string visitCardUrl = 8;
+  string userUuid = 9;
+  uint32 outlineColor = 10;
+  bool hasOutline = 11;
+  AvailabilityStatus availabilityStatus = 12;
+  map<string, string> variables = 13;
 }
 
 message UserLeftZoneMessage {

--- a/play/src/front/Api/IframeListener.ts
+++ b/play/src/front/Api/IframeListener.ts
@@ -860,7 +860,7 @@ class IframeListener {
     // << TODO delete with chat XMPP integration for the discussion circle
     sendWritingStatusToChatIframe(list: Set<PlayerInterface>) {
         const usersTyping: Array<string> = [];
-        list.forEach((user) => usersTyping.push(user.userUuid));
+        list.forEach((user) => usersTyping.push(user.userJid));
         this.postMessageToChat({
             type: "updateWritingStatusChatList",
             data: usersTyping,

--- a/play/src/front/Connexion/ConnexionModels.ts
+++ b/play/src/front/Connexion/ConnexionModels.ts
@@ -10,6 +10,7 @@ export interface MessageUserMovedInterface {
 
 export interface MessageUserJoined {
     userId: number;
+    userJid: string;
     name: string;
     characterLayers: BodyResourceDescriptionInterface[];
     position: PositionMessage;

--- a/play/src/front/Connexion/RoomConnection.ts
+++ b/play/src/front/Connexion/RoomConnection.ts
@@ -753,6 +753,7 @@ export class RoomConnection implements RoomConnection {
 
         return {
             userId: message.userId,
+            userJid: message.userJid,
             name: message.name,
             characterLayers,
             visitCardUrl: message.visitCardUrl,

--- a/play/src/front/Phaser/Game/PlayerInterface.ts
+++ b/play/src/front/Phaser/Game/PlayerInterface.ts
@@ -3,6 +3,7 @@ import type { BodyResourceDescriptionInterface } from "../Entity/PlayerTextures"
 
 export interface PlayerInterface {
     userId: number;
+    userJid: string;
     name: string;
     characterLayers: BodyResourceDescriptionInterface[];
     visitCardUrl: string | null;

--- a/play/src/front/Stores/ChatStore.ts
+++ b/play/src/front/Stores/ChatStore.ts
@@ -66,7 +66,7 @@ function createChatMessagesStore() {
                 /* @deprecated with new chat service */
                 iframeListener.sendComingUserToChatIframe({
                     type: ChatMessageTypes.userIncoming,
-                    targets: [getAuthor(authorId).userUuid],
+                    targets: [getAuthor(authorId).userJid],
                     date: new Date(),
                 });
 
@@ -89,7 +89,7 @@ function createChatMessagesStore() {
                 /* @deprecated with new chat service */
                 iframeListener.sendComingUserToChatIframe({
                     type: ChatMessageTypes.userOutcoming,
-                    targets: [getAuthor(authorId).userUuid],
+                    targets: [getAuthor(authorId).userJid],
                     date: new Date(),
                 });
 
@@ -147,7 +147,7 @@ function createChatMessagesStore() {
                 iframeListener.sendMessageToChatIframe({
                     type: ChatMessageTypes.text,
                     text: [text],
-                    author: author.userUuid === "dummy" ? author.name : author.userUuid,
+                    author: author.userUuid === "dummy" ? author.name : author.userJid,
                     date: new Date(),
                 });
 

--- a/play/src/front/Stores/PlayersStore.ts
+++ b/play/src/front/Stores/PlayersStore.ts
@@ -25,6 +25,7 @@ function createPlayersStore() {
                 update((users) => {
                     users.set(message.userId, {
                         userId: message.userId,
+                        userJid: message.userJid,
                         name: message.name,
                         characterLayers: message.characterLayers,
                         visitCardUrl: message.visitCardUrl,
@@ -66,6 +67,7 @@ function createPlayersStore() {
             update((users) => {
                 users.set(newUserId, {
                     userId: newUserId,
+                    userJid: "fake",
                     name,
                     characterLayers: [],
                     visitCardUrl: null,

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -70,6 +70,7 @@ interface UpgradeData {
     rejected: false;
     token: string;
     userUuid: string;
+    userJid: string;
     IPAddress: string;
     roomId: string;
     name: string;
@@ -486,6 +487,7 @@ export class IoSocketController {
                                 rejected: false,
                                 token,
                                 userUuid: userData.userUuid,
+                                userJid: userData.jabberId,
                                 IPAddress,
                                 userIdentifier,
                                 roomId,
@@ -747,6 +749,7 @@ export class IoSocketController {
         const client: ExSocketInterface = ws;
         client.userId = this.nextUserId;
         this.nextUserId++;
+        client.userJid = ws.userJid;
         client.userUuid = ws.userUuid;
         client.IPAddress = ws.IPAddress;
         client.token = ws.token;

--- a/play/src/pusher/models/Websocket/ExSocketInterface.ts
+++ b/play/src/pusher/models/Websocket/ExSocketInterface.ts
@@ -23,6 +23,7 @@ export interface ExSocketInterface extends compressors.WebSocket, Identificable 
     //userId: number;   // A temporary (autoincremented) identifier for this user
     userUuid: string; // A unique identifier for this user
     userIdentifier: string;
+    userJid: string;
     isLogged: boolean;
     IPAddress: string; // IP address
     name: string;

--- a/play/src/pusher/models/Zone.ts
+++ b/play/src/pusher/models/Zone.ts
@@ -49,6 +49,7 @@ export type LeavesCallback = (thing: Movable, listener: User) => void;*/
 export class UserDescriptor {
     private constructor(
         public readonly userId: number,
+        public readonly userJid: string,
         private userUuid: string,
         private name: string,
         private characterLayers: CharacterLayerMessage[],
@@ -71,6 +72,7 @@ export class UserDescriptor {
         }
         return new UserDescriptor(
             message.getUserid(),
+            message.getUserjid(),
             message.getUseruuid(),
             message.getName(),
             message.getCharacterlayersList(),
@@ -111,6 +113,7 @@ export class UserDescriptor {
         const userJoinedMessage = new UserJoinedMessage();
 
         userJoinedMessage.setUserid(this.userId);
+        userJoinedMessage.setUserjid(this.userJid);
         userJoinedMessage.setName(this.name);
         userJoinedMessage.setCharacterlayersList(this.characterLayers);
         userJoinedMessage.setPosition(this.position);

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -179,6 +179,7 @@ export class SocketManager implements ZoneEventListener {
         try {
             const joinRoomMessage = new JoinRoomMessage();
             joinRoomMessage.setUseruuid(client.userUuid);
+            joinRoomMessage.setUserjid(client.userJid);
             joinRoomMessage.setIpaddress(client.IPAddress);
             joinRoomMessage.setRoomid(client.roomId);
             joinRoomMessage.setName(client.name);


### PR DESCRIPTION
Add the userJid in the joinRoomMessage will send the userJid of the current user to all other users, timeline is based on userJid, now it will work every time, no more lost messages in timeline!