### PR TITLE
Computing favicon from full URL

### DIFF
--- a/play/src/front/Components/EmbedScreens/CoWebsiteThumbnailSlot.svelte
+++ b/play/src/front/Components/EmbedScreens/CoWebsiteThumbnailSlot.svelte
@@ -37,9 +37,9 @@
             icon.src = meetingIcon;
             cowebsiteName = "BigBlueButton meeting";
         } else {
-            icon.src = `${ICON_URL}/icon?url=${
-                coWebsite.getUrl().hostname
-            }&size=64..96..256&fallback_icon_color=14304c`;
+            icon.src = `${ICON_URL}/icon?url=${encodeURIComponent(
+                coWebsite.getUrl().toString()
+            )}&size=64..96..256&fallback_icon_color=14304c`;
             cowebsiteName = coWebsite.getUrl().hostname;
         }
         icon.alt = coWebsite.getUrl().hostname;


### PR DESCRIPTION
We use the full URL (and not only the domain name) to fetch the favicon. This way, if a webpage has a favicon different from the favicon of the domain, we can fetch that properly.