### PR TITLE
[MAP EDITOR] Better filters & selected item UI

### DIFF
--- a/play/src/front/Components/MapEditor/EntityPropertiesEditor.svelte
+++ b/play/src/front/Components/MapEditor/EntityPropertiesEditor.svelte
@@ -95,7 +95,7 @@
     {$LL.mapEditor.entityEditor.editInstructions()}
 {:else}
     <div class="header-container">
-        <h2>Editing {$mapEditorSelectedEntityStore.getEntityData().prefab.name}</h2>
+        <h2>Editing: {$mapEditorSelectedEntityStore.getEntityData().prefab.name}</h2>
     </div>
     <div class="properties-buttons tw-flex tw-flex-row">
         <AddPropertyButton

--- a/play/src/front/Components/MapEditor/ItemPicker.svelte
+++ b/play/src/front/Components/MapEditor/ItemPicker.svelte
@@ -27,7 +27,7 @@
     let tags = entitiesCollectionsManager.getTags();
 
     onMount(() => {
-        entitiesCollectionsManager.setNameFilter(filter);
+        entitiesCollectionsManager.setFilter(filter);
         updateVisiblePrefabs();
     });
 
@@ -75,12 +75,17 @@
         if (selectedTag !== "") {
             filter = selectedTag;
             selectedTag = "";
-            onFilterChange();
+            onTagChange();
         }
     }
 
-    function onFilterChange() {
-        entitiesCollectionsManager.setNameFilter(filter);
+    function onNameChange() {
+        entitiesCollectionsManager.setFilter(filter);
+        updateVisiblePrefabs();
+    }
+
+    function onTagChange() {
+        entitiesCollectionsManager.setFilter(filter, true);
         updateVisiblePrefabs();
     }
 
@@ -110,7 +115,7 @@
             class="filter-input"
             type="search"
             bind:value={filter}
-            on:input={onFilterChange}
+            on:input={onNameChange}
             on:focus={onMapEditorInputFocus}
             on:blur={onMapEditorInputUnfocus}
             placeholder={$LL.mapEditor.entityEditor.itemPicker.searchPlaceholder()}
@@ -121,7 +126,6 @@
             {/each}
         </select>
     </div>
-    <div class="item-name">{pickedItem?.name ?? "no entity selected"}</div>
     <div class="item-picker-container">
         {#each rootItem as item (item.name)}
             <div
@@ -132,28 +136,30 @@
             </div>
         {/each}
     </div>
-    <div class="separator">{$LL.mapEditor.entityEditor.itemPicker.selectVariationInstructions()}</div>
-    {#if pickedItem !== null}
-        <div class="item-variant-picker-container">
-            {#each currentVariants as item}
-                <div
-                    class="pickable-item {item.imagePath === pickedVariant?.imagePath ? 'active' : ''}"
-                    on:click={() => onPickItemVariant(item)}
-                >
-                    <img class="item-image" src={item.imagePath} alt={item.name} />
-                </div>
-            {/each}
-        </div>
-        <div class="color-container">
-            {#each variantColors as color}
-                <div class={currentColor === color ? "active" : ""}>
-                    <button
-                        class="color-selector"
-                        style="background-color: {color};"
-                        on:click={() => onColorChange(color)}
-                    />
-                </div>
-            {/each}
+    {#if pickedItem}
+        <div class="item-variations">
+            <div class="item-name">{pickedItem?.name ?? "this entity"}</div>
+            <div class="item-variant-picker-container">
+                {#each currentVariants as item}
+                    <div
+                        class="pickable-item {item.imagePath === pickedVariant?.imagePath ? 'active' : ''}"
+                        on:click={() => onPickItemVariant(item)}
+                    >
+                        <img class="item-image" src={item.imagePath} alt={item.name} />
+                    </div>
+                {/each}
+            </div>
+            <div class="color-container">
+                {#each variantColors as color}
+                    <div class={currentColor === color ? "active" : ""}>
+                        <button
+                            class="color-selector"
+                            style="background-color: {color};"
+                            on:click={() => onColorChange(color)}
+                        />
+                    </div>
+                {/each}
+            </div>
         </div>
     {/if}
 </div>
@@ -173,6 +179,12 @@
                 margin-bottom: 0;
                 position: absolute;
                 overflow-y: auto;
+            }
+        }
+        .item-variations {
+            margin-top: 30px;
+            .item-name {
+                font-weight: bold;
             }
         }
         .item-picker-container,

--- a/play/src/front/Phaser/Game/MapEditor/EntitiesCollectionsManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/EntitiesCollectionsManager.ts
@@ -26,22 +26,30 @@ export class EntitiesCollectionsManager {
         );
     }
 
-    public setNameFilter(filter: string) {
+    public setFilter(filter: string, isTag = false) {
         this.filter = filter;
-        this.applyFilters();
+        this.applyFilters(isTag);
     }
 
-    private applyFilters() {
+    private applyFilters(isTag: boolean) {
         const filters = this.filter
             .toLowerCase()
             .split(" ")
             .filter((v) => v.trim() !== "");
         let newCollection = this.currentCollection.collection;
-        newCollection = newCollection.filter(
-            (item) =>
-                filters.every((word) => item.name.toLowerCase().includes(word)) ||
-                filters.every((word) => item.tags.includes(word))
-        );
+
+        if (isTag) {
+            newCollection = newCollection.filter((item) =>
+                filters.every((word) => item.tags.some((tag) => tag.toLowerCase() === word.toLowerCase()))
+            );
+        } else {
+            newCollection = newCollection.filter(
+                (item) =>
+                    filters.every((word) => item.name.toLowerCase().includes(word.toLowerCase())) ||
+                    filters.every((word) => item.tags.some((tag) => tag.toLowerCase() === word.toLowerCase()))
+            );
+        }
+
         this.entitiesPrefabs = newCollection;
     }
 

--- a/play/src/i18n/de-DE/mapEditor.ts
+++ b/play/src/i18n/de-DE/mapEditor.ts
@@ -40,8 +40,7 @@ const mapEditor: BaseTranslation = {
     },
     entityEditor: {
         itemPicker: {
-            searchPlaceholder: "Nach namen oder Tags suchen",
-            selectVariationInstructions: "Variante auswählen",
+            searchPlaceholder: "Forschen",
         },
         deleteButton: "Löschen",
         testInteractionButton: "Interaktion testen",

--- a/play/src/i18n/en-US/mapEditor.ts
+++ b/play/src/i18n/en-US/mapEditor.ts
@@ -84,8 +84,7 @@ const mapEditor: BaseTranslation = {
     },
     entityEditor: {
         itemPicker: {
-            searchPlaceholder: "Search for name or tags",
-            selectVariationInstructions: "Select a variant",
+            searchPlaceholder: "Search",
         },
         deleteButton: "Delete",
         testInteractionButton: "Test Interaction",

--- a/play/src/i18n/fr-FR/mapEditor.ts
+++ b/play/src/i18n/fr-FR/mapEditor.ts
@@ -45,8 +45,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
     },
     entityEditor: {
         itemPicker: {
-            searchPlaceholder: "Rechercher nom ou tag",
-            selectVariationInstructions: "Sélectionnez une variation",
+            searchPlaceholder: "Rechercher",
         },
         deleteButton: "Supprimer",
         testInteractionButton: "Tester interaction",


### PR DESCRIPTION
This simplifies a bit the UI of the map editor (it felt too developer oriented)
![image](https://github.com/thecodingmachine/workadventure/assets/14997703/afc1c95c-3602-438c-9439-14460083433d)

In addition to that the filters now are working slightly differently:

BEFORE
Your name search or tag selection did the same thing, it applied a `.filter()` on the name or tag.

NOW
Searching for a name and selecting a tag are two different actions.
- Entering "offi" will find entities whose name contains "offi" (case insensitive)
- Entering "office" will do the same but as it matches the exact name of the tag it will also find entities with the tag "Office" (case insensitive)
- Selecting the "Office" tag will find entities with an "Office" tag