### PR TITLE
Trying to wait for docker-compose to be up

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=proto-builder /usr/src/generated ./back/src/Messages/generated
 WORKDIR /usr/src/back
 
 RUN apt-get update && apt-get install -y curl
-HEALTHCHECK --interval=5s --timeout=10s --start-period=5s --retries=10 CMD curl -f http://localhost:8080/ping || exit 1
+HEALTHCHECK --interval=10s --timeout=7s --start-period=10s --retries=15 CMD curl -f http://localhost:8080/ping || exit 1
 
 USER node
 CMD ["npm", "run", "runprod"]

--- a/play/Dockerfile
+++ b/play/Dockerfile
@@ -52,7 +52,7 @@ COPY --from=builder --chown=node:node /usr/src/play /usr/src/play
 WORKDIR /usr/src/play
 
 RUN apt-get update && apt-get install -y curl
-HEALTHCHECK --interval=5s --timeout=10s --start-period=5s --retries=10 CMD curl -f http://localhost:3000 || exit 1
+HEALTHCHECK --interval=10s --timeout=7s --start-period=10s --retries=15 CMD curl -f http://localhost:3000 || exit 1
 
 USER node
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
For some reason, docker-compose up times out after 2 minutes. It is sometimes not long enough for containers to be healthy in CI. We try here to improve this by adding the "--wait" flag.