### PR TITLE
Fixing Play container crash on special request from bots

### DIFF
--- a/tests/tests/metadata.spec.ts
+++ b/tests/tests/metadata.spec.ts
@@ -32,4 +32,19 @@ test.describe('Meta tags', () => {
     // Validate the description can be found
     await expect(data2).not.toContain('Cette carte est tr');
   });
+
+  test('there is no error an funky URLs with bots.', async ({
+                                                                          request,
+                                                                        }) => {
+
+    const result = await request.get(`http://play.workadventure.localhost/_/global/`, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; adidxbot/2.0; +http://www.bing.com/bingbot.htm)',
+      }
+    });
+
+    // Note: in the future, it would be even better to return a 404 error code.
+    await expect(result.ok()).toBeTruthy();
+    await expect(await result.text()).not.toContain('Cette carte est tr');
+  });
 });


### PR DESCRIPTION
Fixing bug where Play container would crash if a bot asks for a requests in the form of http://play.workadventure.localhost/_/global/

Closes #3072