### PR TITLE
Making a distinction between editable room and canEdit

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -634,6 +634,7 @@ export class GameRoom implements BrothersFinder {
             return {
                 mapUrl,
                 canEdit,
+                editable: canEdit,
                 entityCollectionsUrls,
                 authenticationMandatory: null,
                 group: null,

--- a/libs/messages/src/JsonMessages/MapDetailsData.ts
+++ b/libs/messages/src/JsonMessages/MapDetailsData.ts
@@ -167,9 +167,12 @@ export const isMapDetailsData = z.object({
         description: 'Whether the "report" feature is enabled or not on this room',
         example: true,
     }),
-    // Whether the "report" feature is enabled or not on this room
     canEdit: extendApi(z.optional(z.boolean()), {
-        description: 'Whether the "map editor" feature is enabled or not on this room',
+        description: 'Whether the "map editor" feature is enabled for the current user',
+        example: true,
+    }),
+    editable: extendApi(z.optional(z.boolean()), {
+        description: 'Whether the "map editor" feature is enabled or not on this room (true if the map comes from the map-storage)',
         example: true,
     }),
     loadingCowebsiteLogo: extendApi(z.string().nullable().optional(), {


### PR DESCRIPTION
An editable room is a map stored in the map-storage canEdit says if the current user can edit the room in the map-storage.