### PR TITLE
Fixing jitsiRoomAdminTag not handled when uppercase jitsi room name

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -280,6 +280,54 @@ jobs:
         run: npm test
         working-directory: "libs/map-editor"
 
+  continuous-integration-shared-utils:
+    name: "Continuous Integration shared-utils Library"
+
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2.0.0"
+
+      - name: "Setup NodeJS"
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "npm"
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: '3.x'
+
+      - name: "Install dependencies"
+        run: npm ci --workspace=@workadventure/shared-utils
+
+      - name: "Install messages dependencies"
+        run: npm ci
+        working-directory: "messages"
+
+      - name: "Build proto messages"
+        run: npm run ts-proto && npm run proto
+        working-directory: "messages"
+
+      - name: "Typecheck"
+        run: npm run typecheck
+        working-directory: "libs/shared-utils"
+
+      - name: "Lint"
+        run: npm run lint
+        working-directory: "libs/shared-utils"
+
+      - name: "Pretty"
+        run: npm run pretty-check
+        working-directory: "libs/shared-utils"
+
+      - name: "jest"
+        run: npm test
+        working-directory: "libs/shared-utils"
+
   continuous-integration-map-storage:
     name: "Continuous Integration Map Storage"
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -28,3 +28,7 @@ npm run precommit
 cd libs/map-editor || exit
 npm run precommit
 )
+(
+cd libs/shared-utils || exit
+npm run precommit
+)

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -18,6 +18,7 @@ COPY libs/map-editor/package.json libs/map-editor/package.json
 COPY libs/math-utils/package.json libs/math-utils/package.json
 COPY libs/tailwind/package.json libs/tailwind/package.json
 COPY libs/store-utils/package.json libs/store-utils/package.json
+COPY libs/shared-utils/package.json libs/shared-utils/package.json
 ENV NODE_ENV=production
 RUN npm ci --omit=dev --workspace workadventureback
 COPY libs ./libs

--- a/back/package.json
+++ b/back/package.json
@@ -43,6 +43,7 @@
     "@anatine/zod-openapi": "^1.3.0",
     "@grpc/grpc-js": "^1.7.1",
     "@workadventure/messages": "1.0.0",
+    "@workadventure/shared-utils": "1.0.0",
     "@workadventure/tiled-map-type-guard": "^2.1.0",
     "axios": "^0.21.2",
     "bigbluebutton-js": "^0.1.1",

--- a/back/src/Services/ModeratorTagFinder.ts
+++ b/back/src/Services/ModeratorTagFinder.ts
@@ -6,41 +6,37 @@ export class ModeratorTagFinder {
      */
     private _roomModerators = new Map<string, string>();
 
-    constructor(private map: ITiledMap, mainProperty: string, tagProperty: string) {
+    constructor(
+        private map: ITiledMap,
+        private parseProperty: (properties: ITiledMapProperty[]) => { mainValue: string; tagValue: string } | undefined
+    ) {
         for (const layer of map.layers) {
-            this.findModeratorTagInLayer(layer, mainProperty, tagProperty);
+            this.findModeratorTagInLayer(layer);
         }
     }
 
-    private findModeratorTagInLayer(layer: ITiledMapLayer, mainProperty: string, tagProperty: string) {
+    private findModeratorTagInLayer(layer: ITiledMapLayer) {
         if (layer.type === "objectgroup") {
             for (const object of layer.objects) {
                 if (object.class === "area" || object.type === "area") {
-                    this.registerProperties(layer.properties ?? [], mainProperty, tagProperty);
+                    this.registerProperties(layer.properties ?? []);
                 }
             }
         } else if (layer.type === "tilelayer") {
-            this.registerProperties(layer.properties ?? [], mainProperty, tagProperty);
+            this.registerProperties(layer.properties ?? []);
         } else if (layer.type === "group") {
             for (const innerLayer of layer.layers) {
-                this.findModeratorTagInLayer(innerLayer, mainProperty, tagProperty);
+                this.findModeratorTagInLayer(innerLayer);
             }
         }
     }
 
-    private registerProperties(properties: ITiledMapProperty[], mainProperty: string, tagProperty: string): void {
-        let mainValue: string | undefined = undefined;
-        let tagValue: string | undefined = undefined;
-        for (const property of properties ?? []) {
-            if (property.name === mainProperty && typeof property.value === "string") {
-                mainValue = property.value;
-            } else if (property.name === tagProperty && typeof property.value === "string") {
-                tagValue = property.value;
-            }
+    private registerProperties(properties: ITiledMapProperty[]): void {
+        const result = this.parseProperty(properties);
+        if (result === undefined) {
+            return;
         }
-        if (mainValue !== undefined && tagValue !== undefined) {
-            this._roomModerators.set(mainValue, tagValue);
-        }
+        this._roomModerators.set(result.mainValue, result.tagValue);
     }
 
     public getModeratorTag(roomName: string): string | undefined {

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -714,11 +714,7 @@ export class SocketManager {
         if (user.tags.includes("admin")) {
             isAdmin = true;
         } else {
-            // Let's remove the prefix added by the front to make the Jitsi room unique:
-            // Note: this is not 100% perfect as this will fail on Jitsi rooms with "NoPrefix" option set and containing a "-" in the room name.
-            const jitsiRoomSuffix = jitsiRoom.match(/\w*-(.+)/);
-            const finalRoomName = jitsiRoomSuffix && jitsiRoomSuffix[1] ? jitsiRoomSuffix[1] : jitsiRoom;
-            const moderatorTag = await gameRoom.getModeratorTagForJitsiRoom(finalRoomName);
+            const moderatorTag = await gameRoom.getModeratorTagForJitsiRoom(jitsiRoom);
             if (moderatorTag && user.tags.includes(moderatorTag)) {
                 isAdmin = true;
             }

--- a/docker-compose.minio.yaml
+++ b/docker-compose.minio.yaml
@@ -28,12 +28,16 @@ services:
 
   map-storage:
     environment:
-      AWS_ACCESS_KEY_ID: "minio-access-key"
-      AWS_SECRET_ACCESS_KEY: "minio-secret-access-key"
+#      AWS_ACCESS_KEY_ID: "minio-access-key"
+#      AWS_SECRET_ACCESS_KEY: "minio-secret-access-key"
+#      AWS_DEFAULT_REGION: "eu-west-1"
+#      AWS_BUCKET: "mapstorage"
+#      AWS_URL: "http://minio-mapstorage:9000"
+#      AWS_ENDPOINT: "http://cdn-mapstorage.workadventure.localhost/"
+      AWS_ACCESS_KEY_ID: "AKIAUKVIEPEMFALFADUN"
+      AWS_SECRET_ACCESS_KEY: "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"
       AWS_DEFAULT_REGION: "eu-west-1"
-      AWS_BUCKET: "mapstorage"
-      AWS_URL: "http://minio-mapstorage:9000"
-      AWS_ENDPOINT: "http://cdn-mapstorage.workadventure.localhost/"
+      AWS_BUCKET: "workadventure-map-storage-staging"
       USE_DOMAIN_NAME_IN_PATH: "true"
 
 

--- a/libs/shared-utils/.eslintrc.js
+++ b/libs/shared-utils/.eslintrc.js
@@ -1,0 +1,31 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir : __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint/eslint-plugin'],
+  extends: [
+    'eslint:recommended',
+    "plugin:@typescript-eslint/eslint-recommended",
+    'plugin:@typescript-eslint/recommended',
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    'plugin:prettier/recommended',
+  ],
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  ignorePatterns: ['.eslintrc.js'],
+  rules: {
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-explicit-any': 'error',
+    "@typescript-eslint/no-unused-vars": [
+      "error", { "args": "none", "caughtErrors": "all", "varsIgnorePattern": "_exhaustiveCheck" }
+    ],
+  },
+};

--- a/libs/shared-utils/.gitignore
+++ b/libs/shared-utils/.gitignore
@@ -1,0 +1,3 @@
+/dist
+/node_modules
+/coverage

--- a/libs/shared-utils/.prettierrc
+++ b/libs/shared-utils/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 120,
+  "tabWidth": 4
+}

--- a/libs/shared-utils/README.md
+++ b/libs/shared-utils/README.md
@@ -1,0 +1,3 @@
+# Shared utils for WorkAdventure
+
+A very small library containing the few utility functions that need to be shared between some containers.

--- a/libs/shared-utils/jest.config.js
+++ b/libs/shared-utils/jest.config.js
@@ -1,0 +1,13 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+    preset: "ts-jest",
+    testEnvironment: "node",
+    transform: {
+        "^.+\\.ts?$": "ts-jest",
+    },
+    transformIgnorePatterns: ["<rootDir>/node_modules/"],
+    roots: [
+      "./tests"
+    ],
+    //globalSetup: "<rootDir>/tests/globalTestSetup.ts"
+};

--- a/libs/shared-utils/package.json
+++ b/libs/shared-utils/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@workadventure/shared-utils",
+  "version": "1.0.0",
+  "description": "Map Editor commands types",
+  "main": "./src/index.ts",
+  "scripts": {
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "precommit": "lint-staged",
+    "pretty": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "pretty-check": "prettier --check 'src/**/*.{ts,tsx}' 'tests/**/*.{ts,tsx}'",
+    "test": "jest --detectOpenHandles",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "typecheck": "tsc --noEmit",
+    "build": "tsc"
+  },
+  "author": "WorkAdventure",
+  "license": "ISC",
+  "dependencies": {
+    "@workadventure/map-editor": "1.0.0",
+    "@workadventure/tiled-map-type-guard": "^2.1.0"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.3.1",
+    "@types/node": "^18.11.18",
+    "@typescript-eslint/eslint-plugin": "^5.48.1",
+    "@typescript-eslint/parser": "^5.48.1",
+    "eslint": "^8.31.0",
+    "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "jest": "^29.3.1",
+    "lint-staged": "^13.1.0",
+    "prettier": "^2.8.2",
+    "ts-jest": "^29.0.3",
+    "typescript": "^4.9.4"
+  },
+  "files": [
+    "src"
+  ],
+  "lint-staged": {
+    "*.ts": [
+      "eslint --fix",
+      "prettier --write"
+    ]
+  }
+}

--- a/libs/shared-utils/src/Jitsi/slugify.ts
+++ b/libs/shared-utils/src/Jitsi/slugify.ts
@@ -1,0 +1,27 @@
+import { shortHash } from "../String/shartHash";
+import { GameMapProperties } from "@workadventure/map-editor";
+import { Json } from "@workadventure/tiled-map-type-guard";
+
+const slugify = (...args: (string | number)[]): string => {
+    const value = args.join(" ");
+
+    return value
+        .normalize("NFD") // split an accented letter in the base letter and the accent
+        .replace(/[\u0300-\u036f]/g, "") // remove all previously split accents
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9-_ ]/g, "") // remove all chars not letters, numbers, dash, underscores and spaces (to be replaced)
+        .replace(/\s+/g, "-"); // separator
+};
+
+export function slugifyJitsiRoomName(
+    roomName: string,
+    roomId: string,
+    allProps: Map<string, string | number | boolean | Json>
+): string {
+    let addPrefix = true;
+    if (allProps.get(GameMapProperties.JITSI_NO_PREFIX)) {
+        addPrefix = false;
+    }
+    return slugify((addPrefix ? shortHash(roomId) + "-" : "") + roomName);
+}

--- a/libs/shared-utils/src/String/shartHash.ts
+++ b/libs/shared-utils/src/String/shartHash.ts
@@ -1,0 +1,16 @@
+/**
+ * Computes a "short URL" hash of the string passed in parameter.
+ */
+export function shortHash(s: string): string {
+    let hash = 0;
+    const strLength = s.length;
+    if (strLength === 0) {
+        return "";
+    }
+    for (let i = 0; i < strLength; i++) {
+        const c = s.charCodeAt(i);
+        hash = (hash << 5) - hash + c;
+        hash = hash & hash; // Convert to 32bit integer
+    }
+    return Math.abs(hash).toString(36);
+}

--- a/libs/shared-utils/tests/Jitsi/slugify.spec.ts
+++ b/libs/shared-utils/tests/Jitsi/slugify.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "@jest/globals";
+import { slugifyJitsiRoomName } from "../../src/Jitsi/slugify";
+import { Json } from "@workadventure/tiled-map-type-guard";
+
+describe("Shared utils", () => {
+    it("should slugify Jitsi room", () => {
+        const properties = new Map<string, string | number | boolean | Json>();
+        const jitsiRoom = slugifyJitsiRoomName(
+            "Foo",
+            "https://play.workadventure.localhost/_/foo/bar.com/map.tmj",
+            properties
+        );
+
+        expect(jitsiRoom).toBe("y6v7zb-foo");
+
+        properties.set("jitsiNoPrefix", true);
+        const jitsiRoom2 = slugifyJitsiRoomName(
+            "Foo",
+            "https://play.workadventure.localhost/_/foo/bar.com/map.tmj",
+            properties
+        );
+
+        expect(jitsiRoom2).toBe("foo");
+    });
+});

--- a/libs/shared-utils/tsconfig.json
+++ b/libs/shared-utils/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+      "rootDir": ".",
+      "outDir": "dist",
+      "target": "ES2020",
+      "lib": [
+        "es2019",
+        "dom",
+      ],
+      "module": "CommonJS",
+      "esModuleInterop": true,
+      "strict": true,
+      "declaration": true,
+      "sourceMap": true,
+      "importsNotUsedAsValues": "remove"
+    }
+  }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@anatine/zod-openapi": "^1.3.0",
         "@grpc/grpc-js": "^1.7.1",
         "@workadventure/messages": "1.0.0",
+        "@workadventure/shared-utils": "1.0.0",
         "@workadventure/tiled-map-type-guard": "^2.1.0",
         "axios": "^0.21.2",
         "bigbluebutton-js": "^0.1.1",
@@ -521,6 +522,207 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "libs/shared-utils": {
+      "name": "@workadventure/shared-utils",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@workadventure/map-editor": "1.0.0",
+        "@workadventure/tiled-map-type-guard": "^2.1.0"
+      },
+      "devDependencies": {
+        "@jest/globals": "^29.3.1",
+        "@types/node": "^18.11.18",
+        "@typescript-eslint/eslint-plugin": "^5.48.1",
+        "@typescript-eslint/parser": "^5.48.1",
+        "eslint": "^8.31.0",
+        "eslint-config-prettier": "^8.6.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "jest": "^29.3.1",
+        "lint-staged": "^13.1.0",
+        "prettier": "^2.8.2",
+        "ts-jest": "^29.0.3",
+        "typescript": "^4.9.4"
+      }
+    },
+    "libs/shared-utils/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "libs/shared-utils/node_modules/execa": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^3.0.1",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "libs/shared-utils/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "libs/shared-utils/node_modules/lilconfig": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "libs/shared-utils/node_modules/lint-staged": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.1.0.tgz",
+      "integrity": "sha512-pn/sR8IrcF/T0vpWLilih8jmVouMlxqXxKuAojmbiGX5n/gDnz+abdPptlj0vYnbfE0SQNl3CY/HwtM0+yfOVQ==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^3.1.0",
+        "colorette": "^2.0.19",
+        "commander": "^9.4.1",
+        "debug": "^4.3.4",
+        "execa": "^6.1.0",
+        "lilconfig": "2.0.6",
+        "listr2": "^5.0.5",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "object-inspect": "^1.12.2",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.1",
+        "yaml": "^2.1.3"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "libs/shared-utils/node_modules/listr2": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.7.tgz",
+      "integrity": "sha512-MD+qXHPmtivrHIDRwPYdfNkrzqDiuaKU/rfBcec3WMyMF3xylQj3jMq344OtvQxz7zaCFViRAeqlr2AFhPvXHw==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.19",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.8.0",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
+      },
+      "peerDependenciesMeta": {
+        "enquirer": {
+          "optional": true
+        }
+      }
+    },
+    "libs/shared-utils/node_modules/listr2/node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "libs/shared-utils/node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "libs/shared-utils/node_modules/rxjs": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "libs/shared-utils/node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "libs/shared-utils/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "libs/shared-utils/node_modules/yaml": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "libs/store-utils": {
       "name": "@workadventure/store-utils",
@@ -6027,6 +6229,10 @@
     },
     "node_modules/@workadventure/messages": {
       "resolved": "libs/messages",
+      "link": true
+    },
+    "node_modules/@workadventure/shared-utils": {
+      "resolved": "libs/shared-utils",
       "link": true
     },
     "node_modules/@workadventure/store-utils": {
@@ -21177,6 +21383,7 @@
         "@workadventure/map-editor": "1.0.0",
         "@workadventure/math-utils": "1.0.0",
         "@workadventure/messages": "1.0.0",
+        "@workadventure/shared-utils": "1.0.0",
         "@workadventure/store-utils": "1.0.0",
         "@workadventure/tailwind": "1.0.0",
         "@workadventure/tiled-map-type-guard": "^2.1.0",
@@ -26376,6 +26583,154 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@workadventure/shared-utils": {
+      "version": "file:libs/shared-utils",
+      "requires": {
+        "@jest/globals": "^29.3.1",
+        "@types/node": "^18.11.18",
+        "@typescript-eslint/eslint-plugin": "^5.48.1",
+        "@typescript-eslint/parser": "^5.48.1",
+        "@workadventure/map-editor": "1.0.0",
+        "@workadventure/tiled-map-type-guard": "^2.1.0",
+        "eslint": "^8.31.0",
+        "eslint-config-prettier": "^8.6.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "jest": "^29.3.1",
+        "lint-staged": "^13.1.0",
+        "prettier": "^2.8.2",
+        "ts-jest": "^29.0.3",
+        "typescript": "^4.9.4"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "execa": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+          "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^3.0.1",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "lilconfig": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+          "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+          "dev": true
+        },
+        "lint-staged": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.1.0.tgz",
+          "integrity": "sha512-pn/sR8IrcF/T0vpWLilih8jmVouMlxqXxKuAojmbiGX5n/gDnz+abdPptlj0vYnbfE0SQNl3CY/HwtM0+yfOVQ==",
+          "dev": true,
+          "requires": {
+            "cli-truncate": "^3.1.0",
+            "colorette": "^2.0.19",
+            "commander": "^9.4.1",
+            "debug": "^4.3.4",
+            "execa": "^6.1.0",
+            "lilconfig": "2.0.6",
+            "listr2": "^5.0.5",
+            "micromatch": "^4.0.5",
+            "normalize-path": "^3.0.0",
+            "object-inspect": "^1.12.2",
+            "pidtree": "^0.6.0",
+            "string-argv": "^0.3.1",
+            "yaml": "^2.1.3"
+          }
+        },
+        "listr2": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.7.tgz",
+          "integrity": "sha512-MD+qXHPmtivrHIDRwPYdfNkrzqDiuaKU/rfBcec3WMyMF3xylQj3jMq344OtvQxz7zaCFViRAeqlr2AFhPvXHw==",
+          "dev": true,
+          "requires": {
+            "cli-truncate": "^2.1.0",
+            "colorette": "^2.0.19",
+            "log-update": "^4.0.0",
+            "p-map": "^4.0.0",
+            "rfdc": "^1.3.0",
+            "rxjs": "^7.8.0",
+            "through": "^2.3.8",
+            "wrap-ansi": "^7.0.0"
+          },
+          "dependencies": {
+            "cli-truncate": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+              "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+              "dev": true,
+              "requires": {
+                "slice-ansi": "^3.0.0",
+                "string-width": "^4.2.0"
+              }
+            }
+          }
+        },
+        "pidtree": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+          "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+          "dev": true
+        },
+        "rxjs": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+          "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "yaml": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+          "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+          "dev": true
         }
       }
     },
@@ -37705,6 +38060,7 @@
         "@workadventure/map-editor": "1.0.0",
         "@workadventure/math-utils": "1.0.0",
         "@workadventure/messages": "1.0.0",
+        "@workadventure/shared-utils": "1.0.0",
         "@workadventure/store-utils": "1.0.0",
         "@workadventure/tailwind": "1.0.0",
         "@workadventure/tiled-map-type-guard": "^2.1.0",
@@ -37876,6 +38232,7 @@
         "@typescript-eslint/eslint-plugin": "^5.8.0",
         "@typescript-eslint/parser": "^5.8.0",
         "@workadventure/messages": "1.0.0",
+        "@workadventure/shared-utils": "1.0.0",
         "@workadventure/tiled-map-type-guard": "^2.1.0",
         "axios": "^0.21.2",
         "bigbluebutton-js": "^0.1.1",

--- a/play/Dockerfile
+++ b/play/Dockerfile
@@ -19,6 +19,7 @@ COPY libs/map-editor/package.json libs/map-editor/package.json
 COPY libs/math-utils/package.json libs/math-utils/package.json
 COPY libs/tailwind/package.json libs/tailwind/package.json
 COPY libs/store-utils/package.json libs/store-utils/package.json
+COPY libs/shared-utils/package.json libs/shared-utils/package.json
 RUN npm ci --workspace=workadventure-play --workspace=@workadventure/iframe-api-typings...
 COPY libs ./libs
 COPY --from=proto-builder /usr/libs/messages/src ./libs/messages/src
@@ -40,6 +41,7 @@ COPY libs/map-editor/package.json libs/map-editor/package.json
 COPY libs/math-utils/package.json libs/math-utils/package.json
 COPY libs/tailwind/package.json libs/tailwind/package.json
 COPY libs/store-utils/package.json libs/store-utils/package.json
+COPY libs/shared-utils/package.json libs/shared-utils/package.json
 ENV NODE_ENV=production
 RUN npm ci --omit=dev --workspace workadventure-play
 COPY --from=builder /usr/src/libs /usr/src/libs

--- a/play/package.json
+++ b/play/package.json
@@ -99,6 +99,7 @@
     "@workadventure/map-editor": "1.0.0",
     "@workadventure/math-utils": "1.0.0",
     "@workadventure/messages": "1.0.0",
+    "@workadventure/shared-utils": "1.0.0",
     "@workadventure/store-utils": "1.0.0",
     "@workadventure/tailwind": "1.0.0",
     "@workadventure/tiled-map-type-guard": "^2.1.0",

--- a/play/src/front/Phaser/Game/GameMapPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/GameMapPropertiesListener.ts
@@ -7,7 +7,6 @@ import { get } from "svelte/store";
 import { ON_ACTION_TRIGGER_BUTTON, ON_ICON_TRIGGER_BUTTON } from "../../WebRtc/LayoutManager";
 import type { CoWebsite } from "../../WebRtc/CoWebsite/CoWesbite";
 import { SimpleCoWebsite } from "../../WebRtc/CoWebsite/SimpleCoWebsite";
-import { jitsiFactory } from "../../WebRtc/JitsiFactory";
 import { bbbFactory } from "../../WebRtc/BBBFactory";
 import { JITSI_PRIVATE_MODE, JITSI_URL } from "../../Enum/EnvironmentVariable";
 import { JitsiCoWebsite } from "../../WebRtc/CoWebsite/JitsiCoWebsite";
@@ -22,6 +21,7 @@ import { chatZoneLiveStore } from "../../Stores/ChatStore";
 import type { GameMapFrontWrapper } from "./GameMap/GameMapFrontWrapper";
 import { GameMapProperties } from "@workadventure/map-editor";
 import { connectionManager } from "../../Connexion/ConnectionManager";
+import { slugifyJitsiRoomName } from "@workadventure/shared-utils/src/Jitsi/slugify";
 
 interface OpenCoWebsite {
     actionId: string;
@@ -78,11 +78,7 @@ export class GameMapPropertiesListener {
                 }
             }
             const openJitsiRoomFunction = async () => {
-                let addPrefix = true;
-                if (allProps.get(GameMapProperties.JITSI_NO_PREFIX)) {
-                    addPrefix = false;
-                }
-                const roomName = jitsiFactory.getRoomName(newValue.toString(), this.scene.roomUrl, addPrefix);
+                const roomName = slugifyJitsiRoomName(newValue.toString(), this.scene.roomUrl, allProps);
                 let jitsiUrl = allProps.get(GameMapProperties.JITSI_URL) as string | undefined;
 
                 let jwt: string | undefined;

--- a/play/src/front/Utils/StringUtils.ts
+++ b/play/src/front/Utils/StringUtils.ts
@@ -10,23 +10,6 @@ export class StringUtils {
         return { x: values[0], y: values[1] };
     }
 
-    /**
-     * Computes a "short URL" hash of the string passed in parameter.
-     */
-    public static shortHash = function (s: string): string {
-        let hash = 0;
-        const strLength = s.length;
-        if (strLength === 0) {
-            return "";
-        }
-        for (let i = 0; i < strLength; i++) {
-            const c = s.charCodeAt(i);
-            hash = (hash << 5) - hash + c;
-            hash = hash & hash; // Convert to 32bit integer
-        }
-        return Math.abs(hash).toString(36);
-    };
-
     public static normalizeDeviceName = function (label: string): string {
         // remove IDs (that can appear in Chrome, like: "HD Pro Webcam (4df7:4eda)"
         return label.replace(/(\([[0-9a-f]{4}:[0-9a-f]{4}\))/g, "").trim();

--- a/play/src/front/WebRtc/JitsiFactory.ts
+++ b/play/src/front/WebRtc/JitsiFactory.ts
@@ -5,7 +5,6 @@ import { get } from "svelte/store";
 import CancelablePromise from "cancelable-promise";
 import { gameManager } from "../Phaser/Game/GameManager";
 import { jitsiParticipantsCountStore, userIsJitsiDominantSpeakerStore } from "../Stores/GameStore";
-import { StringUtils } from "../Utils/StringUtils";
 
 interface jitsiConfigInterface {
     startWithAudioMuted: boolean;
@@ -114,18 +113,6 @@ const defaultInterfaceConfig = {
     ],
 };
 
-const slugify = (...args: (string | number)[]): string => {
-    const value = args.join(" ");
-
-    return value
-        .normalize("NFD") // split an accented letter in the base letter and the accent
-        .replace(/[\u0300-\u036f]/g, "") // remove all previously split accents
-        .toLowerCase()
-        .trim()
-        .replace(/[^a-z0-9-_ ]/g, "") // remove all chars not letters, numbers, dash, underscores and spaces (to be replaced)
-        .replace(/\s+/g, "-"); // separator
-};
-
 class JitsiFactory {
     private jitsiApi?: JitsiApi;
     private audioCallback = this.onAudioChange.bind(this);
@@ -133,13 +120,6 @@ class JitsiFactory {
     private dominantSpeakerChangedCallback = this.onDominantSpeakerChanged.bind(this);
     private participantsCountChangeCallback = this.onParticipantsCountChange.bind(this);
     private jitsiScriptLoaded = false;
-
-    /**
-     * Slugifies the room name and prepends the room name with the instance
-     */
-    public getRoomName(roomName: string, roomId: string, addPrefix: boolean): string {
-        return slugify((addPrefix ? StringUtils.shortHash(roomId) + "-" : "") + roomName);
-    }
 
     public start(
         roomName: string,
@@ -152,7 +132,7 @@ class JitsiFactory {
         return new CancelablePromise((resolve, reject, cancel) => {
             // Jitsi meet external API maintains some data in local storage
             // which is sent via the appData URL parameter when joining a
-            // conference. Problem is that this data grows indefinitely. Thus
+            // conference. Problem is that this data grows indefinitely. Thus,
             // after some time the URLs get so huge that loading the iframe
             // becomes slow and eventually breaks completely. Thus lets just
             // clear jitsi local storage before starting a new conference.


### PR DESCRIPTION
The previous fix trying to fix broken "jitsiRoomAdminTag" did only part of the job.

We tried to remove the prefix added by the front to make the Jitsi room unique

But the "jitsiRoom" is actually slugified on the front (in addition to a prefix being added)

As a result, if the jitsiRoom property contained an uppercase or a special character, the back could not find this jitsiRoom property.

This commit fixes everything by computing the exact same slug on the front and the back. To do so, a new "shared-utils" library is added in "/lib" to contain small utility functions that are common to several containers.