### PR TITLE
Turning off microphone when "camera energy saving" is on

### DIFF
--- a/play/src/front/Components/EnableCamera/EnableCameraScene.svelte
+++ b/play/src/front/Components/EnableCamera/EnableCameraScene.svelte
@@ -4,6 +4,7 @@
     import { EnableCameraSceneName } from "../../Phaser/Login/EnableCameraScene";
     import {
         audioConstraintStore,
+        batchGetUserMediaStore,
         cameraListStore,
         localStreamStore,
         localVolumeStore,
@@ -70,11 +71,13 @@
     });
 
     onMount(() => {
-        //init the componenent to enable webcam and microphone
+        //init the component to enable webcam and microphone
+        batchGetUserMediaStore.startBatch();
         myCameraStore.set(true);
         myMicrophoneStore.set(true);
         requestedCameraState.enableWebcam();
         requestedMicrophoneState.enableMicrophone();
+        batchGetUserMediaStore.commitChanges();
     });
 
     function selectCamera() {

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -52,11 +52,11 @@
     onMount(() => {
         resizeObserver.observe(videoContainer);
         subscribeChangeOutput = speakerSelectedStore.subscribe((deviceId) => {
-            if (deviceId != undefined) setAudioOutPut(deviceId);
+            if (deviceId != undefined) setAudioOutput(deviceId);
         });
 
         subscribeStreamStore = streamStore.subscribe(() => {
-            if ($speakerSelectedStore != undefined) setAudioOutPut($speakerSelectedStore);
+            if ($speakerSelectedStore != undefined) setAudioOutput($speakerSelectedStore);
         });
     });
 
@@ -66,13 +66,15 @@
     });
 
     //sets the ID of the audio device to use for output
-    function setAudioOutPut(deviceId: string) {
+    function setAudioOutput(deviceId: string) {
         // Check HTMLMediaElement.setSinkId() compatibility for browser => https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId
         try {
             // @ts-ignore
             if (videoElement != undefined && videoElement.setSinkId != undefined) {
                 // @ts-ignore
-                videoElement.setSinkId(deviceId);
+                videoElement.setSinkId(deviceId).catch((e) => {
+                    console.info("Error setting the audio output device: ", e);
+                });
             }
         } catch (err) {
             console.info(

--- a/play/src/front/Phaser/Login/SelectCharacterScene.ts
+++ b/play/src/front/Phaser/Login/SelectCharacterScene.ts
@@ -25,6 +25,7 @@ import { DraggableGridEvent } from "@home-based-studio/phaser3-utils/lib/utils/g
 import { wokaList } from "@workadventure/messages";
 import { myCameraStore, myMicrophoneStore } from "../../Stores/MyMediaStore";
 import { get } from "svelte/store";
+import { batchGetUserMediaStore } from "../../Stores/MediaStore";
 
 //todo: put this constants in a dedicated file
 export const SelectCharacterSceneName = "SelectCharacterScene";
@@ -150,8 +151,10 @@ export class SelectCharacterScene extends AbstractCharacterScene {
             return;
         }
         this.selectedWoka = null;
+        batchGetUserMediaStore.startBatch();
         myCameraStore.set(false);
         myMicrophoneStore.set(false);
+        batchGetUserMediaStore.commitChanges();
         this.scene.sleep(SelectCharacterSceneName);
         this.scene.run(CustomizeSceneName);
         selectCharacterSceneVisibleStore.set(false);

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -348,9 +348,7 @@ export const mediaStreamConstraintsStore = derived(
         // Disable webcam for energy reasons (the user is not moving and we are talking to no one)
         if ($cameraEnergySavingStore === true && $enableCameraSceneVisibilityStore === false) {
             currentVideoConstraint = false;
-            //this optimization is desactivated because of sound issues on chrome
-            //todo: fix this conflicts and reactivate this optimization
-            //currentAudioConstraint = false;
+            currentAudioConstraint = false;
         }
 
         if (
@@ -361,7 +359,7 @@ export const mediaStreamConstraintsStore = derived(
             currentAudioConstraint = false;
         }
 
-        // Let's make the changes only if the new value is different from the old one.tile
+        // Let's make the changes only if the new value is different from the old one.
         if (
             !deepEqual(previousComputedVideoConstraint, currentVideoConstraint) ||
             !deepEqual(previousComputedAudioConstraint, currentAudioConstraint)

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -267,7 +267,7 @@ function createAudioConstraintStore() {
 
 export const audioConstraintStore = createAudioConstraintStore();
 
-let timeout: NodeJS.Timeout;
+//let timeout: NodeJS.Timeout;
 
 let previousComputedVideoConstraint: boolean | MediaTrackConstraints = false;
 let previousComputedAudioConstraint: boolean | MediaTrackConstraints = false;
@@ -374,17 +374,19 @@ export const mediaStreamConstraintsStore = derived(
                 previousComputedAudioConstraint = { ...previousComputedAudioConstraint };
             }
 
-            if (timeout) {
+            /*if (timeout) {
                 clearTimeout(timeout);
-            }
+            }*/
 
             // Let's wait a little bit to avoid sending too many constraint changes.
-            timeout = setTimeout(() => {
-                set({
-                    video: currentVideoConstraint,
-                    audio: currentAudioConstraint,
-                });
-            }, 100);
+            // PREVIOUSLY, WE TRIED TO THROTTLE CALLS TO getUserMedia, BUT setTimeout CAN BE THROTTLED BY THE CHROME
+            //timeout = setTimeout(() => {
+            set({
+                video: currentVideoConstraint,
+                audio: currentAudioConstraint,
+            });
+            /*    timeout = undefined;
+            }, 100);*/
         }
 
         if ($enableCameraSceneVisibilityStore) {

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -491,7 +491,7 @@ export const localStreamStore = derived<Readable<MediaStreamConstraints>, LocalS
                         return stream;
                     })
                     .catch((e) => {
-                        if (constraints.video !== false || constraints.audio !== false) {
+                        if (constraints.video !== false /* || constraints.audio !== false*/) {
                             console.info(
                                 "Error. Unable to get microphone and/or camera access. Trying audio only.",
                                 constraints,
@@ -503,12 +503,12 @@ export const localStreamStore = derived<Readable<MediaStreamConstraints>, LocalS
                                 error: e instanceof Error ? e : new Error("An unknown error happened"),
                             });
                             // Let's try without video constraints
-                            if (constraints.video !== false) {
-                                requestedCameraState.disableWebcam();
-                            }
-                            if (constraints.audio !== false) {
+                            //if (constraints.video !== false) {
+                            requestedCameraState.disableWebcam();
+                            //}
+                            /*if (constraints.audio !== false) {
                                 requestedMicrophoneState.disableMicrophone();
-                            }
+                            }*/
                         } else if (!constraints.video && !constraints.audio) {
                             set({
                                 type: "error",

--- a/play/src/front/WebRtc/SimplePeer.ts
+++ b/play/src/front/WebRtc/SimplePeer.ts
@@ -12,6 +12,7 @@ import { screenSharingLocalStreamStore } from "../Stores/ScreenSharingStore";
 import { playersStore } from "../Stores/PlayersStore";
 import { peerStore, screenSharingPeerStore } from "../Stores/PeerStore";
 import type { Subscription } from "rxjs";
+import { batchGetUserMediaStore } from "../Stores/MediaStore";
 
 export interface UserSimplePeerInterface {
     userId: number;
@@ -93,8 +94,10 @@ export class SimplePeer {
             )
         );
 
+        batchGetUserMediaStore.startBatch();
         mediaManager.enableMyCamera();
         mediaManager.enableMyMicrophone();
+        batchGetUserMediaStore.commitChanges();
 
         //receive message start
         this.rxJsUnsubscribers.push(


### PR DESCRIPTION
When the cameraEnergySavingStore is true, we are now ALSO turning off microphone.

This was commented 2 years ago due to a bug in Google Chrome. However, the bug does not seem to happen anymore. Needs extensive testing!

In addition, we remove the "setTimeout" trying to throttle the calls to GetUserMedia because they might be throttled by Chrome in heavy throttling mode. Instead, we use an explicit "batching store" to tell when a lot of changes are happening and trigger only one GetUserMedia query.