### PR TITLE
Fixing GameRoom.usersByUuid removal

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -242,7 +242,13 @@ export class GameRoom implements BrothersFinder {
         }
 
         this.users.delete(user.id);
-        this.usersByUuid.delete(user.uuid);
+        const set = this.usersByUuid.get(user.uuid);
+        if (set !== undefined) {
+            set.delete(user);
+            if (set.size === 0) {
+                this.usersByUuid.delete(user.uuid);
+            }
+        }
 
         if (user !== undefined) {
             this.positionNotifier.leave(user);


### PR DESCRIPTION
The removal of GameRoom.usersByUuid elements was buggy. All users sharing the same UUID were removed when the first user was leaving the room.

This could subsequently cause issues where users were not found by UUID.

This is now fixed.