### PR TITLE
[Draft] Run install only if yarn.lock changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ _
 !/.yarn/releases
 !/.yarn/plugins
 yarn-error.log
+/.yarn.lock.checksum

--- a/xmpp/ejabberd.template.yml
+++ b/xmpp/ejabberd.template.yml
@@ -8,7 +8,7 @@
 hosts:
   - ${EJABBERD_DOMAIN}
 
-loglevel: 5
+loglevel: 3
 log_rotate_size: 10485760
 log_rotate_count: 1
 

--- a/yarn-install.sh
+++ b/yarn-install.sh
@@ -9,4 +9,5 @@ set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 cd "$SCRIPT_DIR"
-flock ./install.lock -c "yarn install"
+
+flock ./install.lock -c "if ( cat .yarn.lock.checksum | shasum -c ); then echo 'Yarn: Nothing to install'; else yarn install && shasum yarn.lock > .yarn.lock.checksum; fi"


### PR DESCRIPTION
This is an optimization to avoid running `yarn install` if the `yarn.lock` file is untouched.

Alas, this currently does not work because of https://github.com/yarnpkg/berry/issues/5134 that makes running "yarn install" having a different behaviour in the containers or out of the containers.