### PR TITLE
Adding support for an authentication token in the webhook

### DIFF
--- a/docs/schema/1.0/wam.json
+++ b/docs/schema/1.0/wam.json
@@ -403,6 +403,10 @@
             "copyright": {
               "type": "string",
               "description": "Copyright notice for this map. Can be a link to a license. Parts of this map like tilesets or images can have their own copyright."
+            },
+            "thumbnail": {
+              "type": "string",
+              "description": "URL to a thumbnail image. This image will be used in social networks when sharing a link to the map."
             }
           },
           "additionalProperties": false,

--- a/libs/map-editor/src/WAMVersionHash.ts
+++ b/libs/map-editor/src/WAMVersionHash.ts
@@ -1,0 +1,10 @@
+import fs from "fs";
+import crypto from "crypto";
+
+const fileBuffer = fs.readFileSync(__dirname + "/types.ts");
+const hashSum = crypto.createHash("sha256");
+hashSum.update(fileBuffer);
+
+// This hash is used to make sure we don't serve a "cache file" with outdated versions of the WAM descriptors.
+// Each time the WAM descriptor changes, this hash will be updated.
+export const WAMVersionHash = hashSum.digest("hex");

--- a/libs/map-editor/src/types.ts
+++ b/libs/map-editor/src/types.ts
@@ -126,6 +126,12 @@ export const WAMMetadata = z.object({
         .describe(
             "Copyright notice for this map. Can be a link to a license. Parts of this map like tilesets or images can have their own copyright."
         ),
+    thumbnail: z
+        .string()
+        .optional()
+        .describe(
+            "URL to a thumbnail image. This image will be used in social networks when sharing a link to the map."
+        ),
 });
 
 export const WAMVendor = z
@@ -150,9 +156,12 @@ export const MapsCacheSingleMapFormat = z.object({
     metadata: WAMMetadata.optional(),
     vendor: WAMVendor.optional(),
 });
-export const MapsCacheFileFormat = z
-    .record(z.string(), MapsCacheSingleMapFormat)
-    .describe("The format of the output of the /maps API call on the map-storage container.");
+export const MapsCacheFileFormat = z.object({
+    version: z.string(),
+    maps: z
+        .record(z.string(), MapsCacheSingleMapFormat)
+        .describe("The format of the output of the /maps API call on the map-storage container."),
+});
 
 export type EntityRawPrefab = z.infer<typeof EntityRawPrefab>;
 export type EntityPrefab = z.infer<typeof EntityPrefab>;

--- a/map-storage/src/Enum/EnvironmentVariable.ts
+++ b/map-storage/src/Enum/EnvironmentVariable.ts
@@ -41,4 +41,5 @@ export const STORAGE_DIRECTORY = env.STORAGE_DIRECTORY;
 // By default, cache only 10 seconds in the CDN
 export const CACHE_CONTROL = env.CACHE_CONTROL;
 export const WEB_HOOK_URL = env.WEB_HOOK_URL;
+export const WEB_HOOK_API_TOKEN = env.WEB_HOOK_API_TOKEN;
 export const ENV_VARS = env;

--- a/map-storage/src/Enum/EnvironmentVariableValidator.ts
+++ b/map-storage/src/Enum/EnvironmentVariableValidator.ts
@@ -41,6 +41,12 @@ const BasicEnvironmentVariables = z.object({
         .describe(
             "The URL of the webhook to call when a WAM file is created / updated / deleted. The URL will be called using POST."
         ),
+    WEB_HOOK_API_TOKEN: z
+        .string()
+        .optional()
+        .describe(
+            "The (optional) API token to use when calling the webhook. The token will be sent in the Authorization header of the POST request."
+        ),
 });
 
 const BearerAuthEnvVariables = z.object({

--- a/map-storage/src/Services/MapListService.ts
+++ b/map-storage/src/Services/MapListService.ts
@@ -1,9 +1,11 @@
 import { MapsCacheFileFormat, WAMFileFormat } from "@workadventure/map-editor";
+import { WAMVersionHash } from "@workadventure/map-editor/src/WAMVersionHash";
 import pLimit from "p-limit";
 import { fileSystem } from "../fileSystem";
 import { FileSystemInterface } from "../Upload/FileSystemInterface";
+import { FileNotFoundError } from "../Upload/FileNotFoundError";
 import { mapPathUsingDomain } from "./PathMapper";
-import {WebHookService} from "./WebHookService";
+import { WebHookService } from "./WebHookService";
 
 /**
  * Manages the cache file containing the list of maps.
@@ -24,23 +26,23 @@ export class MapListService {
         return this.limit(domain, async () => {
             const files = await fileSystem.listFiles(mapPathUsingDomain("/", domain), ".wam");
 
-            const wamFiles: MapsCacheFileFormat = {};
+            const wamFiles: MapsCacheFileFormat = {
+                version: WAMVersionHash,
+                maps: {},
+            };
 
             for (const wamFilePath of files) {
                 const virtualPath = mapPathUsingDomain(wamFilePath, domain);
                 const wamFileString = await this.fileSystem.readFileAsString(virtualPath);
                 const wamFile = WAMFileFormat.parse(JSON.parse(wamFileString));
-                wamFiles[wamFilePath] = {
+                wamFiles.maps[wamFilePath] = {
                     mapUrl: wamFile.mapUrl,
                     metadata: wamFile.metadata,
                     vendor: wamFile.vendor,
                 };
             }
 
-            await fileSystem.writeStringAsFile(
-                mapPathUsingDomain("/" + MapListService.CACHE_NAME, domain),
-                JSON.stringify(wamFiles, null, 2)
-            );
+            await this.writeCacheFileNoLimit(domain, wamFiles);
             this.webHookService.callWebHook(domain, undefined, "update");
         });
     }
@@ -71,43 +73,72 @@ export class MapListService {
         });
     }
 
-    public updateWAMFileInCache(domain: string, wamFilePath: string, wamFile: WAMFileFormat): Promise<void> {
-        return this.limit(domain, async () => {
-            const cacheFilePath = mapPathUsingDomain("/" + MapListService.CACHE_NAME, domain);
-            const cacheFileString = await this.fileSystem.readFileAsString(cacheFilePath);
-            const cacheFile = MapsCacheFileFormat.parse(JSON.parse(cacheFileString));
-            if (wamFilePath.startsWith("/")) {
-                wamFilePath = wamFilePath.substring(1);
+    public async updateWAMFileInCache(domain: string, wamFilePath: string, wamFile: WAMFileFormat): Promise<void> {
+        try {
+            return await this.limit(domain, async () => {
+                const cacheFile = await this.readCacheFileNoLimit(domain);
+                if (wamFilePath.startsWith("/")) {
+                    wamFilePath = wamFilePath.substring(1);
+                }
+                cacheFile.maps[wamFilePath] = {
+                    mapUrl: wamFile.mapUrl,
+                    metadata: wamFile.metadata,
+                    vendor: wamFile.vendor,
+                };
+                await this.writeCacheFileNoLimit(domain, cacheFile);
+                this.webHookService.callWebHook(domain, wamFilePath, "update");
+            });
+        } catch (e) {
+            if (e instanceof FileNotFoundError) {
+                // The file does not exist. Let's generate it
+                await this.generateCacheFile(domain);
+                return;
             }
-            cacheFile[wamFilePath] = {
-                mapUrl: wamFile.mapUrl,
-                metadata: wamFile.metadata,
-                vendor: wamFile.vendor,
-            };
-            await this.fileSystem.writeStringAsFile(cacheFilePath, JSON.stringify(cacheFile, null, 2));
-            this.webHookService.callWebHook(domain, wamFilePath, "update");
-        });
+            throw e;
+        }
     }
 
-    public deleteWAMFileInCache(domain: string, wamFilePath: string): Promise<void> {
-        return this.limit(domain, async () => {
-            const cacheFilePath = mapPathUsingDomain("/" + MapListService.CACHE_NAME, domain);
-            const cacheFileString = await this.fileSystem.readFileAsString(cacheFilePath);
-            const cacheFile = MapsCacheFileFormat.parse(JSON.parse(cacheFileString));
-            if (wamFilePath.startsWith("/")) {
-                wamFilePath = wamFilePath.substring(1);
+    public async deleteWAMFileInCache(domain: string, wamFilePath: string): Promise<void> {
+        try {
+            return await this.limit(domain, async () => {
+                const cacheFile = await this.readCacheFileNoLimit(domain);
+                if (wamFilePath.startsWith("/")) {
+                    wamFilePath = wamFilePath.substring(1);
+                }
+                delete cacheFile.maps[wamFilePath];
+                await this.writeCacheFileNoLimit(domain, cacheFile);
+                this.webHookService.callWebHook(domain, wamFilePath, "delete");
+            });
+        } catch (e) {
+            if (e instanceof FileNotFoundError) {
+                // The file does not exist. Let's generate it
+                await this.generateCacheFile(domain);
+                return;
             }
-            delete cacheFile[wamFilePath];
-            await this.fileSystem.writeStringAsFile(cacheFilePath, JSON.stringify(cacheFile, null, 2));
-            this.webHookService.callWebHook(domain, wamFilePath, "delete");
-        });
+            throw e;
+        }
     }
 
     public readCacheFile(domain: string): Promise<MapsCacheFileFormat> {
         return this.limit(domain, async () => {
-            const cacheFilePath = mapPathUsingDomain("/" + MapListService.CACHE_NAME, domain);
-            const cacheFileString = await this.fileSystem.readFileAsString(cacheFilePath);
-            return MapsCacheFileFormat.parse(JSON.parse(cacheFileString));
+            return this.readCacheFileNoLimit(domain);
         });
+    }
+
+    private async readCacheFileNoLimit(domain: string): Promise<MapsCacheFileFormat> {
+        const cacheFilePath = mapPathUsingDomain("/" + MapListService.CACHE_NAME, domain);
+        const cacheFileString = await this.fileSystem.readFileAsString(cacheFilePath);
+        const cacheFile = MapsCacheFileFormat.parse(JSON.parse(cacheFileString));
+        if (cacheFile.version !== WAMVersionHash) {
+            // The cache file might not be up to the latest version. We need to regenerate it.
+            await this.generateCacheFile(domain);
+            return this.readCacheFileNoLimit(domain);
+        }
+        return cacheFile;
+    }
+
+    private async writeCacheFileNoLimit(domain: string, cacheFile: MapsCacheFileFormat): Promise<void> {
+        const cacheFilePath = mapPathUsingDomain("/" + MapListService.CACHE_NAME, domain);
+        await this.fileSystem.writeStringAsFile(cacheFilePath, JSON.stringify(cacheFile, null, 2));
     }
 }

--- a/map-storage/src/Services/WebHookService.ts
+++ b/map-storage/src/Services/WebHookService.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { WEB_HOOK_API_TOKEN } from "../Enum/EnvironmentVariable";
 
 /**
  * Calls a webhook each time a WAM map is created, updated or deleted.
@@ -16,6 +17,12 @@ export class WebHookService {
         if (!this.webHookUrl) {
             return;
         }
+
+        const headers: Record<string, string> = {};
+        if (WEB_HOOK_API_TOKEN) {
+            headers["Authorization"] = WEB_HOOK_API_TOKEN;
+        }
+
         // Make a POST request to the webhook URL using axios. Don't wait for the answer but log an error in case of problem.
         axios
             .post(
@@ -29,6 +36,7 @@ export class WebHookService {
                     maxContentLength: 1000000,
                     headers: {
                         "Content-Type": "application/json",
+                        ...headers,
                     },
                     timeout: 10000,
                 }

--- a/map-storage/src/index.ts
+++ b/map-storage/src/index.ts
@@ -14,8 +14,8 @@ import { passportStrategy } from "./Services/Authentication";
 import { mapPathUsingDomain } from "./Services/PathMapper";
 import { ValidatorController } from "./Upload/ValidatorController";
 import { MapListService } from "./Services/MapListService";
-import {WebHookService} from "./Services/WebHookService";
-import {WEB_HOOK_URL} from "./Enum/EnvironmentVariable";
+import { WebHookService } from "./Services/WebHookService";
+import { WEB_HOOK_URL } from "./Enum/EnvironmentVariable";
 
 const server = new grpc.Server();
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -32,6 +32,8 @@ server.bindAsync(`0.0.0.0:50053`, grpc.ServerCredentials.createInsecure(), (err,
 });
 
 const app = express();
+// We need to trust the proxy in order to be able to bind the "X-Forwarded-Host" header to the hostname.
+app.set("trust proxy", true);
 app.use(cors());
 app.use(
     bodyParser.json({

--- a/tests/tests/map_storage_upload.spec.ts
+++ b/tests/tests/map_storage_upload.spec.ts
@@ -268,8 +268,8 @@ test.describe('Map-storage Upload API', () => {
 
         let listOfMaps = await request.get("maps");
         let maps = await listOfMaps.json();
-        await expect(maps["map.wam"]).toBeDefined();
-        await expect(maps["foo/map.wam"]).toBeDefined();
+        await expect(maps["maps"]["map.wam"]).toBeDefined();
+        await expect(maps["maps"]["foo/map.wam"]).toBeDefined();
 
         const uploadFileAlone = await request.post("upload", {
             multipart: {
@@ -281,8 +281,8 @@ test.describe('Map-storage Upload API', () => {
         await expect(uploadFileAlone.ok()).toBeTruthy();
         listOfMaps = await request.get("maps");
         maps = await listOfMaps.json();
-        await expect(maps["map.wam"]).toBeDefined();
-        await expect(Object.keys(maps)).toHaveLength(1);
+        await expect(maps["maps"]["map.wam"]).toBeDefined();
+        await expect(Object.keys(maps["maps"])).toHaveLength(1);
     });
 
     test("delete the root folder", async ({
@@ -298,8 +298,8 @@ test.describe('Map-storage Upload API', () => {
 
         let listOfMaps = await request.get("maps");
         let maps = await listOfMaps.json();
-        await expect(maps["map.wam"]).toBeDefined();
-        await expect(Object.keys(maps)).toHaveLength(1);
+        await expect(maps["maps"]["map.wam"]).toBeDefined();
+        await expect(Object.keys(maps["maps"])).toHaveLength(1);
 
         const deleteRoot = await request.delete(`delete?path=/`);
 
@@ -307,7 +307,7 @@ test.describe('Map-storage Upload API', () => {
 
         listOfMaps = await request.get("maps");
         maps = await listOfMaps.json();
-        await expect(Object.keys(maps)).toHaveLength(0);
+        await expect(Object.keys(maps["maps"])).toHaveLength(0);
     });
 
     test("delete a folder", async ({
@@ -323,7 +323,7 @@ test.describe('Map-storage Upload API', () => {
 
         let listOfMaps = await request.get("maps");
         let maps = await listOfMaps.json();
-        await expect(maps["toDelete/map.wam"]).toBeDefined();
+        await expect(maps["maps"]["toDelete/map.wam"]).toBeDefined();
 
         const deleteRoot = await request.delete(`delete?path=/toDelete`);
 
@@ -331,7 +331,7 @@ test.describe('Map-storage Upload API', () => {
 
         listOfMaps = await request.get("maps");
         maps = await listOfMaps.json();
-        await expect(maps).toEqual({});
+        await expect(maps["maps"]).toEqual({});
     });
 
     test("move a folder", async ({
@@ -347,7 +347,7 @@ test.describe('Map-storage Upload API', () => {
 
         let listOfMaps = await request.get("maps");
         let maps = await listOfMaps.json();
-        await expect(maps["toMove/map.wam"]).toBeDefined();
+        await expect(maps["maps"]["toMove/map.wam"]).toBeDefined();
 
         const moveDir = await request.post(`move`, {
             data: {
@@ -360,8 +360,8 @@ test.describe('Map-storage Upload API', () => {
 
         listOfMaps = await request.get("maps");
         maps = await listOfMaps.json();
-        await expect(maps["moved/map.wam"]).toBeDefined();
-        await expect(maps["toMove/map.wam"]).toBeUndefined();
+        await expect(maps["maps"]["moved/map.wam"]).toBeDefined();
+        await expect(maps["maps"]["toMove/map.wam"]).toBeUndefined();
     });
 
     test("copy a folder", async ({
@@ -377,7 +377,7 @@ test.describe('Map-storage Upload API', () => {
 
         let listOfMaps = await request.get("maps");
         let maps = await listOfMaps.json();
-        await expect(maps["toCopy/map.wam"]).toBeDefined();
+        await expect(maps["maps"]["toCopy/map.wam"]).toBeDefined();
 
         const copyDir = await request.post(`copy`, {
             data: {
@@ -390,8 +390,8 @@ test.describe('Map-storage Upload API', () => {
 
         listOfMaps = await request.get("maps");
         maps = await listOfMaps.json();
-        await expect(maps["toCopy/map.wam"]).toBeDefined();
-        await expect(maps["copied/map.wam"]).toBeDefined();
+        await expect(maps["maps"]["toCopy/map.wam"]).toBeDefined();
+        await expect(maps["maps"]["copied/map.wam"]).toBeDefined();
     });
 
     test('fails on invalid maps', async ({
@@ -444,7 +444,7 @@ test.describe('Map-storage Upload API', () => {
 
         const listOfMaps = await request.get("maps");
         const maps = await listOfMaps.json();
-        await expect(maps["single-map.wam"]).toBeDefined();
+        await expect(maps["maps"]["single-map.wam"]).toBeDefined();
 
         const patch = await request.patch(`single-map.wam`, {
             headers: {


### PR DESCRIPTION
Adding "trust proxy" setting to express to be sure we can read the host from the "X-Forwarded-Host" header Making sure we regenerate the cache file if not found during a put/patch/delete