### PR TITLE
Allow accessing traefik dashboard from outside container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
             - "8080"
         ports:
             - "80:80"
+            - "8080:8080"
         command:
             - --api.insecure=true
             - --providers.docker


### PR DESCRIPTION
Currently this is not accessible when starting the containers using docker-compose, even though it's mentioned in the README that it should be.