### PR TITLE
Remember currentlyClickedRemotePlayer to dispatch actionsMenuActionClickedEvent

### DIFF
--- a/play/src/front/Api/Iframe/ui.ts
+++ b/play/src/front/Api/Iframe/ui.ts
@@ -111,7 +111,9 @@ export class WorkAdventureUiCommands extends IframeApiContribution<WorkAdventure
         apiCallback({
             type: "remotePlayerClickedEvent",
             callback: (payloadData: AddPlayerEvent) => {
-                this._onRemotePlayerClicked.next(new RemotePlayer(payloadData));
+                const remotePlayer = new RemotePlayer(payloadData);
+                this.currentlyClickedRemotePlayer = remotePlayer;
+                this._onRemotePlayerClicked.next(remotePlayer);
             },
         }),
         apiCallback({


### PR DESCRIPTION
Fixes #2854
## What is the issue

Callbacks for `remotePlayer.addAction` are not being invoked.

https://github.com/thecodingmachine/workadventure/blob/e75a52ac69ef2ad8f3d2fd4a6f8a928003165ebf/front/src/Api/Iframe/ui.ts#L114-L119

`this.currentlyClickedRemotePlayer` is always `undefined` because it is never assigned. This is due this change: https://github.com/thecodingmachine/workadventure/commit/e75a52ac69ef2ad8f3d2fd4a6f8a928003165ebf

### Solution

Assign `this.currentlyClickedRemotePlayer` when `remotePlayerClickedEvent` fires.

## How to test

On a map with the following code:

```
WA.ui.onRemotePlayerClicked.subscribe((remotePlayer: RemotePlayer) => {
        remotePlayer.addAction('Custom menu', () => {
            console.log('callback was invoked');
        });
    });
```

1. Click another player
2. Click button 'Custom menu'

Expected result: Console log message saying 'callback was invoked'


