### PR TITLE
Fixing work with relative WAM URLs

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -386,6 +386,7 @@ export class GameScene extends DirtyScene {
         this.load.scenePlugin("AnimatedTiles", AnimatedTiles, "animatedTiles", "animatedTiles");
 
         if (this.wamUrlFile) {
+            const absoluteWamFileUrl = new URL(this.wamUrlFile, window.location.href).toString();
             this.superLoad
                 .json(
                     this.wamUrlFile,
@@ -394,7 +395,7 @@ export class GameScene extends DirtyScene {
                     undefined,
                     (key: string, type: string, wamFile: unknown) => {
                         this.wamFile = WAMFileFormat.parse(wamFile);
-                        this.mapUrlFile = new URL(this.wamFile.mapUrl, this.wamUrlFile).toString();
+                        this.mapUrlFile = new URL(this.wamFile.mapUrl, absoluteWamFileUrl).toString();
                         this.doLoadTMJFile(this.mapUrlFile);
                     }
                 )


### PR DESCRIPTION
This can happen on self-hosted WorkAdventure installs. Should fix the docker-compose self-hosted tests.