### PR TITLE
Adding a temporary test mode to debug Chrome heavy throttling

### DIFF
--- a/play/index.html
+++ b/play/index.html
@@ -51,6 +51,55 @@
             }
         </style>
         <script>
+            if (localStorage && localStorage.getItem("debug_throttle")) {
+                // This is a TEMPORARY TEST MODE that overloads setTimeout to detect when Chrome is throttling the page.
+                // If you see this message in the console, it means that Chrome is throttling the page.
+                console.log("Debug mode: setTimeout/setInterval are overloaded to detect when Chrome is throttling the page.")
+
+                // To test, see: https://docs.google.com/document/d/11FhKHRcABGS4SWPFGwoL6g0ALMqrFKapCk5ZTKKupEk/edit
+                // google-chrome --enable-features="IntensiveWakeUpThrottling:grace_period_seconds/10,OptOutZeroTimeoutTimersFromThrottling,AllowAggressiveThrottlingWithWebSocket"
+
+                var _ = setTimeout;
+                var __ = setInterval;
+                window.setTimeout = function (callback, delay) {
+                    const startTimestamp = Date.now();
+                    return _(() => {
+                        const endTimestamp = Date.now();
+                        // If the delay is more than 500ms longer than expected, it means that Chrome throttled the page.
+                        if (endTimestamp - startTimestamp > delay + 500) {
+                            console.warn(
+                                'setTimeout was throttled by Chrome! Delay was ' +
+                                (endTimestamp - startTimestamp) +
+                                'ms, but should have been ' +
+                                delay +
+                                'ms.'
+                            );
+                            console.trace();
+                        }
+                        callback();
+                    }, delay);
+                };
+                window.setInterval = function (callback, delay) {
+                    let timestamp = Date.now();
+                    return __(() => {
+                        const newTimestamp = Date.now();
+                        if (newTimestamp - timestamp > delay + 500) {
+                            console.warn(
+                                'setInterval was throttled by Chrome! Delay was ' +
+                                (newTimestamp - timestamp) +
+                                'ms, but should have been ' +
+                                delay +
+                                'ms.'
+                            );
+                            console.trace();
+                        }
+                        timestamp = newTimestamp;
+                        callback();
+                    }, delay);
+                };
+            }
+        </script>
+        <script>
             {{{ script }}}
         </script>
 


### PR DESCRIPTION
Chrome can enable heavy throttling on some tabs, which increases the setTimeout/setInterval calls to a minimum of 1 second (lite) or 1 minute (heavy).

Here, we are monkey-patching the setTimeout and setInterval functions to detect if they were throttled. If yes, we are also adding a console.trace() call to know what function was really throttled.