### PR TITLE
Unsetting the pong timeout when someone disconnects

### DIFF
--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -230,6 +230,10 @@ const roomManager: IRoomManagerServer = {
             if (pingIntervalId) {
                 clearInterval(pingIntervalId);
             }
+            if (pongTimeoutId) {
+                clearTimeout(pongTimeoutId);
+                pongTimeoutId = undefined;
+            }
             call.end();
             room = null;
             user = null;


### PR DESCRIPTION
Otherwise we are getting weird logs about connection being lost while someone just disconnected naturally.