### PR TITLE
Create "vendor" and "metadata" entries before JSONPatch

### DIFF
--- a/map-storage/src/Upload/UploadController.ts
+++ b/map-storage/src/Upload/UploadController.ts
@@ -367,8 +367,17 @@ export class UploadController {
 
                     let errors: Partial<OrganizedErrors> = {};
 
-                    //eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                    const content = JSON.parse(await this.fileSystem.readFileAsString(virtualPath));
+                    const content = WAMFileFormat.parse(
+                        JSON.parse(await this.fileSystem.readFileAsString(virtualPath))
+                    );
+
+                    // Let's make things easy: if "vendor" or "metadata" is not defined, let's add an empty object.
+                    if (!content.vendor) {
+                        content.vendor = {};
+                    }
+                    if (!content.metadata) {
+                        content.metadata = {};
+                    }
 
                     //eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                     const patchedContent = jsonpatch.applyPatch(


### PR DESCRIPTION
In case the "vendor" and "metadata" entries don't exist in WAM file, we create those so that the JsonPatch can be applied easily.

Otherwise, a patch on /metadata/name would fail because "metadata" is not defined.