### PR TITLE
🚑️ Fixing chat crash when no JID found

### DIFF
--- a/chat/src/IframeListener.ts
+++ b/chat/src/IframeListener.ts
@@ -124,7 +124,12 @@ class IframeListener {
                             const mucRoomDefault = mucRoomsStore.getDefaultRoom();
                             let userData = undefined;
                             if (mucRoomDefault && iframeEvent.data.author.jid !== "fake") {
-                                userData = mucRoomDefault.getUserByJid(iframeEvent.data.author.jid);
+                                try {
+                                    userData = mucRoomDefault.getUserByJid(iframeEvent.data.author.jid);
+                                } catch (e) {
+                                    console.warn("Can't fetch user data from Ejabberd", e);
+                                    userData = iframeEvent.data.author;
+                                }
                             } else {
                                 userData = iframeEvent.data.author;
                             }


### PR DESCRIPTION
Fixing crash about the chat when data can't get found in the default MUC room when userJid is coming from Peer conneciton.