### PR TITLE
Fixing missing env var in .env.template

### DIFF
--- a/contrib/docker/.env.prod.template
+++ b/contrib/docker/.env.prod.template
@@ -213,6 +213,12 @@ ENABLE_TELEMETRY=
 # ENABLE_TELEMETRY must be set to "true" for this to work.
 SECURITY_EMAIL=
 
+# MAP EDITOR SETTINGS
+ENABLE_MAP_EDITOR=true
+# If you want to allow only some users to access the map editor, you can set the list of authorized users here, email separated by commas. (Only possible if OpenID Connect is configured)
+# Leave blank if you want to allow all users to access the map editor.
+# This variable is ignored if an AdminAPI is configured
+MAP_EDITOR_ALLOWED_USERS=
 
 # You MUST decide an authentication strategy for the map-storage container.
 # This must be one of "Basic", "Digest" or "Bearer".


### PR DESCRIPTION
The variables to configure the map editor were missing in the production docker-compose file.