### PR TITLE
Auto generate area id so that check for different areas actually work

### DIFF
--- a/play/src/front/Phaser/Game/DynamicAreaManager.ts
+++ b/play/src/front/Phaser/Game/DynamicAreaManager.ts
@@ -7,6 +7,7 @@ import type { GameMapFrontWrapper } from "./GameMap/GameMapFrontWrapper";
 export class DynamicAreaManager {
     private readonly gameMapFrontWrapper: GameMapFrontWrapper;
     private readonly subscription: Subscription;
+    private nextAreaId = 1;
 
     constructor(gameMapFrontWrapper: GameMapFrontWrapper) {
         this.gameMapFrontWrapper = gameMapFrontWrapper;
@@ -59,7 +60,7 @@ export class DynamicAreaManager {
             this.gameMapFrontWrapper.addArea(
                 {
                     ...createAreaEvent,
-                    id: -1,
+                    id: this.nextAreaId++,
                     visible: true,
                     properties: {
                         customProperties: {},


### PR DESCRIPTION
Fixes #2920

Generates a sequential id so that it doesn't prevent creating multiple dynamic areas