### PR TITLE
Automated redirection to Admin to implement autologin links

### DIFF
--- a/play/redirectToAdmin.html
+++ b/play/redirectToAdmin.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        function getUrlWithoutAccessKey() {
+            const url = new URL(window.location.href);
+            url.searchParams.delete("access_key");
+            return url.href;
+        }
+
+        window.location.href = "{{{ADMIN_URL}}}/workadventure/login?token={{accessKey}}&playUri=" + encodeURIComponent(getUrlWithoutAccessKey())
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/play/src/front/Url/UrlManager.ts
+++ b/play/src/front/Url/UrlManager.ts
@@ -23,7 +23,7 @@ class UrlManager {
         } else if (url.includes("_/") || url.includes("*/") || url.includes("@/") || url.includes("~/")) {
             return GameConnexionTypes.room;
         }
-        //@deprecated register url will be replace by "?token=<private access token>"
+        //@deprecated register url will be replaced by "?token=<private access token>"
         else if (url.includes("register/")) {
             return GameConnexionTypes.register;
         } else if (url === "/") {

--- a/play/src/pusher/controllers/FrontController.ts
+++ b/play/src/pusher/controllers/FrontController.ts
@@ -220,6 +220,9 @@ export class FrontController extends BaseHttpController {
         // Read the access_key from the query parameter. If it is set, redirect to the admin to attempt a login.
         const accessKey = req.query.access_key;
         if (accessKey && typeof accessKey === "string" && accessKey.length > 0) {
+            if (!ADMIN_URL) {
+                return res.status(400).send("ADMIN_URL is not configured.");
+            }
             const html = Mustache.render(this.redirectToAdminFile, {
                 accessKey,
                 ADMIN_URL,


### PR DESCRIPTION
In some cases, a user might want to automatically someone in using a special URL. This is typically done from an admin.

This commit adds a special "?=access_key=XXX" query param. When this query param is detected, the user is automatically redirected to: [ADMIN_URL]/workadventure/start?roomUri=[...]&token=[access_key]

Note that the redirection is done from the front in JS (not using an HTTP 302). This is on purpose because the roomUri parameter MUST embed any hash (so that we can come back from the admin on the same "hash"). So redirect is done by a minimalist HTML page containing a small snippet that does redirect the user.