### PR TITLE
Fixing jitsiRoomAdminTag

### DIFF
--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -680,7 +680,11 @@ export class SocketManager {
         if (user.tags.includes("admin")) {
             isAdmin = true;
         } else {
-            const moderatorTag = await gameRoom.getModeratorTagForJitsiRoom(jitsiRoom);
+            // Let's remove the prefix added by the front to make the Jitsi room unique:
+            // Note: this is not 100% perfect as this will fail on Jitsi rooms with "NoPrefix" option set and containing a "-" in the room name.
+            const jitsiRoomSuffix = jitsiRoom.match(/\w*-(.+)/);
+            const finalRoomName = jitsiRoomSuffix && jitsiRoomSuffix[1] ? jitsiRoomSuffix[1] : jitsiRoom;
+            const moderatorTag = await gameRoom.getModeratorTagForJitsiRoom(finalRoomName);
             if (moderatorTag && user.tags.includes(moderatorTag)) {
                 isAdmin = true;
             }

--- a/maps/tests/index.html
+++ b/maps/tests/index.html
@@ -478,6 +478,14 @@
                         <a href="#" class="testLink" data-testmap="CoWebsite/cowebsite_jitsiroom.json" target="_blank">Open co-websites and Jitsi room by layer properties</a>
                     </td>
                 </tr>
+                <tr>
+                    <td>
+                        <input type="radio" name="test-jitsi_room_admin_tag"> Success <input type="radio" name="test-jitsi_room_admin_tag"> Failure <input type="radio" name="test-jitsi_room_admin_tag" checked> Pending
+                    </td>
+                    <td>
+                        <a href="#" class="testLink" data-testmap="jitsi_room_admin_tag.json" target="_blank">Test moderation of Jitsi rooms <i>Requires an admin and a non local environment</i></a>
+                    </td>
+                </tr>
             </table>
             <h2>Pathfinding</h2>
             <table class="table">

--- a/maps/tests/jitsi_room_admin_tag.json
+++ b/maps/tests/jitsi_room_admin_tag.json
@@ -1,0 +1,138 @@
+{ "compressionlevel":-1,
+ "height":10,
+ "infinite":false,
+ "layers":[
+        {
+         "data":[1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+         "height":10,
+         "id":1,
+         "name":"floor",
+         "opacity":1,
+         "type":"tilelayer",
+         "visible":true,
+         "width":10,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "data":[0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            12, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+         "height":10,
+         "id":2,
+         "name":"start",
+         "opacity":1,
+         "type":"tilelayer",
+         "visible":true,
+         "width":10,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "data":[0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 34, 34, 34, 34, 34,
+            0, 0, 0, 0, 0, 34, 34, 34, 34, 34,
+            0, 0, 0, 0, 0, 34, 34, 34, 34, 34,
+            0, 0, 0, 0, 0, 34, 34, 34, 34, 34,
+            0, 0, 0, 0, 0, 34, 34, 34, 34, 34,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+         "height":10,
+         "id":5,
+         "name":"jitsiConf",
+         "opacity":1,
+         "properties":[
+                {
+                 "name":"jitsiRoom",
+                 "type":"string",
+                 "value":"myRoom"
+                }, 
+                {
+                 "name":"jitsiRoomAdminTag",
+                 "type":"string",
+                 "value":"speaker"
+                }],
+         "type":"tilelayer",
+         "visible":true,
+         "width":10,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "draworder":"topdown",
+         "id":3,
+         "name":"floorLayer",
+         "objects":[
+                {
+                 "class":"",
+                 "height":163.652982988579,
+                 "id":1,
+                 "name":"",
+                 "properties":[
+                        {
+                         "name":"font-family",
+                         "type":"string",
+                         "value":"\"Press Start 2P\""
+                        }],
+                 "rotation":0,
+                 "text":
+                    {
+                     "fontfamily":"Sans Serif",
+                     "pixelsize":8,
+                     "text":"Test:\nTo be done with the admin: create a room in the admin referencing this map. Create a member with the \"speaker\" tag.\nGo to that room.\n\nNote: you cannot perform this test if the room is hosted locally.\n\nResult:\nJitsi opens in moderator mode.",
+                     "wrap":true
+                    },
+                 "visible":true,
+                 "width":317.361946929159,
+                 "x":2.32853056864467,
+                 "y":2.25624950083909
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "x":0,
+         "y":0
+        }],
+ "nextlayerid":6,
+ "nextobjectid":2,
+ "orientation":"orthogonal",
+ "renderorder":"right-down",
+ "tiledversion":"1.9.2",
+ "tileheight":32,
+ "tilesets":[
+        {
+         "columns":11,
+         "firstgid":1,
+         "image":"tileset1.png",
+         "imageheight":352,
+         "imagewidth":352,
+         "margin":0,
+         "name":"tileset1",
+         "spacing":0,
+         "tilecount":121,
+         "tileheight":32,
+         "tilewidth":32
+        }],
+ "tilewidth":32,
+ "type":"map",
+ "version":"1.9",
+ "width":10
+}


### PR DESCRIPTION
jitsiRoomAdminTag was not correctly handled in the back since we added prefixes in the rooms.

The fix removes the prefix automatically in the back.