### PR TITLE
Testing single-domain install in Github Actions

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -615,6 +615,84 @@ jobs:
           path: tests/playwright-report/
           retention-days: 30
 
+  prod-single-domain-deploy-tests:
+    name: "Test production docker-compose"
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [ 'chromium' ]
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
+    needs:
+      - build-play
+      - build-chat
+      - build-back
+      - build-maps
+      - build-uploader
+      - build-map-storage
+      - build-ejabberd
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: npm ci
+        working-directory: tests
+      - name: Install Playwright
+        run: npx playwright install --with-deps ${{ matrix.browser }}
+        working-directory: tests
+      - name: 'Setup .env file'
+        run: cp .env.prod.template .env
+        working-directory: contrib/docker
+      - uses: rlespinasse/github-slug-action@3.1.0
+
+      - name: Fill .env file
+        run: |
+          sed -i "s/SECRET_KEY=/SECRET_KEY=someSecret/g" .env
+          sed -i "s/VERSION=master/VERSION=${DOCKER_TAG}/g" .env
+        env:
+          DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+        working-directory: contrib/docker
+      - name: Start WorkAdventure
+        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml up -d
+        env:
+          DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+        working-directory: contrib/docker
+      - name: Wait for environment to Start
+        run: sleep 30
+      - name: Run Playwright tests
+        run: npm run test-prod-like -- --project=${{ matrix.browser }}
+        working-directory: tests
+        env:
+          DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+      - name: Display docker-compose logs on failure
+        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml logs
+        if: failure()
+        env:
+          DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+        working-directory: contrib/docker
+      - name: Display containers state
+        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml ps
+        if: failure()
+        env:
+          DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+        working-directory: contrib/docker
+      - name: Side-load docker-compose logs in the playwright report
+        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml logs > ../../tests/playwright-report/docker-compose.log
+        if: failure()
+        env:
+          DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+        working-directory: contrib/docker
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: playwright-report-${{ matrix.browser }}
+          path: tests/playwright-report/
+          retention-days: 30
+
+
   deeploy:
     needs:
       - build-play

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -652,6 +652,9 @@ jobs:
         run: |
           sed -i "s/SECRET_KEY=/SECRET_KEY=someSecret/g" .env
           sed -i "s/VERSION=master/VERSION=${DOCKER_TAG}/g" .env
+          sed -i "s/DOMAIN=workadventure.localhost/DOMAIN=play.workadventure.localhost/g" .env
+          sed -i "s/MAP_STORAGE_AUTHENTICATION_USER=/MAP_STORAGE_AUTHENTICATION_USER=john.doe/g" .env
+          sed -i "s/MAP_STORAGE_AUTHENTICATION_PASSWORD=/MAP_STORAGE_AUTHENTICATION_PASSWORD=password/g" .env
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -666,7 +666,7 @@ jobs:
       - name: Wait for environment to Start
         run: sleep 30
       - name: Run Playwright tests
-        run: npm run test-prod-like -- --project=${{ matrix.browser }}
+        run: npm run test-prod-like -- --project=${{ matrix.browser }} --grep-invert @docker
         working-directory: tests
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -655,6 +655,7 @@ jobs:
           sed -i "s/DOMAIN=workadventure.localhost/DOMAIN=play.workadventure.localhost/g" .env
           sed -i "s/MAP_STORAGE_AUTHENTICATION_USER=/MAP_STORAGE_AUTHENTICATION_USER=john.doe/g" .env
           sed -i "s/MAP_STORAGE_AUTHENTICATION_PASSWORD=/MAP_STORAGE_AUTHENTICATION_PASSWORD=password/g" .env
+          sed -i "s/UPLOADER_REDIS_HOST=/UPLOADER_REDIS_HOST=redis/g" .env
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -659,7 +659,7 @@ jobs:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
       - name: Start WorkAdventure
-        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml up -d
+        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml up -d
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
@@ -671,19 +671,19 @@ jobs:
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
       - name: Display docker-compose logs on failure
-        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml logs
+        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml logs
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
       - name: Display containers state
-        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml ps
+        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml ps
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
       - name: Side-load docker-compose logs in the playwright report
-        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml logs > ../../tests/playwright-report/docker-compose.log
+        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml logs > ../../tests/playwright-report/docker-compose.log
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -641,7 +641,7 @@ jobs:
         run: npm ci
         working-directory: tests
       - name: Install Playwright
-        run: npx playwright install --with-deps ${{ matrix.browser }}
+        run: npx playwright install --with-deps chromium
         working-directory: tests
       - name: 'Setup .env file'
         run: cp .env.prod.template .env
@@ -666,7 +666,7 @@ jobs:
       - name: Wait for environment to Start
         run: sleep 30
       - name: Run Playwright tests
-        run: npm run test-prod-like -- --project=${{ matrix.browser }} --grep-invert @docker
+        run: npm run test-prod-like -- --project=chromium --grep-invert @docker
         working-directory: tests
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
@@ -691,7 +691,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: playwright-report-${{ matrix.browser }}
+          name: playwright-report-single-domain
           path: tests/playwright-report/
           retention-days: 30
 

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -655,6 +655,7 @@ jobs:
           sed -i "s/DOMAIN=workadventure.localhost/DOMAIN=play.workadventure.localhost/g" .env
           sed -i "s/MAP_STORAGE_AUTHENTICATION_USER=/MAP_STORAGE_AUTHENTICATION_USER=john.doe/g" .env
           sed -i "s/MAP_STORAGE_AUTHENTICATION_PASSWORD=/MAP_STORAGE_AUTHENTICATION_PASSWORD=password/g" .env
+          sed -i "s/OPID_WOKA_NAME_POLICY=/OPID_WOKA_NAME_POLICY=user_input/g" .env
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -671,6 +671,7 @@ jobs:
         working-directory: tests
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          MAP_STORAGE_URL: "http://john.doe:password@play.workadventure.localhost/map-storage"
       - name: Display docker-compose logs on failure
         run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml logs
         if: failure()

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -667,11 +667,10 @@ jobs:
         run: sleep 30
       - name: Run Playwright tests
         # Run all tests, except the ones needing to restart Docker and the ones relying on an OIDC server
-        run: npm run test-prod-like -- --project=chromium --grep-invert "@docker|@oidc"
+        run: npm run test-single-domain-install
         working-directory: tests
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
-          MAP_STORAGE_URL: "http://john.doe:password@play.workadventure.localhost/map-storage"
       - name: Display docker-compose logs on failure
         run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml logs
         if: failure()

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -661,7 +661,7 @@ jobs:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
       - name: Start WorkAdventure
-        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml -f ../../docker-compose-oidc.yaml -f tests/docker-compose.oidc-overload.yaml up -d
+        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml up -d
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
@@ -674,19 +674,19 @@ jobs:
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
       - name: Display docker-compose logs on failure
-        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml -f ../../docker-compose-oidc.yaml -f tests/docker-compose.oidc-overload.yaml logs
+        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml logs
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
       - name: Display containers state
-        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml -f ../../docker-compose-oidc.yaml -f tests/docker-compose.oidc-overload.yaml ps
+        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml ps
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
       - name: Side-load docker-compose logs in the playwright report
-        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml -f ../../docker-compose-oidc.yaml -f tests/docker-compose.oidc-overload.yaml logs > ../../tests/playwright-report/docker-compose.log
+        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml logs > ../../tests/playwright-report/docker-compose.log
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -656,6 +656,7 @@ jobs:
           sed -i "s/MAP_STORAGE_AUTHENTICATION_USER=/MAP_STORAGE_AUTHENTICATION_USER=john.doe/g" .env
           sed -i "s/MAP_STORAGE_AUTHENTICATION_PASSWORD=/MAP_STORAGE_AUTHENTICATION_PASSWORD=password/g" .env
           sed -i "s/UPLOADER_REDIS_HOST=/UPLOADER_REDIS_HOST=redis/g" .env
+          sed -i "s/ADMIN_API_TOKEN=/ADMIN_API_TOKEN=123/g" .env
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -666,7 +666,8 @@ jobs:
       - name: Wait for environment to Start
         run: sleep 30
       - name: Run Playwright tests
-        run: npm run test-prod-like -- --project=chromium --grep-invert @docker
+        # Run all tests, except the ones needing to restart Docker and the ones relying on an OIDC server
+        run: npm run test-prod-like -- --project=chromium --grep-invert "@docker|@oidc"
         working-directory: tests
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -659,7 +659,7 @@ jobs:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
       - name: Start WorkAdventure
-        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml up -d
+        run: docker-compose -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml -f ../../docker-compose-oidc.yaml -f tests/docker-compose.oidc-overload.yaml up -d
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
@@ -672,19 +672,19 @@ jobs:
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
       - name: Display docker-compose logs on failure
-        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml logs
+        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml -f ../../docker-compose-oidc.yaml -f tests/docker-compose.oidc-overload.yaml logs
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
       - name: Display containers state
-        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml ps
+        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml -f ../../docker-compose-oidc.yaml -f tests/docker-compose.oidc-overload.yaml ps
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker
       - name: Side-load docker-compose logs in the playwright report
-        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml logs > ../../tests/playwright-report/docker-compose.log
+        run: docker-compose  -f docker-compose.prod.yaml -f docker-compose.single-domain.yaml -f tests/docker-compose.test-maps.yaml -f ../../docker-compose-oidc.yaml -f tests/docker-compose.oidc-overload.yaml logs > ../../tests/playwright-report/docker-compose.log
         if: failure()
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -655,7 +655,6 @@ jobs:
           sed -i "s/DOMAIN=workadventure.localhost/DOMAIN=play.workadventure.localhost/g" .env
           sed -i "s/MAP_STORAGE_AUTHENTICATION_USER=/MAP_STORAGE_AUTHENTICATION_USER=john.doe/g" .env
           sed -i "s/MAP_STORAGE_AUTHENTICATION_PASSWORD=/MAP_STORAGE_AUTHENTICATION_PASSWORD=password/g" .env
-          sed -i "s/OPID_WOKA_NAME_POLICY=/OPID_WOKA_NAME_POLICY=user_input/g" .env
         env:
           DOCKER_TAG: ${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
         working-directory: contrib/docker

--- a/back/src/Enum/EnvironmentVariable.ts
+++ b/back/src/Enum/EnvironmentVariable.ts
@@ -6,7 +6,7 @@ type BoolAsString = z.infer<typeof BoolAsString>;
 const PositiveIntAsString = z.string().regex(/^\d*$/, { message: "Must be a positive integer number" });
 type PositiveIntAsString = z.infer<typeof PositiveIntAsString>;
 
-const AbsoluteOrRelativeUrl = z.string().url().or(z.string().startsWith("/"));
+const AbsoluteOrRelativeUrl = z.string().url().or(z.string().startsWith("/")).or(z.literal(""));
 
 const EnvironmentVariables = z.object({
     PLAY_URL: z.string().url(),

--- a/chat/Dockerfile
+++ b/chat/Dockerfile
@@ -31,6 +31,8 @@ COPY chat ./chat
 RUN cd chat && npm run typesafe-i18n && NODE_OPTIONS="--max-old-space-size=6144" npm run build
 
 RUN mv /usr/src/chat/dist/index.html /usr/src/chat/dist/index.tpl.html
+# Bypassing a bug in envconfig generation that does not take into account relative base.
+RUN sed -i 's|src="/env-config|src="./env-config|g' /usr/src/chat/dist/index.tpl.html
 
 # final production image
 FROM nginx:1.21.6-alpine

--- a/chat/index.html
+++ b/chat/index.html
@@ -27,7 +27,7 @@
         <meta name="msapplication-TileImage" content="static/images/favicons/ms-icon-144x144.png">
         <meta name="theme-color" content="#000000">
 
-        <base href="/">
+        <!--<base href="/">-->
         <style>/*hide cowebsite container before scss is loaded*/#cowebsite { visibility: collapse };</style>
 
         <title>Chat WorkAdventure</title>

--- a/chat/src/Components/Chat.svelte
+++ b/chat/src/Components/Chat.svelte
@@ -248,7 +248,7 @@
     </section>
 </aside>
 
-<audio id="newMessageSound" src="/static/new-message.mp3" style="width: 0;height: 0;opacity: 0" />
+<audio id="newMessageSound" src="./static/new-message.mp3" style="width: 0;height: 0;opacity: 0" />
 
 <style lang="scss">
     aside.chatWindow {

--- a/chat/src/Components/ChatMucRoom.svelte
+++ b/chat/src/Components/ChatMucRoom.svelte
@@ -34,7 +34,7 @@
 
 <div class={`wa-chat-item`} on:mouseleave={closeChatUserMenu}>
     <div class="tw-relative" on:click|stopPropagation={() => open()}>
-        <img class={``} src="/static/images/logo-wa-2.png" alt="Send" width="35" />
+        <img class={``} src="./static/images/logo-wa-2.png" alt="Send" width="35" />
         <div class="tw-block tw-absolute tw-right-0 tw-top-0 tw-transform tw-translate-x-2 -tw-translate-y-1">
             {#if mucRoom.type === "live"}
                 <div class="tw-block tw-relative">

--- a/chat/src/Components/Timeline/Timeline.svelte
+++ b/chat/src/Components/Timeline/Timeline.svelte
@@ -36,7 +36,7 @@
     <div>
         <div class="wa-chat-item">
             <div id="openTimeline" class="tw-relative" on:click|stopPropagation={open}>
-                <img src="/static/images/logo-wa-2.png" alt="Send" width="35" />
+                <img src="./static/images/logo-wa-2.png" alt="Send" width="35" />
 
                 <!-- use chat store and get new notification -->
                 {#if $chatPeerConnectionInProgress}

--- a/chat/src/Media/MediaManager.ts
+++ b/chat/src/Media/MediaManager.ts
@@ -28,9 +28,9 @@ class MediaManager {
 
         if (this.hasNotification()) {
             const options = {
-                icon: "/static/images/logo-WA-min.png",
-                image: "/static/images/logo-WA-min.png",
-                badge: "/static/images/logo-WA-min.png",
+                icon: "./static/images/logo-WA-min.png",
+                image: "./static/images/logo-WA-min.png",
+                badge: "./static/images/logo-WA-min.png",
             };
             switch (notificationType) {
                 case NotificationType.discussion:

--- a/chat/vite.config.ts
+++ b/chat/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
             clientPort: 80,
         },
     },
+    base: "./",
     build: {
         sourcemap: true,
         rollupOptions: {

--- a/contrib/docker/.env.prod.template
+++ b/contrib/docker/.env.prod.template
@@ -136,7 +136,7 @@ OPID_LOGOUT_REDIRECT_URL=
 #   user_input: the user will be prompted for his/her Woka name
 #   force_opid: the user cannot decide his/her Woka name
 #   allow_override_opid: by default, the user name from OpenID is used, but the user can change it
-OPID_WOKA_NAME_POLICY=
+OPID_WOKA_NAME_POLICY=user_input
 
 #
 # Advanced configuration
@@ -163,9 +163,6 @@ STORE_VARIABLES_FOR_LOCAL_MAPS=true
 # Debugging options
 DEBUG_MODE=false
 LOG_LEVEL=WARN
-
-# Internal URLs
-API_URL=back:50051
 
 RESTART_POLICY=unless-stopped
 

--- a/contrib/docker/.env.prod.template
+++ b/contrib/docker/.env.prod.template
@@ -226,3 +226,13 @@ ENABLE_TELEMETRY=
 # This email address will be notified if your WorkAdventure version contains a known security flaw.
 # ENABLE_TELEMETRY must be set to "true" for this to work.
 SECURITY_EMAIL=
+
+
+# You MUST decide an authentication strategy for the map-storage container.
+# This must be one of "Basic", "Digest" or "Bearer".
+MAP_STORAGE_AUTHENTICATION_STRATEGY=Basic
+# If you choose "Basic" or "Digest", you MUST set a username and password.
+MAP_STORAGE_AUTHENTICATION_USER=
+MAP_STORAGE_AUTHENTICATION_PASSWORD=
+# If you choose "Bearer", you MUST set a secret token.
+MAP_STORAGE_AUTHENTICATION_TOKEN=

--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -47,7 +47,7 @@ services:
       - DISABLE_ANONYMOUS
       - DISABLE_NOTIFICATIONS
       - SECRET_KEY
-      - API_URL
+      - API_URL=back:50051
       - FRONT_URL=https://${FRONT_HOST}
       - CHAT_URL=https://${CHAT_HOST}
       - PUBLIC_MAP_STORAGE_URL=https://${MAP_STORAGE_HOST}

--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -215,6 +215,11 @@ services:
     image: thecodingmachine/workadventure-map-storage:${VERSION}
     environment:
       PROMETHEUS_AUTHORIZATION_TOKEN: "$PROMETHEUS_AUTHORIZATION_TOKEN"
+      AUTHENTICATION_STRATEGY: "$MAP_STORAGE_AUTHENTICATION_STRATEGY"
+      AUTHENTICATION_USER: "$MAP_STORAGE_AUTHENTICATION_USER"
+      AUTHENTICATION_PASSWORD: "$MAP_STORAGE_AUTHENTICATION_PASSWORD"
+      AUTHENTICATION_TOKEN: "$MAP_STORAGE_AUTHENTICATION_TOKEN"
+
     labels:
       traefik.enable: "true"
       traefik.http.routers.map-storage.rule: "Host(`${MAP_STORAGE_HOST}`)"

--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -65,6 +65,8 @@ services:
       # Report issues menu
       - ENABLE_REPORT_ISSUES_MENU=${ENABLE_REPORT_ISSUES_MENU}
       - REPORT_ISSUES_URL=${REPORT_ISSUES_URL}
+      - ENABLE_OPENAPI_ENDPOINT=true
+      - ADMIN_API_TOKEN
     labels:
       traefik.enable: "true"
       traefik.http.routers.play.rule: "Host(`${FRONT_HOST}`)"

--- a/contrib/docker/docker-compose.single-domain.yaml
+++ b/contrib/docker/docker-compose.single-domain.yaml
@@ -5,7 +5,7 @@ services:
       - PUSHER_URL=/
       - ICON_URL=/icon
       - FRONT_URL=/
-      - CHAT_URL=/chat
+      - CHAT_URL=/chat/
       - UPLOADER_URL=/uploader
       - PUBLIC_MAP_STORAGE_URL=/map-storage
     labels:

--- a/contrib/docker/docker-compose.single-domain.yaml
+++ b/contrib/docker/docker-compose.single-domain.yaml
@@ -26,6 +26,7 @@ services:
   back:
     environment:
       - PUBLIC_MAP_STORAGE_URL=/map-storage
+      - PLAY_URL=https://${DOMAIN}
     labels:
       traefik.http.middlewares.strip-api-prefix.stripprefix.prefixes: "/api"
       traefik.http.routers.back.rule: "Host(`${DOMAIN}`) && PathPrefix(`/api`)"

--- a/contrib/docker/docker-compose.single-domain.yaml
+++ b/contrib/docker/docker-compose.single-domain.yaml
@@ -4,10 +4,10 @@ services:
     environment:
       - PUSHER_URL=/
       - ICON_URL=/icon
-      - API_URL=/api
       - FRONT_URL=/
       - CHAT_URL=/chat
       - UPLOADER_URL=/uploader
+      - PUBLIC_MAP_STORAGE_URL=/map-storage
     labels:
       traefik.http.routers.play.rule: "Host(`${DOMAIN}`) && PathPrefix(`/`)"
       traefik.http.routers.play-ssl.rule: "Host(`${DOMAIN}`) && PathPrefix(`/`)"

--- a/contrib/docker/docker-compose.single-domain.yaml
+++ b/contrib/docker/docker-compose.single-domain.yaml
@@ -16,6 +16,7 @@ services:
     environment:
       - PUSHER_URL=/
       - UPLOADER_URL=/uploader
+      - EJABBERD_WS_URI=wss://${DOMAIN}/xmpp/ws
     labels:
       traefik.http.middlewares.strip-chat-prefix.stripprefix.prefixes: "/chat"
       traefik.http.routers.chat.rule: "Host(`${DOMAIN}`) && PathPrefix(`/chat`)"

--- a/contrib/docker/tests/docker-compose.oidc-overload.yaml
+++ b/contrib/docker/tests/docker-compose.oidc-overload.yaml
@@ -1,0 +1,5 @@
+version: "3.6"
+services:
+  oidc-server-mock:
+    volumes:
+      - ../oidc-server-mock:/tmp/config:ro

--- a/contrib/docker/tests/docker-compose.oidc-overload.yaml
+++ b/contrib/docker/tests/docker-compose.oidc-overload.yaml
@@ -1,5 +1,0 @@
-version: "3.6"
-services:
-  oidc-server-mock:
-    volumes:
-      - ../oidc-server-mock:/tmp/config:ro

--- a/contrib/docker/tests/docker-compose.test-maps.yaml
+++ b/contrib/docker/tests/docker-compose.test-maps.yaml
@@ -3,7 +3,7 @@ services:
   maps:
     image: thecodingmachine/php:8.1-v4-apache-node12
     environment:
-      FRONT_URL: http://play.workadventure.localhost
+      FRONT_URL: https://play.workadventure.localhost
       #APACHE_DOCUMENT_ROOT: dist/
       #APACHE_EXTENSIONS: headers
       #APACHE_EXTENSION_HEADERS: 1

--- a/contrib/docker/tests/docker-compose.test-maps.yaml
+++ b/contrib/docker/tests/docker-compose.test-maps.yaml
@@ -1,0 +1,23 @@
+version: "3.6"
+services:
+  maps:
+    image: thecodingmachine/php:8.1-v4-apache-node12
+    environment:
+      FRONT_URL: http://play.workadventure.localhost
+      #APACHE_DOCUMENT_ROOT: dist/
+      #APACHE_EXTENSIONS: headers
+      #APACHE_EXTENSION_HEADERS: 1
+      STARTUP_COMMAND_0: sudo a2enmod headers
+      STARTUP_COMMAND_1: yarn install
+    volumes:
+      - ../../maps:/var/www/html
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.maps.rule: "Host(`maps.workadventure.localhost`)"
+      traefik.http.routers.maps.entryPoints: "web,traefik"
+      traefik.http.services.maps.loadbalancer.server.port: "80"
+      traefik.http.routers.maps-ssl.rule: "Host(`maps.workadventure.localhost`)"
+      traefik.http.routers.maps-ssl.entryPoints: "websecure"
+      traefik.http.routers.maps-ssl.service: "maps"
+      traefik.http.routers.maps-ssl.tls: "true"
+      traefik.http.routers.maps-ssl.tls.certresolver: "myresolver"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -310,7 +310,7 @@ services:
         - "traefik.enable=true"
         - "traefik.http.routers.xmpp.rule=Host(`xmpp.workadventure.localhost`)"
         - "traefik.http.routers.xmpp.entryPoints=web"
-        - "traedocfik.http.services.xmpp.loadbalancer.server.port=5443"
+        - "traefik.http.services.xmpp.loadbalancer.server.port=5443"
 
     # A mock server to test OpenID connect connectivity
     oidc-server-mock:

--- a/map-storage/src/Upload/index.html
+++ b/map-storage/src/Upload/index.html
@@ -11,7 +11,7 @@
         <div style="padding: 10px; margin: 20px;">
             <h2>Upload map</h2>
             <p>Use this very simple web interface to upload a map (as a ZIP file).</p>
-            <form action="/upload" method="post" enctype="multipart/form-data">
+            <form action="./upload" method="post" enctype="multipart/form-data">
                 <label for="file">Select a file to upload:</label><br>
                 <input type="file" name="file" id="file" accept=".zip"><br>
                 <label for="directory">Directory:</label><br>
@@ -21,7 +21,7 @@
         </div>
         <div style="padding: 10px; margin: 20px;">
             <h2>Download map</h2>
-            <form action="/download" method="get">
+            <form action="./download" method="get">
                 <label for="directoryDownload">Directory:</label><br>
                 <input type="text" name="directory" id="directoryDownload" value="/"><br><br>
                 <input type="submit" value="Submit">

--- a/play/src/front/Connexion/AxiosUtils.ts
+++ b/play/src/front/Connexion/AxiosUtils.ts
@@ -3,11 +3,18 @@ import axiosRetry, { isNetworkOrIdempotentRequestError } from "axios-retry";
 import { errorStore } from "../Stores/ErrorStore";
 import LL from "../../i18n/i18n-svelte";
 import { get } from "svelte/store";
+import {ABSOLUTE_PUSHER_URL} from "../Enum/ComputedConst";
+
+export const axiosToPusher = axios.create({
+    baseURL: ABSOLUTE_PUSHER_URL,
+})
 
 /**
  * This instance of Axios will retry in case of an issue and display an error message as a HTML overlay.
  */
-export const axiosWithRetry = axios.create();
+export const axiosWithRetry = axios.create({
+    baseURL: ABSOLUTE_PUSHER_URL,
+});
 
 axiosRetry(axiosWithRetry, {
     retryDelay: (retryCount: number) => {

--- a/play/src/front/Connexion/AxiosUtils.ts
+++ b/play/src/front/Connexion/AxiosUtils.ts
@@ -3,11 +3,11 @@ import axiosRetry, { isNetworkOrIdempotentRequestError } from "axios-retry";
 import { errorStore } from "../Stores/ErrorStore";
 import LL from "../../i18n/i18n-svelte";
 import { get } from "svelte/store";
-import {ABSOLUTE_PUSHER_URL} from "../Enum/ComputedConst";
+import { ABSOLUTE_PUSHER_URL } from "../Enum/ComputedConst";
 
 export const axiosToPusher = axios.create({
     baseURL: ABSOLUTE_PUSHER_URL,
-})
+});
 
 /**
  * This instance of Axios will retry in case of an issue and display an error message as a HTML overlay.

--- a/play/src/front/Connexion/ConnectionManager.ts
+++ b/play/src/front/Connexion/ConnectionManager.ts
@@ -11,7 +11,7 @@ import { _ServiceWorker } from "../Network/ServiceWorker";
 import { loginSceneVisibleIframeStore } from "../Stores/LoginSceneStore";
 import { subMenusStore, userIsConnected, warningContainerStore } from "../Stores/MenuStore";
 import { analyticsClient } from "../Administration/AnalyticsClient";
-import {axiosToPusher, axiosWithRetry} from "./AxiosUtils";
+import { axiosToPusher, axiosWithRetry } from "./AxiosUtils";
 import type { AvailabilityStatus } from "@workadventure/messages";
 import { isRegisterData } from "@workadventure/messages";
 import { limitMapStore } from "../Stores/GameStore";
@@ -119,9 +119,7 @@ class ConnectionManager {
         //@deprecated
         else if (this.connexionType === GameConnexionTypes.register) {
             const organizationMemberToken = urlManager.getOrganizationToken();
-            const result = await axiosToPusher.post("register", { organizationMemberToken }).then(
-                (res) => res.data
-            );
+            const result = await axiosToPusher.post("register", { organizationMemberToken }).then((res) => res.data);
 
             const registerDataChecking = isRegisterData.safeParse(result);
 
@@ -374,14 +372,13 @@ class ConnectionManager {
         //set connected store for menu at false
         userIsConnected.set(false);
 
-        const { authToken, userUuid, email, username, locale, textures, visitCardUrl } = await axiosToPusher.get(
-            "me",
-            {
+        const { authToken, userUuid, email, username, locale, textures, visitCardUrl } = await axiosToPusher
+            .get("me", {
                 params: { token, playUri: this.currentRoom?.key },
-            }
-        ).then((res) => {
-            return res.data;
-        });
+            })
+            .then((res) => {
+                return res.data;
+            });
 
         localUserStore.setAuthToken(authToken);
         this.localUser = new LocalUser(userUuid, email);

--- a/play/src/front/Connexion/ConnectionManager.ts
+++ b/play/src/front/Connexion/ConnectionManager.ts
@@ -11,7 +11,7 @@ import { _ServiceWorker } from "../Network/ServiceWorker";
 import { loginSceneVisibleIframeStore } from "../Stores/LoginSceneStore";
 import { subMenusStore, userIsConnected, warningContainerStore } from "../Stores/MenuStore";
 import { analyticsClient } from "../Administration/AnalyticsClient";
-import { axiosWithRetry } from "./AxiosUtils";
+import {axiosToPusher, axiosWithRetry} from "./AxiosUtils";
 import type { AvailabilityStatus } from "@workadventure/messages";
 import { isRegisterData } from "@workadventure/messages";
 import { limitMapStore } from "../Stores/GameStore";
@@ -72,7 +72,7 @@ class ConnectionManager {
 
         //Logout user in pusher and hydra
         const token = localUserStore.getAuthToken();
-        await Axios.get(`${PUSHER_URL}/logout-callback`, { params: { token } }).then((res) => res.data);
+        await axiosToPusher.get("logout-callback", { params: { token } }).then((res) => res.data);
         localUserStore.setAuthToken(null);
 
         //Go on root page
@@ -119,7 +119,7 @@ class ConnectionManager {
         //@deprecated
         else if (this.connexionType === GameConnexionTypes.register) {
             const organizationMemberToken = urlManager.getOrganizationToken();
-            const result = await Axios.post(`${PUSHER_URL}/register`, { organizationMemberToken }).then(
+            const result = await axiosToPusher.post("register", { organizationMemberToken }).then(
                 (res) => res.data
             );
 
@@ -248,7 +248,7 @@ class ConnectionManager {
     }
 
     public async anonymousLogin(isBenchmark = false): Promise<void> {
-        const data = await axiosWithRetry.post(`${PUSHER_URL}/anonymLogin`).then((res) => res.data);
+        const data = await axiosWithRetry.post("anonymLogin").then((res) => res.data);
         this.localUser = new LocalUser(data.userUuid, data.email);
         this.authToken = data.authToken;
         if (!isBenchmark) {
@@ -374,8 +374,8 @@ class ConnectionManager {
         //set connected store for menu at false
         userIsConnected.set(false);
 
-        const { authToken, userUuid, email, username, locale, textures, visitCardUrl } = await Axios.get(
-            `${PUSHER_URL}/me`,
+        const { authToken, userUuid, email, username, locale, textures, visitCardUrl } = await axiosToPusher.get(
+            "me",
             {
                 params: { token, playUri: this.currentRoom?.key },
             }

--- a/play/src/front/Connexion/ConnectionManager.ts
+++ b/play/src/front/Connexion/ConnectionManager.ts
@@ -1,6 +1,5 @@
 import { HtmlUtils } from "./../WebRtc/HtmlUtils";
-import Axios from "axios";
-import { ENABLE_OPENID, PUSHER_URL } from "../Enum/EnvironmentVariable";
+import { ENABLE_OPENID } from "../Enum/EnvironmentVariable";
 import { RoomConnection } from "./RoomConnection";
 import type { OnConnectInterface, PositionInterface, ViewportInterface } from "./ConnexionModels";
 import { GameConnexionTypes, urlManager } from "../Url/UrlManager";

--- a/play/src/front/Connexion/Room.ts
+++ b/play/src/front/Connexion/Room.ts
@@ -11,7 +11,7 @@ import { axiosWithRetry } from "./AxiosUtils";
 import type { MucRoomDefinition, LegalsData } from "@workadventure/messages";
 import { isMapDetailsData, isRoomRedirect, ErrorApiData, OpidWokaNamePolicy } from "@workadventure/messages";
 import { ApiError } from "../Stores/Errors/ApiError";
-import {ABSOLUTE_PUSHER_URL} from "../Enum/ComputedConst";
+import { ABSOLUTE_PUSHER_URL } from "../Enum/ComputedConst";
 export class MapDetail {
     constructor(public readonly mapUrl: string) {}
 }
@@ -117,15 +117,12 @@ export class Room {
 
     private async getMapDetail(): Promise<MapDetail | RoomRedirect> {
         try {
-            const result = await axiosWithRetry.get<unknown>(
-                "map",
-                {
-                    params: {
-                        playUri: this.roomUrl.toString(),
-                        authToken: localUserStore.getAuthToken(),
-                    },
-                }
-            );
+            const result = await axiosWithRetry.get<unknown>("map", {
+                params: {
+                    playUri: this.roomUrl.toString(),
+                    authToken: localUserStore.getAuthToken(),
+                },
+            });
 
             const data = result.data;
 
@@ -150,7 +147,8 @@ export class Room {
                 this._group = data.group;
                 this._authenticationMandatory =
                     data.authenticationMandatory != null ? data.authenticationMandatory : DISABLE_ANONYMOUS;
-                this._iframeAuthentication = data.iframeAuthentication || new URL("login-screen", ABSOLUTE_PUSHER_URL).toString();
+                this._iframeAuthentication =
+                    data.iframeAuthentication || new URL("login-screen", ABSOLUTE_PUSHER_URL).toString();
                 this._opidLogoutRedirectUrl = data.opidLogoutRedirectUrl || OPID_LOGOUT_REDIRECT_URL || "/";
                 this._contactPage = data.contactPage || CONTACT_URL;
                 if (data.expireOn) {

--- a/play/src/front/Connexion/Room.ts
+++ b/play/src/front/Connexion/Room.ts
@@ -3,7 +3,6 @@ import {
     DISABLE_ANONYMOUS,
     OPID_LOGOUT_REDIRECT_URL,
     OPID_WOKA_NAME_POLICY,
-    PUSHER_URL,
 } from "../Enum/EnvironmentVariable";
 import { localUserStore } from "./LocalUserStore";
 import axios from "axios";

--- a/play/src/front/Connexion/Room.ts
+++ b/play/src/front/Connexion/Room.ts
@@ -11,6 +11,7 @@ import { axiosWithRetry } from "./AxiosUtils";
 import type { MucRoomDefinition, LegalsData } from "@workadventure/messages";
 import { isMapDetailsData, isRoomRedirect, ErrorApiData, OpidWokaNamePolicy } from "@workadventure/messages";
 import { ApiError } from "../Stores/Errors/ApiError";
+import {ABSOLUTE_PUSHER_URL} from "../Enum/ComputedConst";
 export class MapDetail {
     constructor(public readonly mapUrl: string) {}
 }
@@ -19,12 +20,10 @@ export interface RoomRedirect {
     redirectUrl: string;
 }
 
-console.log("pusher url !", PUSHER_URL);
-
 export class Room {
     public readonly id: string;
     private _authenticationMandatory: boolean = DISABLE_ANONYMOUS;
-    private _iframeAuthentication?: string = PUSHER_URL + "/login-screen";
+    private _iframeAuthentication?: string = new URL("login-screen", ABSOLUTE_PUSHER_URL).toString();
     private _opidLogoutRedirectUrl = "/";
     private _opidWokaNamePolicy: OpidWokaNamePolicy | undefined;
     private _mapUrl: string | undefined;
@@ -119,7 +118,7 @@ export class Room {
     private async getMapDetail(): Promise<MapDetail | RoomRedirect> {
         try {
             const result = await axiosWithRetry.get<unknown>(
-                new URL("/map", new URL(PUSHER_URL, window.location.href)).toString(),
+                "map",
                 {
                     params: {
                         playUri: this.roomUrl.toString(),
@@ -151,7 +150,7 @@ export class Room {
                 this._group = data.group;
                 this._authenticationMandatory =
                     data.authenticationMandatory != null ? data.authenticationMandatory : DISABLE_ANONYMOUS;
-                this._iframeAuthentication = data.iframeAuthentication || PUSHER_URL + "/login-screen";
+                this._iframeAuthentication = data.iframeAuthentication || new URL("login-screen", ABSOLUTE_PUSHER_URL).toString();
                 this._opidLogoutRedirectUrl = data.opidLogoutRedirectUrl || OPID_LOGOUT_REDIRECT_URL || "/";
                 this._contactPage = data.contactPage || CONTACT_URL;
                 if (data.expireOn) {

--- a/play/src/front/Connexion/RoomConnection.ts
+++ b/play/src/front/Connexion/RoomConnection.ts
@@ -1,4 +1,4 @@
-import { ENABLE_FEATURE_MAP_EDITOR, PUSHER_URL, UPLOADER_URL } from "../Enum/EnvironmentVariable";
+import { ENABLE_FEATURE_MAP_EDITOR, UPLOADER_URL } from "../Enum/EnvironmentVariable";
 import Axios from "axios";
 
 import type { UserSimplePeerInterface } from "../WebRtc/SimplePeer";

--- a/play/src/front/Connexion/RoomConnection.ts
+++ b/play/src/front/Connexion/RoomConnection.ts
@@ -74,7 +74,7 @@ import type { AreaData, AtLeast, EntityData } from "@workadventure/map-editor";
 import type { SetPlayerVariableEvent } from "../Api/Events/SetPlayerVariableEvent";
 import { iframeListener } from "../Api/IframeListener";
 import { assertObjectKeys } from "../Utils/CustomTypeGuards";
-import {ABSOLUTE_PUSHER_URL} from "../Enum/ComputedConst";
+import { ABSOLUTE_PUSHER_URL } from "../Enum/ComputedConst";
 
 // This must be greater than IoSocketController's PING_INTERVAL
 const manualPingDelay = 100000;

--- a/play/src/front/Connexion/RoomConnection.ts
+++ b/play/src/front/Connexion/RoomConnection.ts
@@ -74,6 +74,7 @@ import type { AreaData, AtLeast, EntityData } from "@workadventure/map-editor";
 import type { SetPlayerVariableEvent } from "../Api/Events/SetPlayerVariableEvent";
 import { iframeListener } from "../Api/IframeListener";
 import { assertObjectKeys } from "../Utils/CustomTypeGuards";
+import {ABSOLUTE_PUSHER_URL} from "../Enum/ComputedConst";
 
 // This must be greater than IoSocketController's PING_INTERVAL
 const manualPingDelay = 100000;
@@ -215,7 +216,7 @@ export class RoomConnection implements RoomConnection {
         availabilityStatus: AvailabilityStatus,
         lastCommandId?: string
     ) {
-        let url = new URL(PUSHER_URL, window.location.toString()).toString();
+        let url = ABSOLUTE_PUSHER_URL;
         url = url.replace("http://", "ws://").replace("https://", "wss://");
         if (!url.endsWith("/")) {
             url += "/";

--- a/play/src/front/Enum/ComputedConst.ts
+++ b/play/src/front/Enum/ComputedConst.ts
@@ -1,3 +1,3 @@
-import {PUSHER_URL} from "./EnvironmentVariable";
+import { PUSHER_URL } from "./EnvironmentVariable";
 
 export const ABSOLUTE_PUSHER_URL = new URL(PUSHER_URL, window.location.toString()).toString();

--- a/play/src/front/Enum/ComputedConst.ts
+++ b/play/src/front/Enum/ComputedConst.ts
@@ -1,0 +1,3 @@
+import {PUSHER_URL} from "./EnvironmentVariable";
+
+export const ABSOLUTE_PUSHER_URL = new URL(PUSHER_URL, window.location.toString()).toString();

--- a/play/src/front/Phaser/Companion/CompanionTexturesLoadingManager.ts
+++ b/play/src/front/Phaser/Companion/CompanionTexturesLoadingManager.ts
@@ -1,7 +1,6 @@
 import LoaderPlugin = Phaser.Loader.LoaderPlugin;
 import CancelablePromise from "cancelable-promise";
 import { CompanionTexture, CompanionCollectionList, companionCollectionList } from "@workadventure/messages";
-import { PUSHER_URL } from "../../Enum/EnvironmentVariable";
 import { gameManager } from "../Game/GameManager";
 import { localUserStore } from "../../Connexion/LocalUserStore";
 import type { SuperLoaderPlugin } from "../Services/SuperLoaderPlugin";

--- a/play/src/front/Phaser/Companion/CompanionTexturesLoadingManager.ts
+++ b/play/src/front/Phaser/Companion/CompanionTexturesLoadingManager.ts
@@ -5,6 +5,7 @@ import { PUSHER_URL } from "../../Enum/EnvironmentVariable";
 import { gameManager } from "../Game/GameManager";
 import { localUserStore } from "../../Connexion/LocalUserStore";
 import type { SuperLoaderPlugin } from "../Services/SuperLoaderPlugin";
+import {ABSOLUTE_PUSHER_URL} from "../../Enum/ComputedConst";
 
 export function companionListMetakey() {
     return "companion-list" + gameManager.currentStartedRoom.href;
@@ -20,7 +21,7 @@ export class CompanionTexturesLoadingManager {
         this.superLoad
             .json(
                 companionListMetakey(),
-                `${PUSHER_URL}/companion/list?roomUrl=` + encodeURIComponent(gameManager.currentStartedRoom.href),
+                new URL(`companion/list?roomUrl=` + encodeURIComponent(gameManager.currentStartedRoom.href), ABSOLUTE_PUSHER_URL).toString(),
                 undefined,
                 {
                     responseType: "text",

--- a/play/src/front/Phaser/Companion/CompanionTexturesLoadingManager.ts
+++ b/play/src/front/Phaser/Companion/CompanionTexturesLoadingManager.ts
@@ -5,7 +5,7 @@ import { PUSHER_URL } from "../../Enum/EnvironmentVariable";
 import { gameManager } from "../Game/GameManager";
 import { localUserStore } from "../../Connexion/LocalUserStore";
 import type { SuperLoaderPlugin } from "../Services/SuperLoaderPlugin";
-import {ABSOLUTE_PUSHER_URL} from "../../Enum/ComputedConst";
+import { ABSOLUTE_PUSHER_URL } from "../../Enum/ComputedConst";
 
 export function companionListMetakey() {
     return "companion-list" + gameManager.currentStartedRoom.href;
@@ -21,7 +21,10 @@ export class CompanionTexturesLoadingManager {
         this.superLoad
             .json(
                 companionListMetakey(),
-                new URL(`companion/list?roomUrl=` + encodeURIComponent(gameManager.currentStartedRoom.href), ABSOLUTE_PUSHER_URL).toString(),
+                new URL(
+                    `companion/list?roomUrl=` + encodeURIComponent(gameManager.currentStartedRoom.href),
+                    ABSOLUTE_PUSHER_URL
+                ).toString(),
                 undefined,
                 {
                     responseType: "text",

--- a/play/src/front/Phaser/Login/CustomizeScene.ts
+++ b/play/src/front/Phaser/Login/CustomizeScene.ts
@@ -9,7 +9,6 @@ import { areCharacterLayersValid } from "../../Connexion/LocalUser";
 import { SelectCharacterSceneName } from "./SelectCharacterScene";
 import { waScaleManager } from "../Services/WaScaleManager";
 import { analyticsClient } from "../../Administration/AnalyticsClient";
-import { PUSHER_URL } from "../../Enum/EnvironmentVariable";
 import type { CustomWokaPreviewerConfig } from "../Components/CustomizeWoka/CustomWokaPreviewer";
 import {
     CustomWokaBodyPart,

--- a/play/src/front/Phaser/Login/CustomizeScene.ts
+++ b/play/src/front/Phaser/Login/CustomizeScene.ts
@@ -28,6 +28,7 @@ import { TexturesHelper } from "../Helpers/TexturesHelper";
 import type { IconButtonConfig } from "../Components/Ui/IconButton";
 import { IconButton, IconButtonEvent } from "../Components/Ui/IconButton";
 import { selectCharacterCustomizeSceneVisibleStore } from "../../Stores/SelectCharacterStore";
+import {ABSOLUTE_PUSHER_URL} from "../../Enum/ComputedConst";
 
 export const CustomizeSceneName = "CustomizeScene";
 
@@ -85,7 +86,7 @@ export class CustomizeScene extends AbstractCharacterScene {
         this.superLoad
             .json(
                 wokaMetadataKey,
-                `${PUSHER_URL}/woka/list?roomUrl=` + encodeURIComponent(gameManager.currentStartedRoom.href),
+                new URL("/woka/list?roomUrl=" + encodeURIComponent(gameManager.currentStartedRoom.href), ABSOLUTE_PUSHER_URL).toString(),
                 undefined,
                 {
                     responseType: "text",

--- a/play/src/front/Phaser/Login/CustomizeScene.ts
+++ b/play/src/front/Phaser/Login/CustomizeScene.ts
@@ -28,7 +28,7 @@ import { TexturesHelper } from "../Helpers/TexturesHelper";
 import type { IconButtonConfig } from "../Components/Ui/IconButton";
 import { IconButton, IconButtonEvent } from "../Components/Ui/IconButton";
 import { selectCharacterCustomizeSceneVisibleStore } from "../../Stores/SelectCharacterStore";
-import {ABSOLUTE_PUSHER_URL} from "../../Enum/ComputedConst";
+import { ABSOLUTE_PUSHER_URL } from "../../Enum/ComputedConst";
 
 export const CustomizeSceneName = "CustomizeScene";
 
@@ -86,7 +86,10 @@ export class CustomizeScene extends AbstractCharacterScene {
         this.superLoad
             .json(
                 wokaMetadataKey,
-                new URL("/woka/list?roomUrl=" + encodeURIComponent(gameManager.currentStartedRoom.href), ABSOLUTE_PUSHER_URL).toString(),
+                new URL(
+                    "/woka/list?roomUrl=" + encodeURIComponent(gameManager.currentStartedRoom.href),
+                    ABSOLUTE_PUSHER_URL
+                ).toString(),
                 undefined,
                 {
                     responseType: "text",

--- a/play/src/front/Phaser/Login/SelectCharacterScene.ts
+++ b/play/src/front/Phaser/Login/SelectCharacterScene.ts
@@ -13,7 +13,6 @@ import { PinchManager } from "../UserInput/PinchManager";
 import { selectCharacterSceneVisibleStore } from "../../Stores/SelectCharacterStore";
 import { waScaleManager } from "../Services/WaScaleManager";
 import { analyticsClient } from "../../Administration/AnalyticsClient";
-import { PUSHER_URL } from "../../Enum/EnvironmentVariable";
 import {
     collectionsSizeStore,
     customizeAvailableStore,

--- a/play/src/front/Phaser/Login/SelectCharacterScene.ts
+++ b/play/src/front/Phaser/Login/SelectCharacterScene.ts
@@ -25,6 +25,7 @@ import { DraggableGridEvent } from "@home-based-studio/phaser3-utils/lib/utils/g
 import { wokaList } from "@workadventure/messages";
 import { myCameraStore, myMicrophoneStore } from "../../Stores/MyMediaStore";
 import { get } from "svelte/store";
+import {ABSOLUTE_PUSHER_URL} from "../../Enum/ComputedConst";
 
 //todo: put this constants in a dedicated file
 export const SelectCharacterSceneName = "SelectCharacterScene";
@@ -58,7 +59,7 @@ export class SelectCharacterScene extends AbstractCharacterScene {
         this.superLoad
             .json(
                 wokaMetadataKey,
-                `${PUSHER_URL}/woka/list?roomUrl=` + encodeURIComponent(gameManager.currentStartedRoom.href),
+                new URL("woka/list?roomUrl=" + encodeURIComponent(gameManager.currentStartedRoom.href), ABSOLUTE_PUSHER_URL).toString(),
                 undefined,
                 {
                     responseType: "text",

--- a/play/src/front/Phaser/Login/SelectCharacterScene.ts
+++ b/play/src/front/Phaser/Login/SelectCharacterScene.ts
@@ -25,7 +25,7 @@ import { DraggableGridEvent } from "@home-based-studio/phaser3-utils/lib/utils/g
 import { wokaList } from "@workadventure/messages";
 import { myCameraStore, myMicrophoneStore } from "../../Stores/MyMediaStore";
 import { get } from "svelte/store";
-import {ABSOLUTE_PUSHER_URL} from "../../Enum/ComputedConst";
+import { ABSOLUTE_PUSHER_URL } from "../../Enum/ComputedConst";
 
 //todo: put this constants in a dedicated file
 export const SelectCharacterSceneName = "SelectCharacterScene";
@@ -59,7 +59,10 @@ export class SelectCharacterScene extends AbstractCharacterScene {
         this.superLoad
             .json(
                 wokaMetadataKey,
-                new URL("woka/list?roomUrl=" + encodeURIComponent(gameManager.currentStartedRoom.href), ABSOLUTE_PUSHER_URL).toString(),
+                new URL(
+                    "woka/list?roomUrl=" + encodeURIComponent(gameManager.currentStartedRoom.href),
+                    ABSOLUTE_PUSHER_URL
+                ).toString(),
                 undefined,
                 {
                     responseType: "text",

--- a/play/src/front/Stores/ErrorScreenStore.ts
+++ b/play/src/front/Stores/ErrorScreenStore.ts
@@ -49,7 +49,7 @@ function createErrorScreenStore() {
                             error.response.status +
                             " - " +
                             (error.response.data ? error.response.data : error.response.statusText),
-                        details: "An error occurred while accessing URL: " + error.response.config?.url,
+                        details: "An error occurred while accessing URL: " + error.config?.url,
                     })
                 );
                 return;

--- a/play/src/front/Stores/MenuStore.ts
+++ b/play/src/front/Stores/MenuStore.ts
@@ -7,6 +7,7 @@ import type { Translation } from "../../i18n/i18n-types";
 import { localUserStore } from "../Connexion/LocalUserStore";
 import { connectionManager } from "../Connexion/ConnectionManager";
 import { AddButtonActionBarEvent, RemoveButtonActionBarEvent } from "../Api/Events/Ui/ButtonActionBarEvent";
+import {ABSOLUTE_PUSHER_URL} from "../Enum/ComputedConst";
 
 export const menuIconVisiblilityStore = writable(false);
 export const menuVisiblilityStore = writable(false);
@@ -219,10 +220,10 @@ export function handleMenuUnregisterEvent(menuName: string) {
 }
 
 export function getProfileUrl() {
-    return (
-        PUSHER_URL +
-        `/profile-callback?token=${localUserStore.getAuthToken()}&playUri=${connectionManager.currentRoom?.key}`
-    );
+    return new URL(
+        `profile-callback?token=${localUserStore.getAuthToken()}&playUri=${connectionManager.currentRoom?.key}`,
+        ABSOLUTE_PUSHER_URL
+    ).toString();
 }
 
 function createAdditionalButtonsMenu() {

--- a/play/src/front/Stores/MenuStore.ts
+++ b/play/src/front/Stores/MenuStore.ts
@@ -2,7 +2,7 @@ import { ENABLE_REPORT_ISSUES_MENU, REPORT_ISSUES_URL } from "./../Enum/Environm
 import { AddClassicButtonActionBarEvent, AddActionButtonActionBarEvent } from "./../Api/Events/Ui/ButtonActionBarEvent";
 import { derived, get, writable } from "svelte/store";
 import { userIsAdminStore } from "./GameStore";
-import { CONTACT_URL, OPID_PROFILE_SCREEN_PROVIDER, PUSHER_URL } from "../Enum/EnvironmentVariable";
+import { CONTACT_URL, OPID_PROFILE_SCREEN_PROVIDER } from "../Enum/EnvironmentVariable";
 import type { Translation } from "../../i18n/i18n-types";
 import { localUserStore } from "../Connexion/LocalUserStore";
 import { connectionManager } from "../Connexion/ConnectionManager";

--- a/play/src/front/Stores/MenuStore.ts
+++ b/play/src/front/Stores/MenuStore.ts
@@ -7,7 +7,7 @@ import type { Translation } from "../../i18n/i18n-types";
 import { localUserStore } from "../Connexion/LocalUserStore";
 import { connectionManager } from "../Connexion/ConnectionManager";
 import { AddButtonActionBarEvent, RemoveButtonActionBarEvent } from "../Api/Events/Ui/ButtonActionBarEvent";
-import {ABSOLUTE_PUSHER_URL} from "../Enum/ComputedConst";
+import { ABSOLUTE_PUSHER_URL } from "../Enum/ComputedConst";
 
 export const menuIconVisiblilityStore = writable(false);
 export const menuVisiblilityStore = writable(false);

--- a/tests/package.json
+++ b/tests/package.json
@@ -22,7 +22,7 @@
     "test-headed-firefox": "dotenv -e ../.env -- playwright test --headed --project=firefox",
     "test-headed-webkit": "dotenv -e ../.env -- playwright test --headed --project=webkit",
     "test-prod-like": "OVERRIDE_DOCKER_COMPOSE=docker-compose.e2e.yml npm run test -- ",
-    "test-single-domain-install": "MAP_STORAGE_PROTOCOL=https MAP_STORAGE_ENDPOINT=play.workadventure.localhost/map-storage/ playwright test --project=chromium --grep-invert \"@docker|@oidc\"",
+    "test-single-domain-install": "ADMIN_API_TOKEN=123 MAP_STORAGE_PROTOCOL=https MAP_STORAGE_ENDPOINT=play.workadventure.localhost/map-storage/ playwright test --project=chromium --grep-invert \"@docker|@oidc|@selfsigned\"",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -22,7 +22,7 @@
     "test-headed-firefox": "dotenv -e ../.env -- playwright test --headed --project=firefox",
     "test-headed-webkit": "dotenv -e ../.env -- playwright test --headed --project=webkit",
     "test-prod-like": "OVERRIDE_DOCKER_COMPOSE=docker-compose.e2e.yml npm run test -- ",
-    "test-single-domain-install": "MAP_STORAGE_ENDPOINT=http://john.doe:password@play.workadventure.localhost/map-storage playwright test --project=chromium --grep-invert \"@docker|@oidc\"",
+    "test-single-domain-install": "MAP_STORAGE_ENDPOINT=http://john.doe:password@play.workadventure.localhost/map-storage/ playwright test --project=chromium --grep-invert \"@docker|@oidc\"",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -22,6 +22,7 @@
     "test-headed-firefox": "dotenv -e ../.env -- playwright test --headed --project=firefox",
     "test-headed-webkit": "dotenv -e ../.env -- playwright test --headed --project=webkit",
     "test-prod-like": "OVERRIDE_DOCKER_COMPOSE=docker-compose.e2e.yml npm run test -- ",
+    "test-single-domain-install": "MAP_STORAGE_ENDPOINT=http://john.doe:password@play.workadventure.localhost/map-storage playwright test --project=chromium --grep-invert \"@docker|@oidc\"",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -22,7 +22,7 @@
     "test-headed-firefox": "dotenv -e ../.env -- playwright test --headed --project=firefox",
     "test-headed-webkit": "dotenv -e ../.env -- playwright test --headed --project=webkit",
     "test-prod-like": "OVERRIDE_DOCKER_COMPOSE=docker-compose.e2e.yml npm run test -- ",
-    "test-single-domain-install": "MAP_STORAGE_ENDPOINT=http://john.doe:password@play.workadventure.localhost/map-storage/ playwright test --project=chromium --grep-invert \"@docker|@oidc\"",
+    "test-single-domain-install": "MAP_STORAGE_PROTOCOL=https MAP_STORAGE_ENDPOINT=play.workadventure.localhost/map-storage/ playwright test --project=chromium --grep-invert \"@docker|@oidc\"",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -27,8 +27,8 @@ const config: PlaywrightTestConfig = {
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests. */
   workers: 1,
-  /* Limit failures to 5 in CI (to finish early) */
-  maxFailures: process.env.CI ? 5 : undefined,
+  /* Limit failures to 9 in CI (to finish early) */
+  maxFailures: process.env.CI ? 9 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['html'],

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -27,6 +27,8 @@ const config: PlaywrightTestConfig = {
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests. */
   workers: 1,
+  /* Limit failures to 5 in CI (to finish early) */
+  maxFailures: process.env.CI ? 5 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['html'],

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -52,6 +52,7 @@ const config: PlaywrightTestConfig = {
       use: {
         ...devices['Desktop Chrome'],
         permissions: ["microphone","camera"],
+        ignoreHTTPSErrors: true,
         launchOptions: {
           args: ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream'],
         },
@@ -69,6 +70,7 @@ const config: PlaywrightTestConfig = {
             "permissions.default.camera": 1,
           },
         },
+        ignoreHTTPSErrors: true,
         ...devices['Desktop Firefox'],
       },
     },
@@ -76,6 +78,7 @@ const config: PlaywrightTestConfig = {
     {
       name: 'webkit',
       use: {
+        ignoreHTTPSErrors: true,
         ...devices['Desktop Safari'],
       },
     },

--- a/tests/tests/api_players.spec.ts
+++ b/tests/tests/api_players.spec.ts
@@ -1,6 +1,5 @@
 
 import {} from "../../play/packages/iframe-api-typings/iframe_api";
-//import {} from "../../front/src/iframe_api";
 import {expect, test, Browser, Page} from '@playwright/test';
 import { login } from './utils/roles';
 import {getCoWebsiteIframe} from "./utils/iframe";

--- a/tests/tests/api_players.spec.ts
+++ b/tests/tests/api_players.spec.ts
@@ -284,7 +284,7 @@ test.describe('API WA.players', () => {
     await runPersistenceTest(page, browser);
   });
 
-  test('Test variable persistence for logged users.', async ({ page, browser }) => {
+  test('Test variable persistence for logged users. @oidc', async ({ page, browser }) => {
     test.setTimeout(120_000); // Fix Webkit that can take more than 60s
     await page.goto(
         'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/E2E/empty.json'

--- a/tests/tests/chat.spec.ts
+++ b/tests/tests/chat.spec.ts
@@ -176,7 +176,7 @@ test.describe('Chat', () => {
       await Chat.forumExist(page, 'Welcome');
     });
 
-    await test.step('disconnect and reconnect to ejabberd and pusher', async () => {
+    await test.step('disconnect and reconnect to ejabberd and pusher @docker', async () => {
       const chat = page.frameLocator('iframe#chatWorkAdventure').locator('aside.chatWindow');
       await Chat.slideToUsers(page);
       await Chat.checkNameInChat(page, nickname, TIMEOUT_TO_GET_LIST);

--- a/tests/tests/chat.spec.ts
+++ b/tests/tests/chat.spec.ts
@@ -12,12 +12,12 @@ test.setTimeout(750_000);
 
 test.describe('Chat', () => {
   test('main', async ({ page, browser, browserName }) => {
-    page.on('console', msg => console.log(browserName + ' - ' + msg.type() + ' - ' + msg.text()));
+    /*page.on('console', msg => console.log(browserName + ' - ' + msg.type() + ' - ' + msg.text()));
     page.on('response', response => {
       if (response.status() >= 400) {
         console.log('>>', response.status(), response.url());
       }
-    });
+    });*/
 
 
     await page.goto(

--- a/tests/tests/map_storage_upload.spec.ts
+++ b/tests/tests/map_storage_upload.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import fs from "fs";
 
 test.use({
-    baseURL: 'http://john.doe:password@map-storage.workadventure.localhost',
+    baseURL: process.env.MAP_STORAGE_URL ?? 'http://john.doe:password@map-storage.workadventure.localhost',
 })
 
 test.describe('Map-storage Upload API', () => {

--- a/tests/tests/map_storage_upload.spec.ts
+++ b/tests/tests/map_storage_upload.spec.ts
@@ -9,7 +9,7 @@ test.describe('Map-storage Upload API', () => {
     test('can upload ZIP file', async ({
                                            request,
                                        }) => {
-        const uploadFile1 = await request.post(`/upload`, {
+        const uploadFile1 = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/file1.zip"),
             }
@@ -17,11 +17,11 @@ test.describe('Map-storage Upload API', () => {
         await expect(uploadFile1.ok()).toBeTruthy();
 
         // Now, let's try to fetch the file.
-        const accessFile1 = await request.get(`/file1.txt`);
+        const accessFile1 = await request.get(`file1.txt`);
         await expect(accessFile1.ok()).toBeTruthy();
         await expect(await accessFile1.text()).toContain("hello");
 
-        const uploadFile2 = await request.post(`/upload`, {
+        const uploadFile2 = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/file2.zip"),
             }
@@ -29,16 +29,16 @@ test.describe('Map-storage Upload API', () => {
         await expect(uploadFile2.ok()).toBeTruthy();
 
         // Now, let's try to fetch the file.
-        const accessFile2 = await request.get(`/subdir/file2.txt`);
+        const accessFile2 = await request.get(`subdir/file2.txt`);
         await expect(accessFile2.ok()).toBeTruthy();
         await expect(await accessFile2.text()).toContain("world");
 
         // Let's check that the old file is gone
-        const accessFile3 = await request.get(`/file1.txt`);
+        const accessFile3 = await request.get(`file1.txt`);
         await expect(accessFile3.status()).toBe(404);
 
         // Now let's try to upload zip1 again, but in a directory
-        const uploadFile3 = await request.post(`/upload`, {
+        const uploadFile3 = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/file1.zip"),
                 directory: "/foo"
@@ -47,12 +47,12 @@ test.describe('Map-storage Upload API', () => {
         await expect(uploadFile3.ok()).toBeTruthy();
 
         // Now, let's try to fetch the file.
-        const accessFile4 = await request.get(`/foo/file1.txt`);
+        const accessFile4 = await request.get(`foo/file1.txt`);
         await expect(accessFile4.ok()).toBeTruthy();
         await expect(await accessFile4.text()).toContain("hello");
 
         // Because we uploaded in "/foo", the "/subdir" directory should always be here.
-        const accessFile5 = await request.get(`/subdir/file2.txt`);
+        const accessFile5 = await request.get(`subdir/file2.txt`);
         await expect(accessFile5.ok()).toBeTruthy();
         await expect(await accessFile5.text()).toContain("world");
     });
@@ -73,7 +73,7 @@ test.describe('Map-storage Upload API', () => {
                                 request,
                             }) => {
         // upload zip (file2.zip), download the "subdir" that contains only one file, reupload the subdir in "/bar", access the file
-        const uploadFile1 = await request.post(`/upload`, {
+        const uploadFile1 = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/file2.zip"),
             }
@@ -81,12 +81,12 @@ test.describe('Map-storage Upload API', () => {
         await expect(uploadFile1.ok()).toBeTruthy();
 
         // Now, let's try to fetch the file.
-        const downloadFile1 = await request.get(`/download?directory=subdir`);
+        const downloadFile1 = await request.get(`download?directory=subdir`);
         await expect(downloadFile1.ok()).toBeTruthy();
         const buffer = await downloadFile1.body();
 
         // Let's reupload this ZIP file in subdirectory "bar"
-        const uploadFile2 = await request.post(`/upload`, {
+        const uploadFile2 = await request.post("upload", {
             multipart: {
                 file: {
                     buffer,
@@ -99,7 +99,7 @@ test.describe('Map-storage Upload API', () => {
         await expect(uploadFile2.ok()).toBeTruthy();
 
         // Now, let's see if file /bar/file2.txt exists
-        const accessFile1 = await request.get(`/bar/file2.txt`);
+        const accessFile1 = await request.get(`bar/file2.txt`);
         await expect(accessFile1.ok()).toBeTruthy();
         await expect(await accessFile1.text()).toContain("world");
 
@@ -112,19 +112,19 @@ test.describe('Map-storage Upload API', () => {
         // It contains 2 files: immutable.a45b7e8f.js and normal-file.js.
         // When accessed, normal-file.js should have a small cache-control TTL
         // immutable.a45b7e8f.js should have a "immutable" Cache-Control HTTP header
-        const uploadFile1 = await request.post(`/upload`, {
+        const uploadFile1 = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/cache-control.zip"),
             }
         });
         await expect(uploadFile1.ok()).toBeTruthy();
 
-        const accessNormalFile = await request.get(`/normal-file.js`);
+        const accessNormalFile = await request.get(`normal-file.js`);
         await expect(accessNormalFile.ok()).toBeTruthy();
         await expect(accessNormalFile.headers()['etag']).toBeDefined();
         await expect(accessNormalFile.headers()['cache-control']).toContain('public, s-max-age=10')
 
-        const accessCacheControlFile = await request.get(`/immutable.a45b7e8f.js`);
+        const accessCacheControlFile = await request.get(`immutable.a45b7e8f.js`);
         await expect(accessCacheControlFile.ok()).toBeTruthy();
         await expect(accessCacheControlFile.headers()['etag']).toBeDefined();
         await expect(accessCacheControlFile.headers()['cache-control']).toContain("immutable");
@@ -133,13 +133,13 @@ test.describe('Map-storage Upload API', () => {
     test("get list of maps", async ({
         request,
     }) => {
-        const uploadFile = await request.post(`/upload`, {
+        const uploadFile = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/file1.zip"),
                 directory: "/"
             }
         });
-        const uploadFileToDir = await request.post(`/upload`, {
+        const uploadFileToDir = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/file1.zip"),
                 directory: "/foo"
@@ -148,10 +148,10 @@ test.describe('Map-storage Upload API', () => {
         await expect(uploadFile.ok()).toBeTruthy();
         await expect(uploadFileToDir.ok()).toBeTruthy();
 
-        let listOfMaps = await request.get("/maps");
+        let listOfMaps = await request.get("maps");
         await expect(await listOfMaps.text() === JSON.stringify(["foo/map.tmj","map.tmj"])).toBeTruthy();
 
-        const uploadFileAlone = await request.post(`/upload`, {
+        const uploadFileAlone = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/file1.zip"),
                 directory: "/"
@@ -159,14 +159,14 @@ test.describe('Map-storage Upload API', () => {
         });
 
         await expect(uploadFileAlone.ok()).toBeTruthy();
-        listOfMaps = await request.get("/maps");
+        listOfMaps = await request.get("maps");
         await expect(await listOfMaps.text() === JSON.stringify(["map.tmj"])).toBeTruthy();
     });
 
     test("delete the root folder", async ({
         request,
     }) => {
-        const uploadFileToDir = await request.post(`/upload`, {
+        const uploadFileToDir = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/file1.zip"),
                 directory: "/"
@@ -174,21 +174,21 @@ test.describe('Map-storage Upload API', () => {
         });
         await expect(uploadFileToDir.ok()).toBeTruthy();
 
-        let listOfMaps = await request.get("/maps");
+        let listOfMaps = await request.get("maps");
         await expect(await listOfMaps.text() === JSON.stringify(["map.tmj"])).toBeTruthy();
 
-        const deleteRoot = await request.delete(`/delete?path=/`);
+        const deleteRoot = await request.delete(`delete?path=/`);
 
        await expect(deleteRoot.status() === 204).toBeTruthy();
 
-        listOfMaps = await request.get("/maps");
+        listOfMaps = await request.get("maps");
         await expect(await listOfMaps.text() === JSON.stringify([])).toBeTruthy();
     });
 
     test("delete a folder", async ({
         request,
     }) => {
-        const uploadFileToDir = await request.post(`/upload`, {
+        const uploadFileToDir = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/file1.zip"),
                 directory: "/toDelete"
@@ -196,21 +196,21 @@ test.describe('Map-storage Upload API', () => {
         });
         await expect(uploadFileToDir.ok()).toBeTruthy();
 
-        let listOfMaps = await request.get("/maps");
+        let listOfMaps = await request.get("maps");
         await expect(await listOfMaps.text() === JSON.stringify(["toDelete/map.tmj"])).toBeTruthy();
 
-        const deleteRoot = await request.delete(`/delete?path=/toDelete`);
+        const deleteRoot = await request.delete(`delete?path=/toDelete`);
 
        await expect(deleteRoot.status() === 204).toBeTruthy();
 
-        listOfMaps = await request.get("/maps");
+        listOfMaps = await request.get("maps");
         await expect(await listOfMaps.text() === JSON.stringify([])).toBeTruthy();
     });
 
     test("move a folder", async ({
         request,
     }) => {
-        const uploadFileToDir = await request.post(`/upload`, {
+        const uploadFileToDir = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/file1.zip"),
                 directory: "/toMove"
@@ -218,7 +218,7 @@ test.describe('Map-storage Upload API', () => {
         });
         await expect(uploadFileToDir.ok()).toBeTruthy();
 
-        let listOfMaps = await request.get("/maps");
+        let listOfMaps = await request.get("maps");
         await expect(JSON.parse(await listOfMaps.text()).includes("toMove/map.tmj")).toBeTruthy();
 
         const moveDir = await request.post(`/move`, {
@@ -230,7 +230,7 @@ test.describe('Map-storage Upload API', () => {
 
         await expect(moveDir.ok()).toBeTruthy();
 
-        listOfMaps = await request.get("/maps");
+        listOfMaps = await request.get("maps");
         await expect(JSON.parse(await listOfMaps.text()).includes("moved/map.tmj")).toBeTruthy();
         await expect(JSON.parse(await listOfMaps.text()).includes("toMove/map.tmj")).toBeFalsy();
     });
@@ -238,7 +238,7 @@ test.describe('Map-storage Upload API', () => {
     test("copy a folder", async ({
         request,
     }) => {
-        const uploadFileToDir = await request.post(`/upload`, {
+        const uploadFileToDir = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/file1.zip"),
                 directory: "/toCopy"
@@ -246,7 +246,7 @@ test.describe('Map-storage Upload API', () => {
         });
         await expect(uploadFileToDir.ok()).toBeTruthy();
 
-        let listOfMaps = await request.get("/maps");
+        let listOfMaps = await request.get("maps");
         await expect(JSON.parse(await listOfMaps.text()).includes("toCopy/map.tmj")).toBeTruthy();
 
         const copyDir = await request.post(`/copy`, {
@@ -258,7 +258,7 @@ test.describe('Map-storage Upload API', () => {
 
         await expect(copyDir.ok()).toBeTruthy();
 
-        listOfMaps = await request.get("/maps");
+        listOfMaps = await request.get("maps");
         const maps = JSON.parse(await listOfMaps.text());
         await expect(["toCopy/map.tmj", "copied/map.tmj"].every((value) => maps.includes(value))).toBeTruthy();
     });
@@ -266,7 +266,7 @@ test.describe('Map-storage Upload API', () => {
     test('fails on invalid maps', async ({
                                            request,
                                        }) => {
-        const uploadFile1 = await request.post(`/upload`, {
+        const uploadFile1 = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/missing-image.zip"),
             }
@@ -278,7 +278,7 @@ test.describe('Map-storage Upload API', () => {
     test('fails on JSON extension', async ({
                                              request,
                                          }) => {
-        const uploadFile1 = await request.post(`/upload`, {
+        const uploadFile1 = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/json-map.zip"),
             }
@@ -290,7 +290,7 @@ test.describe('Map-storage Upload API', () => {
     test('special characters support', async ({
                                                request,
                                            }) => {
-        const uploadFile1 = await request.post(`/upload`, {
+        const uploadFile1 = await request.post("upload", {
             multipart: {
                 file: fs.createReadStream("./assets/special_characters.zip"),
             }

--- a/tests/tests/map_storage_upload.spec.ts
+++ b/tests/tests/map_storage_upload.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import fs from "fs";
 
 test.use({
-    baseURL: process.env.MAP_STORAGE_ENDPOINT ?? 'http://john.doe:password@map-storage.workadventure.localhost',
+    baseURL: (process.env.MAP_STORAGE_PROTOCOL ?? "http") + "://john.doe:password@" + (process.env.MAP_STORAGE_ENDPOINT ?? 'map-storage.workadventure.localhost'),
 })
 
 test.describe('Map-storage Upload API', () => {
@@ -60,7 +60,7 @@ test.describe('Map-storage Upload API', () => {
     test('not authenticated requests are rejected', async ({
                                            request,
                                        }) => {
-        const uploadFile1 = await request.post(`http://bad:credentials@map-storage.workadventure.localhost/upload`, {
+        const uploadFile1 = await request.post((process.env.MAP_STORAGE_PROTOCOL ?? "http") + "://bad:credentials@" + (process.env.MAP_STORAGE_ENDPOINT ?? 'map-storage.workadventure.localhost/') + "upload", {
             multipart: {
                 file: fs.createReadStream("./assets/file1.zip"),
             }
@@ -221,7 +221,7 @@ test.describe('Map-storage Upload API', () => {
         let listOfMaps = await request.get("maps");
         await expect(JSON.parse(await listOfMaps.text()).includes("toMove/map.tmj")).toBeTruthy();
 
-        const moveDir = await request.post(`/move`, {
+        const moveDir = await request.post(`move`, {
             data: {
                 source: "/toMove",
                 destination: "/moved",
@@ -249,7 +249,7 @@ test.describe('Map-storage Upload API', () => {
         let listOfMaps = await request.get("maps");
         await expect(JSON.parse(await listOfMaps.text()).includes("toCopy/map.tmj")).toBeTruthy();
 
-        const copyDir = await request.post(`/copy`, {
+        const copyDir = await request.post(`copy`, {
             data: {
                 source: "/toCopy",
                 destination: "/copied",
@@ -297,11 +297,11 @@ test.describe('Map-storage Upload API', () => {
         });
         await expect(uploadFile1.ok()).toBeTruthy();
 
-        const accessFileWithSpace = await request.get(`/file+with%20space.txt`);
+        const accessFileWithSpace = await request.get(`file+with%20space.txt`);
         await expect(accessFileWithSpace.ok()).toBeTruthy();
         await expect(await accessFileWithSpace.text()).toContain("ok");
 
-        const accessFileWithEmoji = await request.get(`/🍕.txt`);
+        const accessFileWithEmoji = await request.get(`🍕.txt`);
         await expect(accessFileWithEmoji.ok()).toBeTruthy();
         await expect(await accessFileWithEmoji.text()).toContain("ok");
     });

--- a/tests/tests/map_storage_upload.spec.ts
+++ b/tests/tests/map_storage_upload.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import fs from "fs";
 
 test.use({
-    baseURL: process.env.MAP_STORAGE_URL ?? 'http://john.doe:password@map-storage.workadventure.localhost',
+    baseURL: process.env.MAP_STORAGE_ENDPOINT ?? 'http://john.doe:password@map-storage.workadventure.localhost',
 })
 
 test.describe('Map-storage Upload API', () => {

--- a/tests/tests/metadata.spec.ts
+++ b/tests/tests/metadata.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import axios from "axios";
 
 test.describe('Meta tags', () => {
-  test('check they are populated when the user-agent is a bot.', async ({
+  test('check they are populated when the user-agent is a bot. @selfsigned', async ({
     page,
   }) => {
     const data: string = (await axios({
@@ -33,7 +33,7 @@ test.describe('Meta tags', () => {
     await expect(data2).not.toContain('Cette carte est tr');
   });
 
-  test('there is no error an funky URLs with bots.', async ({
+  test('there is no error an funky URLs with bots. @selfsigned', async ({
                                                                           request,
                                                                         }) => {
 

--- a/tests/tests/oidc.spec.ts
+++ b/tests/tests/oidc.spec.ts
@@ -3,7 +3,7 @@ import { login } from './utils/roles';
 import {oidcLogin, oidcLogout} from "./utils/oidc";
 import {evaluateScript} from "./utils/scripting";
 
-test.describe('OpenID connect', () => {
+test.describe('OpenID connect @oidc', () => {
   test('can login and logout', async ({
     page,
   }) => {

--- a/tests/tests/reconnect.spec.ts
+++ b/tests/tests/reconnect.spec.ts
@@ -4,7 +4,7 @@ import { login } from './utils/roles';
 
 test.setTimeout(180_000);
 test.describe('Connection', () => {
-  test('can succeed even if WorkAdventure starts while pusher is down', async ({ page }) => {
+  test('can succeed even if WorkAdventure starts while pusher is down @docker', async ({ page }) => {
     await page.goto(
       'http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/mousewheel.json'
     );

--- a/tests/tests/utils/debug.ts
+++ b/tests/tests/utils/debug.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import fs from 'fs';
+import {APIRequestContext, APIResponse} from "@playwright/test";
 
 const ADMIN_API_TOKEN = process.env.ADMIN_API_TOKEN;
 
@@ -29,18 +30,24 @@ export async function getBackDump(): Promise<Array<{roomUrl: string}>> {
     })).data;
 }
 
-export async function getPusherRooms(): Promise<Record<string, number>> {
+export async function getPusherRooms(request: APIRequestContext): Promise<APIResponse> {
     let url = 'http://play.workadventure.localhost/rooms';
     if (fs.existsSync('/project')) {
         // We are inside a container. Let's use a direct route
         url = 'http://play:3000/rooms';
     }
 
+    return request.get(url, {
+        headers: {
+            "Authorization": ADMIN_API_TOKEN,
+        }
+    })
+/*
     return (await axios({
         url,
         method: 'get',
         headers: {
             "Authorization": ADMIN_API_TOKEN
         }
-    })).data;
+    })).data;*/
 }

--- a/tests/tests/variables.spec.ts
+++ b/tests/tests/variables.spec.ts
@@ -17,7 +17,7 @@ test.setTimeout(180000);
 test.describe('Variables', () => {
   // WARNING: Since this test restarts traefik and other components, it might fail when run against the vite dev server.
   // when running with --headed you can manually reload the page to avoid this issue.
-  test('storage works', async ({ page }) => {
+  test('storage works @docker', async ({ page }) => {
     await resetRedis();
 
     await Promise.all([rebootBack(), rebootPlay()]);

--- a/tests/tests/variables.spec.ts
+++ b/tests/tests/variables.spec.ts
@@ -130,6 +130,7 @@ test.describe('Variables', () => {
   test('cache doesnt prevent setting a variable in case the map changes', async ({
     page,
     browser,
+    request,
   }) => {
     // Let's start by visiting a map that DOES not have the variable.
 
@@ -170,8 +171,11 @@ test.describe('Variables', () => {
 
     // Let's check the pusher getRooms endpoint returns 2 users on the map
     await expect.poll(async () => {
-      const rooms = await getPusherRooms();
-      return rooms['http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json'];
+      const rooms = await getPusherRooms(request);
+      const json = await rooms.json();
+      // Note: the value can come from http or https (in case of single domain test)
+      const users = (json['http://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json'] ?? 0) + (json['https://play.workadventure.localhost/_/global/maps.workadventure.localhost/tests/Variables/Cache/variables_tmp.json'] ?? 0);
+      return users;
     }).toBe(2);
 
     await page2.close();

--- a/uploader/src/Enum/EnvironmentVariable.ts
+++ b/uploader/src/Enum/EnvironmentVariable.ts
@@ -10,7 +10,7 @@ const AWS_ENDPOINT = process.env.AWS_ENDPOINT;
 const UPLOADER_AWS_SIGNED_URL_EXPIRATION = parseInt(process.env.UPLOADER_AWS_SIGNED_URL_EXPIRATION || "60")
 
 const REDIS_HOST = process.env.REDIS_HOST;
-const REDIS_PORT = process.env.REDIS_PORT;
+const REDIS_PORT = process.env.REDIS_PORT || "6379";
 const REDIS_DB_NUMBER = process.env.REDIS_DB_NUMBER;
 const REDIS_PASSWORD = process.env.REDIS_PASSWORD;
 


### PR DESCRIPTION
The single-domain install file is not tested regularly because we (WorkAdventure devs) do not use it internally. As a result, it is very often getting out of date.

This commit adds an automated test to run end-to-end tests against it. This way, we will be able to detect when it gets out of sync.



- [x] Last issue seems to be with the chat container: Traefik adds a "X-Forwarded-Prefix" header to let the server know about the path prefix stripping, but Nginx probably ignores that.