### PR TITLE
add example config for putting traefik behind another reverse proxy

### DIFF
--- a/contrib/docker/.env.prod.template
+++ b/contrib/docker/.env.prod.template
@@ -39,6 +39,11 @@ EJABBERD_HOST=ejabberd.workadventure.localhost
 # SAAS admin panel
 ADMIN_API_URL=
 
+# when using an existing reverse proxy, whitelist it here
+# the values here are examples only and heavily depend on your setup
+# PROXY_TRUSTED_IPS=172.1.0.0/16,192.168.0.0/16
+
+
 #
 # Basic configuration
 #

--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -8,23 +8,28 @@ services:
       - --providers.docker.exposedbydefault=false
       # Entry points
       - --entryPoints.web.address=:${HTTP_PORT}
-      - --entrypoints.web.http.redirections.entryPoint.to=websecure
-      - --entrypoints.web.http.redirections.entryPoint.scheme=https
+      - --entrypoints.web.proxyProtocol.trustedIPs=${PROXY_TRUSTED_IPS}
+#      - --entrypoints.web.http.redirections.entryPoint.to=websecure
+#      - --entrypoints.web.http.redirections.entryPoint.scheme=https
       - --entryPoints.websecure.address=:${HTTPS_PORT}
       # HTTP challenge
-      - --certificatesresolvers.myresolver.acme.email=${ACME_EMAIL}
-      - --certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json
-      - --certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web
+#      - --certificatesresolvers.myresolver.acme.email=${ACME_EMAIL}
+#      - --certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json
+#      - --certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web
       # Let's Encrypt's staging server
       # uncomment during testing to avoid rate limiting
       #- --certificatesresolvers.dnsresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
-    ports:
-      - "${HTTP_PORT}:80"
-      - "${HTTPS_PORT}:443"
+#    ports:
+#      - "${HTTP_PORT}:80"
+#      - "${HTTPS_PORT}:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ${DATA_DIR}/letsencrypt/:/letsencrypt/
+#      - ${DATA_DIR}/letsencrypt/:/letsencrypt/
     restart: ${RESTART_POLICY}
+    networks:
+      work.adventure:
+      reverse_proxy_shared_network:      
+
 
   play:
     image: thecodingmachine/workadventure-play:${VERSION}
@@ -76,6 +81,8 @@ services:
       traefik.http.routers.play-ssl.tls.certresolver: "myresolver"
       traefik.http.routers.play-ssl.service: "play"
     restart: ${RESTART_POLICY}
+    networks:
+      work.adventure:
 
   chat:
     image: thecodingmachine/workadventure-chat:${VERSION}
@@ -97,6 +104,8 @@ services:
       traefik.http.routers.chat-ssl.tls: "true"
       traefik.http.routers.chat-ssl.tls.certresolver: "myresolver"
     restart: ${RESTART_POLICY}
+    networks:
+      work.adventure:
 
   back:
     image: thecodingmachine/workadventure-back:${VERSION}
@@ -140,6 +149,8 @@ services:
       traefik.http.routers.back-ssl.tls: "true"
       traefik.http.routers.back-ssl.tls.certresolver: "myresolver"
     restart: ${RESTART_POLICY}
+    networks:
+      work.adventure:
 
   uploader:
     image: thecodingmachine/workadventure-uploader:${VERSION}
@@ -169,6 +180,8 @@ services:
       traefik.http.routers.uploader-ssl.service: "uploader"
       traefik.http.routers.uploader-ssl.tls: "true"
       traefik.http.routers.uploader-ssl.tls.certresolver: "myresolver"
+    networks:
+      work.adventure:
 
   icon:
     image: matthiasluedtke/iconserver:v3.13.0
@@ -182,11 +195,15 @@ services:
       traefik.http.routers.icon-ssl.service: "icon"
       traefik.http.routers.icon-ssl.tls: "true"
       traefik.http.routers.icon-ssl.tls.certresolver: "myresolver"
+    networks:
+      work.adventure:
 
   redis:
     image: redis:6
     volumes:
       - redisdata:/data
+    networks:
+      work.adventure:
 
   ejabberd:
     image: workadventure/ejabberd:v1
@@ -210,6 +227,9 @@ services:
       traefik.http.routers.ejabberd-ssl.service: "ejabberd"
       traefik.http.routers.ejabberd-ssl.tls: "true"
       traefik.http.routers.ejabberd-ssl.tls.certresolver: "myresolver"
+    networks:
+      work.adventure:
+      reverse_proxy_shared_network:
 
   map-storage:
     image: thecodingmachine/workadventure-map-storage:${VERSION}
@@ -225,6 +245,13 @@ services:
       traefik.http.routers.map-storage-ssl.service: "map-storage"
       traefik.http.routers.map-storage-ssl.tls: "true"
       traefik.http.routers.map-storage-ssl.tls.certresolver: "myresolver"
+    networks:
+      work.adventure:
 
 volumes:
   redisdata:
+
+networks:
+  work.adventure:
+  reverse_proxy_shared_network:
+    external: true


### PR DESCRIPTION
This is an example config how to put the complete (multi-domain at the moment) workadventure service behind an existing reverse proxy. This should help to allow people with existing reverse proxies to deploy workadventure easily.

The main change is to disable HTTPS and whitelist the IPs/subnets from the existing reverse proxy. HTTPS is then handled by the existing reverse proxy and traefik should not try to request a certificate by itself.

Furthermore I added an explicit network for all workadventure containers, and additionally an external "shared (with the reverse proxy)" network for only those containers that need external access. This seems to be a recommended practice when using for instance Nginx Proxy Manager.

The proxy is configured for every subdomain (except ejabberd) to forward to traefik on port 80, using its internal hostname (e.g. http://reverse-proxy:80). The exception is ejabberd, which is forwarded to its container directly (e.g. http://ejabberd:5443). This is also the reason why the ports of traefik and ejabberd don't need to be mapped anymore.

This is obviously not ready to be merged. I tried to minimize the changes, but I could not get rid of the errors in traefik about the non-existing https resolver. Maybe there are ideas how to make this configuration integrate easily (and optionally) into the proposed config(s).
