### PR TITLE
Moving canEdit from /map to /user/access endpoint

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -645,7 +645,6 @@ export class GameRoom implements BrothersFinder {
             }
             return {
                 mapUrl,
-                canEdit,
                 editable: canEdit,
                 entityCollectionsUrls,
                 authenticationMandatory: null,

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -146,6 +146,8 @@ export class SocketManager {
         roomJoinedMessage.setTagList(joinRoomMessage.getTagList());
         roomJoinedMessage.setUserroomtoken(joinRoomMessage.getUserroomtoken());
         roomJoinedMessage.setCharacterlayerList(joinRoomMessage.getCharacterlayerList());
+        roomJoinedMessage.setCanedit(joinRoomMessage.getCanedit());
+
         if (commandsToApply) {
             const editMapCommandsArrayMessage = new EditMapCommandsArrayMessage();
             editMapCommandsArrayMessage.setEditmapcommandsList(commandsToApply);

--- a/libs/messages/src/JsonMessages/MapDetailsData.ts
+++ b/libs/messages/src/JsonMessages/MapDetailsData.ts
@@ -167,10 +167,6 @@ export const isMapDetailsData = z.object({
         description: 'Whether the "report" feature is enabled or not on this room',
         example: true,
     }),
-    canEdit: extendApi(z.optional(z.boolean()), {
-        description: 'Whether the "map editor" feature is enabled for the current user',
-        example: true,
-    }),
     editable: extendApi(z.optional(z.boolean()), {
         description: 'Whether the "map editor" feature is enabled or not on this room (true if the map comes from the map-storage)',
         example: true,

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -440,6 +440,7 @@ message RoomJoinedMessage {
   EditMapCommandsArrayMessage editMapCommandsArrayMessage = 13;
   string webrtcUserName = 14;
   string webrtcPassword = 15;
+  bool canEdit = 16;
 }
 
 message WebRtcStartMessage {
@@ -560,6 +561,7 @@ message JoinRoomMessage {
   repeated ApplicationMessage applications = 14;
   string userJid = 15;
   string lastCommandId = 16;
+  bool canEdit = 17;
 }
 
 message UserJoinedZoneMessage {

--- a/play/src/front/Components/ActionBar/ActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ActionBar.svelte
@@ -49,6 +49,7 @@
         additionnalButtonsMenu,
         addClassicButtonActionBarEvent,
         addActionButtonActionBarEvent,
+        mapEditorActivated,
     } from "../../Stores/MenuStore";
     import {
         emoteDataStore,
@@ -71,7 +72,6 @@
     import { peerStore } from "../../Stores/PeerStore";
     import { StringUtils } from "../../Utils/StringUtils";
     import Tooltip from "../Util/Tooltip.svelte";
-    import { gameSceneIsLoadedStore } from "../../Stores/GameSceneStore";
     import { modalIframeStore, modalVisibilityStore } from "../../Stores/ModalStore";
     import { userHasAccessToBackOfficeStore } from "../../Stores/GameStore";
     import { AddButtonActionBarEvent } from "../../Api/Events/Ui/ButtonActionBarEvent";
@@ -701,7 +701,7 @@
                         <img draggable="false" src={menuImg} style="padding: 2px" alt={$LL.menu.icon.open.menu()} />
                     </button>
                 </div>
-                {#if $gameSceneIsLoadedStore && gameManager.getCurrentGameScene().isMapEditorEnabled()}
+                {#if $mapEditorActivated}
                     <div
                         on:dragstart|preventDefault={noDrag}
                         on:click={toggleMapEditorMode}
@@ -722,7 +722,7 @@
                     >
                         <Tooltip text={$LL.actionbar.bo()} />
 
-                        <button id="mapEditorIcon">
+                        <button id="backOfficeIcon">
                             <img draggable="false" src={hammerImg} style="padding: 2px" alt="toggle-map-editor" />
                         </button>
                     </div>

--- a/play/src/front/Connexion/Room.ts
+++ b/play/src/front/Connexion/Room.ts
@@ -33,7 +33,6 @@ export class Room {
     private _group: string | null = null;
     private _expireOn: Date | undefined;
     private _canReport = false;
-    private _canEditMap = false;
     private _miniLogo: string | undefined;
     private _loadingCowebsiteLogo: string | undefined;
     private _loadingLogo: string | undefined;
@@ -161,7 +160,6 @@ export class Room {
                 }
                 this._opidWokaNamePolicy = data.opidWokaNamePolicy ?? OPID_WOKA_NAME_POLICY;
                 this._canReport = data.canReport ?? false;
-                this._canEditMap = data.canEdit ?? false;
                 this._miniLogo = data.miniLogo ?? undefined;
                 this._loadingCowebsiteLogo = data.loadingCowebsiteLogo ?? undefined;
                 this._loadingLogo = data.loadingLogo ?? undefined;
@@ -284,10 +282,6 @@ export class Room {
 
     get canReport(): boolean {
         return this._canReport;
-    }
-
-    get canEditMap(): boolean {
-        return this._canEditMap;
     }
 
     get loadingCowebsiteLogo(): string | undefined {

--- a/play/src/front/Connexion/RoomConnection.ts
+++ b/play/src/front/Connexion/RoomConnection.ts
@@ -1,4 +1,4 @@
-import { PUSHER_URL, UPLOADER_URL } from "../Enum/EnvironmentVariable";
+import { ENABLE_FEATURE_MAP_EDITOR, PUSHER_URL, UPLOADER_URL } from "../Enum/EnvironmentVariable";
 import Axios from "axios";
 
 import type { UserSimplePeerInterface } from "../WebRtc/SimplePeer";
@@ -19,6 +19,7 @@ import { get } from "svelte/store";
 import { followRoleStore, followUsersStore } from "../Stores/FollowStore";
 import {
     inviteUserActivated,
+    mapEditorActivated,
     menuIconVisiblilityStore,
     menuVisiblilityStore,
     warningContainerStore,
@@ -393,6 +394,7 @@ export class RoomConnection implements RoomConnection {
                             ? roomJoinedMessage.activatedInviteUser
                             : true
                     );
+                    mapEditorActivated.set(ENABLE_FEATURE_MAP_EDITOR && roomJoinedMessage.canEdit);
 
                     // If there are scripts from the admin, run it
                     if (roomJoinedMessage.applications != undefined) {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -2933,8 +2933,4 @@ ${escapedMessage}
     public getActivatablesManager(): ActivatablesManager {
         return this.activatablesManager;
     }
-
-    public isMapEditorEnabled(): boolean {
-        return ENABLE_FEATURE_MAP_EDITOR && connectionManager.currentRoom?.canEditMap === true;
-    }
 }

--- a/play/src/front/Stores/MapEditorStore.ts
+++ b/play/src/front/Stores/MapEditorStore.ts
@@ -1,10 +1,9 @@
 import type { PredefinedPropertyData, EntityPrefab } from "@workadventure/map-editor";
-import { writable } from "svelte/store";
-import { connectionManager } from "../Connexion/ConnectionManager";
-import { ENABLE_FEATURE_MAP_EDITOR } from "../Enum/EnvironmentVariable";
+import { writable, get } from "svelte/store";
 import type { AreaPreview } from "../Phaser/Components/MapEditor/AreaPreview";
 import { EditorToolName } from "../Phaser/Game/MapEditor/MapEditorModeManager";
 import { Entity } from "../Phaser/ECS/Entity";
+import { mapEditorActivated } from "./MenuStore";
 
 function createMapEditorModeStore() {
     const { set, subscribe } = writable(false);
@@ -12,7 +11,7 @@ function createMapEditorModeStore() {
     return {
         subscribe,
         switchMode: (value: boolean) => {
-            set(ENABLE_FEATURE_MAP_EDITOR && connectionManager.currentRoom?.canEditMap === true && value);
+            set(get(mapEditorActivated) && value);
         },
     };
 }

--- a/play/src/front/Stores/MenuStore.ts
+++ b/play/src/front/Stores/MenuStore.ts
@@ -70,6 +70,7 @@ export const inviteMenu: MenuItem = {
 };
 
 export const inviteUserActivated = writable(true);
+export const mapEditorActivated = writable(false);
 
 function createSubMenusStore() {
     const { subscribe, update } = writable<MenuItem[]>([

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -92,6 +92,7 @@ interface UpgradeData {
     mucRooms: Array<MucRoomDefinitionInterface> | undefined;
     activatedInviteUser: boolean | undefined;
     isLogged: boolean;
+    canEdit: boolean;
 }
 
 interface UpgradeFailedInvalidData {
@@ -378,6 +379,7 @@ export class IoSocketController {
                             jabberPassword: null,
                             mucRooms: [],
                             activatedInviteUser: true,
+                            canEdit: false,
                         };
 
                         let characterLayerObjs: WokaDetail[];
@@ -510,6 +512,7 @@ export class IoSocketController {
                                 jabberPassword: userData.jabberPassword,
                                 mucRooms: userData.mucRooms,
                                 activatedInviteUser: userData.activatedInviteUser,
+                                canEdit: userData.canEdit ?? false,
                                 applications: userData.applications,
                                 position: {
                                     x: x,
@@ -759,6 +762,7 @@ export class IoSocketController {
         client.jabberPassword = ws.jabberPassword;
         client.mucRooms = ws.mucRooms;
         client.activatedInviteUser = ws.activatedInviteUser;
+        client.canEdit = ws.canEdit;
         client.isLogged = ws.isLogged;
         client.applications = ws.applications;
         client.customJsonReplacer = (key: unknown, value: unknown): string | undefined => {

--- a/play/src/pusher/models/Websocket/ExSocketInterface.ts
+++ b/play/src/pusher/models/Websocket/ExSocketInterface.ts
@@ -54,4 +54,5 @@ export interface ExSocketInterface extends compressors.WebSocket, Identificable,
     activatedInviteUser: boolean | undefined;
     mucRooms: Array<MucRoomDefinitionInterface>;
     applications: Array<ApplicationDefinitionInterface> | undefined;
+    canEdit: boolean;
 }

--- a/play/src/pusher/services/AdminApi.ts
+++ b/play/src/pusher/services/AdminApi.ts
@@ -81,6 +81,9 @@ export const isFetchMemberDataByUuidResponse = z.object({
     applications: extendApi(z.array(isApplicationDefinitionInterface).nullable().optional(), {
         description: "The applications run into the customer's world",
     }),
+    canEdit: extendApi(z.boolean().nullable().optional(), {
+        description: "True if the user can edit the map",
+    }),
 });
 
 export type FetchMemberDataByUuidResponse = z.infer<typeof isFetchMemberDataByUuidResponse>;

--- a/play/src/pusher/services/LocalAdmin.ts
+++ b/play/src/pusher/services/LocalAdmin.ts
@@ -27,6 +27,12 @@ class LocalAdmin implements AdminInterface {
         characterLayers: string[],
         locale?: string
     ): Promise<FetchMemberDataByUuidResponse> {
+        let canEdit = false;
+        const roomUrl = new URL(playUri);
+        const match = /\/~\/(.+)/.exec(roomUrl.pathname);
+        if (match) {
+            canEdit = true;
+        }
         const mucRooms = [{ name: "Connected users", url: playUri, type: "default", subscribe: false }];
         if (ENABLE_CHAT) {
             mucRooms.push({ name: "Welcome", url: `${playUri}/forum/welcome`, type: "forum", subscribe: false });
@@ -41,6 +47,7 @@ class LocalAdmin implements AdminInterface {
             userRoomToken: undefined,
             mucRooms,
             activatedInviteUser: true,
+            canEdit,
         };
     }
 
@@ -59,13 +66,11 @@ class LocalAdmin implements AdminInterface {
         }
 
         let mapUrl = "";
-        let canEdit = false;
         const entityCollectionsUrls = [];
         let match = /\/~\/(.+)/.exec(roomUrl.pathname);
         if (match) {
             mapUrl = `${PUBLIC_MAP_STORAGE_URL}/${match[1]}`;
             entityCollectionsUrls.push(`${PUBLIC_MAP_STORAGE_URL}/entityCollections`);
-            canEdit = true;
         } else {
             match = /\/_\/[^/]+\/(.+)/.exec(roomUrl.pathname);
             if (!match) {
@@ -85,7 +90,6 @@ class LocalAdmin implements AdminInterface {
 
         return Promise.resolve({
             mapUrl,
-            canEdit,
             entityCollectionsUrls,
             authenticationMandatory: DISABLE_ANONYMOUS,
             contactPage: null,

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -204,6 +204,7 @@ export class SocketManager implements ZoneEventListener {
             joinRoomMessage.setActivatedinviteuser(
                 client.activatedInviteUser != undefined ? client.activatedInviteUser : true
             );
+            joinRoomMessage.setCanedit(client.canEdit);
 
             if (client.applications != undefined) {
                 for (const aplicationValue of client.applications) {


### PR DESCRIPTION
This is more logical as the canEdit is user related, like tags.