### PR TITLE
Fixing a race condition about concurrency in Github Actions

### DIFF
--- a/.github/workflows/push-to-npm.yml
+++ b/.github/workflows/push-to-npm.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
@@ -56,10 +56,10 @@ jobs:
           ADMIN_URL: "//localhost:80"
         working-directory: "play"
 
-      - name: Install dependencies in package
-        run: npm ci
-        #working-directory: "play/packages/iframe-api-typings"
-        if: ${{ github.event_name == 'release' }}
+#      - name: Install dependencies in package
+#        run: npm ci
+#        working-directory: "play/packages/iframe-api-typings"
+#        if: ${{ github.event_name == 'release' }}
 
       - name: Publish package
         run: npm publish


### PR DESCRIPTION
Because the push and the release actions were sharing the same concurrency group, the Push to NPM workflow was sometimes skipped.