### PR TITLE
Fix chat regressions

### DIFF
--- a/chat/src/Components/ChatMessageForm.svelte
+++ b/chat/src/Components/ChatMessageForm.svelte
@@ -102,7 +102,7 @@
         }
         mucRoom.updateComposingState(ChatState.Paused);
         mucRoom.sendMessage(newMessageText);
-        newMessageText = "";
+        htmlMessageText = "";
         dispatch("scrollDown");
         setTimeout(() => dispatch("formHeight", messageForm.clientHeight), 0);
         return false;

--- a/chat/src/Components/ChatMessageForm.svelte
+++ b/chat/src/Components/ChatMessageForm.svelte
@@ -102,6 +102,7 @@
         }
         mucRoom.updateComposingState(ChatState.Paused);
         mucRoom.sendMessage(newMessageText);
+        newMessageText = "";
         htmlMessageText = "";
         dispatch("scrollDown");
         setTimeout(() => dispatch("formHeight", messageForm.clientHeight), 0);

--- a/chat/src/Components/Timeline/ChatActiveThreadTimeline.svelte
+++ b/chat/src/Components/Timeline/ChatActiveThreadTimeline.svelte
@@ -65,10 +65,8 @@
     function handlerKeyDown(keyDownEvent: KeyboardEvent) {
         if (keyDownEvent.key === "Enter" && !keyDownEvent.shiftKey) {
             saveMessage();
-            setTimeout(() => {
-                newMessageText = "";
-                writing();
-            }, 10);
+            htmlMessageText = "";
+            writing();
             return false;
         }
         return true;

--- a/chat/src/Components/Timeline/ChatActiveThreadTimeline.svelte
+++ b/chat/src/Components/Timeline/ChatActiveThreadTimeline.svelte
@@ -285,7 +285,7 @@
                                                 {#await HtmlUtils.urlify(text)}
                                                     <p>...waiting</p>
                                                 {:then html}
-                                                    <HtmlMessage {html} {message} />
+                                                    {@html html}
                                                 {/await}
                                             </div>
                                         {/each}

--- a/chat/src/Components/Timeline/ChatActiveThreadTimeline.svelte
+++ b/chat/src/Components/Timeline/ChatActiveThreadTimeline.svelte
@@ -19,6 +19,7 @@
     import { EmojiButton } from "@joeattardi/emoji-button";
     import { HtmlUtils } from "../../Utils/HtmlUtils";
     import { defaultWoka } from "../../Xmpp/AbstractRoom";
+    import HtmlMessage from "../Content/HtmlMessage.svelte";
 
     const dispatch = createEventDispatcher();
     const defaultMucRoom = mucRoomsStore.getDefaultRoom();
@@ -284,7 +285,7 @@
                                                 {#await HtmlUtils.urlify(text)}
                                                     <p>...waiting</p>
                                                 {:then html}
-                                                    {@html html}
+                                                    <HtmlMessage {html} {message} />
                                                 {/await}
                                             </div>
                                         {/each}

--- a/chat/src/Components/Timeline/ChatActiveThreadTimeline.svelte
+++ b/chat/src/Components/Timeline/ChatActiveThreadTimeline.svelte
@@ -19,7 +19,6 @@
     import { EmojiButton } from "@joeattardi/emoji-button";
     import { HtmlUtils } from "../../Utils/HtmlUtils";
     import { defaultWoka } from "../../Xmpp/AbstractRoom";
-    import HtmlMessage from "../Content/HtmlMessage.svelte";
 
     const dispatch = createEventDispatcher();
     const defaultMucRoom = mucRoomsStore.getDefaultRoom();

--- a/chat/src/Event/ChatMessageEvent.ts
+++ b/chat/src/Event/ChatMessageEvent.ts
@@ -5,6 +5,7 @@ export const isAddChatMessageEvent = z.object({
     type: z.number(),
     date: z.any(),
     author: z.nullable(isPlayer),
+    name: z.optional(z.nullable(z.string())),
     targets: z.undefined(z.array(isPlayer)),
     text: z.nullable(z.array(z.string())),
 });

--- a/chat/src/IframeListener.ts
+++ b/chat/src/IframeListener.ts
@@ -88,22 +88,20 @@ class IframeListener {
                             break;
                         }
                         case "addChatMessage": {
-                            if (iframeEvent.data.author == undefined || iframeEvent.data.text == undefined) {
+                            if (iframeEvent.data.text == undefined) {
                                 break;
                             }
                             const mucRoomDefault = mucRoomsStore.getDefaultRoom();
                             if (mucRoomDefault) {
                                 let userData = undefined;
-                                try {
+                                if (iframeEvent.data.author) {
                                     userData = mucRoomDefault.getUserByJid(iframeEvent.data.author);
-                                } catch (_) {
-                                    //  nothing to do
                                 }
                                 for (const chatMessageText of iframeEvent.data.text) {
                                     chatMessagesStore.addExternalMessage(
                                         userData,
                                         chatMessageText,
-                                        userData ? undefined : iframeEvent.data.author
+                                        userData ? undefined : iframeEvent.data.name
                                     );
                                 }
                             }

--- a/chat/src/IframeListener.ts
+++ b/chat/src/IframeListener.ts
@@ -96,7 +96,7 @@ class IframeListener {
                                 let userData = undefined;
                                 try {
                                     userData = mucRoomDefault.getUserByJid(iframeEvent.data.author);
-                                } catch(_){
+                                } catch (_) {
                                     //  nothing to do
                                 }
                                 for (const chatMessageText of iframeEvent.data.text) {

--- a/chat/src/IframeListener.ts
+++ b/chat/src/IframeListener.ts
@@ -96,8 +96,8 @@ class IframeListener {
                                 let userData = undefined;
                                 try {
                                     userData = mucRoomDefault.getUserByJid(iframeEvent.data.author);
-                                } finally {
-                                    // Nothing to do
+                                } catch(_){
+                                    //  nothing to do
                                 }
                                 for (const chatMessageText of iframeEvent.data.text) {
                                     chatMessagesStore.addExternalMessage(

--- a/chat/src/Services/WebLinkManager.ts
+++ b/chat/src/Services/WebLinkManager.ts
@@ -244,10 +244,10 @@ export class WebLink {
                 } catch (err) {
                     console.error(err);
                     console.error("Error get data from website: ", this.link);
-                    return this.getHyperLinkHTMLElement().outerHTML;
+                    return this.getHyperLinkHTMLElement(false).outerHTML;
                 }
             } else {
-                return this.getHyperLinkHTMLElement().outerHTML;
+                return this.getHyperLinkHTMLElement(false).outerHTML;
             }
         })();
     }

--- a/play/src/front/Api/Events/ChatEvent.ts
+++ b/play/src/front/Api/Events/ChatEvent.ts
@@ -20,6 +20,7 @@ export const isChatMessage = z.object({
     type: isChatMessageTypes,
     date: z.date(),
     author: z.optional(z.nullable(z.string())),
+    name: z.optional(z.nullable(z.string())),
     targets: z.optional(z.nullable(z.array(z.nullable(z.string())))),
     text: z.optional(z.nullable(z.array(z.nullable(z.string())))),
 });

--- a/play/src/front/Components/Chat/Chat.svelte
+++ b/play/src/front/Components/Chat/Chat.svelte
@@ -166,8 +166,6 @@
         if (e.key === "Escape" && $chatVisibilityStore) {
             closeChat();
             chatIframe.blur();
-        } else if (e.key === "c" && !$chatVisibilityStore) {
-            openChat();
         }
     }
 </script>

--- a/play/src/front/Components/Chat/Chat.svelte
+++ b/play/src/front/Components/Chat/Chat.svelte
@@ -159,9 +159,6 @@
     function closeChat() {
         chatVisibilityStore.set(false);
     }
-    function openChat() {
-        chatVisibilityStore.set(true);
-    }
     function onKeyDown(e: KeyboardEvent) {
         if (e.key === "Escape" && $chatVisibilityStore) {
             closeChat();

--- a/play/src/front/Stores/ChatStore.ts
+++ b/play/src/front/Stores/ChatStore.ts
@@ -147,7 +147,8 @@ function createChatMessagesStore() {
                 iframeListener.sendMessageToChatIframe({
                     type: ChatMessageTypes.text,
                     text: [text],
-                    author: author.userUuid === "dummy" ? author.name : author.userJid,
+                    author: author.userUuid === "dummy" ? null : author.userJid,
+                    name: author.name,
                     date: new Date(),
                 });
 


### PR DESCRIPTION
- Fix the messages sent to the chat by the ScriptingAPI.
- Disable embedly from the chat because the free plan contain too much bug.
- Disable press 'c' to open the chat.
- Fix message input was not empty on send message.