### PR TITLE
Allow passing authToken via POST and not only GET to keep clean logs

### DIFF
--- a/play/index.html
+++ b/play/index.html
@@ -55,6 +55,7 @@
         </script>
     </head>
     <body id="body" style="margin: 0; background-color: #000">
+        <input type="hidden" id="authToken" value="{{ authToken }}" name="authToken">
         <div class="main-container" id="main-container">
             <!-- Create the editor container -->
             <div id="game" class="game">

--- a/play/src/front/Connexion/ConnectionManager.ts
+++ b/play/src/front/Connexion/ConnectionManager.ts
@@ -1,3 +1,4 @@
+import { HtmlUtils } from "./../WebRtc/HtmlUtils";
 import Axios from "axios";
 import { ENABLE_OPENID, PUSHER_URL } from "../Enum/EnvironmentVariable";
 import { RoomConnection } from "./RoomConnection";
@@ -88,8 +89,14 @@ class ConnectionManager {
         this._currentRoom = null;
 
         const urlParams = new URLSearchParams(window.location.search);
-        const token = urlParams.get("token");
-        if (token) {
+        let token = urlParams.get("token");
+        // get token injected by post method from pusher
+        if (token == undefined) {
+            const input = HtmlUtils.getElementByIdOrFail("authToken");
+            if (input.value != undefined && input.value != "") token = input.value;
+        }
+
+        if (token != undefined) {
             this.authToken = token;
             localUserStore.setAuthToken(token);
 

--- a/play/src/pusher/controllers/FrontController.ts
+++ b/play/src/pusher/controllers/FrontController.ts
@@ -51,8 +51,20 @@ export class FrontController extends BaseHttpController {
              */
             return this.displayFront(req, res, this.getFullUrl(req));
         });
+        this.app.post("/_/*", (req: Request, res: Response) => {
+            /**
+             * get infos from map file details
+             */
+            return this.displayFront(req, res, this.getFullUrl(req));
+        });
 
         this.app.get("/*/*", (req: Request, res: Response) => {
+            /**
+             * get infos from map file details
+             */
+            return this.displayFront(req, res, this.getFullUrl(req));
+        });
+        this.app.post("/*/*", (req: Request, res: Response) => {
             /**
              * get infos from map file details
              */
@@ -65,8 +77,20 @@ export class FrontController extends BaseHttpController {
              */
             return this.displayFront(req, res, this.getFullUrl(req));
         });
+        this.app.post("/@/*", (req: Request, res: Response) => {
+            /**
+             * get infos from admin else map file details
+             */
+            return this.displayFront(req, res, this.getFullUrl(req));
+        });
 
         this.app.get("/~/*", (req: Request, res: Response) => {
+            /**
+             * get infos from map file details
+             */
+            return this.displayFront(req, res, this.getFullUrl(req));
+        });
+        this.app.post("/~/*", (req: Request, res: Response) => {
             /**
              * get infos from map file details
              */
@@ -156,6 +180,9 @@ export class FrontController extends BaseHttpController {
             return res.redirect(redirectUrl);
         }
 
+        // get auth token from post /authToken
+        const { authToken } = await req.urlencoded();
+
         try {
             const metaTagsData = await builder.getMeta(req.header("User-Agent"));
             html = Mustache.render(this.indexFile, {
@@ -163,6 +190,7 @@ export class FrontController extends BaseHttpController {
                 msApplicationTileImage: metaTagsData.favIcons[metaTagsData.favIcons.length - 1].src,
                 url,
                 script: this.script,
+                authToken: authToken,
             });
         } catch (e) {
             console.log(`Cannot render metatags on ${url}`, e);


### PR DESCRIPTION
 - Create endpoint post to share auth token
 - Add hidden input auth token, get by connection manager if there are no token in the url