### PR TITLE
Fixing random disconnects

### DIFF
--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -110,8 +110,8 @@ type UpgradeFailedData = UpgradeFailedErrorData | UpgradeFailedInvalidData;
 
 // Maximum time to wait for a pong answer to a ping before closing connection.
 // Note: PONG_TIMEOUT must be less than PING_INTERVAL
-const PONG_TIMEOUT = 10000;
-const PING_INTERVAL = 15000;
+const PONG_TIMEOUT = 70000; // PONG_TIMEOUT is > 1 minute because of Chrome heavy throttling. See: https://docs.google.com/document/d/11FhKHRcABGS4SWPFGwoL6g0ALMqrFKapCk5ZTKKupEk/edit#
+const PING_INTERVAL = 80000;
 
 export class IoSocketController {
     private nextUserId = 1;


### PR DESCRIPTION
Because of Chrome heavy throttling mechanism (https://docs.google.com/document/d/11FhKHRcABGS4SWPFGwoL6g0ALMqrFKapCk5ZTKKupEk/edit#), we believe some connections can be randomly detected as not acknowledged (if Chrome takes more than 10 seconds to answer) This is surprising because we don't use setTimeout and yet, it seems Chrome can slow down answers on the websocket for some reason.

Here, we are increasing the time allowed to answer a ping request to more than 60 seconds. That should be enough even for a throttled Chrome to answer.