### PR TITLE
Migrating Pusher to use ts-proto

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory: "messages"
 
       - name: "Build proto messages"
-        run: npm run ts-proto && npm run proto && npm run copy-to-play
+        run: npm run ts-proto && npm run proto
         working-directory: "messages"
 
       - name: "Generate i18n files"

--- a/.github/workflows/push-to-npm.yml
+++ b/.github/workflows/push-to-npm.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: "messages"
 
       - name: "Build proto messages"
-        run: npm run ts-proto && npm run copy-to-play
+        run: npm run ts-proto
         working-directory: "messages"
 
       - name: "Generate i18n files"

--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -196,7 +196,7 @@ export class GameRoom implements BrothersFinder {
             joinRoomMessage.getAvailabilitystatus(),
             socket,
             joinRoomMessage.getTagList(),
-            joinRoomMessage.getVisitcardurl(),
+            joinRoomMessage.getVisitcardurl()?.getValue() ?? null,
             joinRoomMessage.getName(),
             ProtobufUtils.toCharacterLayerObjects(joinRoomMessage.getCharacterlayerList()),
             this.roomUrl,

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -113,7 +113,7 @@ export class SocketManager {
 
         if (lastCommandId) {
             const updateMapToNewestMessage = new UpdateMapToNewestMessage();
-            updateMapToNewestMessage.setCommandid(lastCommandId);
+            updateMapToNewestMessage.setCommandid(lastCommandId.getValue());
 
             const updateMapToNewestWithKeyMessage = new UpdateMapToNewestWithKeyMessage();
             updateMapToNewestWithKeyMessage.setMapkey(room.mapUrl);

--- a/chat/src/Event/XmppSettingsMessageEvent.ts
+++ b/chat/src/Event/XmppSettingsMessageEvent.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { isMucRoomDefinition } from "@workadventure/messages";
 
 export const isXmppSettingsMessageEvent = z.object({
-    jid: z.string(),
     conferenceDomain: z.string(),
     rooms: z.array(isMucRoomDefinition),
     jabberId: z.string(),

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,10 +42,8 @@ services:
         environment:
             # On startup, we ask the messages container to regenerate the files.
             # Note: we need to use this "messages" container because of ARM64 processors that are not supported with protoc (used in "messages" container)
-            STARTUP_COMMAND_0: touch /usr/src/app/play/src/messages/generate_request/need_regenerate
             STARTUP_COMMAND_1: ../npm-install.sh
             STARTUP_COMMAND_2: npm run typesafe-i18n
-            STARTUP_COMMAND_5: while [ -f /usr/src/app/play/src/messages/generate_request/need_regenerate ]; do sleep 1; done
             DEBUG: "socket:*"
             DEBUG_ERROR_MESSAGES: "true"
             DEBUG_MODE: "$DEBUG_MODE"

--- a/messages/package.json
+++ b/messages/package.json
@@ -6,11 +6,10 @@
     "proto": "grpc_tools_node_protoc --grpc_out=grpc_js:generated  --js_out=\"import_style=commonjs,binary:generated\" --ts_out=grpc_js:generated -I ./protos protos/*.proto",
     "ts-proto": "grpc_tools_node_protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=../libs/messages/src/ts-proto-generated --ts_proto_opt=outputServices=grpc-js --ts_proto_opt=oneof=unions --ts_proto_opt=esModuleInterop=true -I ./protos protos/*.proto",
     "copy-to-back": "syncdir generated/ ../back/src/Messages/generated && rm -f ../back/src/Messages/generate_request/need_regenerate",
-    "proto-all": "npm run proto && npm run ts-proto && npm run copy-to-back && npm run copy-to-play",
+    "proto-all": "npm run proto && npm run ts-proto && npm run copy-to-back",
     "proto:watch": "npm run proto-all; run-p proto:watch-need-regenerate proto:watch-files",
     "proto:watch-need-regenerate": "chokidar '../back/src/Messages/generate_request/*' '../play/src/messages/generate_request/*' -c \"if [ '{event}' = 'add' ]; then npm run proto-all; fi;\"",
     "proto:watch-files": "chokidar 'protos/messages.proto' -c 'npm run proto-all'",
-    "copy-to-play": "syncdir generated/ ../play/src/messages/generated && rm -f ../play/src/messages/generate_request/need_regenerate",
     "tag-version": "sed -i \"s/apiVersionHash = \\\".*\\\"/apiVersionHash = \\\"$(sha1sum protos/messages.proto ../libs/messages/src/JsonMessages/* | sha1sum | cut -c1-8)\\\"/g\" ../libs/messages/src/JsonMessages/ApiVersion.ts",
     "precommit": "lint-staged",
     "pretty": "npm prettier --write '../libs/messages/src/JsonMessages/**/*.ts'"

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -213,7 +213,6 @@ message ClientToServerMessage {
     WebRtcSignalToServerMessage webRtcSignalToServerMessage = 7;
     WebRtcSignalToServerMessage webRtcScreenSharingSignalToServerMessage = 8;
     PlayGlobalMessage playGlobalMessage = 9;
-    StopGlobalMessage stopGlobalMessage = 10;
     ReportPlayerMessage reportPlayerMessage = 11;
     EmotePromptMessage emotePromptMessage = 13;
     VariableMessage variableMessage = 14;
@@ -278,10 +277,6 @@ message PlayGlobalMessage {
   string type = 1;
   string content = 2;
   bool broadcastToWorld = 3;
-}
-
-message StopGlobalMessage {
-  string id = 1;
 }
 
 /************ Queries and answers ****************/
@@ -356,7 +351,7 @@ message SubMessage {
 }
 
 message BatchMessage {
-  string event = 1;
+  string event = 1; // FIXME: event seems to be useless
   repeated SubMessage payload = 2;
 }
 
@@ -553,14 +548,14 @@ message JoinRoomMessage {
   repeated string tag = 6;
   string IPAddress = 7;
   CompanionMessage companion = 8;
-  string visitCardUrl = 9;
+  google.protobuf.StringValue visitCardUrl = 9;
   string userRoomToken = 10;
   AvailabilityStatus availabilityStatus = 11;
   bool activatedInviteUser = 12;
   bool isLogged = 13;
   repeated ApplicationMessage applications = 14;
   string userJid = 15;
-  string lastCommandId = 16;
+  google.protobuf.StringValue lastCommandId = 16;
   bool canEdit = 17;
 }
 
@@ -800,7 +795,6 @@ message MucRoomDefinitionMessage {
 }
 
 message XmppSettingsMessage{
-  string jid = 1;
   string conferenceDomain = 2;
   repeated MucRoomDefinitionMessage rooms = 3;
   string jabberId = 4;

--- a/play/src/front/Api/Events/XmppSettingsMessageEvent.ts
+++ b/play/src/front/Api/Events/XmppSettingsMessageEvent.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { isMucRoomDefinition } from "@workadventure/messages";
 
 export const isXmppSettingsMessageEvent = z.object({
-    jid: z.string(),
     conferenceDomain: z.string(),
     rooms: z.array(isMucRoomDefinition),
     jabberId: z.string(),

--- a/play/src/messages/.gitignore
+++ b/play/src/messages/.gitignore
@@ -1,1 +1,0 @@
-/generated/

--- a/play/src/messages/generate_request/.gitignore
+++ b/play/src/messages/generate_request/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/play/src/pusher/controllers/AdminController.ts
+++ b/play/src/pusher/controllers/AdminController.ts
@@ -1,19 +1,9 @@
 import { apiClientRepository } from "../services/ApiClientRepository";
-import type { RoomsList } from "../../messages/generated/messages_pb";
-import {
-    AdminRoomMessage,
-    WorldFullWarningToRoomMessage,
-    RefreshRoomPromptMessage,
-    EmptyMessage,
-    ChatMessagePrompt,
-    MucRoomDefinitionMessage,
-    JoinMucRoomMessage,
-    LeaveMucRoomMessage,
-} from "../../messages/generated/messages_pb";
 import { adminToken } from "../middlewares/AdminToken";
 import { BaseHttpController } from "./BaseHttpController";
 import { Metadata } from "@grpc/grpc-js";
 import type { Request, Response } from "hyper-express";
+import { ChatMessagePrompt, RoomsList } from "@workadventure/messages";
 
 export class AdminController extends BaseHttpController {
     routes(): void {
@@ -57,12 +47,14 @@ export class AdminController extends BaseHttpController {
 
             await apiClientRepository.getClient(roomId).then((roomClient) => {
                 return new Promise<void>((res, rej) => {
-                    const roomMessage = new RefreshRoomPromptMessage();
-                    roomMessage.setRoomid(roomId);
-
-                    roomClient.sendRefreshRoomPrompt(roomMessage, (err) => {
-                        err ? rej(err) : res();
-                    });
+                    roomClient.sendRefreshRoomPrompt(
+                        {
+                            roomId,
+                        },
+                        (err) => {
+                            err ? rej(err) : res();
+                        }
+                    );
                 });
             });
 
@@ -129,20 +121,25 @@ export class AdminController extends BaseHttpController {
                     return apiClientRepository.getClient(roomId).then((roomClient) => {
                         return new Promise<void>((res, rej) => {
                             if (type === "message") {
-                                const roomMessage = new AdminRoomMessage();
-                                roomMessage.setMessage(text);
-                                roomMessage.setRoomid(roomId);
-
-                                roomClient.sendAdminMessageToRoom(roomMessage, (err) => {
-                                    err ? rej(err) : res();
-                                });
+                                roomClient.sendAdminMessageToRoom(
+                                    {
+                                        message: text,
+                                        roomId: roomId,
+                                        type: "", // TODO: what to put here?
+                                    },
+                                    (err) => {
+                                        err ? rej(err) : res();
+                                    }
+                                );
                             } else if (type === "capacity") {
-                                const roomMessage = new WorldFullWarningToRoomMessage();
-                                roomMessage.setRoomid(roomId);
-
-                                roomClient.sendWorldFullWarningToRoom(roomMessage, (err) => {
-                                    err ? rej(err) : res();
-                                });
+                                roomClient.sendWorldFullWarningToRoom(
+                                    {
+                                        roomId,
+                                    },
+                                    (err) => {
+                                        err ? rej(err) : res();
+                                    }
+                                );
                             }
                         });
                     });
@@ -181,14 +178,12 @@ export class AdminController extends BaseHttpController {
         this.app.get("/rooms", [adminToken], async (req: Request, res: Response) => {
             const roomClients = await apiClientRepository.getAllClients();
 
-            const emptyMessage = new EmptyMessage();
-
             const promises: Promise<RoomsList>[] = [];
             for (const roomClient of roomClients) {
                 promises.push(
                     new Promise<RoomsList>((resolve, reject) => {
                         roomClient.getRooms(
-                            emptyMessage,
+                            {},
                             new Metadata(),
                             {
                                 deadline: Date.now() + 1000,
@@ -212,8 +207,8 @@ export class AdminController extends BaseHttpController {
 
             for (const roomsListResult of roomsListsResult) {
                 if (roomsListResult.status === "fulfilled") {
-                    for (const room of roomsListResult.value.getRoomdescriptionList()) {
-                        rooms[room.getRoomid()] = room.getNbusers();
+                    for (const room of roomsListResult.value.roomDescription) {
+                        rooms[room.roomId] = room.nbUsers;
                     }
                 } else {
                     console.warn(
@@ -250,24 +245,29 @@ export class AdminController extends BaseHttpController {
                 const mucRoomName: string = body.mucRoomName;
                 const mucRoomType: string = body.mucRoomType;
 
-                const chatMessagePrompt = new ChatMessagePrompt();
-                chatMessagePrompt.setRoomid(body.roomId);
+                const chatMessagePrompt: ChatMessagePrompt = {
+                    roomId: body.roomId,
+                };
 
                 if (body.type === "join") {
-                    const mucRoomDefinition = new MucRoomDefinitionMessage();
-                    mucRoomDefinition.setUrl(mucRoomUrl);
-                    mucRoomDefinition.setName(mucRoomName);
-                    mucRoomDefinition.setType(mucRoomType);
-
-                    const joinMucRoomMessage = new JoinMucRoomMessage();
-                    joinMucRoomMessage.setMucroomdefinitionmessage(mucRoomDefinition);
-
-                    chatMessagePrompt.setJoinmucroommessage(joinMucRoomMessage);
+                    chatMessagePrompt.message = {
+                        $case: "joinMucRoomMessage",
+                        joinMucRoomMessage: {
+                            mucRoomDefinitionMessage: {
+                                url: mucRoomUrl,
+                                name: mucRoomName,
+                                type: mucRoomType,
+                                subscribe: false,
+                            },
+                        },
+                    };
                 } else if (body.type === "leave") {
-                    const leaveMucRoomMessage = new LeaveMucRoomMessage();
-                    leaveMucRoomMessage.setUrl(mucRoomUrl);
-
-                    chatMessagePrompt.setLeavemucroommessage(leaveMucRoomMessage);
+                    chatMessagePrompt.message = {
+                        $case: "leaveMucRoomMessage",
+                        leaveMucRoomMessage: {
+                            url: mucRoomUrl,
+                        },
+                    };
                 } else {
                     throw new Error("Incorrect type parameter value");
                 }

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -1,33 +1,5 @@
 import type { ExSocketInterface } from "../models/Websocket/ExSocketInterface";
 import type { PointInterface } from "../models/Websocket/PointInterface";
-import {
-    SubMessage,
-    BatchMessage,
-    ClientToServerMessage,
-    SendUserMessage,
-    ServerToClientMessage,
-    CompanionMessage,
-} from "../../messages/generated/messages_pb";
-import type {
-    UserMovesMessage,
-    SetPlayerDetailsMessage,
-    ItemEventMessage,
-    ViewportMessage,
-    WebRtcSignalToServerMessage,
-    PlayGlobalMessage,
-    ReportPlayerMessage,
-    EmotePromptMessage,
-    FollowRequestMessage,
-    FollowConfirmationMessage,
-    FollowAbortMessage,
-    VariableMessage,
-    LockGroupPromptMessage,
-    AskPositionMessage,
-    AvailabilityStatus,
-    QueryMessage,
-    EditMapCommandMessage,
-    PingMessage,
-} from "../../messages/generated/messages_pb";
 import qs from "qs";
 import type { AdminSocketTokenData } from "../services/JWTTokenManager";
 import { jwtTokenManager, tokenInvalidException } from "../services/JWTTokenManager";
@@ -43,19 +15,24 @@ import {
 } from "../enums/EnvironmentVariable";
 import type { Zone } from "../models/Zone";
 import type { ExAdminSocketInterface } from "../models/Websocket/ExAdminSocketInterface";
-import { isAdminMessageInterface } from "../models/Websocket/Admin/AdminMessages";
 import type { AdminMessageInterface } from "../models/Websocket/Admin/AdminMessages";
+import { isAdminMessageInterface } from "../models/Websocket/Admin/AdminMessages";
 import Axios from "axios";
 import { InvalidTokenError } from "./InvalidTokenError";
 import type HyperExpress from "hyper-express";
 import { z } from "zod";
 import { adminService } from "../services/AdminService";
 import {
-    MucRoomDefinitionInterface,
-    ErrorApiData,
-    WokaDetail,
     apiVersionHash,
+    AvailabilityStatus,
+    ClientToServerMessage,
+    CompanionMessage,
+    ErrorApiData,
     isErrorApiData,
+    MucRoomDefinitionInterface,
+    ServerToClientMessage as ServerToClientMessageTsProto,
+    SubMessage,
+    WokaDetail,
 } from "@workadventure/messages";
 import Jwt from "jsonwebtoken";
 import { v4 as uuid } from "uuid";
@@ -322,8 +299,9 @@ export class IoSocketController {
                         let companion: CompanionMessage | undefined = undefined;
 
                         if (typeof query.companion === "string") {
-                            companion = new CompanionMessage();
-                            companion.setName(query.companion);
+                            companion = {
+                                name: query.companion,
+                            };
                         }
 
                         if (typeof name !== "string") {
@@ -608,99 +586,139 @@ export class IoSocketController {
                     //get data information and show messages
                     if (client.messages && Array.isArray(client.messages)) {
                         client.messages.forEach((c: unknown) => {
+                            // FIXME: dangerous cast
                             const messageToSend = c as { type: string; message: string };
 
-                            const sendUserMessage = new SendUserMessage();
-                            sendUserMessage.setType(messageToSend.type);
-                            sendUserMessage.setMessage(messageToSend.message);
-
-                            const serverToClientMessage = new ServerToClientMessage();
-                            serverToClientMessage.setSendusermessage(sendUserMessage);
+                            const bytes = ServerToClientMessageTsProto.encode({
+                                message: {
+                                    $case: "sendUserMessage",
+                                    sendUserMessage: {
+                                        type: messageToSend.type,
+                                        message: messageToSend.message,
+                                    },
+                                },
+                            }).finish();
 
                             if (!client.disconnecting) {
-                                client.send(serverToClientMessage.serializeBinary().buffer, true);
+                                client.send(bytes, true);
                             }
                         });
                     }
+
+                    // Performance test
+                    /*
+                    const positionMessage = new PositionMessage();
+                    positionMessage.setMoving(true);
+                    positionMessage.setX(300);
+                    positionMessage.setY(300);
+                    positionMessage.setDirection(PositionMessage.Direction.DOWN);
+
+                    const userMovedMessage = new UserMovedMessage();
+                    userMovedMessage.setUserid(1);
+                    userMovedMessage.setPosition(positionMessage);
+
+                    const subMessage = new SubMessage();
+                    subMessage.setUsermovedmessage(userMovedMessage);
+
+                    const startTimestamp2 = Date.now();
+                    for (let i = 0; i < 100000; i++) {
+                        const batchMessage = new BatchMessage();
+                        batchMessage.setEvent("");
+                        batchMessage.setPayloadList([
+                            subMessage
+                        ]);
+
+                        const serverToClientMessage = new ServerToClientMessage();
+                        serverToClientMessage.setBatchmessage(batchMessage);
+
+                        client.send(serverToClientMessage.serializeBinary().buffer, true);
+                    }
+                    const endTimestamp2 = Date.now();
+                    console.log("Time taken 2: " + (endTimestamp2 - startTimestamp2) + "ms");
+
+                    const startTimestamp = Date.now();
+                    for (let i = 0; i < 100000; i++) {
+                        // Let's do a performance test!
+                        const bytes = ServerToClientMessageTsProto.encode({
+                            message: {
+                                $case: "batchMessage",
+                                batchMessage: {
+                                    event: '',
+                                    payload: [
+                                        {
+                                            message: {
+                                                $case: "userMovedMessage",
+                                                userMovedMessage: {
+                                                    userId: 1,
+                                                    position: {
+                                                        moving: true,
+                                                        x: 300,
+                                                        y: 300,
+                                                        direction: PositionMessage_Direction.DOWN,
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }).finish();
+
+                        client.send(bytes);
+                    }
+                    const endTimestamp = Date.now();
+                    console.log("Time taken: " + (endTimestamp - startTimestamp) + "ms");
+                    */
                 })().catch((e) => console.error(e));
             },
             message: (ws, arrayBuffer): void => {
                 (async () => {
                     const client = ws as ExSocketInterface;
-                    const message = ClientToServerMessage.deserializeBinary(new Uint8Array(arrayBuffer));
 
-                    if (message.hasViewportmessage()) {
-                        socketManager.handleViewport(
-                            client,
-                            (message.getViewportmessage() as ViewportMessage).toObject()
-                        );
-                    } else if (message.hasUsermovesmessage()) {
-                        socketManager.handleUserMovesMessage(client, message.getUsermovesmessage() as UserMovesMessage);
-                    } else if (message.hasSetplayerdetailsmessage()) {
-                        socketManager.handleSetPlayerDetails(
-                            client,
-                            message.getSetplayerdetailsmessage() as SetPlayerDetailsMessage
-                        );
-                    } else if (message.hasItemeventmessage()) {
-                        socketManager.handleItemEvent(client, message.getItemeventmessage() as ItemEventMessage);
-                    } else if (message.hasVariablemessage()) {
-                        socketManager.handleVariableEvent(client, message.getVariablemessage() as VariableMessage);
-                    } else if (message.hasWebrtcsignaltoservermessage()) {
-                        socketManager.emitVideo(
-                            client,
-                            message.getWebrtcsignaltoservermessage() as WebRtcSignalToServerMessage
-                        );
-                    } else if (message.hasWebrtcscreensharingsignaltoservermessage()) {
-                        socketManager.emitScreenSharing(
-                            client,
-                            message.getWebrtcscreensharingsignaltoservermessage() as WebRtcSignalToServerMessage
-                        );
-                    } else if (message.hasPlayglobalmessage()) {
-                        await socketManager.emitPlayGlobalMessage(
-                            client,
-                            message.getPlayglobalmessage() as PlayGlobalMessage
-                        );
-                    } else if (message.hasReportplayermessage()) {
-                        await socketManager.handleReportMessage(
-                            client,
-                            message.getReportplayermessage() as ReportPlayerMessage
-                        );
-                    } else if (message.hasQuerymessage()) {
-                        socketManager.handleQueryMessage(client, message.getQuerymessage() as QueryMessage);
-                    } else if (message.hasEmotepromptmessage()) {
-                        socketManager.handleEmotePromptMessage(
-                            client,
-                            message.getEmotepromptmessage() as EmotePromptMessage
-                        );
-                    } else if (message.hasFollowrequestmessage()) {
-                        socketManager.handleFollowRequest(
-                            client,
-                            message.getFollowrequestmessage() as FollowRequestMessage
-                        );
-                    } else if (message.hasFollowconfirmationmessage()) {
-                        socketManager.handleFollowConfirmation(
-                            client,
-                            message.getFollowconfirmationmessage() as FollowConfirmationMessage
-                        );
-                    } else if (message.hasFollowabortmessage()) {
-                        socketManager.handleFollowAbort(client, message.getFollowabortmessage() as FollowAbortMessage);
-                    } else if (message.hasLockgrouppromptmessage()) {
-                        socketManager.handleLockGroup(
-                            client,
-                            message.getLockgrouppromptmessage() as LockGroupPromptMessage
-                        );
-                    } else if (message.hasPingmessage()) {
-                        socketManager.handlePingMessage(client, message.getPingmessage() as PingMessage);
-                    } else if (message.hasEditmapcommandmessage()) {
-                        socketManager.handleEditMapCommandMessage(
-                            client,
-                            message.getEditmapcommandmessage() as EditMapCommandMessage
-                        );
-                    } else if (message.hasAskpositionmessage()) {
-                        socketManager.handleAskPositionMessage(
-                            client,
-                            message.getAskpositionmessage() as AskPositionMessage
-                        );
+                    const message = ClientToServerMessage.decode(new Uint8Array(arrayBuffer));
+
+                    if (!message.message) {
+                        console.warn("Empty message received.");
+                        return;
+                    }
+
+                    switch (message.message.$case) {
+                        case "viewportMessage": {
+                            socketManager.handleViewport(client, message.message.viewportMessage);
+                            break;
+                        }
+                        case "userMovesMessage": {
+                            socketManager.handleUserMovesMessage(client, message.message.userMovesMessage);
+                            break;
+                        }
+                        case "playGlobalMessage": {
+                            await socketManager.emitPlayGlobalMessage(client, message.message.playGlobalMessage);
+                            break;
+                        }
+                        case "reportPlayerMessage": {
+                            await socketManager.handleReportMessage(client, message.message.reportPlayerMessage);
+                            break;
+                        }
+                        case "setPlayerDetailsMessage":
+                        case "itemEventMessage":
+                        case "variableMessage":
+                        case "webRtcSignalToServerMessage":
+                        case "webRtcScreenSharingSignalToServerMessage":
+                        case "queryMessage":
+                        case "emotePromptMessage":
+                        case "followRequestMessage":
+                        case "followConfirmationMessage":
+                        case "followAbortMessage":
+                        case "lockGroupPromptMessage":
+                        case "pingMessage":
+                        case "editMapCommandMessage":
+                        case "askPositionMessage": {
+                            socketManager.forwardMessageToBack(client, message.message);
+                            break;
+                        }
+                        default: {
+                            const _exhaustiveCheck: never = message.message;
+                        }
                     }
 
                     /* Ok is false if backpressure was built up, wait for drain */
@@ -740,7 +758,10 @@ export class IoSocketController {
         client.userUuid = ws.userUuid;
         client.IPAddress = ws.IPAddress;
         client.token = ws.token;
-        client.batchedMessages = new BatchMessage();
+        client.batchedMessages = {
+            event: "",
+            payload: [],
+        };
         client.batchTimeout = null;
         client.emitInBatch = (payload: SubMessage): void => {
             emitInBatch(client, payload);

--- a/play/src/pusher/controllers/PingController.ts
+++ b/play/src/pusher/controllers/PingController.ts
@@ -1,6 +1,6 @@
 import { BaseHttpController } from "./BaseHttpController";
 import { apiClientRepository } from "../services/ApiClientRepository";
-import { PingMessage } from "../../messages/generated/messages_pb";
+import { PingMessage } from "@workadventure/messages";
 import { Metadata } from "@grpc/grpc-js";
 
 export class PingController extends BaseHttpController {
@@ -60,7 +60,7 @@ export class PingController extends BaseHttpController {
                 promises.push(
                     new Promise<PingMessage>((resolve, reject) => {
                         client.ping(
-                            new PingMessage(),
+                            {},
                             new Metadata(),
                             {
                                 deadline: Date.now() + 1000,

--- a/play/src/pusher/models/Websocket/ExAdminSocketInterface.ts
+++ b/play/src/pusher/models/Websocket/ExAdminSocketInterface.ts
@@ -1,4 +1,4 @@
-import type { AdminPusherToBackMessage, ServerToAdminClientMessage } from "../../../messages/generated/messages_pb";
+import type { AdminPusherToBackMessage, ServerToAdminClientMessage } from "@workadventure/messages";
 import type { compressors } from "hyper-express";
 import type { ClientDuplexStream } from "@grpc/grpc-js";
 

--- a/play/src/pusher/models/Websocket/ExSocketInterface.ts
+++ b/play/src/pusher/models/Websocket/ExSocketInterface.ts
@@ -1,20 +1,22 @@
 import type { PointInterface } from "./PointInterface";
 import type { Identificable } from "./Identificable";
 import type { ViewportInterface } from "./ViewportMessage";
-import type {
-    AvailabilityStatus,
-    BatchMessage,
-    CompanionMessage,
-    PusherToBackMessage,
-    ServerToClientMessage,
-    SubMessage,
-} from "../../../messages/generated/messages_pb";
 import type { ClientDuplexStream } from "@grpc/grpc-js";
 import type { Zone } from "../Zone";
 import type { compressors } from "hyper-express";
-import type { WokaDetail, MucRoomDefinitionInterface, ApplicationDefinitionInterface } from "@workadventure/messages";
+import type {
+    WokaDetail,
+    MucRoomDefinitionInterface,
+    ApplicationDefinitionInterface,
+    CompanionMessage,
+    SubMessage,
+    BatchMessage,
+    PusherToBackMessage,
+    ServerToClientMessage,
+} from "@workadventure/messages";
 import type { PusherRoom } from "../PusherRoom";
 import { CustomJsonReplacerInterface } from "../CustomJsonReplacerInterface";
+import { AvailabilityStatus } from "@workadventure/messages";
 
 export type BackConnection = ClientDuplexStream<PusherToBackMessage, ServerToClientMessage>;
 

--- a/play/src/pusher/models/Websocket/ProtobufUtils.ts
+++ b/play/src/pusher/models/Websocket/ProtobufUtils.ts
@@ -1,110 +1,30 @@
 import type { PointInterface } from "./PointInterface";
-import {
-    CharacterLayerMessage,
-    ItemEventMessage,
-    PointMessage,
-    PositionMessage,
-} from "../../../messages/generated/messages_pb";
-import Direction = PositionMessage.Direction;
-import type { ItemEventMessageInterface } from "../../models/Websocket/ItemEventMessage";
-import type { PositionInterface } from "../../models/PositionInterface";
-import type { WokaDetail } from "@workadventure/messages";
+import type { PositionMessage } from "@workadventure/messages";
+import { PositionMessage_Direction } from "@workadventure/messages";
 
 export class ProtobufUtils {
     public static toPositionMessage(point: PointInterface): PositionMessage {
-        let direction: Direction;
+        let direction: PositionMessage_Direction;
         switch (point.direction) {
             case "up":
-                direction = Direction.UP;
+                direction = PositionMessage_Direction.UP;
                 break;
             case "down":
-                direction = Direction.DOWN;
+                direction = PositionMessage_Direction.DOWN;
                 break;
             case "left":
-                direction = Direction.LEFT;
+                direction = PositionMessage_Direction.LEFT;
                 break;
             case "right":
-                direction = Direction.RIGHT;
+                direction = PositionMessage_Direction.RIGHT;
                 break;
             default:
                 throw new Error("unexpected direction");
         }
 
-        const position = new PositionMessage();
-        position.setX(point.x);
-        position.setY(point.y);
-        position.setMoving(point.moving);
-        position.setDirection(direction);
-
-        return position;
-    }
-
-    public static toPointInterface(position: PositionMessage): PointInterface {
-        let direction: string;
-        switch (position.getDirection()) {
-            case Direction.UP:
-                direction = "up";
-                break;
-            case Direction.DOWN:
-                direction = "down";
-                break;
-            case Direction.LEFT:
-                direction = "left";
-                break;
-            case Direction.RIGHT:
-                direction = "right";
-                break;
-            default:
-                throw new Error("Unexpected direction");
-        }
-
-        // sending to all clients in room except sender
         return {
-            x: position.getX(),
-            y: position.getY(),
+            ...point,
             direction,
-            moving: position.getMoving(),
         };
-    }
-
-    public static toPointMessage(point: PositionInterface): PointMessage {
-        const position = new PointMessage();
-        position.setX(Math.floor(point.x));
-        position.setY(Math.floor(point.y));
-
-        return position;
-    }
-
-    public static toItemEvent(itemEventMessage: ItemEventMessage): ItemEventMessageInterface {
-        return {
-            itemId: itemEventMessage.getItemid(),
-            event: itemEventMessage.getEvent(),
-            parameters: JSON.parse(itemEventMessage.getParametersjson()),
-            state: JSON.parse(itemEventMessage.getStatejson()),
-        };
-    }
-
-    public static toItemEventProtobuf(itemEvent: ItemEventMessageInterface): ItemEventMessage {
-        const itemEventMessage = new ItemEventMessage();
-        itemEventMessage.setItemid(itemEvent.itemId);
-        itemEventMessage.setEvent(itemEvent.event);
-        itemEventMessage.setParametersjson(JSON.stringify(itemEvent.parameters));
-        itemEventMessage.setStatejson(JSON.stringify(itemEvent.state));
-
-        return itemEventMessage;
-    }
-
-    public static toCharacterLayerMessages(characterLayers: WokaDetail[]): CharacterLayerMessage[] {
-        return characterLayers.map(function (characterLayer): CharacterLayerMessage {
-            const message = new CharacterLayerMessage();
-            message.setName(characterLayer.id);
-            if (characterLayer.url) {
-                message.setUrl(characterLayer.url);
-            }
-            if (characterLayer.layer) {
-                message.setLayer(characterLayer.layer);
-            }
-            return message;
-        });
     }
 }

--- a/play/src/pusher/services/ApiClientRepository.ts
+++ b/play/src/pusher/services/ApiClientRepository.ts
@@ -1,12 +1,12 @@
 /**
  * A class to get connections to the correct "api" server given a room name.
  */
-import { RoomManagerClient } from "../../messages/generated/services_grpc_pb";
 import * as grpc from "@grpc/grpc-js";
 import crypto from "crypto";
 import { API_URL } from "../enums/EnvironmentVariable";
 
 import Debug from "debug";
+import { RoomManagerClient } from "@workadventure/messages/src/ts-proto-generated/services";
 
 const debug = Debug("apiClientRespository");
 

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -1,52 +1,5 @@
 import { PusherRoom } from "../models/PusherRoom";
 import type { ExSocketInterface } from "../models/Websocket/ExSocketInterface";
-import {
-    EmoteEventMessage,
-    EmotePromptMessage,
-    FollowRequestMessage,
-    FollowConfirmationMessage,
-    FollowAbortMessage,
-    ItemEventMessage,
-    PlayGlobalMessage,
-    RefreshRoomMessage,
-    ReportPlayerMessage,
-    RoomJoinedMessage,
-    ServerToAdminClientMessage,
-    SetPlayerDetailsMessage,
-    UserJoinedRoomMessage,
-    UserLeftRoomMessage,
-    UserMovesMessage,
-    ViewportMessage,
-    WebRtcSignalToServerMessage,
-    VariableMessage,
-    ErrorMessage,
-    PlayerDetailsUpdatedMessage,
-    LockGroupPromptMessage,
-    QueryMessage,
-    AskPositionMessage,
-    BanUserByUuidMessage,
-    EditMapCommandMessage,
-    AdminMessage,
-    AdminPusherToBackMessage,
-    AdminRoomMessage,
-    BanMessage,
-    CharacterLayerMessage,
-    GroupDeleteMessage,
-    JoinRoomMessage,
-    PusherToBackMessage,
-    ServerToClientMessage,
-    SubMessage,
-    UserLeftMessage,
-    WorldConnexionMessage,
-    TokenExpiredMessage,
-    WorldFullMessage,
-    InvalidTextureMessage,
-    ErrorScreenMessage,
-    ApplicationMessage,
-    XmppSettingsMessage,
-    MucRoomDefinitionMessage,
-    PingMessage,
-} from "../../messages/generated/messages_pb";
 
 import { ProtobufUtils } from "../models/Websocket/ProtobufUtils";
 import { emitInBatch } from "./IoSocketHelpers";
@@ -59,8 +12,29 @@ import Debug from "debug";
 import type { AdminConnection, ExAdminSocketInterface } from "../models/Websocket/ExAdminSocketInterface";
 import type { compressors } from "hyper-express";
 import { adminService } from "./AdminService";
-import { ErrorApiData, MucRoomDefinitionInterface } from "@workadventure/messages";
-import { BoolValue, Int32Value, StringValue } from "google-protobuf/google/protobuf/wrappers_pb";
+import {
+    AdminMessage,
+    AdminPusherToBackMessage,
+    AdminRoomMessage,
+    BanMessage,
+    BanUserByUuidMessage,
+    CharacterLayerMessage,
+    EmoteEventMessage,
+    ErrorApiData,
+    ErrorMessage,
+    ErrorScreenMessage,
+    JoinRoomMessage,
+    MucRoomDefinitionInterface,
+    PlayerDetailsUpdatedMessage,
+    PlayGlobalMessage,
+    PusherToBackMessage,
+    ReportPlayerMessage,
+    ServerToAdminClientMessage,
+    ServerToClientMessage,
+    UserMovesMessage,
+    ViewportMessage,
+    XmppSettingsMessage,
+} from "@workadventure/messages";
 import { EJABBERD_DOMAIN } from "../enums/EnvironmentVariable";
 
 const debug = Debug("socket");
@@ -103,35 +77,60 @@ export class SocketManager implements ZoneEventListener {
 
         adminRoomStream
             .on("data", (message: ServerToAdminClientMessage) => {
-                if (message.hasUserjoinedroom()) {
-                    const userJoinedRoomMessage = message.getUserjoinedroom() as UserJoinedRoomMessage;
-                    if (!client.disconnecting) {
-                        client.send(
-                            JSON.stringify({
-                                type: "MemberJoin",
-                                data: {
-                                    uuid: userJoinedRoomMessage.getUuid(),
-                                    name: userJoinedRoomMessage.getName(),
-                                    ipAddress: userJoinedRoomMessage.getIpaddress(),
-                                    roomId: roomId,
-                                },
-                            })
-                        );
+                if (!message.message) {
+                    console.error("Empty message returned on adminRoomStream");
+                    return;
+                }
+                switch (message.message.$case) {
+                    case "userJoinedRoom": {
+                        const userJoinedRoomMessage = message.message.userJoinedRoom;
+                        if (!client.disconnecting) {
+                            client.send(
+                                JSON.stringify({
+                                    type: "MemberJoin",
+                                    data: {
+                                        uuid: userJoinedRoomMessage.uuid,
+                                        name: userJoinedRoomMessage.name,
+                                        ipAddress: userJoinedRoomMessage.ipAddress,
+                                        roomId: roomId,
+                                    },
+                                })
+                            );
+                        }
+                        break;
                     }
-                } else if (message.hasUserleftroom()) {
-                    const userLeftRoomMessage = message.getUserleftroom() as UserLeftRoomMessage;
-                    if (!client.disconnecting) {
-                        client.send(
-                            JSON.stringify({
-                                type: "MemberLeave",
-                                data: {
-                                    uuid: userLeftRoomMessage.getUuid(),
-                                },
-                            })
-                        );
+                    case "userLeftRoom": {
+                        const userLeftRoomMessage = message.message.userLeftRoom;
+                        if (!client.disconnecting) {
+                            client.send(
+                                JSON.stringify({
+                                    type: "MemberLeave",
+                                    data: {
+                                        uuid: userLeftRoomMessage.uuid,
+                                    },
+                                })
+                            );
+                        }
+                        break;
                     }
-                } else {
-                    throw new Error("Unexpected admin message");
+                    case "errorMessage": {
+                        const errorMessage = message.message.errorMessage;
+                        console.error("Error message received from adminRoomStream: " + errorMessage.message);
+                        if (!client.disconnecting) {
+                            client.send(
+                                JSON.stringify({
+                                    type: "Error",
+                                    data: {
+                                        message: errorMessage.message,
+                                    },
+                                })
+                            );
+                        }
+                        break;
+                    }
+                    default: {
+                        const _exhaustiveCheck: never = message.message;
+                    }
                 }
             })
             .on("end", () => {
@@ -161,8 +160,12 @@ export class SocketManager implements ZoneEventListener {
                 }
             });
 
-        const message = new AdminPusherToBackMessage();
-        message.setSubscribetoroom(roomId);
+        const message: AdminPusherToBackMessage = {
+            message: {
+                $case: "subscribeToRoom",
+                subscribeToRoom: roomId,
+            },
+        };
 
         console.log(
             `Admin socket handle room ${roomId} connections for a client on ${Buffer.from(
@@ -182,54 +185,43 @@ export class SocketManager implements ZoneEventListener {
     async handleJoinRoom(client: ExSocketInterface): Promise<void> {
         const viewport = client.viewport;
         try {
-            const joinRoomMessage = new JoinRoomMessage();
-            joinRoomMessage.setUseruuid(client.userUuid);
-            joinRoomMessage.setUserjid(client.userJid);
-            joinRoomMessage.setIpaddress(client.IPAddress);
-            joinRoomMessage.setRoomid(client.roomId);
-            joinRoomMessage.setName(client.name);
-            joinRoomMessage.setAvailabilitystatus(client.availabilityStatus);
-            joinRoomMessage.setPositionmessage(ProtobufUtils.toPositionMessage(client.position));
-            joinRoomMessage.setTagList(client.tags);
-            joinRoomMessage.setIslogged(client.isLogged);
-
-            if (client.userRoomToken) {
-                joinRoomMessage.setUserroomtoken(client.userRoomToken);
-            }
-
-            if (client.visitCardUrl) {
-                joinRoomMessage.setVisitcardurl(client.visitCardUrl);
-            }
-            joinRoomMessage.setCompanion(client.companion);
-            joinRoomMessage.setActivatedinviteuser(
-                client.activatedInviteUser != undefined ? client.activatedInviteUser : true
-            );
-            joinRoomMessage.setCanedit(client.canEdit);
+            const joinRoomMessage: JoinRoomMessage = {
+                userUuid: client.userUuid,
+                userJid: client.userJid,
+                IPAddress: client.IPAddress,
+                roomId: client.roomId,
+                name: client.name,
+                availabilityStatus: client.availabilityStatus,
+                positionMessage: ProtobufUtils.toPositionMessage(client.position),
+                tag: client.tags,
+                isLogged: client.isLogged,
+                companion: client.companion,
+                activatedInviteUser: client.activatedInviteUser != undefined ? client.activatedInviteUser : true,
+                canEdit: client.canEdit,
+                characterLayer: [],
+                applications: [],
+                visitCardUrl: client.visitCardUrl ?? "", // TODO: turn this into an optional field
+                userRoomToken: client.userRoomToken ?? "", // TODO: turn this into an optional field
+                lastCommandId: client.lastCommandId ?? "", // TODO: turn this into an optional field
+            };
 
             if (client.applications != undefined) {
-                for (const aplicationValue of client.applications) {
-                    const application = new ApplicationMessage();
-                    application.setName(aplicationValue.name);
-                    application.setScript(aplicationValue.script);
-                    joinRoomMessage.addApplications(application);
+                for (const applicationValue of client.applications) {
+                    joinRoomMessage.applications.push({
+                        name: applicationValue.name,
+                        script: applicationValue.script,
+                    });
                 }
-            }
-
-            if (client.lastCommandId !== undefined) {
-                joinRoomMessage.setLastcommandid(client.lastCommandId);
             }
 
             for (const characterLayer of client.characterLayers) {
-                const characterLayerMessage = new CharacterLayerMessage();
-                characterLayerMessage.setName(characterLayer.id);
-                if (characterLayer.url !== undefined) {
-                    characterLayerMessage.setUrl(characterLayer.url);
-                }
-                if (characterLayer.layer !== undefined) {
-                    characterLayerMessage.setLayer(characterLayer.layer);
-                }
+                const characterLayerMessage: CharacterLayerMessage = {
+                    name: characterLayer.id,
+                    url: characterLayer.url ?? "", // FIXME: turn this into an optional field
+                    layer: characterLayer.layer ?? "", // FIXME: turn this into an optional field
+                };
 
-                joinRoomMessage.addCharacterlayer(characterLayerMessage);
+                joinRoomMessage.characterLayer.push(characterLayerMessage);
             }
 
             debug("Calling joinRoom '" + client.roomId + "'");
@@ -241,22 +233,28 @@ export class SocketManager implements ZoneEventListener {
 
             streamToPusher
                 .on("data", (message: ServerToClientMessage) => {
-                    if (message.hasRoomjoinedmessage()) {
-                        client.userId = (message.getRoomjoinedmessage() as RoomJoinedMessage).getCurrentuserid();
-
-                        // If this is the first message sent, send back the viewport.
-                        this.handleViewport(client, viewport);
+                    if (!message.message) {
+                        console.error("Empty message returned on streamToPusher");
+                        return;
                     }
+                    switch (message.message.$case) {
+                        case "roomJoinedMessage": {
+                            client.userId = message.message.roomJoinedMessage.currentUserId;
 
-                    if (message.hasRefreshroommessage()) {
-                        const refreshMessage: RefreshRoomMessage =
-                            message.getRefreshroommessage() as unknown as RefreshRoomMessage;
-                        this.refreshRoomData(refreshMessage.getRoomid(), refreshMessage.getVersionnumber());
+                            // If this is the first message sent, send back the viewport.
+                            this.handleViewport(client, viewport);
+                            break;
+                        }
+                        case "refreshRoomMessage": {
+                            const refreshMessage = message.message.refreshRoomMessage;
+                            this.refreshRoomData(refreshMessage.roomId, refreshMessage.versionNumber);
+                            break;
+                        }
                     }
 
                     // Let's pass data over from the back to the client.
                     if (!client.disconnecting) {
-                        client.send(message.serializeBinary().buffer, true);
+                        client.send(ServerToClientMessage.encode(message).finish(), true);
                     }
                 })
                 .on("end", () => {
@@ -286,8 +284,12 @@ export class SocketManager implements ZoneEventListener {
                     }
                 });
 
-            const pusherToBackMessage = new PusherToBackMessage();
-            pusherToBackMessage.setJoinroommessage(joinRoomMessage);
+            const pusherToBackMessage: PusherToBackMessage = {
+                message: {
+                    $case: "joinRoomMessage",
+                    joinRoomMessage,
+                },
+            };
             streamToPusher.write(pusherToBackMessage);
 
             const pusherRoom = await this.getOrCreateRoom(client.roomId);
@@ -310,7 +312,7 @@ export class SocketManager implements ZoneEventListener {
         client.end(code, reason);
     }
 
-    handleViewport(client: ExSocketInterface, viewport: ViewportMessage.AsObject): void {
+    handleViewport(client: ExSocketInterface, viewport: ViewportMessage): void {
         try {
             client.viewport = viewport;
 
@@ -327,106 +329,59 @@ export class SocketManager implements ZoneEventListener {
     }
 
     handleUserMovesMessage(client: ExSocketInterface, userMovesMessage: UserMovesMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setUsermovesmessage(userMovesMessage);
+        client.backConnection.write({
+            message: {
+                $case: "userMovesMessage",
+                userMovesMessage,
+            },
+        });
 
-        client.backConnection.write(pusherToBackMessage);
-
-        const viewport = userMovesMessage.getViewport();
+        const viewport = userMovesMessage.viewport;
         if (viewport === undefined) {
             throw new Error("Missing viewport in UserMovesMessage");
         }
 
         // Now, we need to listen to the correct viewport.
-        this.handleViewport(client, viewport.toObject());
-    }
-
-    handleFollowRequest(client: ExSocketInterface, message: FollowRequestMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setFollowrequestmessage(message);
-        client.backConnection.write(pusherToBackMessage);
-    }
-
-    handleFollowConfirmation(client: ExSocketInterface, message: FollowConfirmationMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setFollowconfirmationmessage(message);
-        client.backConnection.write(pusherToBackMessage);
-    }
-
-    handleFollowAbort(client: ExSocketInterface, message: FollowAbortMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setFollowabortmessage(message);
-        client.backConnection.write(pusherToBackMessage);
-    }
-
-    handleLockGroup(client: ExSocketInterface, message: LockGroupPromptMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setLockgrouppromptmessage(message);
-        client.backConnection.write(pusherToBackMessage);
-    }
-
-    handlePingMessage(client: ExSocketInterface, message: PingMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setPingmessage(message);
-        client.backConnection.write(pusherToBackMessage);
-    }
-    handleEditMapCommandMessage(client: ExSocketInterface, message: EditMapCommandMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setEditmapcommandmessage(message);
-        client.backConnection.write(pusherToBackMessage);
+        this.handleViewport(client, viewport);
     }
 
     onEmote(emoteMessage: EmoteEventMessage, listener: ExSocketInterface): void {
-        const subMessage = new SubMessage();
-        subMessage.setEmoteeventmessage(emoteMessage);
-
-        emitInBatch(listener, subMessage);
+        emitInBatch(listener, {
+            message: {
+                $case: "emoteEventMessage",
+                emoteEventMessage: emoteMessage,
+            },
+        });
     }
 
     onPlayerDetailsUpdated(
         playerDetailsUpdatedMessage: PlayerDetailsUpdatedMessage,
         listener: ExSocketInterface
     ): void {
-        const subMessage = new SubMessage();
-        subMessage.setPlayerdetailsupdatedmessage(playerDetailsUpdatedMessage);
-
-        emitInBatch(listener, subMessage);
+        emitInBatch(listener, {
+            message: {
+                $case: "playerDetailsUpdatedMessage",
+                playerDetailsUpdatedMessage,
+            },
+        });
     }
 
     onError(errorMessage: ErrorMessage, listener: ExSocketInterface): void {
-        const subMessage = new SubMessage();
-        subMessage.setErrormessage(errorMessage);
-
-        emitInBatch(listener, subMessage);
+        emitInBatch(listener, {
+            message: {
+                $case: "errorMessage",
+                errorMessage,
+            },
+        });
     }
 
     // Useless now, will be useful again if we allow editing details in game
-    handleSetPlayerDetails(client: ExSocketInterface, playerDetailsMessage: SetPlayerDetailsMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setSetplayerdetailsmessage(playerDetailsMessage);
-
-        client.backConnection.write(pusherToBackMessage);
-    }
-
-    handleItemEvent(client: ExSocketInterface, itemEventMessage: ItemEventMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setItemeventmessage(itemEventMessage);
-
-        client.backConnection.write(pusherToBackMessage);
-    }
-
-    handleVariableEvent(client: ExSocketInterface, variableMessage: VariableMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setVariablemessage(variableMessage);
-
-        client.backConnection.write(pusherToBackMessage);
-    }
 
     async handleReportMessage(client: ExSocketInterface, reportPlayerMessage: ReportPlayerMessage): Promise<void> {
         try {
             await adminService.reportPlayer(
-                reportPlayerMessage.getReporteduseruuid(),
-                reportPlayerMessage.getReportcomment(),
+                reportPlayerMessage.reportedUserUuid,
+                reportPlayerMessage.reportComment,
                 client.userUuid,
                 client.roomId,
                 "en"
@@ -435,20 +390,6 @@ export class SocketManager implements ZoneEventListener {
             console.error('An error occurred on "handleReportMessage"');
             console.error(e);
         }
-    }
-
-    emitVideo(socket: ExSocketInterface, data: WebRtcSignalToServerMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setWebrtcsignaltoservermessage(data);
-
-        socket.backConnection.write(pusherToBackMessage);
-    }
-
-    emitScreenSharing(socket: ExSocketInterface, data: WebRtcSignalToServerMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setWebrtcscreensharingsignaltoservermessage(data);
-
-        socket.backConnection.write(pusherToBackMessage);
     }
 
     leaveRoom(socket: ExSocketInterface): void {
@@ -511,13 +452,6 @@ export class SocketManager implements ZoneEventListener {
         return this.rooms;
     }
 
-    public handleQueryMessage(client: ExSocketInterface, queryMessage: QueryMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setQuerymessage(queryMessage);
-
-        client.backConnection.write(pusherToBackMessage);
-    }
-
     public async emitSendUserMessage(userUuid: string, message: string, type: string, roomId: string): Promise<void> {
         /*const client = this.searchClientByUuid(userUuid);
         if(client) {
@@ -531,11 +465,12 @@ export class SocketManager implements ZoneEventListener {
         }*/
 
         const backConnection = await apiClientRepository.getClient(roomId);
-        const backAdminMessage = new AdminMessage();
-        backAdminMessage.setMessage(message);
-        backAdminMessage.setRoomid(roomId);
-        backAdminMessage.setRecipientuuid(userUuid);
-        backAdminMessage.setType(type);
+        const backAdminMessage: AdminMessage = {
+            message,
+            roomId,
+            recipientUuid: userUuid,
+            type,
+        };
         backConnection.sendAdminMessage(backAdminMessage, (error: unknown) => {
             if (error !== null) {
                 console.error("Error while sending admin message", error);
@@ -556,11 +491,12 @@ export class SocketManager implements ZoneEventListener {
         }*/
 
         const backConnection = await apiClientRepository.getClient(roomId);
-        const banMessage = new BanMessage();
-        banMessage.setMessage(message);
-        banMessage.setRoomid(roomId);
-        banMessage.setRecipientuuid(userUuid);
-        banMessage.setType(type);
+        const banMessage: BanMessage = {
+            message,
+            roomId,
+            recipientUuid: userUuid,
+            type,
+        };
         backConnection.ban(banMessage, (error: unknown) => {
             if (error !== null) {
                 console.error("Error while sending admin message", error);
@@ -569,34 +505,41 @@ export class SocketManager implements ZoneEventListener {
     }
 
     public onUserEnters(user: UserDescriptor, listener: ExSocketInterface): void {
-        const subMessage = new SubMessage();
-        subMessage.setUserjoinedmessage(user.toUserJoinedMessage());
-
-        emitInBatch(listener, subMessage);
+        emitInBatch(listener, {
+            message: {
+                $case: "userJoinedMessage",
+                userJoinedMessage: user.toUserJoinedMessage(),
+            },
+        });
     }
 
     public onUserMoves(user: UserDescriptor, listener: ExSocketInterface): void {
-        const subMessage = new SubMessage();
-        subMessage.setUsermovedmessage(user.toUserMovedMessage());
-
-        emitInBatch(listener, subMessage);
+        emitInBatch(listener, {
+            message: {
+                $case: "userMovedMessage",
+                userMovedMessage: user.toUserMovedMessage(),
+            },
+        });
     }
 
     public onUserLeaves(userId: number, listener: ExSocketInterface): void {
-        const userLeftMessage = new UserLeftMessage();
-        userLeftMessage.setUserid(userId);
-
-        const subMessage = new SubMessage();
-        subMessage.setUserleftmessage(userLeftMessage);
-
-        emitInBatch(listener, subMessage);
+        emitInBatch(listener, {
+            message: {
+                $case: "userLeftMessage",
+                userLeftMessage: {
+                    userId,
+                },
+            },
+        });
     }
 
     public onGroupEnters(group: GroupDescriptor, listener: ExSocketInterface): void {
-        const subMessage = new SubMessage();
-        subMessage.setGroupupdatemessage(group.toGroupUpdateMessage());
-
-        emitInBatch(listener, subMessage);
+        emitInBatch(listener, {
+            message: {
+                $case: "groupUpdateMessage",
+                groupUpdateMessage: group.toGroupUpdateMessage(),
+            },
+        });
     }
 
     public onGroupMoves(group: GroupDescriptor, listener: ExSocketInterface): void {
@@ -604,85 +547,118 @@ export class SocketManager implements ZoneEventListener {
     }
 
     public onGroupLeaves(groupId: number, listener: ExSocketInterface): void {
-        const groupDeleteMessage = new GroupDeleteMessage();
-        groupDeleteMessage.setGroupid(groupId);
-
-        const subMessage = new SubMessage();
-        subMessage.setGroupdeletemessage(groupDeleteMessage);
-
-        emitInBatch(listener, subMessage);
+        emitInBatch(listener, {
+            message: {
+                $case: "groupDeleteMessage",
+                groupDeleteMessage: {
+                    groupId,
+                },
+            },
+        });
     }
 
     public emitWorldFullMessage(client: compressors.WebSocket): void {
-        const errorMessage = new WorldFullMessage();
-
-        const serverToClientMessage = new ServerToClientMessage();
-        serverToClientMessage.setWorldfullmessage(errorMessage);
-
         if (!client.disconnecting) {
-            client.send(serverToClientMessage.serializeBinary().buffer, true);
+            client.send(
+                ServerToClientMessage.encode({
+                    message: {
+                        $case: "worldFullMessage",
+                        worldFullMessage: {},
+                    },
+                }).finish(),
+                true
+            );
         }
     }
 
     public emitTokenExpiredMessage(client: compressors.WebSocket): void {
-        const errorMessage = new TokenExpiredMessage();
-
-        const serverToClientMessage = new ServerToClientMessage();
-        serverToClientMessage.setTokenexpiredmessage(errorMessage);
-
         if (!client.disconnecting) {
-            client.send(serverToClientMessage.serializeBinary().buffer, true);
+            client.send(
+                ServerToClientMessage.encode({
+                    message: {
+                        $case: "tokenExpiredMessage",
+                        tokenExpiredMessage: {},
+                    },
+                }).finish(),
+                true
+            );
         }
     }
 
     public emitInvalidTextureMessage(client: compressors.WebSocket): void {
-        const errorMessage = new InvalidTextureMessage();
-
-        const serverToClientMessage = new ServerToClientMessage();
-        serverToClientMessage.setInvalidtexturemessage(errorMessage);
-
         if (!client.disconnecting) {
-            client.send(serverToClientMessage.serializeBinary().buffer, true);
+            client.send(
+                ServerToClientMessage.encode({
+                    message: {
+                        $case: "invalidTextureMessage",
+                        invalidTextureMessage: {},
+                    },
+                }).finish(),
+                true
+            );
         }
     }
 
     public emitConnexionErrorMessage(client: compressors.WebSocket, message: string): void {
-        const errorMessage = new WorldConnexionMessage();
-        errorMessage.setMessage(message);
-
-        const serverToClientMessage = new ServerToClientMessage();
-        serverToClientMessage.setWorldconnexionmessage(errorMessage);
-
-        client.send(serverToClientMessage.serializeBinary().buffer, true);
+        client.send(
+            ServerToClientMessage.encode({
+                message: {
+                    $case: "worldConnexionMessage",
+                    worldConnexionMessage: {
+                        message,
+                    },
+                },
+            }).finish(),
+            true
+        );
     }
 
     public emitErrorScreenMessage(client: compressors.WebSocket, errorApi: ErrorApiData): void {
-        const errorMessage = new ErrorScreenMessage();
-        errorMessage.setType(errorApi.type);
+        // FIXME: improve typing of ErrorScreenMessage
+        const errorScreenMessage: ErrorScreenMessage = {
+            type: errorApi.type,
+            code: "",
+            title: undefined,
+            subtitle: "",
+            details: "",
+            image: "",
+            buttonTitle: "",
+            canRetryManual: false,
+            timeToRetry: 0,
+            urlToRedirect: "",
+        };
+
         if (errorApi.type == "retry" || errorApi.type == "error" || errorApi.type == "unauthorized") {
-            errorMessage.setCode(new StringValue().setValue(errorApi.code));
-            errorMessage.setTitle(new StringValue().setValue(errorApi.title));
-            errorMessage.setSubtitle(new StringValue().setValue(errorApi.subtitle));
-            errorMessage.setDetails(new StringValue().setValue(errorApi.details));
-            errorMessage.setImage(new StringValue().setValue(errorApi.image));
-            if (errorApi.type == "unauthorized" && errorApi.buttonTitle)
-                errorMessage.setButtontitle(new StringValue().setValue(errorApi.buttonTitle));
+            errorScreenMessage.code = errorApi.code;
+            errorScreenMessage.title = errorApi.title;
+            errorScreenMessage.subtitle = errorApi.subtitle;
+            errorScreenMessage.details = errorApi.details;
+            errorScreenMessage.image = errorApi.image;
+            if (errorApi.type == "unauthorized" && errorApi.buttonTitle) {
+                errorScreenMessage.buttonTitle = errorApi.buttonTitle;
+            }
         }
         if (errorApi.type == "retry") {
-            if (errorApi.buttonTitle) errorMessage.setButtontitle(new StringValue().setValue(errorApi.buttonTitle));
-            if (errorApi.canRetryManual !== undefined)
-                errorMessage.setCanretrymanual(new BoolValue().setValue(errorApi.canRetryManual));
-            if (errorApi.timeToRetry)
-                errorMessage.setTimetoretry(new Int32Value().setValue(Number(errorApi.timeToRetry)));
+            if (errorApi.buttonTitle) {
+                errorScreenMessage.buttonTitle = errorApi.buttonTitle;
+            }
+            if (errorApi.canRetryManual !== undefined) errorScreenMessage.canRetryManual = errorApi.canRetryManual;
+            if (errorApi.timeToRetry) errorScreenMessage.timeToRetry = errorApi.timeToRetry;
         }
-        if (errorApi.type == "redirect" && errorApi.urlToRedirect)
-            errorMessage.setUrltoredirect(new StringValue().setValue(errorApi.urlToRedirect));
-
-        const serverToClientMessage = new ServerToClientMessage();
-        serverToClientMessage.setErrorscreenmessage(errorMessage);
+        if (errorApi.type == "redirect" && errorApi.urlToRedirect) {
+            errorScreenMessage.urlToRedirect = errorApi.urlToRedirect;
+        }
 
         //if (!client.disconnecting) {
-        client.send(serverToClientMessage.serializeBinary().buffer, true);
+        client.send(
+            ServerToClientMessage.encode({
+                message: {
+                    $case: "errorScreenMessage",
+                    errorScreenMessage,
+                },
+            }).finish(),
+            true
+        );
         //}
     }
 
@@ -691,13 +667,6 @@ export class SocketManager implements ZoneEventListener {
         //this function is run for every users connected to the room, so we need to make sure the room wasn't already refreshed.
         if (!room || !room.needsUpdate(versionNumber)) return;
         //TODO check right of user in admin
-    }
-
-    handleEmotePromptMessage(client: ExSocketInterface, emoteEventmessage: EmotePromptMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setEmotepromptmessage(emoteEventmessage);
-
-        client.backConnection.write(pusherToBackMessage);
     }
 
     public async emitPlayGlobalMessage(
@@ -711,29 +680,29 @@ export class SocketManager implements ZoneEventListener {
         const clientRoomUrl = client.roomId;
         let tabUrlRooms: string[];
 
-        if (playGlobalMessageEvent.getBroadcasttoworld()) {
+        if (playGlobalMessageEvent.broadcastToWorld) {
             tabUrlRooms = await adminService.getUrlRoomsFromSameWorld(clientRoomUrl, "en");
         } else {
             tabUrlRooms = [clientRoomUrl];
         }
 
-        const roomMessage = new AdminRoomMessage();
-        roomMessage.setMessage(playGlobalMessageEvent.getContent());
-        roomMessage.setType(playGlobalMessageEvent.getType());
-
         for (const roomUrl of tabUrlRooms) {
             const apiRoom = await apiClientRepository.getClient(roomUrl);
-            roomMessage.setRoomid(roomUrl);
+            const roomMessage: AdminRoomMessage = {
+                message: playGlobalMessageEvent.content,
+                type: playGlobalMessageEvent.type,
+                roomId: roomUrl,
+            };
             apiRoom.sendAdminMessageToRoom(roomMessage, () => {
                 return;
             });
         }
     }
 
-    handleAskPositionMessage(client: ExSocketInterface, askPositionMessage: AskPositionMessage): void {
-        const pusherToBackMessage = new PusherToBackMessage();
-        pusherToBackMessage.setAskpositionmessage(askPositionMessage);
-
+    forwardMessageToBack(client: ExSocketInterface, message: PusherToBackMessage["message"]): void {
+        const pusherToBackMessage: PusherToBackMessage = {
+            message: message,
+        };
         client.backConnection.write(pusherToBackMessage);
     }
 
@@ -741,18 +710,18 @@ export class SocketManager implements ZoneEventListener {
         try {
             adminService
                 .banUserByUuid(
-                    banUserByUuidMessage.getUuidtoban(),
-                    banUserByUuidMessage.getPlayuri(),
-                    banUserByUuidMessage.getName(),
-                    banUserByUuidMessage.getMessage(),
-                    banUserByUuidMessage.getByuseremail()
+                    banUserByUuidMessage.uuidToBan,
+                    banUserByUuidMessage.playUri,
+                    banUserByUuidMessage.name,
+                    banUserByUuidMessage.message,
+                    banUserByUuidMessage.byUserEmail
                 )
                 .then(() => {
                     this.emitBan(
-                        banUserByUuidMessage.getUuidtoban(),
-                        banUserByUuidMessage.getMessage(),
+                        banUserByUuidMessage.uuidToBan,
+                        banUserByUuidMessage.message,
                         "banned",
-                        banUserByUuidMessage.getPlayuri()
+                        banUserByUuidMessage.playUri
                     ).catch((err) => {
                         throw err;
                     });
@@ -767,30 +736,33 @@ export class SocketManager implements ZoneEventListener {
     }
 
     emitXMPPSettings(client: ExSocketInterface): void {
-        const xmppSettings = new XmppSettingsMessage();
-        xmppSettings.setConferencedomain("conference." + EJABBERD_DOMAIN);
-        xmppSettings.setRoomsList(
-            client.mucRooms.map((definition: MucRoomDefinitionInterface) => {
-                const mucRoomDefinitionMessage = new MucRoomDefinitionMessage();
+        const xmppSettings: XmppSettingsMessage = {
+            conferenceDomain: "conference." + EJABBERD_DOMAIN,
+            rooms: client.mucRooms.map((definition: MucRoomDefinitionInterface) => {
                 if (!definition.name || !definition.url || !definition.type) {
                     throw new Error("Name URL and type cannot be empty!");
                 }
-                mucRoomDefinitionMessage.setName(definition.name);
-                mucRoomDefinitionMessage.setUrl(definition.url);
-                mucRoomDefinitionMessage.setType(definition.type);
-                mucRoomDefinitionMessage.setSubscribe(definition.subscribe);
-                return mucRoomDefinitionMessage;
-            })
-        );
-
-        xmppSettings.setJabberid(client.jabberId);
-        xmppSettings.setJabberpassword(client.jabberPassword);
-
-        const serverToClientMessage = new ServerToClientMessage();
-        serverToClientMessage.setXmppsettingsmessage(xmppSettings);
+                return {
+                    name: definition.name,
+                    url: definition.url,
+                    type: definition.type,
+                    subscribe: definition.subscribe,
+                };
+            }),
+            jabberId: client.jabberId,
+            jabberPassword: client.jabberPassword,
+        };
 
         if (!client.disconnecting) {
-            client.send(serverToClientMessage.serializeBinary().buffer, true);
+            client.send(
+                ServerToClientMessage.encode({
+                    message: {
+                        $case: "xmppSettingsMessage",
+                        xmppSettingsMessage: xmppSettings,
+                    },
+                }).finish(),
+                true
+            );
         }
     }
 }


### PR DESCRIPTION
Long awaited: the pusher is now using ts-proto, which generates objects way easier to manipulate than the standard grpc-node lib.