### PR TITLE
Adding a temporary test mode to debug Chrome heavy throttling

### DIFF
--- a/play/index.html
+++ b/play/index.html
@@ -51,6 +51,55 @@
             }
         </style>
         <script>
+            if (localStorage && localStorage.getItem("debug_throttle")) {
+                // This is a TEMPORARY TEST MODE that overloads setTimeout to detect when Chrome is throttling the page.
+                // If you see this message in the console, it means that Chrome is throttling the page.
+                console.log("Debug mode: setTimeout/setInterval are overloaded to detect when Chrome is throttling the page.")
+
+                // To test, see: https://docs.google.com/document/d/11FhKHRcABGS4SWPFGwoL6g0ALMqrFKapCk5ZTKKupEk/edit
+                // google-chrome --enable-features="IntensiveWakeUpThrottling:grace_period_seconds/10,OptOutZeroTimeoutTimersFromThrottling,AllowAggressiveThrottlingWithWebSocket"
+
+                var _ = setTimeout;
+                var __ = setInterval;
+                window.setTimeout = function (callback, delay) {
+                    const startTimestamp = Date.now();
+                    return _(() => {
+                        const endTimestamp = Date.now();
+                        // If the delay is more than 500ms longer than expected, it means that Chrome throttled the page.
+                        if (endTimestamp - startTimestamp > delay + 500) {
+                            console.warn(
+                                'setTimeout was throttled by Chrome! Delay was ' +
+                                (endTimestamp - startTimestamp) +
+                                'ms, but should have been ' +
+                                delay +
+                                'ms.'
+                            );
+                            console.trace();
+                        }
+                        callback();
+                    }, delay);
+                };
+                window.setInterval = function (callback, delay) {
+                    let timestamp = Date.now();
+                    return __(() => {
+                        const newTimestamp = Date.now();
+                        if (newTimestamp - timestamp > delay + 500) {
+                            console.warn(
+                                'setInterval was throttled by Chrome! Delay was ' +
+                                (newTimestamp - timestamp) +
+                                'ms, but should have been ' +
+                                delay +
+                                'ms.'
+                            );
+                            console.trace();
+                        }
+                        timestamp = newTimestamp;
+                        callback();
+                    }, delay);
+                };
+            }
+        </script>
+        <script>
             {{{ script }}}
         </script>
 

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -348,9 +348,7 @@ export const mediaStreamConstraintsStore = derived(
         // Disable webcam for energy reasons (the user is not moving and we are talking to no one)
         if ($cameraEnergySavingStore === true && $enableCameraSceneVisibilityStore === false) {
             currentVideoConstraint = false;
-            //this optimization is desactivated because of sound issues on chrome
-            //todo: fix this conflicts and reactivate this optimization
-            //currentAudioConstraint = false;
+            currentAudioConstraint = false;
         }
 
         if (
@@ -361,7 +359,7 @@ export const mediaStreamConstraintsStore = derived(
             currentAudioConstraint = false;
         }
 
-        // Let's make the changes only if the new value is different from the old one.tile
+        // Let's make the changes only if the new value is different from the old one.
         if (
             !deepEqual(previousComputedVideoConstraint, currentVideoConstraint) ||
             !deepEqual(previousComputedAudioConstraint, currentAudioConstraint)

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -267,7 +267,7 @@ function createAudioConstraintStore() {
 
 export const audioConstraintStore = createAudioConstraintStore();
 
-let timeout: NodeJS.Timeout;
+//let timeout: NodeJS.Timeout;
 
 let previousComputedVideoConstraint: boolean | MediaTrackConstraints = false;
 let previousComputedAudioConstraint: boolean | MediaTrackConstraints = false;
@@ -374,17 +374,19 @@ export const mediaStreamConstraintsStore = derived(
                 previousComputedAudioConstraint = { ...previousComputedAudioConstraint };
             }
 
-            if (timeout) {
+            /*if (timeout) {
                 clearTimeout(timeout);
-            }
+            }*/
 
             // Let's wait a little bit to avoid sending too many constraint changes.
-            timeout = setTimeout(() => {
-                set({
-                    video: currentVideoConstraint,
-                    audio: currentAudioConstraint,
-                });
-            }, 100);
+            // PREVIOUSLY, WE TRIED TO THROTTLE CALLS TO getUserMedia, BUT setTimeout CAN BE THROTTLED BY THE CHROME
+            //timeout = setTimeout(() => {
+            set({
+                video: currentVideoConstraint,
+                audio: currentAudioConstraint,
+            });
+            /*    timeout = undefined;
+            }, 100);*/
         }
 
         if ($enableCameraSceneVisibilityStore) {

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -491,7 +491,7 @@ export const localStreamStore = derived<Readable<MediaStreamConstraints>, LocalS
                         return stream;
                     })
                     .catch((e) => {
-                        if (constraints.video !== false || constraints.audio !== false) {
+                        if (constraints.video !== false /* || constraints.audio !== false*/) {
                             console.info(
                                 "Error. Unable to get microphone and/or camera access. Trying audio only.",
                                 constraints,
@@ -503,12 +503,12 @@ export const localStreamStore = derived<Readable<MediaStreamConstraints>, LocalS
                                 error: e instanceof Error ? e : new Error("An unknown error happened"),
                             });
                             // Let's try without video constraints
-                            if (constraints.video !== false) {
-                                requestedCameraState.disableWebcam();
-                            }
-                            if (constraints.audio !== false) {
+                            //if (constraints.video !== false) {
+                            requestedCameraState.disableWebcam();
+                            //}
+                            /*if (constraints.audio !== false) {
                                 requestedMicrophoneState.disableMicrophone();
-                            }
+                            }*/
                         } else if (!constraints.video && !constraints.audio) {
                             set({
                                 type: "error",


### PR DESCRIPTION
Chrome can enable heavy throttling on some tabs, which increases the setTimeout/setInterval
calls to a minimum of 1 second (lite) or 1 minute (heavy).

Here, we are monkey-patching the setTimeout and setInterval functions
to detect if they were throttled. If yes, we are also adding a console.trace() call
to know what function was really throttled.