### PR TITLE
we can no longer drag multiple entities that are stacked together

### DIFF
--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -87,6 +87,7 @@ export class AreaEditorTool extends MapEditorTool {
 
     public activate(): void {
         this.active = true;
+        this.scene.input.topOnly = false;
         this.updateAreaPreviews();
         this.setAreaPreviewsVisibility(true);
         this.bindEventHandlers();

--- a/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
@@ -59,6 +59,7 @@ export class EntityEditorTool extends MapEditorTool {
 
     public update(time: number, dt: number): void {}
     public clear(): void {
+        this.scene.input.topOnly = false;
         mapEditorEntityModeStore.set("ADD");
         this.entitiesManager.clearAllEntitiesTint();
         this.entitiesManager.clearAllEntitiesEditOutlines();
@@ -66,6 +67,7 @@ export class EntityEditorTool extends MapEditorTool {
         this.unbindEventHandlers();
     }
     public activate(): void {
+        this.scene.input.topOnly = true;
         this.entitiesManager.makeAllEntitiesInteractive();
         this.bindEventHandlers();
     }


### PR DESCRIPTION
closes #3238

This issue was introduced by mistake when we added feature of clicking through different areas that are on top of each other.