### PR TITLE
Fix outline sharing when arriving on map

### DIFF
--- a/play/src/pusher/models/Zone.ts
+++ b/play/src/pusher/models/Zone.ts
@@ -98,7 +98,10 @@ export class UserDescriptor {
         if (playerDetails.getRemoveoutlinecolor()) {
             this.outlineColor = undefined;
         } else {
-            this.outlineColor = playerDetails.getOutlinecolor()?.getValue();
+            const outlineColor = playerDetails.getOutlinecolor();
+            if (outlineColor !== undefined) {
+                this.outlineColor = outlineColor.getValue();
+            }
         }
         const availabilityStatus = playerDetails.getAvailabilitystatus();
         if (availabilityStatus !== undefined) {


### PR DESCRIPTION
When arriving on a map you will now see all the outline colors previously defined.

Close #2847 