### PR TITLE
Setting up a ping between pusher and back

### DIFF
--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -35,6 +35,7 @@ import {
     ChatMessagePrompt,
     ServerToClientMessage,
     BatchMessage,
+    SubMessage,
 } from "./Messages/generated/messages_pb";
 import {
     sendUnaryData,
@@ -54,7 +55,6 @@ import { User, UserSocket } from "./Model/User";
 import { GameRoom } from "./Model/GameRoom";
 import Debug from "debug";
 import { Admin } from "./Model/Admin";
-import { SubMessage } from "workadventure-play/src/messages/generated/messages_pb";
 import { clearInterval } from "timers";
 
 const debug = Debug("roommanager");

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -636,6 +636,7 @@ message PusherToBackMessage {
     QueryMessage queryMessage = 21;
     AskPositionMessage askPositionMessage = 22;
     EditMapCommandMessage editMapCommandMessage = 23;
+    PingMessage pingMessage = 24;
   }
 }
 

--- a/play/src/pusher/models/Websocket/ExSocketInterface.ts
+++ b/play/src/pusher/models/Websocket/ExSocketInterface.ts
@@ -48,12 +48,6 @@ export interface ExSocketInterface extends compressors.WebSocket, Identificable,
     listenedZones: Set<Zone>;
     userRoomToken: string | undefined;
     maxHistoryChat: number;
-    // The ID of the timer that sends ping requests.
-    // Ping requests are sent from the server because the setTimeout on the browser is unreliable when the tab is hidden.
-    pingIntervalId: NodeJS.Timeout | undefined;
-    // When this timeout triggers, no pong has been received.
-    pongTimeoutId: NodeJS.Timeout | undefined;
-    resetPongTimeout: () => void;
     pusherRoom: PusherRoom | undefined;
     jabberId: string;
     jabberPassword: string;

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -45,6 +45,7 @@ import {
     ApplicationMessage,
     XmppSettingsMessage,
     MucRoomDefinitionMessage,
+    PingMessage,
 } from "../../messages/generated/messages_pb";
 
 import { ProtobufUtils } from "../models/Websocket/ProtobufUtils";
@@ -363,6 +364,11 @@ export class SocketManager implements ZoneEventListener {
         client.backConnection.write(pusherToBackMessage);
     }
 
+    handlePingMessage(client: ExSocketInterface, message: PingMessage): void {
+        const pusherToBackMessage = new PusherToBackMessage();
+        pusherToBackMessage.setPingmessage(message);
+        client.backConnection.write(pusherToBackMessage);
+    }
     handleEditMapCommandMessage(client: ExSocketInterface, message: EditMapCommandMessage): void {
         const pusherToBackMessage = new PusherToBackMessage();
         pusherToBackMessage.setEditmapcommandmessage(message);


### PR DESCRIPTION
The ping message between front and pusher is now extended to the back. The back server is in charge of sending the ping that flows through the pusher to the front and back again.

This way, we will be able to notice disconnections between the pusher and the back that can (rarely) cause ghost wokas to persist.

See #3072
See #2868