### PR TITLE
Fixing bug after following

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -225,14 +225,11 @@ export class GameRoom implements BrothersFinder {
     }
 
     public leave(user: User) {
-        const userObj = this.users.get(user.id);
-        if (userObj === undefined) {
+        if (!this.users.has(user.id)) {
             console.warn("User ", user.id, "does not belong to this game room! It should!");
         }
-        if (userObj !== undefined && typeof userObj.group !== "undefined") {
-            this.leaveGroup(userObj);
-        }
 
+        // If a user leaves the group, it cannot lead or follow anymore.
         if (user.hasFollowers()) {
             user.stopLeading();
         }
@@ -240,11 +237,15 @@ export class GameRoom implements BrothersFinder {
             user.following.delFollower(user);
         }
 
+        if (user.group !== undefined) {
+            this.leaveGroup(user);
+        }
+
         this.users.delete(user.id);
         this.usersByUuid.delete(user.uuid);
 
-        if (userObj !== undefined) {
-            this.positionNotifier.leave(userObj);
+        if (user !== undefined) {
+            this.positionNotifier.leave(user);
         }
 
         // Notify admins
@@ -415,6 +416,7 @@ export class GameRoom implements BrothersFinder {
         if (group === undefined) {
             throw new Error("The user is part of no group");
         }
+
         group.leave(user);
         if (group.isEmpty()) {
             group.destroy();


### PR DESCRIPTION
There are a number of cases where the users are not correctly marked as "not following" anymore after the leader has left the group. This is the case when a leader enters a "silent" zone (or a Jitsi zone).

Here, we are making the code more robust. If a group has only followers, we still manage to find out its center.

Closes #2868 