### PR TITLE
Fixing screensharing twice

### DIFF
--- a/play/src/front/WebRtc/SimplePeer.ts
+++ b/play/src/front/WebRtc/SimplePeer.ts
@@ -425,7 +425,9 @@ export class SimplePeer {
         PeerConnectionScreenSharing.stopPushingScreenSharingToRemoteUser(stream);
 
         if (!PeerConnectionScreenSharing.isReceivingScreenSharingStream()) {
+            PeerConnectionScreenSharing.toClose = true;
             PeerConnectionScreenSharing.destroy();
+            this.PeerScreenSharingConnectionArray.delete(PeerConnectionScreenSharing.userId);
         }
     }
 }


### PR DESCRIPTION
The P2P connection was not cleanly destroyed when screen sharing was stopped.
Closes #3114