### PR TITLE
Export config types in scripting API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38431,7 +38431,7 @@
         "axios-retry": "^3.4.0",
         "buffer": "^6.0.3",
         "cancelable-promise": "^4.3.0",
-        "cheerio": "*",
+        "cheerio": "^1.0.0-rc.12",
         "circular-json": "^0.5.9",
         "concurrently": "^7.4.0",
         "cross-env": "^7.0.3",

--- a/play/package.json
+++ b/play/package.json
@@ -21,7 +21,7 @@
     "typecheck": "cross-env tsc --noEmit",
     "profile": "tsc && node --prof ./dist/server.js",
     "build-iframe-api": "vite --config iframe-api.vite.config.ts build",
-    "watch-iframe-api": "npm run build-iframe-api --watch",
+    "watch-iframe-api": "npm run build-iframe-api -- --watch",
     "build-typings": "cross-env tsc --project tsconfig-for-iframe-api-typings.json",
     "precommit": "lint-staged",
     "test": "vitest",

--- a/play/src/front/Api/Events/IframeEvent.ts
+++ b/play/src/front/Api/Events/IframeEvent.ts
@@ -28,7 +28,7 @@ import { isMovePlayerToEventAnswer } from "./MovePlayerToEventAnswer";
 import { isAddActionsMenuKeyToRemotePlayerEvent } from "./AddActionsMenuKeyToRemotePlayerEvent";
 import { isRemoveActionsMenuKeyFromRemotePlayerEvent } from "./RemoveActionsMenuKeyFromRemotePlayerEvent";
 import { isSetAreaPropertyEvent } from "./SetAreaPropertyEvent";
-import { isCreateUIWebsiteEvent, isModifyUIWebsiteEvent, isUIWebsite } from "./Ui/UIWebsite";
+import { isCreateUIWebsiteEvent, isModifyUIWebsiteEvent, isUIWebsiteEvent } from "./Ui/UIWebsiteEvent";
 import { isAreaEvent, isCreateAreaEvent } from "./CreateAreaEvent";
 import { isUserInputChatEvent } from "./UserInputChatEvent";
 import { isEnterLeaveEvent } from "./EnterLeaveEvent";
@@ -544,7 +544,7 @@ export const iframeQueryMapTypeGuards = {
     },
     openUIWebsite: {
         query: isCreateUIWebsiteEvent,
-        answer: isUIWebsite,
+        answer: isUIWebsiteEvent,
     },
     closeUIWebsite: {
         query: z.string(),
@@ -552,11 +552,11 @@ export const iframeQueryMapTypeGuards = {
     },
     getUIWebsites: {
         query: z.undefined(),
-        answer: z.array(isUIWebsite),
+        answer: z.array(isUIWebsiteEvent),
     },
     getUIWebsiteById: {
         query: z.string(),
-        answer: isUIWebsite,
+        answer: isUIWebsiteEvent,
     },
     enablePlayersTracking: {
         query: isEnablePlayersTrackingEvent,

--- a/play/src/front/Api/Events/Ui/UIWebsiteEvent.ts
+++ b/play/src/front/Api/Events/Ui/UIWebsiteEvent.ts
@@ -61,7 +61,7 @@ export const isModifyUIWebsiteEvent = z.object({
 
 export type ModifyUIWebsiteEvent = z.infer<typeof isModifyUIWebsiteEvent>;
 
-export const isUIWebsite = z.object({
+export const isUIWebsiteEvent = z.object({
     id: z.string(),
     url: z.string(),
     visible: z.boolean(),
@@ -72,4 +72,4 @@ export const isUIWebsite = z.object({
     margin: isUIWebsiteMargin.partial().optional(),
 });
 
-export type UIWebsite = z.infer<typeof isUIWebsite>;
+export type UIWebsiteEvent = z.infer<typeof isUIWebsiteEvent>;

--- a/play/src/front/Api/Iframe/Ui/UIWebsite.ts
+++ b/play/src/front/Api/Iframe/Ui/UIWebsite.ts
@@ -6,8 +6,8 @@ import type {
     UIWebsiteSize,
     ViewportPositionHorizontal,
     ViewportPositionVertical,
-    UIWebsite as UIWebsiteCore,
-} from "../../Events/Ui/UIWebsite";
+    UIWebsiteEvent,
+} from "../../Events/Ui/UIWebsiteEvent";
 import { IframeApiContribution, queryWorkadventure, sendToWorkadventure } from "../IframeApiContribution";
 
 class UIWebsitePositionInternal {
@@ -200,7 +200,7 @@ export class UIWebsite {
     private _size: UIWebsiteSizeInternal;
     private _margin: UIWebsiteMarginInternal;
 
-    constructor(config: UIWebsiteCore) {
+    constructor(config: UIWebsiteEvent) {
         this.id = config.id;
         this._url = config.url;
         this._visible = config.visible ?? true;

--- a/play/src/front/Api/IframeListener.ts
+++ b/play/src/front/Api/IframeListener.ts
@@ -28,7 +28,7 @@ import type { AddActionsMenuKeyToRemotePlayerEvent } from "./Events/AddActionsMe
 import type { ActionsMenuActionClickedEvent } from "./Events/ActionsMenuActionClickedEvent";
 import type { RemoveActionsMenuKeyFromRemotePlayerEvent } from "./Events/RemoveActionsMenuKeyFromRemotePlayerEvent";
 import type { SetAreaPropertyEvent } from "./Events/SetAreaPropertyEvent";
-import type { ModifyUIWebsiteEvent } from "./Events/Ui/UIWebsite";
+import type { ModifyUIWebsiteEvent } from "./Events/Ui/UIWebsiteEvent";
 import type { ModifyAreaEvent } from "./Events/CreateAreaEvent";
 import type { AskPositionEvent } from "./Events/AskPositionEvent";
 import type { PlayerInterface } from "../Phaser/Game/PlayerInterface";

--- a/play/src/front/Components/UI/Website/UIWebsiteLayer.svelte
+++ b/play/src/front/Components/UI/Website/UIWebsiteLayer.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { onDestroy, onMount } from "svelte";
-    import type { UIWebsite } from "../../../Api/Events/Ui/UIWebsite";
+    import type { UIWebsiteEvent } from "../../../Api/Events/Ui/UIWebsiteEvent";
     import { iframeListener } from "../../../Api/IframeListener";
 
-    export let uiWebsite: UIWebsite;
+    export let uiWebsite: UIWebsiteEvent;
     let main: HTMLDivElement;
     const iframe = document.createElement("iframe");
     iframe.id = `ui-website-${uiWebsite.id}`;

--- a/play/src/front/Phaser/Game/UI/UIWebsiteManager.ts
+++ b/play/src/front/Phaser/Game/UI/UIWebsiteManager.ts
@@ -1,5 +1,5 @@
 import { get } from "svelte/store";
-import type { CreateUIWebsiteEvent, ModifyUIWebsiteEvent, UIWebsite } from "../../../Api/Events/Ui/UIWebsite";
+import type { CreateUIWebsiteEvent, ModifyUIWebsiteEvent, UIWebsiteEvent } from "../../../Api/Events/Ui/UIWebsiteEvent";
 import { iframeListener } from "../../../Api/IframeListener";
 import { v4 as uuidv4 } from "uuid";
 import { uiWebsitesStore } from "../../../Stores/UIWebsiteStore";
@@ -64,8 +64,8 @@ class UIWebsiteManager {
         });
     }
 
-    public open(websiteConfig: CreateUIWebsiteEvent): UIWebsite {
-        const newWebsite: UIWebsite = {
+    public open(websiteConfig: CreateUIWebsiteEvent): UIWebsiteEvent {
+        const newWebsite: UIWebsiteEvent = {
             ...websiteConfig,
             id: uuidv4(),
             visible: websiteConfig.visible ?? true,
@@ -76,11 +76,11 @@ class UIWebsiteManager {
         return newWebsite;
     }
 
-    public getAll(): UIWebsite[] {
+    public getAll(): UIWebsiteEvent[] {
         return get(uiWebsitesStore);
     }
 
-    public getById(websiteId: string): UIWebsite | undefined {
+    public getById(websiteId: string): UIWebsiteEvent | undefined {
         return get(uiWebsitesStore).find((currentWebsite) => currentWebsite.id === websiteId);
     }
 
@@ -95,7 +95,7 @@ class UIWebsiteManager {
     }
 
     public closeAll() {
-        get(uiWebsitesStore).forEach((uiWebsite: UIWebsite) => {
+        get(uiWebsitesStore).forEach((uiWebsite: UIWebsiteEvent) => {
             uiWebsitesStore.remove(uiWebsite);
         });
     }

--- a/play/src/front/Stores/UIWebsiteStore.ts
+++ b/play/src/front/Stores/UIWebsiteStore.ts
@@ -1,22 +1,22 @@
 import { writable } from "svelte/store";
-import type { UIWebsite } from "../Api/Events/Ui/UIWebsite";
+import type { UIWebsiteEvent } from "../Api/Events/Ui/UIWebsiteEvent";
 
 function createUIWebsiteStore() {
-    const { subscribe, update, set } = writable(Array<UIWebsite>());
+    const { subscribe, update, set } = writable(Array<UIWebsiteEvent>());
 
-    set(Array<UIWebsite>());
+    set(Array<UIWebsiteEvent>());
 
     return {
         subscribe,
-        add: (uiWebsite: UIWebsite) => {
+        add: (uiWebsite: UIWebsiteEvent) => {
             update((currentArray) => [...currentArray, uiWebsite]);
         },
-        update: (uiWebsite: UIWebsite) => {
+        update: (uiWebsite: UIWebsiteEvent) => {
             update((currentArray) =>
                 currentArray.map((currentWebsite) => (currentWebsite.id === uiWebsite.id ? uiWebsite : currentWebsite))
             );
         },
-        remove: (uiWebsite: UIWebsite) => {
+        remove: (uiWebsite: UIWebsiteEvent) => {
             update((currentArray) => currentArray.filter((currentWebsite) => currentWebsite.id !== uiWebsite.id));
         },
     };

--- a/play/src/iframe_api.ts
+++ b/play/src/iframe_api.ts
@@ -28,6 +28,22 @@ import type { Popup } from "./front/Api/Iframe/Ui/Popup";
 import type { Sound } from "./front/Api/Iframe/Sound/Sound";
 import { answerPromises, queryWorkadventure } from "./front/Api/Iframe/IframeApiContribution";
 import camera from "./front/Api/Iframe/camera";
+export type {
+    CreateUIWebsiteEvent,
+    ModifyUIWebsiteEvent,
+    UIWebsiteEvent,
+    UIWebsiteCSSValue,
+    UIWebsiteMargin,
+    UIWebsitePosition,
+    UIWebsiteSize,
+    ViewportPositionHorizontal,
+    ViewportPositionVertical,
+} from "./front/Api/Events/Ui/UIWebsiteEvent";
+export type {
+    CreateEmbeddedWebsiteEvent,
+    ModifyEmbeddedWebsiteEvent,
+    Rectangle,
+} from "./front/Api/Events/EmbeddedWebsiteEvent";
 export type { UIWebsite } from "./front/Api/Iframe/Ui/UIWebsite";
 export type { Menu } from "./front/Api/Iframe/Ui/Menu";
 export type { ActionMessage } from "./front/Api/Iframe/Ui/ActionMessage";


### PR DESCRIPTION
For the scripting-api-typings, we are exporting missing config types (like CreateEmbeddedWebsiteEvent) that can be useful to type the configuration of a new embedded website.