### PR TITLE
Triggerring onVariableChange after variable is changed instead of before

### DIFF
--- a/play/src/front/Api/Iframe/players.ts
+++ b/play/src/front/Api/Iframe/players.ts
@@ -36,6 +36,7 @@ export class WorkadventurePlayersCommands extends IframeApiContribution<Workadve
                     return;
                 }
 
+                remotePlayer.setVariable(payloadData.key, payloadData.value);
                 const stream = sharedPlayersVariableStream.get(payloadData.key);
                 if (stream) {
                     stream.next({
@@ -43,7 +44,6 @@ export class WorkadventurePlayersCommands extends IframeApiContribution<Workadve
                         value: payloadData.value,
                     });
                 }
-                remotePlayer.setVariable(payloadData.key, payloadData.value);
             },
         }),
         apiCallback({


### PR DESCRIPTION
`WA.players.onVariableChange` was being triggered BEFORE the value was changed in the player. But WA.player.state.onVariableChange works the other way around. We align on the later.

When the callback to WA.players.onVariableChange is called, the value on the remote player state will already be updated.