### PR TITLE
Improving Webrtc detection

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -21,6 +21,10 @@ MAP_STORAGE_URL=map-storage:50053
 # If you are using Coturn, this is the value of the "static-auth-secret" parameter in your coturn config file.
 # Keep empty if you are sharing hard coded / clear text credentials.
 TURN_STATIC_AUTH_SECRET=
+TURN_SERVER=
+# You can uncomment the 2 lines below and the Coturn section in docker-compose.yaml to test this behaviour locally
+#TURN_SERVER=turn:coturn.workadventure.localhost:3478,turns:coturn.workadventure.localhost:5349
+#TURN_STATIC_AUTH_SECRET=SomeStaticAuthSecret
 DISABLE_NOTIFICATIONS=true
 SKIP_RENDER_OPTIMIZATIONS=false
 

--- a/deeployer.libsonnet
+++ b/deeployer.libsonnet
@@ -92,7 +92,7 @@
           #POSTHOG
           "POSTHOG_API_KEY": if namespace == "master" then env.POSTHOG_API_KEY else "",
           "POSTHOG_URL": if namespace == "master" then env.POSTHOG_URL else "",
-          "TURN_SERVER": "turn:coturn.workadventu.re:443,turns:coturn.workadventu.re:443",
+          "TURN_SERVER": "turn:coturn.workadventure.fr:443,turns:coturn.workadventure.fr:443",
           "JITSI_PRIVATE_MODE": if env.SECRET_JITSI_KEY != '' then "true" else "false",
           "ENABLE_FEATURE_MAP_EDITOR":"true",
           "ENABLE_MAP_EDITOR_AREAS_TOOL":"false",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
             UPLOADER_URL: http://uploader.workadventure.localhost
             ICON_URL: http://icon.workadventure.localhost
             STUN_SERVER: "stun:stun.l.google.com:19302"
-            TURN_SERVER: "turn:coturn.workadventure.localhost:3478,turns:coturn.workadventure.localhost:5349"
+            TURN_SERVER: "$TURN_SERVER"
             DISABLE_NOTIFICATIONS: "$DISABLE_NOTIFICATIONS"
             SKIP_RENDER_OPTIMIZATIONS: "$SKIP_RENDER_OPTIMIZATIONS"
             # Use TURN_USER/TURN_PASSWORD if your Coturn server is secured via hard coded credentials.
@@ -179,7 +179,7 @@ services:
             JITSI_ISS: $JITSI_ISS
             BBB_URL: $BBB_URL
             BBB_SECRET: $BBB_SECRET
-            TURN_STATIC_AUTH_SECRET: SomeStaticAuthSecret
+            TURN_STATIC_AUTH_SECRET: "$TURN_STATIC_AUTH_SECRET"
             MAX_PER_GROUP: "MAX_PER_GROUP"
             REDIS_HOST: redis
             NODE_ENV: development

--- a/play/src/front/Components/HelpSettings/HelpWebRtcSettingsPopup.svelte
+++ b/play/src/front/Components/HelpSettings/HelpWebRtcSettingsPopup.svelte
@@ -9,7 +9,7 @@
     }
 
     function close() {
-        helpWebRtcSettingsVisibleStore.set(false);
+        helpWebRtcSettingsVisibleStore.set("hidden");
     }
 
     function getBackgroundColor() {
@@ -25,12 +25,41 @@
     transition:fly={{ y: -50, duration: 500 }}
 >
     <section class="tw-mb-0">
-        <h2 class="tw-mb-0">{$LL.camera.webrtc.title()}</h2>
+        {#if $helpWebRtcSettingsVisibleStore === "error"}
+            <h2 class="tw-mb-2">{$LL.camera.webrtc.title()}</h2>
+        {:else if $helpWebRtcSettingsVisibleStore === "pending"}
+            <h2 class="tw-mb-2">
+                <div class="text-left">
+                    <div role="status">
+                        <svg
+                            aria-hidden="true"
+                            class="tw-inline tw-w-7 tw-h-7 tw-mr-2 tw-text-gray tw-animate-spin tw-dark:tw-text-gray tw-fill-light-blue"
+                            viewBox="0 0 100 101"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+                                fill="currentColor"
+                            />
+                            <path
+                                d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+                                fill="currentFill"
+                            />
+                        </svg>
+                        <span>{$LL.camera.webrtc.titlePending()}</span>
+                    </div>
+                </div>
+            </h2>
+        {/if}
         <p class="err blue-title">{$LL.camera.webrtc.error()}</p>
         <p>{$LL.camera.webrtc.content()}</p>
-        <p class="tw-mb-0 tw-flex tw-justify-center tw-flex-col">
-            <a href="https://icetest.info/" target="_blank" rel="noreferrer">{$LL.camera.webrtc.testUrl()}</a>
-        </p>
+        <ul>
+            <li>{@html $LL.camera.webrtc.solutionVpn()}</li>
+            <li>{@html $LL.camera.webrtc.solutionHotspot()}</li>
+            <!-- TODO: Bring the link to the network guide from the admin -->
+            <!--<li>{@html $LL.camera.webrtc.solutionNetworkAdmin()}<a href="" target="_blank">{$LL.camera.webrtc.preparingYouNetworkGuide()}</a></li>-->
+        </ul>
     </section>
     <section class="tw-flex tw-row tw-justify-center">
         <button class="light" on:click|preventDefault={refresh}>{$LL.camera.webrtc.refresh()}</button>

--- a/play/src/front/Components/MainLayout.svelte
+++ b/play/src/front/Components/MainLayout.svelte
@@ -39,6 +39,7 @@
     import Modal from "./Modal/Modal.svelte";
     import { coWebsites } from "../Stores/CoWebsiteStore";
     import { isMediaBreakpointUp } from "../Utils/BreakpointsUtils";
+    import { proximityMeetingStore } from "../Stores/MyMediaStore";
 
     let mainLayout: HTMLDivElement;
 
@@ -94,7 +95,7 @@
             <HelpCameraSettingsPopup />
         {/if}
 
-        {#if $helpWebRtcSettingsVisibleStore}
+        {#if $helpWebRtcSettingsVisibleStore !== "hidden" && $proximityMeetingStore === true}
             <HelpWebRtcSettingsPopup />
         {/if}
 

--- a/play/src/front/Components/Video/utils.ts
+++ b/play/src/front/Components/Video/utils.ts
@@ -1,7 +1,9 @@
 import type { UserSimplePeerInterface } from "../../WebRtc/SimplePeer";
 import { STUN_SERVER, TURN_PASSWORD, TURN_SERVER, TURN_USER } from "../../Enum/EnvironmentVariable";
 import { helpWebRtcSettingsVisibleStore } from "../../Stores/HelpSettingsStore";
-import { debugCheckTurn } from "../../Utils/Debuggers";
+import Debug from "debug";
+
+export const debug = Debug("CheckTurn");
 
 export function getColorByString(str: string): string | null {
     let hash = 0;
@@ -76,12 +78,12 @@ export function checkCoturnServer(user: UserSimplePeerInterface) {
     let checkPeerConnexionStatusTimeOut: NodeJS.Timeout | null = null;
 
     if (!TURN_SERVER) {
-        debugCheckTurn("checkCoturnServer => No TURN server configured.");
+        debug("checkCoturnServer => No TURN server configured.");
         return;
     }
 
     if (window.navigator.userAgent.toLowerCase().indexOf("firefox") != -1) {
-        debugCheckTurn(
+        debug(
             "checkCoturnServer => RTC Peer Connection detection development is not available for Firefox browser!"
         );
         return;
@@ -110,18 +112,18 @@ export function checkCoturnServer(user: UserSimplePeerInterface) {
             return;
         }
 
-        debugCheckTurn("checkCoturnServer => onicecandidate => e.candidate.type" + e.candidate.type);
+        debug("checkCoturnServer => onicecandidate => e.candidate.type" + e.candidate.type);
         // If a srflx candidate was found, notify that the STUN server works!
         /*if (e.candidate.type == "srflx") {
-            console.info("checkCoturnServer => onicecandidate => The STUN server is reachable!");
-            console.info(`   Your Public IP Address is: ${e.candidate.address}`);
+            debugCheckTurn("checkCoturnServer => onicecandidate => The STUN server is reachable!");
+            debugCheckTurn(`   Your Public IP Address is: ${e.candidate.address}`);
             valideCoturnCheck = true;
             pc.close();
         }*/
 
         // If a relay candidate was found, notify that the TURN server works!
         if (e.candidate.type == "relay") {
-            console.info("checkCoturnServer => onicecandidate => The TURN server is reachable!");
+            debug("checkCoturnServer => onicecandidate => The TURN server is reachable!");
             turnServerReached = true;
             helpWebRtcSettingsVisibleStore.set("hidden");
             pc.close();
@@ -132,23 +134,23 @@ export function checkCoturnServer(user: UserSimplePeerInterface) {
     // Remember that in most of the cases, even if its working, you will find a STUN host lookup received error
     // Chrome tried to look up the IPv6 DNS record for server and got an error in that process. However, it may still be accessible through the IPv4 address
     pc.onicecandidateerror = (e) => {
-        debugCheckTurn("checkCoturnServer => onicecandidateerror => %O", e);
+        debug("checkCoturnServer => onicecandidateerror => %O", e);
     };
 
     pc.addEventListener("icegatheringstatechange", (ev) => {
-        debugCheckTurn(
+        debug(
             "checkCoturnServer => icegatheringstatechange => pc.iceGatheringState: %s",
             pc.iceGatheringState
         );
         switch (pc.iceGatheringState) {
             case "new":
-                debugCheckTurn("checkCoturnServer => icegatheringstatechange => status is new");
+                debug("checkCoturnServer => icegatheringstatechange => status is new");
                 break;
             case "gathering":
-                debugCheckTurn("checkCoturnServer => icegatheringstatechange => status is gathering");
+                debug("checkCoturnServer => icegatheringstatechange => status is gathering");
                 break;
             case "complete":
-                debugCheckTurn("checkCoturnServer => icegatheringstatechange => status is complete");
+                debug("checkCoturnServer => icegatheringstatechange => status is complete");
                 pc.close();
                 break;
         }
@@ -157,7 +159,7 @@ export function checkCoturnServer(user: UserSimplePeerInterface) {
     pc.createDataChannel("workadventure-peerconnection-test");
     pc.createOffer()
         .then((offer) => pc.setLocalDescription(offer))
-        .catch((err) => debugCheckTurn("checkCoturnServer => Check coturn server error => %O", err));
+        .catch((err) => debug("checkCoturnServer => Check coturn server error => %O", err));
 
     checkPeerConnexionStatusTimeOut = setTimeout(() => {
         if (!turnServerReached) {

--- a/play/src/front/Components/Video/utils.ts
+++ b/play/src/front/Components/Video/utils.ts
@@ -78,14 +78,12 @@ export function checkCoturnServer(user: UserSimplePeerInterface) {
     let checkPeerConnexionStatusTimeOut: NodeJS.Timeout | null = null;
 
     if (!TURN_SERVER) {
-        debug("checkCoturnServer => No TURN server configured.");
+        debug("No TURN server configured.");
         return;
     }
 
     if (window.navigator.userAgent.toLowerCase().indexOf("firefox") != -1) {
-        debug(
-            "checkCoturnServer => RTC Peer Connection detection development is not available for Firefox browser!"
-        );
+        debug("RTC Peer Connection detection development is not available for Firefox browser!");
         return;
     }
 
@@ -102,7 +100,9 @@ export function checkCoturnServer(user: UserSimplePeerInterface) {
         ) {
             pc.close();
 
+            debug("onicecandidate => gathering is complete");
             if (!turnServerReached) {
+                debug("onicecandidate => no turn server found after gathering complete");
                 helpWebRtcSettingsVisibleStore.set("error");
             }
             if (checkPeerConnexionStatusTimeOut) {
@@ -112,10 +112,10 @@ export function checkCoturnServer(user: UserSimplePeerInterface) {
             return;
         }
 
-        debug("checkCoturnServer => onicecandidate => e.candidate.type" + e.candidate.type);
+        debug("onicecandidate => e.candidate.type %s", e.candidate.type);
         // If a srflx candidate was found, notify that the STUN server works!
         /*if (e.candidate.type == "srflx") {
-            debugCheckTurn("checkCoturnServer => onicecandidate => The STUN server is reachable!");
+            debugCheckTurn("onicecandidate => The STUN server is reachable!");
             debugCheckTurn(`   Your Public IP Address is: ${e.candidate.address}`);
             valideCoturnCheck = true;
             pc.close();
@@ -123,7 +123,7 @@ export function checkCoturnServer(user: UserSimplePeerInterface) {
 
         // If a relay candidate was found, notify that the TURN server works!
         if (e.candidate.type == "relay") {
-            debug("checkCoturnServer => onicecandidate => The TURN server is reachable!");
+            debug("onicecandidate => The TURN server is reachable!");
             turnServerReached = true;
             helpWebRtcSettingsVisibleStore.set("hidden");
             pc.close();
@@ -134,23 +134,20 @@ export function checkCoturnServer(user: UserSimplePeerInterface) {
     // Remember that in most of the cases, even if its working, you will find a STUN host lookup received error
     // Chrome tried to look up the IPv6 DNS record for server and got an error in that process. However, it may still be accessible through the IPv4 address
     pc.onicecandidateerror = (e) => {
-        debug("checkCoturnServer => onicecandidateerror => %O", e);
+        debug("onicecandidateerror => %O", e);
     };
 
     pc.addEventListener("icegatheringstatechange", (ev) => {
-        debug(
-            "checkCoturnServer => icegatheringstatechange => pc.iceGatheringState: %s",
-            pc.iceGatheringState
-        );
+        debug("icegatheringstatechange => pc.iceGatheringState: %s", pc.iceGatheringState);
         switch (pc.iceGatheringState) {
             case "new":
-                debug("checkCoturnServer => icegatheringstatechange => status is new");
+                debug("icegatheringstatechange => status is new");
                 break;
             case "gathering":
-                debug("checkCoturnServer => icegatheringstatechange => status is gathering");
+                debug("icegatheringstatechange => status is gathering");
                 break;
             case "complete":
-                debug("checkCoturnServer => icegatheringstatechange => status is complete");
+                debug("icegatheringstatechange => status is complete");
                 pc.close();
                 break;
         }
@@ -159,7 +156,7 @@ export function checkCoturnServer(user: UserSimplePeerInterface) {
     pc.createDataChannel("workadventure-peerconnection-test");
     pc.createOffer()
         .then((offer) => pc.setLocalDescription(offer))
-        .catch((err) => debug("checkCoturnServer => Check coturn server error => %O", err));
+        .catch((err) => debug("Check coturn server error => %O", err));
 
     checkPeerConnexionStatusTimeOut = setTimeout(() => {
         if (!turnServerReached) {

--- a/play/src/front/Components/Video/utils.ts
+++ b/play/src/front/Components/Video/utils.ts
@@ -1,6 +1,7 @@
 import type { UserSimplePeerInterface } from "../../WebRtc/SimplePeer";
 import { STUN_SERVER, TURN_PASSWORD, TURN_SERVER, TURN_USER } from "../../Enum/EnvironmentVariable";
 import { helpWebRtcSettingsVisibleStore } from "../../Stores/HelpSettingsStore";
+import { debugCheckTurn } from "../../Utils/Debuggers";
 
 export function getColorByString(str: string): string | null {
     let hash = 0;
@@ -66,55 +67,63 @@ export function getIceServersConfig(user: UserSimplePeerInterface): RTCIceServer
     return config;
 }
 
-let valideCoturnCheck = false;
-let completeIceCandice = false;
 /**
  * Test STUN and TURN server access
  * @param user UserSimplePeerInterface
  */
 export function checkCoturnServer(user: UserSimplePeerInterface) {
-    // TODO change it to test RTC Peer Connection for Firefox browser
+    let turnServerReached = false;
+    let checkPeerConnexionStatusTimeOut: NodeJS.Timeout | null = null;
+
+    if (!TURN_SERVER) {
+        debugCheckTurn("checkCoturnServer => No TURN server configured.");
+        return;
+    }
+
     if (window.navigator.userAgent.toLowerCase().indexOf("firefox") != -1) {
-        console.info(
-            "checkCoturnServer => Error RTC Peer Connection detection development is in progress for Firefox browser!"
+        debugCheckTurn(
+            "checkCoturnServer => RTC Peer Connection detection development is not available for Firefox browser!"
         );
         return;
     }
 
     const iceServers = getIceServersConfig(user);
+
     const pc = new RTCPeerConnection({ iceServers });
 
     pc.onicecandidate = (e) => {
-        completeIceCandice = false;
-        valideCoturnCheck = false;
-        // Display candidate string e.g
-        // candidate:842163049 1 udp 1677729535 XXX.XXX.XX.XXXX 58481 typ srflx raddr 0.0.0.0 rport 0 generation 0 ufrag sXP5 network-cost 999
+        turnServerReached = false;
 
-        // See documentation regarding https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/icecandidate_event
-        // @ts-ignore
-        if (e.candidate === "") {
-            // is the end of candidate
-            completeIceCandice = true;
+        if (
+            (e.target && e.target instanceof RTCPeerConnection && e.target.iceGatheringState === "complete") ||
+            e.candidate == null
+        ) {
             pc.close();
+
+            if (!turnServerReached) {
+                helpWebRtcSettingsVisibleStore.set("error");
+            }
+            if (checkPeerConnexionStatusTimeOut) {
+                clearTimeout(checkPeerConnexionStatusTimeOut);
+                checkPeerConnexionStatusTimeOut = null;
+            }
+            return;
         }
 
-        if (!e.candidate) return;
-
-        console.log("checkCoturnServer => onicecandidate => e.candidate.type", e.candidate.type);
+        debugCheckTurn("checkCoturnServer => onicecandidate => e.candidate.type" + e.candidate.type);
         // If a srflx candidate was found, notify that the STUN server works!
-        if (e.candidate.type == "srflx") {
+        /*if (e.candidate.type == "srflx") {
             console.info("checkCoturnServer => onicecandidate => The STUN server is reachable!");
             console.info(`   Your Public IP Address is: ${e.candidate.address}`);
             valideCoturnCheck = true;
-            completeIceCandice = true;
             pc.close();
-        }
+        }*/
 
         // If a relay candidate was found, notify that the TURN server works!
         if (e.candidate.type == "relay") {
             console.info("checkCoturnServer => onicecandidate => The TURN server is reachable!");
-            valideCoturnCheck = true;
-            completeIceCandice = true;
+            turnServerReached = true;
+            helpWebRtcSettingsVisibleStore.set("hidden");
             pc.close();
         }
     };
@@ -123,21 +132,23 @@ export function checkCoturnServer(user: UserSimplePeerInterface) {
     // Remember that in most of the cases, even if its working, you will find a STUN host lookup received error
     // Chrome tried to look up the IPv6 DNS record for server and got an error in that process. However, it may still be accessible through the IPv4 address
     pc.onicecandidateerror = (e) => {
-        console.error("checkCoturnServer => onicecandidateerror => The STUN server is on error: ", e);
+        debugCheckTurn("checkCoturnServer => onicecandidateerror => %O", e);
     };
 
     pc.addEventListener("icegatheringstatechange", (ev) => {
-        console.info("checkCoturnServer => icegatheringstatechange => pc.iceGatheringState: ", pc.iceGatheringState);
+        debugCheckTurn(
+            "checkCoturnServer => icegatheringstatechange => pc.iceGatheringState: %s",
+            pc.iceGatheringState
+        );
         switch (pc.iceGatheringState) {
             case "new":
-                console.info("checkCoturnServer => icegatheringstatechange => status is new");
+                debugCheckTurn("checkCoturnServer => icegatheringstatechange => status is new");
                 break;
             case "gathering":
-                console.info("checkCoturnServer => icegatheringstatechange => status is gathering");
+                debugCheckTurn("checkCoturnServer => icegatheringstatechange => status is gathering");
                 break;
             case "complete":
-                console.info("checkCoturnServer => icegatheringstatechange => status is complete");
-                completeIceCandice = true;
+                debugCheckTurn("checkCoturnServer => icegatheringstatechange => status is complete");
                 pc.close();
                 break;
         }
@@ -146,27 +157,15 @@ export function checkCoturnServer(user: UserSimplePeerInterface) {
     pc.createDataChannel("workadventure-peerconnection-test");
     pc.createOffer()
         .then((offer) => pc.setLocalDescription(offer))
-        .catch((err) => console.error("checkCoturnServer => Check coturn server error", err));
+        .catch((err) => debugCheckTurn("checkCoturnServer => Check coturn server error => %O", err));
 
-    checkPeerConnexionStatus(pc);
-}
-
-let checkPeerConnexionStatusTimeOut: NodeJS.Timeout | null = null;
-const checkPeerConnexionStatus = (pc: RTCPeerConnection) => {
     checkPeerConnexionStatusTimeOut = setTimeout(() => {
-        if (
-            pc.connectionState === "closed" ||
-            /** FireFox haven't connectionState implemented, follow MDN documentation https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/connectionState */
-            (pc.connectionState == undefined && completeIceCandice)
-        ) {
-            if (!valideCoturnCheck) {
-                helpWebRtcSettingsVisibleStore.set(true);
-            }
-            if (checkPeerConnexionStatusTimeOut) {
-                clearTimeout(checkPeerConnexionStatusTimeOut);
-            }
-            return;
+        if (!turnServerReached) {
+            helpWebRtcSettingsVisibleStore.set("pending");
         }
-        checkPeerConnexionStatus(pc);
+        if (checkPeerConnexionStatusTimeOut) {
+            clearTimeout(checkPeerConnexionStatusTimeOut);
+            checkPeerConnexionStatusTimeOut = null;
+        }
     }, 5000);
-};
+}

--- a/play/src/front/Connexion/ConnexionModels.ts
+++ b/play/src/front/Connexion/ConnexionModels.ts
@@ -72,6 +72,8 @@ export interface RoomJoinedMessageInterface {
     playerVariables: Map<string, unknown>;
     characterLayers: BodyResourceDescriptionInterface[];
     commandsToApply?: EditMapCommandMessage[];
+    webrtcUserName: string;
+    webrtcPassword: string;
 }
 
 export interface PlayGlobalMessageInterface {

--- a/play/src/front/Connexion/RoomConnection.ts
+++ b/play/src/front/Connexion/RoomConnection.ts
@@ -65,7 +65,6 @@ import { errorScreenStore } from "../Stores/ErrorScreenStore";
 import type { AreaData, AtLeast, EntityData } from "@workadventure/map-editor";
 import type { SetPlayerVariableEvent } from "../Api/Events/SetPlayerVariableEvent";
 import { iframeListener } from "../Api/IframeListener";
-import { checkCoturnServer } from "../Components/Video/utils";
 import { assertObjectKeys } from "../Utils/CustomTypeGuards";
 
 // This must be greater than IoSocketController's PING_INTERVAL
@@ -427,21 +426,11 @@ export class RoomConnection implements RoomConnection {
                             characterLayers,
                             playerVariables,
                             commandsToApply,
+                            webrtcUserName: roomJoinedMessage.webrtcUserName,
+                            webrtcPassword: roomJoinedMessage.webrtcPassword,
                         } as RoomJoinedMessageInterface,
                     });
 
-                    // Check WebRtc connection
-                    if (roomJoinedMessage.webrtcUserName && roomJoinedMessage.webrtcPassword) {
-                        try {
-                            checkCoturnServer({
-                                userId: this.userId,
-                                webRtcUser: roomJoinedMessage.webrtcUserName,
-                                webRtcPassword: roomJoinedMessage.webrtcPassword,
-                            });
-                        } catch (err) {
-                            console.error("Check coturn server exception: ", err);
-                        }
-                    }
                     break;
                 }
                 case "worldFullMessage": {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -154,6 +154,7 @@ import { currentPlayerWokaStore } from "../../Stores/CurrentPlayerWokaStore";
 import { mapEditorModeStore } from "../../Stores/MapEditorStore";
 import { debugAddPlayer, debugRemovePlayer } from "../../Utils/Debuggers";
 import { EntitiesCollectionsManager } from "./MapEditor/EntitiesCollectionsManager";
+import { checkCoturnServer } from "../../Components/Video/utils";
 
 export interface GameSceneInitInterface {
     reconnecting: boolean;
@@ -1062,6 +1063,19 @@ export class GameScene extends DirtyScene {
                 });
 
                 this.emoteManager = new EmoteManager(this, this.connection);
+
+                // Check WebRtc connection
+                if (onConnect.room.webrtcUserName && onConnect.room.webrtcPassword) {
+                    try {
+                        checkCoturnServer({
+                            userId: onConnect.connection.getUserId(),
+                            webRtcUser: onConnect.room.webrtcUserName,
+                            webRtcPassword: onConnect.room.webrtcPassword,
+                        });
+                    } catch (err) {
+                        console.error("Check coturn server exception: ", err);
+                    }
+                }
 
                 // Get position from UUID only after the connection to the pusher is established
                 this.tryMovePlayerWithMoveToUserParameter();

--- a/play/src/front/Stores/HelpSettingsStore.ts
+++ b/play/src/front/Stores/HelpSettingsStore.ts
@@ -1,4 +1,4 @@
 import { writable } from "svelte/store";
 
 export const helpCameraSettingsVisibleStore = writable(false);
-export const helpWebRtcSettingsVisibleStore = writable(false);
+export const helpWebRtcSettingsVisibleStore = writable<"pending" | "error" | "hidden">("hidden");

--- a/play/src/front/Utils/Debuggers.ts
+++ b/play/src/front/Utils/Debuggers.ts
@@ -4,5 +4,3 @@ import debug from "debug";
 export const debugRepo = debug("Players");
 export const debugAddPlayer = debugRepo.extend("AddPlayer");
 export const debugRemovePlayer = debugRepo.extend("RemovePlayer");
-
-export const debugCheckTurn = debug("CheckTurn");

--- a/play/src/front/Utils/Debuggers.ts
+++ b/play/src/front/Utils/Debuggers.ts
@@ -4,3 +4,5 @@ import debug from "debug";
 export const debugRepo = debug("Players");
 export const debugAddPlayer = debugRepo.extend("AddPlayer");
 export const debugRemovePlayer = debugRepo.extend("RemovePlayer");
+
+export const debugCheckTurn = debug("CheckTurn");

--- a/play/src/i18n/ca-ES/camera.ts
+++ b/play/src/i18n/ca-ES/camera.ts
@@ -19,15 +19,18 @@ const camera: DeepPartial<Translation["camera"]> = {
             chrome: "/resources/help-setting-camera-permission/en-US-firefox.png",
         },
     },
-    webrtc: {
-        title: "WebRtc connection error",
-        error: "STUN / TURN server isn't reachable",
-        content:
-            "The video relay server cannot be reached. You may be unable to communicate with other users. If you are connecting via a VPN, please disconnect and refresh the web page. You may click on the link below to test your WebRtc connection.",
-        testUrl: "WebRtc connection test",
-        refresh: "Refresh",
-        continue: "Continue",
-    },
+    /*webrtc: {
+        title: "TODO: Video relay server connection error",
+        titlePending: "TODO: Video relay server connection pending",
+        error: "TODO: TURN server isn't reachable",
+        content: "TODO: The video relay server cannot be reached. You may be unable to communicate with other users.",
+        solutionVpn: "TODO: If you are <strong>connecting via a VPN</strong>, please disconnect from you VPN and refresh the web page.",
+        solutionHotspot: "TODO: If you are on a restricted network (company network...), try switching network. For instance, create a <strong>Wifi hotspot</strong> with your phone and connect via your phone.",
+        solutionNetworkAdmin: "TODO: If you are a <strong>network administrator</strong>, review the ",
+        preparingYouNetworkGuide: 'TODO: "Preparing your network" guide',
+        refresh: "TODO: Refresh",
+        continue: "TODO: Continue",
+    },*/
     my: {
         silentZone: "Zona silenciosa",
         nameTag: "Usted",

--- a/play/src/i18n/de-DE/camera.ts
+++ b/play/src/i18n/de-DE/camera.ts
@@ -19,15 +19,18 @@ const camera: DeepPartial<Translation["camera"]> = {
             chrome: "/resources/help-setting-camera-permission/de-DE-chrome.png",
         },
     },
-    webrtc: {
-        title: "WebRtc connection error",
-        error: "STUN / TURN server isn't reachable",
-        content:
-            "The video relay server cannot be reached. You may be unable to communicate with other users. If you are connecting via a VPN, please disconnect and refresh the web page. You may click on the link below to test your WebRtc connection.",
-        testUrl: "WebRtc connection test",
-        refresh: "Refresh",
-        continue: "Continue",
-    },
+    /*webrtc: {
+        title: "TODO: Video relay server connection error",
+        titlePending: "TODO: Video relay server connection pending",
+        error: "TODO: TURN server isn't reachable",
+        content: "TODO: The video relay server cannot be reached. You may be unable to communicate with other users.",
+        solutionVpn: "TODO: If you are <strong>connecting via a VPN</strong>, please disconnect from you VPN and refresh the web page.",
+        solutionHotspot: "TODO: If you are on a restricted network (company network...), try switching network. For instance, create a <strong>Wifi hotspot</strong> with your phone and connect via your phone.",
+        solutionNetworkAdmin: "TODO: If you are a <strong>network administrator</strong>, review the ",
+        preparingYouNetworkGuide: 'TODO: "Preparing your network" guide',
+        refresh: "TODO: Refresh",
+        continue: "TODO: Continue",
+    },*/
     my: {
         silentZone: "Stiller Bereich",
         nameTag: "Sie",

--- a/play/src/i18n/en-US/camera.ts
+++ b/play/src/i18n/en-US/camera.ts
@@ -19,11 +19,16 @@ const camera: BaseTranslation = {
         },
     },
     webrtc: {
-        title: "WebRtc connection error",
-        error: "STUN / TURN server isn't reachable",
-        content:
-            "The video relay server cannot be reached. You may be unable to communicate with other users. If you are connecting via a VPN, please disconnect and refresh the web page. You may click on the link below to test your WebRtc connection.",
-        testUrl: "WebRtc connection test",
+        title: "Video relay server connection error",
+        titlePending: "Video relay server connection pending",
+        error: "TURN server isn't reachable",
+        content: "The video relay server cannot be reached. You may be unable to communicate with other users.",
+        solutionVpn:
+            "If you are <strong>connecting via a VPN</strong>, please disconnect from you VPN and refresh the web page.",
+        solutionHotspot:
+            "If you are on a restricted network (company network...), try switching network. For instance, create a <strong>Wifi hotspot</strong> with your phone and connect via your phone.",
+        solutionNetworkAdmin: "If you are a <strong>network administrator</strong>, review the ",
+        preparingYouNetworkGuide: '"Preparing your network" guide',
         refresh: "Refresh",
         continue: "Continue",
     },

--- a/play/src/i18n/es-ES/camera.ts
+++ b/play/src/i18n/es-ES/camera.ts
@@ -19,15 +19,18 @@ const camera: DeepPartial<Translation["camera"]> = {
             chrome: "/resources/help-setting-camera-permission/en-US-firefox.png",
         },
     },
-    webrtc: {
-        title: "WebRtc connection error",
-        error: "STUN / TURN server isn't reachable",
-        content:
-            "The video relay server cannot be reached. You may be unable to communicate with other users. If you are connecting via a VPN, please disconnect and refresh the web page. You may click on the link below to test your WebRtc connection.",
-        testUrl: "WebRtc connection test",
-        refresh: "Refresh",
-        continue: "Continue",
-    },
+    /*webrtc: {
+        title: "TODO: Video relay server connection error",
+        titlePending: "TODO: Video relay server connection pending",
+        error: "TODO: TURN server isn't reachable",
+        content: "TODO: The video relay server cannot be reached. You may be unable to communicate with other users.",
+        solutionVpn: "TODO: If you are <strong>connecting via a VPN</strong>, please disconnect from you VPN and refresh the web page.",
+        solutionHotspot: "TODO: If you are on a restricted network (company network...), try switching network. For instance, create a <strong>Wifi hotspot</strong> with your phone and connect via your phone.",
+        solutionNetworkAdmin: "TODO: If you are a <strong>network administrator</strong>, review the ",
+        preparingYouNetworkGuide: 'TODO: "Preparing your network" guide',
+        refresh: "TODO: Refresh",
+        continue: "TODO: Continue",
+    },*/
     my: {
         silentZone: "Zona silenciosa",
         nameTag: "Usted",

--- a/play/src/i18n/fr-FR/camera.ts
+++ b/play/src/i18n/fr-FR/camera.ts
@@ -20,11 +20,17 @@ const camera: DeepPartial<Translation["camera"]> = {
         },
     },
     webrtc: {
-        title: "Erreur de connexion WebRtc",
-        error: "STUN / TURN serveur ne sont pas accessibles",
+        title: "Erreur de connexion avec le serveur vidéo relai",
+        titlePending: "En attente de connexion avec le serveur vidéo relai",
+        error: "Impossible d'accéder au serveur TURN",
         content:
-            "Impossible de se connecter au serveur vidéo relais. La connexion audio/vidéo avec d'autres utilisateurs pourrait ne pas fonctionner. Si vous êtes connectés avec un VPN, vous devez vous déconnecter pour profiter de la meilleure expérience possible. Rendez-vous sur le lien ci-dessous pour tester votre connexion.",
-        testUrl: "Test ma connexion WebRtc",
+            "Impossible de se connecter au serveur vidéo relais. La connexion audio/vidéo avec d'autres utilisateurs pourrait ne pas fonctionner.",
+        solutionVpn:
+            "Si vous êtes connectés avec <strong>un VPN</strong>, vous devez vous déconnecter du VPN et rafraîchir votre page pour profiter de la meilleure expérience possible.",
+        solutionHotspot:
+            "Si vous êtes sur un réseau sécurisé (réseau d'entreprise...), essayez de changer de réseau. Par exemple, en créant un <strong>hotspot Wifi</strong> avec votre smartphone.",
+        solutionNetworkAdmin: "Si vous êtes <strong>administrateur réseay</strong>, consultez le ",
+        preparingYouNetworkGuide: '"guide de préparation du réseau"',
         refresh: "Rafraîchir",
         continue: "Continuer",
     },

--- a/play/src/i18n/hsb-DE/camera.ts
+++ b/play/src/i18n/hsb-DE/camera.ts
@@ -19,15 +19,18 @@ const camera: DeepPartial<Translation["camera"]> = {
             chrome: "/resources/help-setting-camera-permission/de-DE-chrome.png",
         },
     },
-    webrtc: {
-        title: "WebRtc connection error",
-        error: "STUN / TURN server isn't reachable",
-        content:
-            "The video relay server cannot be reached. You may be unable to communicate with other users. If you are connecting via a VPN, please disconnect and refresh the web page. You may click on the link below to test your WebRtc connection.",
-        testUrl: "WebRtc connection test",
-        refresh: "Refresh",
-        continue: "Continue",
-    },
+    /*webrtc: {
+        title: "TODO: Video relay server connection error",
+        titlePending: "TODO: Video relay server connection pending",
+        error: "TODO: TURN server isn't reachable",
+        content: "TODO: The video relay server cannot be reached. You may be unable to communicate with other users.",
+        solutionVpn: "TODO: If you are <strong>connecting via a VPN</strong>, please disconnect from you VPN and refresh the web page.",
+        solutionHotspot: "TODO: If you are on a restricted network (company network...), try switching network. For instance, create a <strong>Wifi hotspot</strong> with your phone and connect via your phone.",
+        solutionNetworkAdmin: "TODO: If you are a <strong>network administrator</strong>, review the ",
+        preparingYouNetworkGuide: 'TODO: "Preparing your network" guide',
+        refresh: "TODO: Refresh",
+        continue: "TODO: Continue",
+    },*/
     my: {
         silentZone: "ćichi wobłuk",
         nameTag: "Wy",

--- a/play/src/i18n/pt-BR/camera.ts
+++ b/play/src/i18n/pt-BR/camera.ts
@@ -19,15 +19,18 @@ const camera: DeepPartial<Translation["camera"]> = {
             chrome: "/resources/help-setting-camera-permission/en-US-firefox.png",
         },
     },
-    webrtc: {
-        title: "WebRtc connection error",
-        error: "STUN / TURN server isn't reachable",
-        content:
-            "The video relay server cannot be reached. You may be unable to communicate with other users. If you are connecting via a VPN, please disconnect and refresh the web page. You may click on the link below to test your WebRtc connection.",
-        testUrl: "WebRtc connection test",
-        refresh: "Refresh",
-        continue: "Continue",
-    },
+    /*webrtc: {
+        title: "TODO: Video relay server connection error",
+        titlePending: "TODO: Video relay server connection pending",
+        error: "TODO: TURN server isn't reachable",
+        content: "TODO: The video relay server cannot be reached. You may be unable to communicate with other users.",
+        solutionVpn: "TODO: If you are <strong>connecting via a VPN</strong>, please disconnect from you VPN and refresh the web page.",
+        solutionHotspot: "TODO: If you are on a restricted network (company network...), try switching network. For instance, create a <strong>Wifi hotspot</strong> with your phone and connect via your phone.",
+        solutionNetworkAdmin: "TODO: If you are a <strong>network administrator</strong>, review the ",
+        preparingYouNetworkGuide: 'TODO: "Preparing your network" guide',
+        refresh: "TODO: Refresh",
+        continue: "TODO: Continue",
+    },*/
     my: {
         silentZone: "Zona silenciosa",
         nameTag: "Você",

--- a/play/src/i18n/zh-CN/camera.ts
+++ b/play/src/i18n/zh-CN/camera.ts
@@ -18,15 +18,18 @@ const camera: DeepPartial<Translation["camera"]> = {
             chrome: "/resources/help-setting-camera-permission/en-US-firefox.png",
         },
     },
-    webrtc: {
-        title: "WebRtc connection error",
-        error: "STUN / TURN server isn't reachable",
-        content:
-            "The video relay server cannot be reached. You may be unable to communicate with other users. If you are connecting via a VPN, please disconnect and refresh the web page. You may click on the link below to test your WebRtc connection.",
-        testUrl: "WebRtc connection test",
-        refresh: "Refresh",
-        continue: "Continue",
-    },
+    /*webrtc: {
+        title: "TODO: Video relay server connection error",
+        titlePending: "TODO: Video relay server connection pending",
+        error: "TODO: TURN server isn't reachable",
+        content: "TODO: The video relay server cannot be reached. You may be unable to communicate with other users.",
+        solutionVpn: "TODO: If you are <strong>connecting via a VPN</strong>, please disconnect from you VPN and refresh the web page.",
+        solutionHotspot: "TODO: If you are on a restricted network (company network...), try switching network. For instance, create a <strong>Wifi hotspot</strong> with your phone and connect via your phone.",
+        solutionNetworkAdmin: "TODO: If you are a <strong>network administrator</strong>, review the ",
+        preparingYouNetworkGuide: 'TODO: "Preparing your network" guide',
+        refresh: "TODO: Refresh",
+        continue: "TODO: Continue",
+    },*/
     my: {
         silentZone: "安静区",
         nameTag: "你",


### PR DESCRIPTION
- [x] Only wait 5 seconds to display the error (don't wait for the end of candidates gathering that can be long). If > 5 seconds, display a pending message When gathering completes, display an error message
- [x] Changed text to more actionable test (propose to start a Wifi hotspot)
- [x] Do not display the message in ghost mode (because no WebRTC connection is possible anyway)
- [x] Do not run the test if no Turn server is configured
- [x] Test on Firefox (KO)
- [x] Test on iOS