### PR TITLE
Renaming button action bar methods + small changes

### DIFF
--- a/docs/maps/api-ui.md
+++ b/docs/maps/api-ui.md
@@ -375,10 +375,10 @@ If the user is in mobile definition, the modal will open in full screen:
 
 ## Action bar button API
 
-### Add action bar
+### Add a button in the action bar
 
 ```ts
-WA.ui.actionBar.addButtonActionBar(id: sring, label: string, clickCallback: (buttonActionBar: AddButtonActionBar)): void
+WA.ui.actionBar.addButton(id: string, label: string, clickCallback: (buttonActionBar: AddButtonActionBar) => void): void
 ```
 - id: the id of the button action bar defined.
 - label: the label to display in button action bar.
@@ -399,19 +399,19 @@ interface AddButtonActionBar{
 }
 ```
 
-### Remove action bar
+### Remove a button from the action bar
 ```ts
-    WA.ui.actionBar.removeButtonActionBar(id: string);
+    WA.ui.actionBar.removeButton(id: string);
 ```
 - id: the id of the button action bar previously defined.
 
 ### Example of action bar button
 ```ts
     // Add action bar button 'Register'.
-    WA.ui.actionBar.addButtonActionBar('register-btn', 'Regsiter', (event) => {
+    WA.ui.actionBar.addButton('register-btn', 'Regsiter', (event) => {
         console.log('Button registered triggered', event);
         // When user click on the action bar button 'Register', we remove it.
-        WA.ui.actionBar.removeButtonActionBar('register-btn');
+        WA.ui.actionBar.removeButton('register-btn');
     });
 ```
 

--- a/maps/tests/MenuActionBar/addButtonActionBar.js
+++ b/maps/tests/MenuActionBar/addButtonActionBar.js
@@ -2,9 +2,9 @@ console.info('In ten seconds, the tuto modal will be launched')
 
 function launchTuto(){
     console.info('Lunch tuto');
-    WA.ui.actionBar.addButtonActionBar('register-btn', 'Regsiter', (event) => {
+    WA.ui.actionBar.addButton('register-btn', 'Register', (event) => {
         console.log('Button registered triggered', event);
-        WA.ui.actionBar.removeButtonActionBar('register-btn');
+        WA.ui.actionBar.removeButton('register-btn');
     });
 }
 

--- a/play/src/front/Api/Iframe/Ui/ButtonActionBar.ts
+++ b/play/src/front/Api/Iframe/Ui/ButtonActionBar.ts
@@ -26,7 +26,7 @@ export class WorkAdventureButtonActionBarCommands extends IframeApiContribution<
      * @param label
      * @param callback
      */
-    addButtonActionBar(id: string, label: string, callback?: ButtonActionBarClickedCallback) {
+    addButton(id: string, label: string, callback?: ButtonActionBarClickedCallback) {
         if (callback != undefined) this._callbacks.set(id, callback);
         sendToWorkadventure({
             type: "addButtonActionBar",
@@ -40,7 +40,7 @@ export class WorkAdventureButtonActionBarCommands extends IframeApiContribution<
      *
      * @param id
      */
-    removeButtonActionBar(id: string) {
+    removeButton(id: string) {
         this._callbacks.delete(id);
         sendToWorkadventure({ type: "removeButtonActionBar", data: { id } });
     }

--- a/play/src/front/Components/ActionBar/ActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ActionBar.svelte
@@ -376,8 +376,6 @@
                 class:tw-translate-x-0={$bottomActionBarVisibilityStore}
                 class:translate-right={!$bottomActionBarVisibilityStore}
             >
-                <!-- svelte-ignore a11y-click-events-have-key-events -->
-                <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <div
                     class="tw-transition-all bottom-action-button"
                     class:disabled={$followStateStore !== "off"}
@@ -390,7 +388,6 @@
                         <img draggable="false" src={followImg} style="padding: 2px" alt="Toggle follow" />
                     </button>
                 </div>
-                <!-- svelte-ignore a11y-click-events-have-key-events -->
 
                 <div
                     class="tw-transition-all bottom-action-button"
@@ -418,8 +415,6 @@
                     </button>
                 </div>
 
-                <!-- svelte-ignore a11y-click-events-have-key-events -->
-                <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <div
                     class="tw-transition-all bottom-action-button"
                     class:disabled={$currentPlayerGroupLockStateStore}
@@ -441,7 +436,6 @@
                         {/if}
                     </button>
                 </div>
-                <!-- svelte-ignore a11y-click-events-have-key-events -->
 
                 <div
                     class="tw-transition-all bottom-action-button"
@@ -476,7 +470,6 @@
             <div class="bottom-action-section tw-flex tw-flex-initial">
                 {#if !$inExternalServiceStore && !$silentStore && $proximityMeetingStore}
                     {#if $myCameraStore}
-                        <!-- svelte-ignore a11y-click-events-have-key-events -->
                         <div
                             class="bottom-action-button tw-relative"
                             on:click={() => analyticsClient.camera()}
@@ -525,8 +518,6 @@
                                     on:mouseleave={() => (cameraActive = false)}
                                 >
                                     {#each $cameraListStore as camera}
-                                        <!-- svelte-ignore a11y-click-events-have-key-events -->
-                                        <!-- svelte-ignore a11y-click-events-have-key-events -->
                                         <span
                                             class="wa-dropdown-item tw-flex"
                                             on:click|stopPropagation|preventDefault={() =>
@@ -544,7 +535,6 @@
                     {/if}
 
                     {#if $myMicrophoneStore}
-                        <!-- svelte-ignore a11y-click-events-have-key-events -->
                         <div
                             class="bottom-action-button tw-relative"
                             on:click={() => analyticsClient.microphone()}
@@ -591,7 +581,6 @@
                                     on:mouseleave={() => (microphoneActive = false)}
                                 >
                                     {#each $microphoneListStore as microphone}
-                                        <!-- svelte-ignore a11y-click-events-have-key-events -->
                                         <span
                                             class="wa-dropdown-item"
                                             on:click|stopPropagation|preventDefault={() =>
@@ -609,7 +598,6 @@
                     {/if}
                 {/if}
 
-                <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <div
                     on:click={() => analyticsClient.openedChat()}
                     on:click={toggleChat}
@@ -641,7 +629,6 @@
                         </span>
                     {/if}
                 </div>
-                <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <div on:click={toggleEmojiPicker} class="bottom-action-button">
                     <Tooltip text={$LL.actionbar.emoji()} />
 
@@ -652,7 +639,6 @@
             </div>
 
             <div class="bottom-action-section tw-flex tw-flex-initial">
-                <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <div
                     on:dragstart|preventDefault={noDrag}
                     on:click={() => analyticsClient.openedMenu()}
@@ -666,7 +652,6 @@
                     </button>
                 </div>
                 {#if gameManager.getCurrentGameScene().isMapEditorEnabled()}
-                    <!-- svelte-ignore a11y-click-events-have-key-events -->
                     <div
                         on:dragstart|preventDefault={noDrag}
                         on:click={toggleMapEditorMode}
@@ -678,7 +663,6 @@
                     </div>
                 {/if}
                 {#if $userHasAccessToBackOfficeStore}
-                    <!-- svelte-ignore a11y-click-events-have-key-events -->
                     <div
                         on:dragstart|preventDefault={noDrag}
                         on:click={() => analyticsClient.openBackOffice()}
@@ -695,7 +679,6 @@
             </div>
 
             {#if $inviteUserActivated}
-                <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <div
                     class="bottom-action-section tw-flex tw-flex-initial"
                     in:fly={{}}
@@ -734,7 +717,6 @@
             {/if}
             -->
             {#each [...$additionnalButtonsMenu.values()] as button}
-                <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <div
                     class="bottom-action-section tw-flex tw-flex-initial"
                     in:fly={{}}
@@ -819,6 +801,7 @@
         </div>
     </div>
 {/if}
+F
 
 <style lang="scss">
     @import "../../style/breakpoints.scss";

--- a/tests/tests/buttonactionbar_script.spec.ts
+++ b/tests/tests/buttonactionbar_script.spec.ts
@@ -14,8 +14,8 @@ test.describe('Button action bar', () => {
 
         // Use script to add new button
         await evaluateScript(page, async () => {
-            return WA.ui.actionBar.addButtonActionBar('register-btn', 'Regsiter', () => {
-                WA.ui.actionBar.removeButtonActionBar('register-btn');
+            return WA.ui.actionBar.addButton('register-btn', 'Register', () => {
+                WA.ui.actionBar.removeButton('register-btn');
             });
         });
 


### PR DESCRIPTION
Renaming `WA.ui.actionBar.addButtonActionBar` to `WA.ui.actionBar.addButton`.

Also, fixing doc and removing "svelte-ignore" that is handled directly in the configuration.