### PR TITLE
Fix docker-compose.prod after adding telemetry 

### DIFF
--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -101,7 +101,7 @@ services:
   back:
     image: thecodingmachine/workadventure-back:${VERSION}
     environment:
-      - PLAY_URL=https://${PLAY_HOST}
+      - PLAY_URL=https://${FRONT_HOST}
       - SECRET_JITSI_KEY
       - ENABLE_FEATURE_MAP_EDITOR
       - SECRET_KEY


### PR DESCRIPTION
There was an error that popped up in this issue:

https://github.com/thecodingmachine/workadventure/issues/3099#issuecomment-1464444289

I saw that after the telemetry service was introduced here:

https://github.com/thecodingmachine/workadventure/commit/069a8bb4f91b68cb4a3c0f9d9e419c0d47c0be29

The env-var "PLAY_HOST" was used, which is not defined in the env template. So in this state the docker-compose file does not work except you do a deep dive into the env-vars.

I changed PLAY_HOST to FRONT_HOST, since FRONT_HOST is also used in the docker-compose file and i think it makes the most sense for the telemetry.