### PR TITLE
Adding the Github Token in aduino/setup-protoc action

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: '3.x'
 
       - name: "Install dependencies"
@@ -110,6 +111,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: '3.x'
 
       # - name: "Copy libs dependencies"
@@ -185,6 +187,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: '3.x'
 
       - name: "Install dependencies"
@@ -269,6 +272,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: '3.x'
 
       - name: "Install dependencies"

--- a/.github/workflows/push-to-npm.yml
+++ b/.github/workflows/push-to-npm.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: '3.x'
 
       - name: "Install play dependencies"


### PR DESCRIPTION
Sometimes, the action would fail because of a "rate limit exceeded" error. This token should solve the issue.