### PR TITLE
Adding polyfills for old browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38129,7 +38129,7 @@
         "@types/quill": "^1.3.7",
         "@types/simple-peer": "^9.11.5",
         "@types/swagger-jsdoc": "^6.0.1",
-        "@types/throttle-debounce": "*",
+        "@types/throttle-debounce": "^5.0.0",
         "@types/uuid": "^8.3.4",
         "@types/xmpp__client": "^0.13.0",
         "@types/xmpp__jid": "^1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5986,11 +5986,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.0.1.tgz",
-      "integrity": "sha512-zKVyTt6rELvPXYwcVPTJcPFtY0AckN5A7xWuc7owBqR0FdtuDYhE9MZZUi6IY1kZUQFSXV1B3UOOIyLkVHYd2w=="
-    },
     "node_modules/@vitejs/plugin-legacy": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-2.3.1.tgz",
@@ -21437,7 +21432,6 @@
         "@joeattardi/emoji-button": "^4.6.2",
         "@tailwindcss/forms": "^0.5.0",
         "@tsconfig/svelte": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.1",
         "@workadventure/map-editor": "1.0.0",
         "@workadventure/math-utils": "1.0.0",
         "@workadventure/messages": "1.0.0",
@@ -26192,11 +26186,6 @@
         "@typescript-eslint/types": "5.48.1",
         "eslint-visitor-keys": "^3.3.0"
       }
-    },
-    "@ungap/structured-clone": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.0.1.tgz",
-      "integrity": "sha512-zKVyTt6rELvPXYwcVPTJcPFtY0AckN5A7xWuc7owBqR0FdtuDYhE9MZZUi6IY1kZUQFSXV1B3UOOIyLkVHYd2w=="
     },
     "@vitejs/plugin-legacy": {
       "version": "2.3.1",
@@ -38146,7 +38135,6 @@
         "@types/xmpp__jid": "^1.3.3",
         "@typescript-eslint/eslint-plugin": "^5.47.0",
         "@typescript-eslint/parser": "^5.47.0",
-        "@ungap/structured-clone": "^1.0.1",
         "@vitejs/plugin-legacy": "^2.3.1",
         "@workadventure/map-editor": "1.0.0",
         "@workadventure/math-utils": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3109,6 +3109,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/standalone": {
+      "version": "7.20.15",
+      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.20.15.tgz",
+      "integrity": "sha512-B3LmZ1NHlTb2eFEaw8rftZc730Wh9MlmsH8ubb6IjsNoIk9+SQ2aAA0nrm/1806+PftPRAACPClmKTu8PG7Tew==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
@@ -5981,6 +5990,26 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.0.1.tgz",
       "integrity": "sha512-zKVyTt6rELvPXYwcVPTJcPFtY0AckN5A7xWuc7owBqR0FdtuDYhE9MZZUi6IY1kZUQFSXV1B3UOOIyLkVHYd2w=="
+    },
+    "node_modules/@vitejs/plugin-legacy": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-2.3.1.tgz",
+      "integrity": "sha512-J5KaGBlSt2tEYPVjM/C8dA6DkRzkFkbPe+Xb4IX5G+XOV5OGbVAfkMjKywdrkO3gGynO8S98i71Lmsff4cWkCQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/standalone": "^7.20.0",
+        "core-js": "^3.26.0",
+        "magic-string": "^0.26.7",
+        "regenerator-runtime": "^0.13.10",
+        "systemjs": "^6.13.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "terser": "^5.4.0",
+        "vite": "^3.0.0"
+      }
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.2.45",
@@ -19125,6 +19154,12 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/systemjs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.13.0.tgz",
+      "integrity": "sha512-P3cgh2bpaPvAO2NE3uRp/n6hmk4xPX4DQf+UzTlCAycssKdqhp6hjw+ENWe+aUS7TogKRFtptMosTSFeC6R55g==",
+      "dev": true
+    },
     "node_modules/tabbable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-4.0.0.tgz",
@@ -21483,6 +21518,7 @@
         "@types/xmpp__jid": "^1.3.3",
         "@typescript-eslint/eslint-plugin": "^5.47.0",
         "@typescript-eslint/parser": "^5.47.0",
+        "@vitejs/plugin-legacy": "^2.3.1",
         "autoprefixer": "^10.4.4",
         "eslint": "^8.30.0",
         "eslint-plugin-svelte3": "^4.0.0",
@@ -23896,6 +23932,12 @@
         "regenerator-runtime": "^0.13.11"
       }
     },
+    "@babel/standalone": {
+      "version": "7.20.15",
+      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.20.15.tgz",
+      "integrity": "sha512-B3LmZ1NHlTb2eFEaw8rftZc730Wh9MlmsH8ubb6IjsNoIk9+SQ2aAA0nrm/1806+PftPRAACPClmKTu8PG7Tew==",
+      "dev": true
+    },
     "@babel/template": {
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
@@ -26155,6 +26197,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.0.1.tgz",
       "integrity": "sha512-zKVyTt6rELvPXYwcVPTJcPFtY0AckN5A7xWuc7owBqR0FdtuDYhE9MZZUi6IY1kZUQFSXV1B3UOOIyLkVHYd2w=="
+    },
+    "@vitejs/plugin-legacy": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-2.3.1.tgz",
+      "integrity": "sha512-J5KaGBlSt2tEYPVjM/C8dA6DkRzkFkbPe+Xb4IX5G+XOV5OGbVAfkMjKywdrkO3gGynO8S98i71Lmsff4cWkCQ==",
+      "dev": true,
+      "requires": {
+        "@babel/standalone": "^7.20.0",
+        "core-js": "^3.26.0",
+        "magic-string": "^0.26.7",
+        "regenerator-runtime": "^0.13.10",
+        "systemjs": "^6.13.0"
+      }
     },
     "@vue/compiler-core": {
       "version": "3.2.45",
@@ -36565,6 +36620,12 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "systemjs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.13.0.tgz",
+      "integrity": "sha512-P3cgh2bpaPvAO2NE3uRp/n6hmk4xPX4DQf+UzTlCAycssKdqhp6hjw+ENWe+aUS7TogKRFtptMosTSFeC6R55g==",
+      "dev": true
+    },
     "tabbable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-4.0.0.tgz",
@@ -38086,6 +38147,7 @@
         "@typescript-eslint/eslint-plugin": "^5.47.0",
         "@typescript-eslint/parser": "^5.47.0",
         "@ungap/structured-clone": "^1.0.1",
+        "@vitejs/plugin-legacy": "^2.3.1",
         "@workadventure/map-editor": "1.0.0",
         "@workadventure/math-utils": "1.0.0",
         "@workadventure/messages": "1.0.0",

--- a/play/package.json
+++ b/play/package.json
@@ -97,7 +97,6 @@
     "@joeattardi/emoji-button": "^4.6.2",
     "@tailwindcss/forms": "^0.5.0",
     "@tsconfig/svelte": "^3.0.0",
-    "@ungap/structured-clone": "^1.0.1",
     "@workadventure/map-editor": "1.0.0",
     "@workadventure/math-utils": "1.0.0",
     "@workadventure/messages": "1.0.0",

--- a/play/package.json
+++ b/play/package.json
@@ -66,6 +66,7 @@
     "@types/xmpp__jid": "^1.3.3",
     "@typescript-eslint/eslint-plugin": "^5.47.0",
     "@typescript-eslint/parser": "^5.47.0",
+    "@vitejs/plugin-legacy": "^2.3.1",
     "autoprefixer": "^10.4.4",
     "eslint": "^8.30.0",
     "eslint-plugin-svelte3": "^4.0.0",

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -135,7 +135,6 @@ import {
     _newChatMessageSubject,
     _newChatMessageWritingStatusSubject,
 } from "../../Stores/ChatStore";
-import structuredClone from "@ungap/structured-clone";
 import type {
     ITiledMap,
     ITiledMapLayer,

--- a/play/src/front/structuredClone.d.ts
+++ b/play/src/front/structuredClone.d.ts
@@ -1,3 +1,0 @@
-declare module "@ungap/structured-clone" {
-    export default structuredClone;
-}

--- a/play/vite.config.ts
+++ b/play/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import sveltePreprocess from "svelte-preprocess";
+import legacy from '@vitejs/plugin-legacy'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -32,6 +33,9 @@ export default defineConfig({
                     defaultHandler(warning);
                 }
             },
+        }),
+        legacy({
+            targets: ['defaults', 'not IE 11']
         }),
     ],
 });

--- a/play/vite.config.ts
+++ b/play/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import sveltePreprocess from "svelte-preprocess";
-import legacy from '@vitejs/plugin-legacy'
+import legacy from "@vitejs/plugin-legacy";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -36,8 +36,10 @@ export default defineConfig({
         }),
         legacy({
             //targets: ['defaults', 'not IE 11', 'iOS > 14.3']
-            polyfills: ['web.structured-clone'],
-            modernPolyfills: ['web.structured-clone'],
+
+            // Structured clone is needed for Safari < 15.4
+            polyfills: ["web.structured-clone"],
+            modernPolyfills: ["web.structured-clone"],
         }),
     ],
 });

--- a/play/vite.config.ts
+++ b/play/vite.config.ts
@@ -35,7 +35,9 @@ export default defineConfig({
             },
         }),
         legacy({
-            targets: ['defaults', 'not IE 11']
+            //targets: ['defaults', 'not IE 11', 'iOS > 14.3']
+            polyfills: ['web.structured-clone'],
+            modernPolyfills: ['web.structured-clone'],
         }),
     ],
 });


### PR DESCRIPTION
Adding @vitejs/plugin-legacy.
The goal is to restore compatibility with iOS >=14.5 and <15.4 that does not support structuredClone.

- [x] Test polyfill on iOS 14.5
- [x] Check bundle size in normal browsers (vs without polyfill)