### PR TITLE
Cleaning up WebRTC connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38431,7 +38431,7 @@
         "axios-retry": "^3.4.0",
         "buffer": "^6.0.3",
         "cancelable-promise": "^4.3.0",
-        "cheerio": "*",
+        "cheerio": "^1.0.0-rc.12",
         "circular-json": "^0.5.9",
         "concurrently": "^7.4.0",
         "cross-env": "^7.0.3",

--- a/play/src/front/Components/Video/MediaBox.svelte
+++ b/play/src/front/Components/Video/MediaBox.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { VideoPeer } from "../../WebRtc/VideoPeer";
+    import { PeerStatus, VideoPeer } from "../../WebRtc/VideoPeer";
     import VideoMediaBox from "./VideoMediaBox.svelte";
     import ScreenSharingMediaBox from "./ScreenSharingMediaBox.svelte";
     import { ScreenSharingPeer } from "../../WebRtc/ScreenSharingPeer";
@@ -21,6 +21,10 @@
     let constraintStore: Readable<ObtainedMediaStreamConstraints | null>;
     if (streamable instanceof VideoPeer) {
         constraintStore = streamable.constraintsStore;
+    }
+    let statusStore: Readable<PeerStatus> | null;
+    if (streamable instanceof VideoPeer || streamable instanceof ScreenSharingPeer) {
+        statusStore = streamable.statusStore;
     }
 
     const gameScene = gameManager.getCurrentGameScene();
@@ -54,7 +58,7 @@
                 <VideoOffBox peer={streamable} clickable={false} />
             </div>
         </div>
-    {:else if $constraintStore && $constraintStore.video}
+    {:else if ($constraintStore && $constraintStore.video) || $statusStore === "error" || $statusStore === "connecting"}
         <div
             class="media-container {isHightlighted ? 'hightlighted tw-mr-6' : 'tw-flex media-box-camera-on-size'}
      media-box-shape-color tw-pointer-events-auto screen-blocker

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -26,8 +26,6 @@
     let name = peer.userName;
     let backGroundColor = getColorByString(peer.userName);
     let textColor = getTextColorByBackgroundColor(backGroundColor);
-    // FIXME: status store is useless here because we only get here if the VIDEO connection was successfully established!
-    // FIXME: Hence, no error is ever displayed.
     let statusStore = peer.statusStore;
     let constraintStore = peer.constraintsStore;
     let subscribeChangeOutput: Unsubscriber;

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -26,6 +26,8 @@
     let name = peer.userName;
     let backGroundColor = getColorByString(peer.userName);
     let textColor = getTextColorByBackgroundColor(backGroundColor);
+    // FIXME: status store is useless here because we only get here if the VIDEO connection was successfully established!
+    // FIXME: Hence, no error is ever displayed.
     let statusStore = peer.statusStore;
     let constraintStore = peer.constraintsStore;
     let subscribeChangeOutput: Unsubscriber;

--- a/play/src/front/WebRtc/MediaManager.ts
+++ b/play/src/front/WebRtc/MediaManager.ts
@@ -1,4 +1,3 @@
-import { HtmlUtils } from "./HtmlUtils";
 import type { UserInputManager } from "../Phaser/UserInput/UserInputManager";
 import { localStreamStore } from "../Stores/MediaStore";
 import { screenSharingLocalStreamStore } from "../Stores/ScreenSharingStore";
@@ -30,9 +29,6 @@ export enum NotificationType {
 const TIME_NOTIFYING_MILLISECOND = 10000;
 
 export class MediaManager {
-    startScreenSharingCallBacks: Set<StartScreenSharingCallback> = new Set<StartScreenSharingCallback>();
-    stopScreenSharingCallBacks: Set<StopScreenSharingCallback> = new Set<StopScreenSharingCallback>();
-
     private userInputManager?: UserInputManager;
 
     private canSendNotification = true;
@@ -113,80 +109,6 @@ export class MediaManager {
 
     public disableProximityMeeting(): void {
         proximityMeetingStore.set(false);
-    }
-
-    private getScreenSharingId(userId: string): string {
-        return `screen-sharing-${userId}`;
-    }
-
-    disabledMicrophoneByUserId(userId: number) {
-        const element = document.getElementById(`microphone-${userId}`);
-        if (!element) {
-            return;
-        }
-        element.classList.add("active"); //todo: why does a method 'disable' add a class 'active'?
-    }
-
-    enabledMicrophoneByUserId(userId: number) {
-        const element = document.getElementById(`microphone-${userId}`);
-        if (!element) {
-            return;
-        }
-        element.classList.remove("active"); //todo: why does a method 'enable' remove a class 'active'?
-    }
-
-    disabledVideoByUserId(userId: number) {
-        let element = document.getElementById(`${userId}`);
-        if (element) {
-            element.style.opacity = "0";
-        }
-        element = document.getElementById(`name-${userId}`);
-        if (element) {
-            element.style.display = "block";
-        }
-    }
-
-    enabledVideoByUserId(userId: number) {
-        let element = document.getElementById(`${userId}`);
-        if (element) {
-            element.style.opacity = "1";
-        }
-        element = document.getElementById(`name-${userId}`);
-        if (element) {
-            element.style.display = "none";
-        }
-    }
-
-    toggleBlockLogo(userId: number, show: boolean): void {
-        const blockLogoElement = HtmlUtils.getElementByIdOrFail<HTMLImageElement>("blocking-" + userId);
-        show ? blockLogoElement.classList.add("active") : blockLogoElement.classList.remove("active");
-    }
-
-    isError(userId: string): void {
-        console.info("isError", `div-${userId}`);
-        const element = document.getElementById(`div-${userId}`);
-        if (!element) {
-            return;
-        }
-        const errorDiv = element.getElementsByClassName("rtc-error").item(0) as HTMLDivElement | null;
-        if (errorDiv === null) {
-            return;
-        }
-        errorDiv.style.display = "block";
-    }
-    isErrorScreenSharing(userId: string): void {
-        this.isError(this.getScreenSharingId(userId));
-    }
-
-    private getSpinner(userId: string): HTMLDivElement | null {
-        const element = document.getElementById(`div-${userId}`);
-        if (!element) {
-            return null;
-        }
-        const connectingSpinnerDiv = element
-            .getElementsByClassName("connecting-spinner")
-            .item(0) as HTMLDivElement | null;
-        return connectingSpinnerDiv;
     }
 
     public setUserInputManager(userInputManager: UserInputManager) {

--- a/play/src/front/WebRtc/VideoPeer.ts
+++ b/play/src/front/WebRtc/VideoPeer.ts
@@ -42,7 +42,7 @@ export class VideoPeer extends Peer {
     private onUnBlockSubscribe: Subscription;
     public readonly streamStore: Writable<MediaStream | null> = writable<MediaStream | null>(null);
     public readonly volumeStore: Readable<number[] | undefined>;
-    public readonly statusStore: Writable<PeerStatus> = writable<PeerStatus>("closed");
+    private readonly _statusStore: Writable<PeerStatus> = writable<PeerStatus>("closed");
     private readonly _constraintsStore: Writable<ObtainedMediaStreamConstraints | null>;
     private newMessageSubscribtion: Subscription | undefined;
     private closing = false; //this is used to prevent destroy() from being called twice
@@ -122,7 +122,7 @@ export class VideoPeer extends Peer {
         this.on("stream", (stream: MediaStream) => this.stream(stream));
 
         this.on("close", () => {
-            this.statusStore.set("closed");
+            this._statusStore.set("closed");
 
             this._connected = false;
             this.toClose = true;
@@ -130,7 +130,7 @@ export class VideoPeer extends Peer {
         });
 
         this.on("error", (err: Error) => {
-            this.statusStore.set("error");
+            this._statusStore.set("error");
 
             console.error(`error for user ${this.userId}`, err);
             if ("code" in err) {
@@ -139,7 +139,7 @@ export class VideoPeer extends Peer {
         });
 
         this.on("connect", () => {
-            this.statusStore.set("connected");
+            this._statusStore.set("connected");
 
             this._connected = true;
             chatMessagesStore.addIncomingUser(this.userId);
@@ -196,7 +196,7 @@ export class VideoPeer extends Peer {
         });
 
         this.once("finish", () => {
-            this.statusStore.set("closed");
+            this._statusStore.set("closed");
 
             this._onFinish();
         });
@@ -313,5 +313,9 @@ export class VideoPeer extends Peer {
 
     get constraintsStore(): Readable<ObtainedMediaStreamConstraints | null> {
         return this._constraintsStore;
+    }
+
+    get statusStore(): Readable<PeerStatus> {
+        return this._statusStore;
     }
 }


### PR DESCRIPTION
Removing deprecated call to MediaManager
Moving the constraintStore from listening to data messages when the Svelte listener starts to listening all the time. This is technically more correct as a data message could arrive before Svelte is ready (though unlikely)