### PR TITLE
Fix issue on MapStore.has

### DIFF
--- a/libs/store-utils/src/MapStore.ts
+++ b/libs/store-utils/src/MapStore.ts
@@ -64,12 +64,12 @@ export class MapStore<K, V> extends Map<K, V> implements Readable<Map<K, V>> {
         return this;
     }
 
-    has(key: K): boolean {
-        return this.storesByKey.has(key);
-    }
-
     getStore(key: K): Readable<V | undefined> {
-        const store = writable(this.get(key), () => {
+        let store = this.storesByKey.get(key);
+        if (store !== undefined) {
+            return store;
+        }
+        store = writable(this.get(key), () => {
             return () => {
                 // No more subscribers!
                 this.storesByKey.delete(key);

--- a/play/tests/front/Stores/Utils/MapStore.test.ts
+++ b/play/tests/front/Stores/Utils/MapStore.test.ts
@@ -16,14 +16,17 @@ describe("Main store", () => {
 
         expect(triggered).toBe(true);
         triggered = false;
+        expect(mapStore.has("foo")).toBe(false);
         mapStore.set("foo", "bar");
         expect(triggered).toBe(true);
+        expect(mapStore.has("foo")).toBe(true);
 
         triggered = false;
         mapStore.delete("baz");
         expect(triggered).toBe(false);
         mapStore.delete("foo");
         expect(triggered).toBe(true);
+        expect(mapStore.has("foo")).toBe(false);
 
         triggered = false;
         mapStore.clear();


### PR DESCRIPTION
The MapStore.has was overloaded when it should never have. Removing the overload.

Also, avoiding creating several writable stores in "getStore" when only one is needed.