### PR TITLE
fix: set Traefik entrypoints ports

### DIFF
--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -7,11 +7,11 @@ services:
       - --providers.docker
       - --providers.docker.exposedbydefault=false
       # Entry points
-      - --entryPoints.web.address=80
+      - --entryPoints.web.address=:80
       - --entrypoints.web.http.redirections.entryPoint.to=websecure
       - --entrypoints.web.http.redirections.entryPoint.scheme=https
-      - --entryPoints.websecure.address=443
-      - --entryPoints.grpc.address=50051
+      - --entryPoints.websecure.address=:443
+      - --entryPoints.grpc.address=:50051
       # HTTP challenge
       - --certificatesresolvers.myresolver.acme.email=${ACME_EMAIL}
       - --certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json

--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -7,11 +7,11 @@ services:
       - --providers.docker
       - --providers.docker.exposedbydefault=false
       # Entry points
-      - --entryPoints.web.address=:${HTTP_PORT}
+      - --entryPoints.web.address=80
       - --entrypoints.web.http.redirections.entryPoint.to=websecure
       - --entrypoints.web.http.redirections.entryPoint.scheme=https
-      - --entryPoints.websecure.address=:${HTTPS_PORT}
-      - --entryPoints.grpc.address=:${GRPC_PORT}
+      - --entryPoints.websecure.address=443
+      - --entryPoints.grpc.address=50051
       # HTTP challenge
       - --certificatesresolvers.myresolver.acme.email=${ACME_EMAIL}
       - --certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json


### PR DESCRIPTION
Inside the Docker container, the ports are fixed for Traefik. The port mapping from .env is only needed for the ports section but not for `entryPoints.web.address` etc.
```
 ports:
      - "${HTTP_PORT}:80"
      - "${HTTPS_PORT}:443"
      - "${GRPC_PORT}:50051"
```