### PR TITLE
Removing prefab mock data from WAM file

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -1101,12 +1101,17 @@ export class GameRoom implements BrothersFinder {
                     emitError(user.socket, err);
                     return;
                 }
-                if (editMapCommandMessage.editMapMessage?.message?.$case === "updateMegaphoneSettingMessage") {
+                if (editMapCommandMessage.editMapMessage?.message?.$case === "updateWAMSettingsMessage") {
                     if (!this._wamSettings) {
                         this._wamSettings = {};
                     }
-                    this._wamSettings.megaphone =
-                        editMapCommandMessage.editMapMessage.message.updateMegaphoneSettingMessage;
+                    if (
+                        editMapCommandMessage.editMapMessage.message.updateWAMSettingsMessage.message?.$case ===
+                        "updateMegaphoneSettingMessage"
+                    ) {
+                        this._wamSettings.megaphone =
+                            editMapCommandMessage.editMapMessage.message.updateWAMSettingsMessage.message.updateMegaphoneSettingMessage;
+                    }
                 }
                 this.dispatchRoomMessage({
                     message: {

--- a/docs/schema/1.0/wam.json
+++ b/docs/schema/1.0/wam.json
@@ -182,15 +182,28 @@
                   ]
                 }
               },
-              "prefabId": {
-                "type": "string"
+              "prefabRef": {
+                "type": "object",
+                "properties": {
+                  "collectionName": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "collectionName",
+                  "id"
+                ],
+                "additionalProperties": false
               }
             },
             "required": [
               "id",
               "x",
               "y",
-              "prefabId"
+              "prefabRef"
             ],
             "additionalProperties": false
           }

--- a/libs/map-editor/src/Commands/Area/CreateAreaCommand.ts
+++ b/libs/map-editor/src/Commands/Area/CreateAreaCommand.ts
@@ -1,35 +1,22 @@
 import type { AreaData } from "../../types";
 import type { GameMap } from "../../GameMap/GameMap";
 import { Command } from "../Command";
-import type { DeleteAreaCommandConfig } from "./DeleteAreaCommand";
-
-export interface CreateAreaCommandConfig {
-    type: "CreateAreaCommand";
-    areaObjectConfig: AreaData;
-}
 
 export class CreateAreaCommand extends Command {
-    private readonly areaConfig: AreaData;
+    protected readonly areaConfig: AreaData;
 
-    private gameMap: GameMap;
+    protected gameMap: GameMap;
 
-    constructor(gameMap: GameMap, config: CreateAreaCommandConfig, commandId?: string) {
+    constructor(gameMap: GameMap, areaObjectConfig: AreaData, commandId?: string) {
         super(commandId);
         this.gameMap = gameMap;
-        this.areaConfig = structuredClone<AreaData>(config.areaObjectConfig);
+        this.areaConfig = structuredClone<AreaData>(areaObjectConfig);
     }
 
-    public execute(): CreateAreaCommandConfig {
+    public execute(): Promise<void> {
         if (!this.gameMap.getGameMapAreas()?.addArea(this.areaConfig)) {
             throw new Error(`MapEditorError: Could not execute CreateArea Command. Area ID: ${this.areaConfig.id}`);
         }
-        return { type: "CreateAreaCommand", areaObjectConfig: this.areaConfig };
-    }
-
-    public undo(): DeleteAreaCommandConfig {
-        if (!this.gameMap.getGameMapAreas()?.deleteArea(this.areaConfig.id)) {
-            throw new Error(`MapEditorError: Could not undo CreateArea Command. Area ID: ${this.areaConfig.id}`);
-        }
-        return { type: "DeleteAreaCommand", id: this.areaConfig.id };
+        return Promise.resolve();
     }
 }

--- a/libs/map-editor/src/Commands/Area/DeleteAreaCommand.ts
+++ b/libs/map-editor/src/Commands/Area/DeleteAreaCommand.ts
@@ -1,39 +1,26 @@
 import type { AreaData } from "../../types";
 import type { GameMap } from "../../GameMap/GameMap";
 import { Command } from "../Command";
-import type { CreateAreaCommandConfig } from "./CreateAreaCommand";
-
-export interface DeleteAreaCommandConfig {
-    type: "DeleteAreaCommand";
-    id: string;
-}
 
 export class DeleteAreaCommand extends Command {
-    private areaConfig: AreaData;
+    protected areaConfig: AreaData;
 
-    private gameMap: GameMap;
+    protected gameMap: GameMap;
 
-    constructor(gameMap: GameMap, config: DeleteAreaCommandConfig, commandId?: string) {
+    constructor(gameMap: GameMap, id: string, commandId?: string) {
         super(commandId);
         this.gameMap = gameMap;
-        const areaConfig = gameMap.getGameMapAreas()?.getArea(config.id);
+        const areaConfig = gameMap.getGameMapAreas()?.getArea(id);
         if (!areaConfig) {
             throw new Error("Trying to delete a non existing Area!");
         }
         this.areaConfig = structuredClone(areaConfig);
     }
 
-    public execute(): DeleteAreaCommandConfig {
+    public execute(): Promise<void> {
         if (!this.gameMap.getGameMapAreas()?.deleteArea(this.areaConfig.id)) {
             throw new Error(`MapEditorError: Could not execute DeleteArea Command. Area ID: ${this.areaConfig.id}`);
         }
-        return { type: "DeleteAreaCommand", id: this.areaConfig.id };
-    }
-
-    public undo(): CreateAreaCommandConfig {
-        if (!this.gameMap.getGameMapAreas()?.addArea(this.areaConfig)) {
-            throw new Error(`MapEditorError: Could not undo DeleteArea Command. Area ID: ${this.areaConfig.id}`);
-        }
-        return { type: "CreateAreaCommand", areaObjectConfig: this.areaConfig };
+        return Promise.resolve();
     }
 }

--- a/libs/map-editor/src/Commands/Area/UpdateAreaCommand.ts
+++ b/libs/map-editor/src/Commands/Area/UpdateAreaCommand.ts
@@ -2,44 +2,45 @@ import { AtLeast, AreaData, AreaDataProperties, AreaDataPropertiesKeys, AreaData
 import type { GameMap } from "../../GameMap/GameMap";
 import { Command } from "../Command";
 
-export interface UpdateAreaCommandConfig {
-    type: "UpdateAreaCommand";
-    dataToModify: AtLeast<AreaData, "id">;
-}
-
 export class UpdateAreaCommand extends Command {
-    private oldConfig: AtLeast<AreaData, "id">;
-    private newConfig: AtLeast<AreaData, "id">;
+    protected oldConfig: AtLeast<AreaData, "id">;
+    protected newConfig: AtLeast<AreaData, "id">;
 
-    private gameMap: GameMap;
+    protected gameMap: GameMap;
 
-    constructor(gameMap: GameMap, config: UpdateAreaCommandConfig, commandId?: string) {
+    constructor(
+        gameMap: GameMap,
+        dataToModify: AtLeast<AreaData, "id">,
+        commandId?: string,
+        oldConfig?: AtLeast<AreaData, "id">
+    ) {
         super(commandId);
         this.gameMap = gameMap;
-        const oldConfig = gameMap.getGameMapAreas()?.getArea(config.dataToModify.id);
         if (!oldConfig) {
-            throw new Error("Trying to update a non existing Area!");
+            const oldConfig = gameMap.getGameMapAreas()?.getArea(dataToModify.id);
+            if (!oldConfig) {
+                throw new Error("Trying to update a non existing Area!");
+            }
+            try {
+                this.oldConfig = structuredClone(oldConfig);
+            } catch (e) {
+                throw new Error(String(e));
+            }
+        } else {
+            this.oldConfig = oldConfig;
         }
         try {
-            this.newConfig = structuredClone(this.parseDataToModify(config.dataToModify));
-            this.oldConfig = structuredClone(oldConfig);
+            this.newConfig = structuredClone(this.parseDataToModify(dataToModify));
         } catch (e) {
             throw new Error(String(e));
         }
     }
 
-    public execute(): UpdateAreaCommandConfig {
+    public execute(): Promise<void> {
         if (!this.gameMap.getGameMapAreas()?.updateArea(this.newConfig.id, this.newConfig)) {
             throw new Error(`MapEditorError: Could not execute UpdateArea Command. Area ID: ${this.newConfig.id}`);
         }
-        return { type: "UpdateAreaCommand", dataToModify: this.newConfig };
-    }
-
-    public undo(): UpdateAreaCommandConfig {
-        if (!this.gameMap.getGameMapAreas()?.updateArea(this.oldConfig.id, this.oldConfig)) {
-            throw new Error(`MapEditorError: Could not undo UpdateArea Command. Area ID: ${this.newConfig.id}`);
-        }
-        return { type: "UpdateAreaCommand", dataToModify: this.oldConfig };
+        return Promise.resolve();
     }
 
     private parseDataToModify(data: AtLeast<AreaData, "id">): AtLeast<AreaData, "id"> {

--- a/libs/map-editor/src/Commands/Command.ts
+++ b/libs/map-editor/src/Commands/Command.ts
@@ -1,5 +1,4 @@
 import { v4 as uuidv4 } from "uuid";
-import type { CommandConfig } from "../types";
 
 export abstract class Command {
     public readonly id: string;
@@ -8,6 +7,6 @@ export abstract class Command {
         this.id = id ?? uuidv4();
     }
 
-    public abstract execute(): CommandConfig;
-    public abstract undo(): CommandConfig;
+    public abstract execute(): Promise<void>;
+    //public abstract undo(): Promise<void>;
 }

--- a/libs/map-editor/src/Commands/Entity/CreateEntityCommand.ts
+++ b/libs/map-editor/src/Commands/Entity/CreateEntityCommand.ts
@@ -1,15 +1,15 @@
-import type { EntityData } from "../../types";
 import type { GameMap } from "../../GameMap/GameMap";
 import { Command } from "../Command";
+import { WAMEntityData } from "../../types";
 import type { DeleteEntityCommandConfig } from "./DeleteEntityCommand";
 
 export interface CreateEntityCommandConfig {
     type: "CreateEntityCommand";
-    entityData: EntityData;
+    entityData: WAMEntityData;
 }
 
 export class CreateEntityCommand extends Command {
-    private entityData: EntityData;
+    private entityData: WAMEntityData;
 
     private gameMap: GameMap;
 

--- a/libs/map-editor/src/Commands/Entity/CreateEntityCommand.ts
+++ b/libs/map-editor/src/Commands/Entity/CreateEntityCommand.ts
@@ -1,35 +1,22 @@
 import type { GameMap } from "../../GameMap/GameMap";
 import { Command } from "../Command";
 import { WAMEntityData } from "../../types";
-import type { DeleteEntityCommandConfig } from "./DeleteEntityCommand";
-
-export interface CreateEntityCommandConfig {
-    type: "CreateEntityCommand";
-    entityData: WAMEntityData;
-}
 
 export class CreateEntityCommand extends Command {
-    private entityData: WAMEntityData;
+    protected entityData: WAMEntityData;
 
-    private gameMap: GameMap;
+    protected gameMap: GameMap;
 
-    constructor(gameMap: GameMap, config: CreateEntityCommandConfig, commandId?: string) {
+    constructor(gameMap: GameMap, entityData: WAMEntityData, commandId?: string) {
         super(commandId);
         this.gameMap = gameMap;
-        this.entityData = structuredClone(config.entityData);
+        this.entityData = structuredClone(entityData);
     }
 
-    public execute(): CreateEntityCommandConfig {
+    public execute(): Promise<void> {
         if (!this.gameMap.getGameMapEntities()?.addEntity(this.entityData)) {
             throw new Error(`MapEditorError: Could not execute CreateEntity Command. Entity ID: ${this.entityData.id}`);
         }
-        return { type: "CreateEntityCommand", entityData: this.entityData };
-    }
-
-    public undo(): DeleteEntityCommandConfig {
-        if (!this.gameMap.getGameMapEntities()?.deleteEntity(this.entityData.id)) {
-            throw new Error(`MapEditorError: Could not undo CreateEntity Command. Entity ID: ${this.entityData.id}`);
-        }
-        return { type: "DeleteEntityCommand", id: this.entityData.id };
+        return Promise.resolve();
     }
 }

--- a/libs/map-editor/src/Commands/Entity/DeleteEntityCommand.ts
+++ b/libs/map-editor/src/Commands/Entity/DeleteEntityCommand.ts
@@ -1,4 +1,4 @@
-import type { EntityData } from "../../types";
+import type { WAMEntityData } from "../../types";
 import type { GameMap } from "../../GameMap/GameMap";
 import { Command } from "../Command";
 import type { CreateEntityCommandConfig } from "./CreateEntityCommand";
@@ -9,7 +9,7 @@ export interface DeleteEntityCommandConfig {
 }
 
 export class DeleteEntityCommand extends Command {
-    private entityData: EntityData;
+    private entityData: WAMEntityData;
 
     private gameMap: GameMap;
 

--- a/libs/map-editor/src/Commands/Entity/DeleteEntityCommand.ts
+++ b/libs/map-editor/src/Commands/Entity/DeleteEntityCommand.ts
@@ -1,39 +1,26 @@
 import type { WAMEntityData } from "../../types";
 import type { GameMap } from "../../GameMap/GameMap";
 import { Command } from "../Command";
-import type { CreateEntityCommandConfig } from "./CreateEntityCommand";
-
-export interface DeleteEntityCommandConfig {
-    type: "DeleteEntityCommand";
-    id: string;
-}
 
 export class DeleteEntityCommand extends Command {
-    private entityData: WAMEntityData;
+    protected entityData: WAMEntityData;
 
-    private gameMap: GameMap;
+    protected gameMap: GameMap;
 
-    constructor(gameMap: GameMap, config: DeleteEntityCommandConfig, commandId?: string) {
+    constructor(gameMap: GameMap, id: string, commandId?: string) {
         super(commandId);
         this.gameMap = gameMap;
-        const entityData = gameMap.getGameMapEntities()?.getEntity(config.id);
+        const entityData = gameMap.getGameMapEntities()?.getEntity(id);
         if (!entityData) {
             throw new Error("Trying to delete a non existing Entity!");
         }
         this.entityData = structuredClone(entityData);
     }
 
-    public execute(): DeleteEntityCommandConfig {
+    public execute(): Promise<void> {
         if (!this.gameMap.getGameMapEntities()?.deleteEntity(this.entityData.id)) {
             throw new Error(`MapEditorError: Could not execute DeleteEntity Command. Entity ID: ${this.entityData.id}`);
         }
-        return { type: "DeleteEntityCommand", id: this.entityData.id };
-    }
-
-    public undo(): CreateEntityCommandConfig {
-        if (!this.gameMap.getGameMapEntities()?.addEntity(this.entityData)) {
-            throw new Error(`MapEditorError: Could not undo DeleteEntity Command. Entity ID: ${this.entityData.id}`);
-        }
-        return { type: "CreateEntityCommand", entityData: this.entityData };
+        return Promise.resolve();
     }
 }

--- a/libs/map-editor/src/GameMap/GameMap.ts
+++ b/libs/map-editor/src/GameMap/GameMap.ts
@@ -6,7 +6,7 @@ import {
     Json,
     upgradeMapToNewest,
 } from "@workadventure/tiled-map-type-guard";
-import { EntityPrefab, WAMFileFormat, GameMapProperties } from "../types";
+import { WAMFileFormat, GameMapProperties } from "../types";
 import type { AreaChangeCallback } from "./GameMapAreas";
 import { GameMapAreas } from "./GameMapAreas";
 import { flattenGroupLayersMap } from "./LayersFlattener";
@@ -70,13 +70,10 @@ export class GameMap {
         }
     }
 
-    public async initialize(entitiesPrefabsPromise?: Promise<Map<string, EntityPrefab>>): Promise<void> {
+    public initialize(): void {
         if (this.wam) {
             this.gameMapAreas = new GameMapAreas(this.wam);
             this.gameMapEntities = new GameMapEntities(this.wam);
-            if (entitiesPrefabsPromise) {
-                await this.gameMapEntities.initialize(entitiesPrefabsPromise);
-            }
         }
     }
 

--- a/libs/map-editor/src/types.ts
+++ b/libs/map-editor/src/types.ts
@@ -1,20 +1,4 @@
 import { z } from "zod";
-import type { CreateAreaCommandConfig } from "./Commands/Area/CreateAreaCommand";
-import type { DeleteAreaCommandConfig } from "./Commands/Area/DeleteAreaCommand";
-import type { UpdateAreaCommandConfig } from "./Commands/Area/UpdateAreaCommand";
-import type { CreateEntityCommandConfig } from "./Commands/Entity/CreateEntityCommand";
-import type { DeleteEntityCommandConfig } from "./Commands/Entity/DeleteEntityCommand";
-import { UpdateEntityCommandConfig } from "./Commands/Entity/UpdateEntityCommand";
-import { UpdateWAMSettingCommandConfig } from "./Commands/WAM/UpdateWAMSettingCommand";
-
-export type CommandConfig =
-    | UpdateAreaCommandConfig
-    | DeleteAreaCommandConfig
-    | CreateAreaCommandConfig
-    | UpdateEntityCommandConfig
-    | CreateEntityCommandConfig
-    | DeleteEntityCommandConfig
-    | UpdateWAMSettingCommandConfig;
 
 export type AtLeast<T, K extends keyof T> = Partial<T> & Pick<T, K>;
 
@@ -188,6 +172,10 @@ export const MegaphoneSettings = z.object({
 
 export type MegaphoneSettings = z.infer<typeof MegaphoneSettings>;
 
+export const WAMSettings = z.object({
+    megaphone: MegaphoneSettings.optional(),
+});
+
 export const WAMFileFormat = z.object({
     version: z.string(),
     mapUrl: z.string(),
@@ -195,11 +183,7 @@ export const WAMFileFormat = z.object({
     areas: z.array(AreaData),
     entityCollections: z.array(CollectionUrl),
     lastCommandId: z.string().optional(),
-    settings: z
-        .object({
-            megaphone: MegaphoneSettings.optional(),
-        })
-        .optional(),
+    settings: WAMSettings.optional(),
     metadata: WAMMetadata.optional().describe("Contains metadata about the map (name, description, copyright, etc.)"),
     vendor: WAMVendor.optional(),
 });
@@ -236,6 +220,7 @@ export type JitsiRoomConfigData = z.infer<typeof JitsiRoomConfigData>;
 export type JitsiRoomPropertyData = z.infer<typeof JitsiRoomPropertyData>;
 export type PlayAudioPropertyData = z.infer<typeof PlayAudioPropertyData>;
 export type OpenWebsitePropertyData = z.infer<typeof OpenWebsitePropertyData>;
+export type WAMSettings = z.infer<typeof WAMSettings>;
 export type WAMFileFormat = z.infer<typeof WAMFileFormat>;
 export type MapsCacheSingleMapFormat = z.infer<typeof MapsCacheSingleMapFormat>;
 export type MapsCacheFileFormat = z.infer<typeof MapsCacheFileFormat>;

--- a/libs/map-editor/src/types.ts
+++ b/libs/map-editor/src/types.ts
@@ -128,6 +128,11 @@ export const EntityPrefab = EntityRawPrefab.extend({
     id: z.string(),
 });
 
+export const EntityPrefabRef = z.object({
+    collectionName: z.string(),
+    id: z.string(),
+});
+
 export const EntityCollection = z.object({
     collectionName: z.string(),
     tags: z.array(z.string()),
@@ -140,10 +145,11 @@ export const EntityData = z.object({
     y: z.number(),
     name: z.string().optional(),
     properties: EntityDataProperties.optional(),
-    prefab: EntityPrefab,
+    prefab: EntityRawPrefab,
+    prefabRef: EntityPrefabRef,
 });
 
-export const WAMEntityData = EntityData.omit({ prefab: true }).extend({ prefabId: z.string() });
+export const WAMEntityData = EntityData.omit({ prefab: true });
 export type WAMEntityData = z.infer<typeof WAMEntityData>;
 
 export const WAMMetadata = z.object({

--- a/map-storage/src/MapStorageServer.ts
+++ b/map-storage/src/MapStorageServer.ts
@@ -185,18 +185,9 @@ const mapStorageServer: MapStorageServer = {
                             type: "CreateEntityCommand",
                             entityData: {
                                 id: message.id,
-                                // Mock Prefab is being used only on map-storage side where we do not have access to Entity Prefabs data.
-                                // Currently we are not validating anything against entityPrefab data so it is safe for now.
-                                prefab: {
+                                prefabRef: {
                                     id: message.prefabId,
                                     collectionName: message.collectionName,
-                                    color: "mock",
-                                    direction: "Down",
-                                    imagePath: "",
-                                    name: "MockPrefab",
-                                    tags: ["mock"],
-                                    collisionGrid: [],
-                                    depthOffset: 0,
                                 },
                                 x: message.x,
                                 y: message.y,

--- a/map-storage/src/MapStorageServer.ts
+++ b/map-storage/src/MapStorageServer.ts
@@ -1,5 +1,17 @@
 import { sendUnaryData, ServerUnaryCall } from "@grpc/grpc-js";
-import { AreaData, AtLeast, EntityData, EntityDataProperties } from "@workadventure/map-editor";
+import {
+    AreaData,
+    AtLeast,
+    CreateAreaCommand,
+    CreateEntityCommand,
+    DeleteAreaCommand,
+    DeleteEntityCommand,
+    EntityData,
+    EntityDataProperties,
+    UpdateAreaCommand,
+    UpdateEntityCommand,
+    UpdateWAMSettingCommand,
+} from "@workadventure/map-editor";
 import {
     EditMapCommandMessage,
     EditMapCommandsArrayMessage,
@@ -79,12 +91,12 @@ const mapStorageServer: MapStorageServer = {
         call: ServerUnaryCall<EditMapCommandWithKeyMessage, Empty>,
         callback: sendUnaryData<EditMapCommandMessage>
     ): void {
-        const editMapCommandMessage = call.request.editMapCommandMessage;
-        if (!editMapCommandMessage || !editMapCommandMessage.editMapMessage?.message) {
-            callback({ name: "MapStorageError", message: "EditMapCommand message does not exist" }, null);
-            return;
-        }
-        try {
+        (async () => {
+            const editMapCommandMessage = call.request.editMapCommandMessage;
+            if (!editMapCommandMessage || !editMapCommandMessage.editMapMessage?.message) {
+                callback({ name: "MapStorageError", message: "EditMapCommand message does not exist" }, null);
+                return;
+            }
             // The mapKey is the complete URL to the map. Let's map it to our virtual path.
             const mapUrl = new URL(call.request.mapKey);
             const mapKey = mapPathUsingDomainWithPrefix(mapUrl.pathname, mapUrl.hostname);
@@ -111,13 +123,9 @@ const mapStorageServer: MapStorageServer = {
                     }
                     const area = gameMap.getGameMapAreas()?.getArea(message.id);
                     if (area) {
-                        mapsManager.executeCommand(
+                        await mapsManager.executeCommand(
                             mapKey,
-                            {
-                                type: "UpdateAreaCommand",
-                                dataToModify,
-                            },
-                            commandId
+                            new UpdateAreaCommand(gameMap, dataToModify, commandId)
                         );
                     } else {
                         console.log(`Could not find area with id: ${message.id}`);
@@ -130,26 +138,15 @@ const mapStorageServer: MapStorageServer = {
                         ...message,
                         visible: true,
                     };
-                    mapsManager.executeCommand(
+                    await mapsManager.executeCommand(
                         mapKey,
-                        {
-                            areaObjectConfig,
-                            type: "CreateAreaCommand",
-                        },
-                        commandId
+                        new CreateAreaCommand(gameMap, areaObjectConfig, commandId)
                     );
                     break;
                 }
                 case "deleteAreaMessage": {
                     const message = editMapMessage.deleteAreaMessage;
-                    mapsManager.executeCommand(
-                        mapKey,
-                        {
-                            type: "DeleteAreaCommand",
-                            id: message.id,
-                        },
-                        commandId
-                    );
+                    await mapsManager.executeCommand(mapKey, new DeleteAreaCommand(gameMap, message.id, commandId));
                     break;
                 }
                 case "modifyEntityMessage": {
@@ -164,13 +161,9 @@ const mapStorageServer: MapStorageServer = {
                     }
                     const entity = gameMap.getGameMapEntities()?.getEntity(message.id);
                     if (entity) {
-                        mapsManager.executeCommand(
+                        await mapsManager.executeCommand(
                             mapKey,
-                            {
-                                type: "UpdateEntityCommand",
-                                dataToModify,
-                            },
-                            commandId
+                            new UpdateEntityCommand(gameMap, dataToModify, commandId)
                         );
                     } else {
                         console.log(`Could not find entity with id: ${message.id}`);
@@ -179,11 +172,11 @@ const mapStorageServer: MapStorageServer = {
                 }
                 case "createEntityMessage": {
                     const message = editMapMessage.createEntityMessage;
-                    mapsManager.executeCommand(
+                    await mapsManager.executeCommand(
                         mapKey,
-                        {
-                            type: "CreateEntityCommand",
-                            entityData: {
+                        new CreateEntityCommand(
+                            gameMap,
+                            {
                                 id: message.id,
                                 prefabRef: {
                                     id: message.prefabId,
@@ -193,34 +186,23 @@ const mapStorageServer: MapStorageServer = {
                                 y: message.y,
                                 properties: message.properties as EntityDataProperties,
                             },
-                        },
-                        commandId
+                            commandId
+                        )
                     );
                     break;
                 }
                 case "deleteEntityMessage": {
                     const message = editMapMessage.deleteEntityMessage;
-                    mapsManager.executeCommand(
-                        mapKey,
-                        {
-                            type: "DeleteEntityCommand",
-                            id: message.id,
-                        },
-                        commandId
-                    );
+                    await mapsManager.executeCommand(mapKey, new DeleteEntityCommand(gameMap, message.id, commandId));
                     break;
                 }
-                case "updateMegaphoneSettingMessage": {
-                    const message = editMapMessage.updateMegaphoneSettingMessage;
-                    mapsManager.executeCommand(
-                        mapKey,
-                        {
-                            type: "UpdateWAMSettingCommand",
-                            name: "megaphone",
-                            dataToModify: message,
-                        },
-                        commandId
-                    );
+                case "updateWAMSettingsMessage": {
+                    const message = editMapMessage.updateWAMSettingsMessage;
+                    const wam = gameMap.getWam();
+                    if (!wam) {
+                        throw new Error("WAM is not defined");
+                    }
+                    await mapsManager.executeCommand(mapKey, new UpdateWAMSettingCommand(wam, message, commandId));
                     break;
                 }
                 default: {
@@ -230,7 +212,7 @@ const mapStorageServer: MapStorageServer = {
             // send edit map message back as a valid one
             mapsManager.addCommandToQueue(mapKey, editMapCommandMessage);
             callback(null, editMapCommandMessage);
-        } catch (e) {
+        })().catch((e: unknown) => {
             console.log(e);
             let message: string;
             if (typeof e === "object" && e !== null) {
@@ -239,7 +221,7 @@ const mapStorageServer: MapStorageServer = {
                 message = "Unknown error";
             }
             callback({ name: "MapStorageError", message }, null);
-        }
+        });
     },
 };
 

--- a/map-storage/src/MapsManager.ts
+++ b/map-storage/src/MapsManager.ts
@@ -1,16 +1,4 @@
-import {
-    Command,
-    CommandConfig,
-    GameMap,
-    UpdateAreaCommand,
-    DeleteAreaCommand,
-    UpdateEntityCommand,
-    CreateAreaCommand,
-    CreateEntityCommand,
-    DeleteEntityCommand,
-    UpdateWAMSettingCommand,
-    WAMFileFormat,
-} from "@workadventure/map-editor";
+import { Command, GameMap, WAMFileFormat } from "@workadventure/map-editor";
 import { EditMapCommandMessage } from "@workadventure/messages";
 import { ITiledMap } from "@workadventure/tiled-map-type-guard";
 import * as Sentry from "@sentry/node";
@@ -43,7 +31,7 @@ class MapsManager {
         this.mapLastChangeTimestamp = new Map<string, number>();
     }
 
-    public executeCommand(mapKey: string, commandConfig: CommandConfig, commandId?: string): void {
+    public async executeCommand(mapKey: string, command: Command): Promise<void> {
         const gameMap = this.getGameMap(mapKey);
         if (!gameMap) {
             throw new Error('Could not find GameMap with key "' + mapKey + '"');
@@ -52,52 +40,7 @@ class MapsManager {
         if (!this.saveMapIntervals.has(mapKey)) {
             this.startSavingMapInterval(mapKey, this.AUTO_SAVE_INTERVAL_MS);
         }
-        let command: Command | undefined;
-        switch (commandConfig.type) {
-            case "UpdateAreaCommand": {
-                command = new UpdateAreaCommand(gameMap, commandConfig, commandId);
-                command.execute();
-                break;
-            }
-            case "CreateAreaCommand": {
-                command = new CreateAreaCommand(gameMap, commandConfig, commandId);
-                command.execute();
-                break;
-            }
-            case "DeleteAreaCommand": {
-                command = new DeleteAreaCommand(gameMap, commandConfig, commandId);
-                command.execute();
-                break;
-            }
-            case "UpdateEntityCommand": {
-                command = new UpdateEntityCommand(gameMap, commandConfig, commandId);
-                command.execute();
-                break;
-            }
-            case "CreateEntityCommand": {
-                command = new CreateEntityCommand(gameMap, commandConfig, commandId);
-                command.execute();
-                break;
-            }
-            case "DeleteEntityCommand": {
-                command = new DeleteEntityCommand(gameMap, commandConfig, commandId);
-                command.execute();
-                break;
-            }
-            case "UpdateWAMSettingCommand": {
-                const wam = gameMap.getWam();
-                if (!wam) {
-                    throw new Error("WAM is not defined");
-                }
-                command = new UpdateWAMSettingCommand(wam, commandConfig, commandId);
-                command.execute();
-                break;
-            }
-            default: {
-                const _exhaustiveCheck: never = commandConfig;
-                break;
-            }
-        }
+        await command.execute();
     }
 
     public getCommandsNewerThan(mapKey: string, commandId: string): EditMapCommandMessage[] {

--- a/map-storage/src/MapsManager.ts
+++ b/map-storage/src/MapsManager.ts
@@ -124,9 +124,7 @@ class MapsManager {
 
     public loadWAMToMemory(key: string, wam: WAMFileFormat): void {
         const gameMap = new GameMap(this.getMockITiledMap(), wam);
-        gameMap.initialize().catch((err) => {
-            console.log(err);
-        });
+        gameMap.initialize();
         this.loadedMaps.set(key, gameMap);
     }
 

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -130,7 +130,13 @@ message EditMapMessage {
     ModifyEntityMessage modifyEntityMessage = 4;
     CreateEntityMessage createEntityMessage = 5;
     DeleteEntityMessage deleteEntityMessage = 6;
-    UpdateMegaphoneSettingMessage updateMegaphoneSettingMessage = 7;
+    UpdateWAMSettingsMessage updateWAMSettingsMessage = 7;
+  }
+}
+
+message UpdateWAMSettingsMessage {
+  oneof message {
+    UpdateMegaphoneSettingMessage updateMegaphoneSettingMessage = 1;
   }
 }
 

--- a/play/src/front/Components/Input/ButtonState.svelte
+++ b/play/src/front/Components/Input/ButtonState.svelte
@@ -17,7 +17,7 @@
             })
             .catch((result) => {
                 state = "error";
-                finalText = result;
+                finalText = result.toString();
             })
             .finally(() => {
                 setTimeout(() => {

--- a/play/src/front/Components/MapEditor/EntityPropertiesEditor.svelte
+++ b/play/src/front/Components/MapEditor/EntityPropertiesEditor.svelte
@@ -95,7 +95,7 @@
     {$LL.mapEditor.entityEditor.editInstructions()}
 {:else}
     <div class="header-container">
-        <h2>Editing: {$mapEditorSelectedEntityStore.getEntityData().prefab.name}</h2>
+        <h2>Editing: {$mapEditorSelectedEntityStore.getPrefab().name}</h2>
     </div>
     <div class="properties-buttons tw-flex tw-flex-row">
         <AddPropertyButton

--- a/play/src/front/Connexion/RoomConnection.ts
+++ b/play/src/front/Connexion/RoomConnection.ts
@@ -46,7 +46,7 @@ import {
     MegaphoneSettings,
 } from "@workadventure/messages";
 import { BehaviorSubject, Subject } from "rxjs";
-import type { AreaData, AtLeast, EntityData } from "@workadventure/map-editor";
+import type { AreaData, AtLeast, EntityData, WAMEntityData } from "@workadventure/map-editor";
 import { selectCharacterSceneVisibleStore } from "../Stores/SelectCharacterStore";
 import { gameManager } from "../Phaser/Game/GameManager";
 import { SelectCharacterScene, SelectCharacterSceneName } from "../Phaser/Login/SelectCharacterScene";
@@ -1174,7 +1174,7 @@ export class RoomConnection implements RoomConnection {
         });
     }
 
-    public emitMapEditorCreateEntity(commandId: string, config: EntityData): void {
+    public emitMapEditorCreateEntity(commandId: string, config: WAMEntityData): void {
         this.send({
             message: {
                 $case: "editMapCommandMessage",
@@ -1187,8 +1187,8 @@ export class RoomConnection implements RoomConnection {
                                 id: config.id,
                                 x: config.x,
                                 y: config.y,
-                                collectionName: config.prefab.collectionName,
-                                prefabId: config.prefab.id,
+                                collectionName: config.prefabRef.collectionName,
+                                prefabId: config.prefabRef.id,
                                 properties: config.properties ?? [],
                             },
                         },

--- a/play/src/front/Connexion/RoomConnection.ts
+++ b/play/src/front/Connexion/RoomConnection.ts
@@ -42,8 +42,8 @@ import {
     RemoveSpaceUserMessage,
     WatchSpaceMessage,
     SpaceFilterMessage,
-    UpdateMegaphoneSettingMessage,
     MegaphoneSettings,
+    UpdateWAMSettingsMessage,
 } from "@workadventure/messages";
 import { BehaviorSubject, Subject } from "rxjs";
 import type { AreaData, AtLeast, EntityData, WAMEntityData } from "@workadventure/map-editor";
@@ -1097,10 +1097,7 @@ export class RoomConnection implements RoomConnection {
         });
     }
 
-    public emitUpdateMegaphoneSettingMessage(
-        commandId: string,
-        updateMegaphoneSettingMessage: UpdateMegaphoneSettingMessage
-    ) {
+    public emitUpdateWAMSettingMessage(commandId: string, updateWAMSettingsMessage: UpdateWAMSettingsMessage) {
         this.send({
             message: {
                 $case: "editMapCommandMessage",
@@ -1108,8 +1105,8 @@ export class RoomConnection implements RoomConnection {
                     id: commandId,
                     editMapMessage: {
                         message: {
-                            $case: "updateMegaphoneSettingMessage",
-                            updateMegaphoneSettingMessage,
+                            $case: "updateWAMSettingsMessage",
+                            updateWAMSettingsMessage,
                         },
                     },
                 },

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -11,6 +11,7 @@ import type {
 import type { Observable } from "rxjs";
 import { Subject } from "rxjs";
 import { MathUtils } from "@workadventure/math-utils";
+import { Deferred } from "ts-deferred";
 import { PathTileType } from "../../../Utils/PathfindingManager";
 import { DEPTH_OVERLAY_INDEX } from "../DepthIndexes";
 import type { GameScene } from "../GameScene";
@@ -25,7 +26,6 @@ export type DynamicArea = {
     height: number;
     properties: { [key: string]: unknown };
 };
-import { EntitiesCollectionsManager } from "../MapEditor/EntitiesCollectionsManager";
 import { EntitiesManager } from "./EntitiesManager";
 import TilemapLayer = Phaser.Tilemaps.TilemapLayer;
 
@@ -110,12 +110,13 @@ export class GameMapFrontWrapper {
      */
     private readonly existingTileIndex;
 
+    public readonly initializedPromise = new Deferred<void>();
+
     constructor(
         scene: GameScene,
         gameMap: GameMap,
         phaserMap: Phaser.Tilemaps.Tilemap,
-        terrains: Array<Phaser.Tilemaps.Tileset>,
-        entitiesCollectionsManager: EntitiesCollectionsManager
+        terrains: Array<Phaser.Tilemaps.Tileset>
     ) {
         this.scene = scene;
         this.gameMap = gameMap;
@@ -126,11 +127,6 @@ export class GameMapFrontWrapper {
         this.entitiesManager = new EntitiesManager(this.scene, this);
 
         this.gameMap.initialize();
-
-        // Spawn first entities from WAM file on the map
-        for (const entityData of this.gameMap.getGameMapEntities()?.getEntities() ?? []) {
-            this.entitiesManager.addEntity(entityData).catch((e) => console.error(e));
-        }
 
         this.updateCollisionGrid(undefined, false);
 
@@ -177,6 +173,20 @@ export class GameMapFrontWrapper {
 
         this.phaserLayers.push(this.entitiesCollisionLayer);
         this.updateCollisionGrid(undefined, false);
+    }
+
+    public initialize(): Promise<void> {
+        // Spawn first entities from WAM file on the map
+        const addEntityPromises: Promise<Entity>[] = [];
+        for (const entityData of this.gameMap.getGameMapEntities()?.getEntities() ?? []) {
+            addEntityPromises.push(this.entitiesManager.addEntity(entityData));
+            // We need to AWAIT for all entities to be created.
+            // OTHERWISE, delete commands might pass FIRST!
+        }
+
+        return Promise.all(addEntityPromises).then(() => {
+            this.initializedPromise.resolve();
+        });
     }
 
     public setLayerVisibility(layerName: string, visible: boolean): void {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -637,9 +637,9 @@ export class GameScene extends DirtyScene {
             this,
             new GameMap(this.mapFile, this.wamFile),
             this.Map,
-            this.Terrains,
-            this.entitiesCollectionsManager
+            this.Terrains
         );
+        const entitiesInitializedPromise = this.gameMapFrontWrapper.initialize();
         for (const layer of this.gameMapFrontWrapper.getFlatLayers()) {
             if (layer.type === "tilelayer") {
                 const exitSceneUrl = this.getExitSceneUrl(layer);
@@ -847,6 +847,7 @@ export class GameScene extends DirtyScene {
             this.connectionAnswerPromiseDeferred.promise as Promise<unknown>,
             ...scriptPromises,
             this.CurrentPlayer.getTextureLoadedPromise() as Promise<unknown>,
+            entitiesInitializedPromise,
         ])
             .then(() => {
                 this.hide(false);
@@ -892,12 +893,12 @@ export class GameScene extends DirtyScene {
                 get(availabilityStatusStore),
                 this.getGameMap().getLastCommandId()
             )
-            .then((onConnect: OnConnectInterface) => {
+            .then(async (onConnect: OnConnectInterface) => {
                 this.connection = onConnect.connection;
                 this.mapEditorModeManager?.subscribeToRoomConnection(this.connection);
                 const commandsToApply = onConnect.room.commandsToApply;
                 if (commandsToApply) {
-                    this.mapEditorModeManager?.updateMapToNewest(commandsToApply);
+                    await this.mapEditorModeManager?.updateMapToNewest(commandsToApply);
                 }
 
                 this.tryOpenMapEditorWithToolEditorParameter();
@@ -1991,8 +1992,7 @@ ${escapedMessage}
                                 this,
                                 new GameMap(this.mapFile, this.wamFile),
                                 this.Map,
-                                this.Terrains,
-                                this.entitiesCollectionsManager.getEntitiesPrefabsMap()
+                                this.Terrains
                             );
                             // Unsubscribe if needed and subscribe to GameMapChanged event again
                             this.subscribeToGameMapChanged();

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Area/CreateAreaFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Area/CreateAreaFrontCommand.ts
@@ -1,0 +1,32 @@
+import { AreaData, CreateAreaCommand, GameMap } from "@workadventure/map-editor";
+import { AreaEditorTool } from "../../Tools/AreaEditorTool";
+import { FrontCommandInterface } from "../FrontCommandInterface";
+import { RoomConnection } from "../../../../../Connexion/RoomConnection";
+import { DeleteAreaFrontCommand } from "./DeleteAreaFrontCommand";
+
+export class CreateAreaFrontCommand extends CreateAreaCommand implements FrontCommandInterface {
+    constructor(
+        gameMap: GameMap,
+        areaObjectConfig: AreaData,
+        commandId: string | undefined,
+        private areaEditorTool: AreaEditorTool,
+        private localCommand: boolean
+    ) {
+        super(gameMap, areaObjectConfig, commandId);
+    }
+
+    public async execute(): Promise<void> {
+        const returnVal = super.execute();
+        this.areaEditorTool.handleAreaPreviewCreation(this.areaConfig, this.localCommand);
+
+        return returnVal;
+    }
+
+    public getUndoCommand(): DeleteAreaFrontCommand {
+        return new DeleteAreaFrontCommand(this.gameMap, this.areaConfig.id, undefined, this.areaEditorTool, false);
+    }
+
+    public emitEvent(roomConnection: RoomConnection): void {
+        roomConnection.emitMapEditorCreateArea(this.id, this.areaConfig);
+    }
+}

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Area/DeleteAreaFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Area/DeleteAreaFrontCommand.ts
@@ -1,0 +1,32 @@
+import { DeleteAreaCommand, GameMap } from "@workadventure/map-editor";
+import { AreaEditorTool } from "../../Tools/AreaEditorTool";
+import { FrontCommandInterface } from "../FrontCommandInterface";
+import { RoomConnection } from "../../../../../Connexion/RoomConnection";
+import { CreateAreaFrontCommand } from "./CreateAreaFrontCommand";
+
+export class DeleteAreaFrontCommand extends DeleteAreaCommand implements FrontCommandInterface {
+    constructor(
+        gameMap: GameMap,
+        id: string,
+        commandId: string | undefined,
+        private areaEditorTool: AreaEditorTool,
+        private localCommand: boolean
+    ) {
+        super(gameMap, id, commandId);
+    }
+
+    public async execute(): Promise<void> {
+        const returnVal = super.execute();
+        this.areaEditorTool.handleAreaPreviewDeletion(this.areaConfig.id);
+
+        return returnVal;
+    }
+
+    public getUndoCommand(): CreateAreaFrontCommand {
+        return new CreateAreaFrontCommand(this.gameMap, this.areaConfig, undefined, this.areaEditorTool, false);
+    }
+
+    public emitEvent(roomConnection: RoomConnection): void {
+        roomConnection.emitMapEditorDeleteArea(this.id, this.areaConfig.id);
+    }
+}

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Area/UpdateAreaFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Area/UpdateAreaFrontCommand.ts
@@ -1,0 +1,31 @@
+import { AreaData, AtLeast, GameMap, UpdateAreaCommand } from "@workadventure/map-editor";
+import { AreaEditorTool } from "../../Tools/AreaEditorTool";
+import { FrontCommandInterface } from "../FrontCommandInterface";
+import { RoomConnection } from "../../../../../Connexion/RoomConnection";
+
+export class UpdateAreaFrontCommand extends UpdateAreaCommand implements FrontCommandInterface {
+    constructor(
+        gameMap: GameMap,
+        dataToModify: AtLeast<AreaData, "id">,
+        commandId: string | undefined,
+        oldConfig: AtLeast<AreaData, "id"> | undefined,
+        private areaEditorTool: AreaEditorTool
+    ) {
+        super(gameMap, dataToModify, commandId, oldConfig);
+    }
+
+    public async execute(): Promise<void> {
+        const returnVal = super.execute();
+        this.areaEditorTool.handleAreaPreviewUpdate(this.newConfig);
+
+        return returnVal;
+    }
+
+    public getUndoCommand(): UpdateAreaFrontCommand {
+        return new UpdateAreaFrontCommand(this.gameMap, this.oldConfig, undefined, this.newConfig, this.areaEditorTool);
+    }
+
+    public emitEvent(roomConnection: RoomConnection): void {
+        roomConnection.emitMapEditorModifyArea(this.id, this.newConfig);
+    }
+}

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Entity/CreateEntityFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Entity/CreateEntityFrontCommand.ts
@@ -1,0 +1,31 @@
+import { Command, CreateEntityCommand, GameMap, WAMEntityData } from "@workadventure/map-editor";
+import { EntitiesManager } from "../../../GameMap/EntitiesManager";
+import { FrontCommandInterface } from "../FrontCommandInterface";
+import { RoomConnection } from "../../../../../Connexion/RoomConnection";
+import { DeleteEntityFrontCommand } from "./DeleteEntityFrontCommand";
+
+export class CreateEntityFrontCommand extends CreateEntityCommand implements FrontCommandInterface {
+    constructor(
+        gameMap: GameMap,
+        entityData: WAMEntityData,
+        commandId: string | undefined,
+        private entitiesManager: EntitiesManager
+    ) {
+        super(gameMap, entityData, commandId);
+    }
+
+    public async execute(): Promise<void> {
+        const returnVal = super.execute();
+        await this.entitiesManager.addEntity(structuredClone(this.entityData), undefined, true);
+
+        return returnVal;
+    }
+
+    public getUndoCommand(): Command & DeleteEntityFrontCommand {
+        return new DeleteEntityFrontCommand(this.gameMap, this.entityData.id, undefined, this.entitiesManager);
+    }
+
+    public emitEvent(roomConnection: RoomConnection): void {
+        roomConnection.emitMapEditorCreateEntity(this.id, this.entityData);
+    }
+}

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Entity/DeleteEntityFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Entity/DeleteEntityFrontCommand.ts
@@ -1,0 +1,24 @@
+import { Command, DeleteEntityCommand, GameMap } from "@workadventure/map-editor";
+import { EntitiesManager } from "../../../GameMap/EntitiesManager";
+import { FrontCommandInterface } from "../FrontCommandInterface";
+import { RoomConnection } from "../../../../../Connexion/RoomConnection";
+import { CreateEntityFrontCommand } from "./CreateEntityFrontCommand";
+
+export class DeleteEntityFrontCommand extends DeleteEntityCommand implements FrontCommandInterface {
+    constructor(gameMap: GameMap, id: string, commandId: string | undefined, private entitiesManager: EntitiesManager) {
+        super(gameMap, id, commandId);
+    }
+
+    public execute(): Promise<void> {
+        this.entitiesManager.deleteEntity(this.entityData.id);
+        return super.execute();
+    }
+
+    public getUndoCommand(): Command & CreateEntityFrontCommand {
+        return new CreateEntityFrontCommand(this.gameMap, this.entityData, undefined, this.entitiesManager);
+    }
+
+    public emitEvent(roomConnection: RoomConnection): void {
+        roomConnection.emitMapEditorDeleteEntity(this.id, this.entityData.id);
+    }
+}

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Entity/UpdateEntityFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Entity/UpdateEntityFrontCommand.ts
@@ -1,0 +1,60 @@
+import { AtLeast, Command, EntityData, GameMap, UpdateEntityCommand } from "@workadventure/map-editor";
+import { EntitiesManager } from "../../../GameMap/EntitiesManager";
+import { Entity } from "../../../../ECS/Entity";
+import { GameScene } from "../../../GameScene";
+import { FrontCommandInterface } from "../FrontCommandInterface";
+import { RoomConnection } from "../../../../../Connexion/RoomConnection";
+
+export class UpdateEntityFrontCommand extends UpdateEntityCommand implements FrontCommandInterface {
+    constructor(
+        gameMap: GameMap,
+        dataToModify: AtLeast<EntityData, "id">,
+        commandId: string | undefined,
+        oldConfig: AtLeast<EntityData, "id"> | undefined,
+        private entitiesManager: EntitiesManager,
+        private scene: GameScene
+    ) {
+        super(gameMap, dataToModify, commandId, oldConfig);
+    }
+
+    public execute(): Promise<void> {
+        const returnVal = super.execute();
+        this.handleEntityUpdate(this.newConfig);
+
+        return returnVal;
+    }
+
+    private handleEntityUpdate(config: AtLeast<EntityData, "id">): void {
+        const entity = this.entitiesManager.getEntities().get(config.id);
+        if (!entity) {
+            return;
+        }
+        const { x: oldX, y: oldY } = entity.getOldPosition();
+        entity?.updateEntity(config);
+        this.updateCollisionGrid(entity, oldX, oldY);
+        this.scene.markDirty();
+    }
+
+    private updateCollisionGrid(entity: Entity, oldX: number, oldY: number): void {
+        const reversedGrid = entity.getReversedCollisionGrid();
+        const grid = entity.getCollisionGrid();
+        if (reversedGrid && grid) {
+            this.scene.getGameMapFrontWrapper().modifyToCollisionsLayer(oldX, oldY, "0", reversedGrid);
+            this.scene.getGameMapFrontWrapper().modifyToCollisionsLayer(entity.x, entity.y, "0", grid);
+        }
+    }
+
+    public getUndoCommand(): Command & FrontCommandInterface {
+        return new UpdateEntityFrontCommand(
+            this.gameMap,
+            this.oldConfig,
+            undefined,
+            this.newConfig,
+            this.entitiesManager,
+            this.scene
+        );
+    }
+    public emitEvent(roomConnection: RoomConnection): void {
+        roomConnection.emitMapEditorModifyEntity(this.id, this.newConfig);
+    }
+}

--- a/play/src/front/Phaser/Game/MapEditor/Commands/Facades.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/Facades.ts
@@ -1,0 +1,25 @@
+import type { UpdateWAMSettingsMessage } from "@workadventure/messages";
+import { gameManager } from "../../GameManager";
+import { UpdateWAMSettingFrontCommand } from "./WAM/UpdateWAMSettingFrontCommand";
+
+/**
+ * A simple facade function that creates a UpdateWAMSettingFrontCommand and executes it.
+ */
+export async function executeUpdateWAMSettings(
+    updateWAMSettingsMessage: UpdateWAMSettingsMessage["message"]
+): Promise<void> {
+    const wamFile = gameManager.getCurrentGameScene().getGameMap().getWam();
+    if (!wamFile) {
+        return;
+    }
+    await gameManager
+        .getCurrentGameScene()
+        .getMapEditorModeManager()
+        .executeCommand(
+            new UpdateWAMSettingFrontCommand(wamFile, {
+                message: updateWAMSettingsMessage,
+            }),
+            true,
+            false
+        );
+}

--- a/play/src/front/Phaser/Game/MapEditor/Commands/FrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/FrontCommand.ts
@@ -1,0 +1,4 @@
+import { Command } from "@workadventure/map-editor";
+import { FrontCommandInterface } from "./FrontCommandInterface";
+
+export type FrontCommand = Command & FrontCommandInterface;

--- a/play/src/front/Phaser/Game/MapEditor/Commands/FrontCommandInterface.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/FrontCommandInterface.ts
@@ -1,0 +1,11 @@
+import { Command } from "@workadventure/map-editor";
+import { RoomConnection } from "../../../../Connexion/RoomConnection";
+
+/**
+ * Commands implementing this interface will be able to emit an event to the Pusher and generate an undo command
+ */
+export interface FrontCommandInterface {
+    getUndoCommand(): Command & FrontCommandInterface;
+
+    emitEvent(roomConnection: RoomConnection): void;
+}

--- a/play/src/front/Phaser/Game/MapEditor/Commands/WAM/UpdateWAMSettingFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/WAM/UpdateWAMSettingFrontCommand.ts
@@ -1,0 +1,29 @@
+import { UpdateWAMSettingCommand } from "@workadventure/map-editor";
+import { FrontCommandInterface } from "../FrontCommandInterface";
+import { RoomConnection } from "../../../../../Connexion/RoomConnection";
+
+export class UpdateWAMSettingFrontCommand extends UpdateWAMSettingCommand implements FrontCommandInterface {
+    public getUndoCommand(): UpdateWAMSettingFrontCommand {
+        if (
+            this.updateWAMSettingsMessage.message?.$case === "updateMegaphoneSettingMessage" &&
+            this.wam.settings?.megaphone
+        ) {
+            return new UpdateWAMSettingFrontCommand(this.wam, {
+                message: {
+                    $case: "updateMegaphoneSettingMessage",
+                    updateMegaphoneSettingMessage: {
+                        ...this.wam.settings?.megaphone,
+                        scope: this.wam.settings?.megaphone.scope ?? "",
+                        rights: this.wam.settings?.megaphone.rights ?? [],
+                    },
+                },
+            });
+        }
+
+        return this;
+    }
+
+    public emitEvent(roomConnection: RoomConnection): void {
+        roomConnection.emitUpdateWAMSettingMessage(this.id, this.updateWAMSettingsMessage);
+    }
+}

--- a/play/src/front/Phaser/Game/MapEditor/EntitiesCollectionsManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/EntitiesCollectionsManager.ts
@@ -30,10 +30,14 @@ export class EntitiesCollectionsManager {
         return this.entitiesPrefabsMapPromise;
     }
 
-    public getEntityPrefab(collectionName: string, entityPrefabId: string): EntityPrefab | undefined {
-        return this.entitiesPrefabs.find(
+    public async getEntityPrefab(collectionName: string, entityPrefabId: string): Promise<EntityPrefab | undefined> {
+        const prefabsMap = await this.entitiesPrefabsMapPromise;
+        return prefabsMap.get(entityPrefabId);
+
+        // FIXME: remove the find from here. Too slow
+        /*return this.entitiesPrefabs.find(
             (prefab) => prefab.collectionName === collectionName && prefab.id === entityPrefabId
-        );
+        );*/
     }
 
     public setFilter(filter: string, isTag = false) {

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -1,15 +1,5 @@
-import {
-    CommandConfig,
-    Command,
-    UpdateEntityCommand,
-    UpdateAreaCommand,
-    CreateAreaCommand,
-    DeleteAreaCommand,
-    UpdateWAMSettingCommand,
-} from "@workadventure/map-editor";
+import { Command, UpdateWAMSettingCommand } from "@workadventure/map-editor";
 import { Unsubscriber, get } from "svelte/store";
-import { CreateEntityCommand } from "@workadventure/map-editor/src/Commands/Entity/CreateEntityCommand";
-import { DeleteEntityCommand } from "@workadventure/map-editor/src/Commands/Entity/DeleteEntityCommand";
 import { EditMapCommandMessage } from "@workadventure/messages";
 import type { RoomConnection } from "../../../Connexion/RoomConnection";
 import type { GameScene } from "../GameScene";
@@ -19,6 +9,8 @@ import type { MapEditorTool } from "./Tools/MapEditorTool";
 import { FloorEditorTool } from "./Tools/FloorEditorTool";
 import { EntityEditorTool } from "./Tools/EntityEditorTool";
 import { WAMSettingsEditorTool } from "./Tools/WAMSettingsEditorTool";
+import { FrontCommandInterface } from "./Commands/FrontCommandInterface";
+import { FrontCommand } from "./Commands/FrontCommand";
 
 export enum EditorToolName {
     AreaEditor = "AreaEditor",
@@ -52,12 +44,12 @@ export class MapEditorModeManager {
     /**
      * We are making use of CommandPattern to implement an Undo-Redo mechanism
      */
-    private localCommandsHistory: Command[];
+    private localCommandsHistory: FrontCommand[];
 
     /**
      * Commands sent by us that are still to be acknowledged by the server
      */
-    private pendingCommands: Command[];
+    private pendingCommands: FrontCommand[];
     /**
      * Which command was called most recently
      */
@@ -91,95 +83,63 @@ export class MapEditorModeManager {
 
         this.subscribeToStores();
         this.subscribeToGameMapFrontWrapperEvents();
+
+        this.currentRunningCommand = this.scene.getGameMapFrontWrapper().initializedPromise.promise;
     }
 
     public update(time: number, dt: number): void {
         this.currentlyActiveTool?.update(time, dt);
     }
 
+    private currentRunningCommand: Promise<void>;
+
     /**
      * Creates new Command object from given command config and executes it, both local and from the back.
-     * @param commandConfig what to execute
+     * @param command what to execute
      * @param emitMapEditorUpdate Should the command be emitted further to the game room? Default true.
      * (for example if command came from the back)
      * @param addToLocalCommandsHistory Should the command be added to the local commands history to be used in undo/redo mechanism? Default true.
      */
-    public executeCommand(
-        commandConfig: CommandConfig,
+    public async executeCommand(
+        command: Command & FrontCommandInterface,
         emitMapEditorUpdate = true,
-        addToLocalCommandsHistory = true,
-        commandId?: string
-    ): boolean {
-        let command: Command;
-        const delay = 0;
-        try {
-            switch (commandConfig.type) {
-                case "UpdateAreaCommand": {
-                    command = new UpdateAreaCommand(this.scene.getGameMap(), commandConfig, commandId);
-                    break;
+        addToLocalCommandsHistory = true
+    ): Promise<void> {
+        // Commands are throttled. Only one at a time.
+        return (this.currentRunningCommand = this.currentRunningCommand.then(async () => {
+            const delay = 0;
+            try {
+                // We do an execution instantly so there will be no lag from user's perspective
+                await command.execute();
+
+                if (emitMapEditorUpdate) {
+                    this.emitMapEditorUpdate(command, delay);
                 }
-                case "CreateAreaCommand": {
-                    command = new CreateAreaCommand(this.scene.getGameMap(), commandConfig, commandId);
-                    break;
+
+                // FIXME: why the exception here regarding UpdateWAMSettingCommand ?
+                if (addToLocalCommandsHistory && !(command instanceof UpdateWAMSettingCommand)) {
+                    // if we are not at the end of commands history and perform an action, get rid of commands later in history than our current point in time
+                    if (this.currentCommandIndex !== this.localCommandsHistory.length - 1) {
+                        this.localCommandsHistory.splice(this.currentCommandIndex + 1);
+                    }
+                    this.pendingCommands.push(command);
+                    this.localCommandsHistory.push(command);
+                    this.currentCommandIndex += 1;
                 }
-                case "DeleteAreaCommand": {
-                    command = new DeleteAreaCommand(this.scene.getGameMap(), commandConfig, commandId);
-                    break;
-                }
-                case "UpdateEntityCommand": {
-                    command = new UpdateEntityCommand(this.scene.getGameMap(), commandConfig, commandId);
-                    break;
-                }
-                case "CreateEntityCommand": {
-                    command = new CreateEntityCommand(this.scene.getGameMap(), commandConfig, commandId);
-                    break;
-                }
-                case "DeleteEntityCommand": {
-                    command = new DeleteEntityCommand(this.scene.getGameMap(), commandConfig, commandId);
-                    break;
-                }
-                case "UpdateWAMSettingCommand": {
-                    command = new UpdateWAMSettingCommand(this.scene.wamFile, commandConfig, commandId);
-                    break;
-                }
-                default: {
-                    const _exhaustiveCheck: never = commandConfig;
-                    return false;
-                }
+
+                this.scene.getGameMap().updateLastCommandIdProperty(command.id);
+                return;
+                //return true;
+            } catch (error) {
+                console.warn(error);
+                //return false;
+                return;
             }
-            if (!command) {
-                return false;
-            }
-            // We do an execution instantly so there will be no lag from user's perspective
-            const executedCommandConfig = command.execute();
-
-            // FIXME: in case of delete, command.execute removes the ID BEFORE handleCommandExecutionByTools is triggered. That's bad.
-            // TODO: maybe the tools should be passed in parameter of the command being created.
-
-            // do any necessary changes for active tool interface
-            this.handleCommandExecutionByTools(executedCommandConfig, emitMapEditorUpdate);
-
-            if (emitMapEditorUpdate) {
-                this.emitMapEditorUpdate(command.id, commandConfig, delay);
-            }
-
-            if (addToLocalCommandsHistory && !(command instanceof UpdateWAMSettingCommand)) {
-                // if we are not at the end of commands history and perform an action, get rid of commands later in history than our current point in time
-                if (this.currentCommandIndex !== this.localCommandsHistory.length - 1) {
-                    this.localCommandsHistory.splice(this.currentCommandIndex + 1);
-                }
-                this.pendingCommands.push(command);
-                this.localCommandsHistory.push(command);
-                this.currentCommandIndex += 1;
-            }
-
-            this.scene.getGameMap().updateLastCommandIdProperty(command.id);
-            return true;
-        } catch (error) {
-            console.warn(error);
-            return false;
-        }
+        }));
     }
+
+    // A simple queue to be sure we run only one undo or redo at once.
+    private runningUndoRedoCommand: Promise<void> = Promise.resolve();
 
     public undoCommand(): void {
         if (this.localCommandsHistory.length === 0 || this.currentCommandIndex === -1) {
@@ -187,14 +147,14 @@ export class MapEditorModeManager {
         }
         try {
             const command = this.localCommandsHistory[this.currentCommandIndex];
-            const commandConfig = command.undo();
+            const undoCommand1 = command.getUndoCommand();
             this.pendingCommands.push(command);
 
             // do any necessary changes for active tool interface
-            this.handleCommandExecutionByTools(commandConfig, true);
+            //this.handleCommandExecutionByTools(undoCommand1, true);
 
             // this should not be called with every change. Use some sort of debounce
-            this.emitMapEditorUpdate(`${command.id}`, commandConfig);
+            this.emitMapEditorUpdate(undoCommand1);
             this.currentCommandIndex -= 1;
         } catch (e) {
             this.localCommandsHistory.splice(this.currentCommandIndex, 1);
@@ -212,14 +172,14 @@ export class MapEditorModeManager {
         }
         try {
             const command = this.localCommandsHistory[this.currentCommandIndex + 1];
-            const commandConfig = command.execute();
+            //const commandConfig = await command.execute();
             this.pendingCommands.push(command);
 
             // do any necessary changes for active tool interface
-            this.handleCommandExecutionByTools(commandConfig, true);
+            //this.handleCommandExecutionByTools(commandConfig, true);
 
             // this should not be called with every change. Use some sort of debounce
-            this.emitMapEditorUpdate(command.id, commandConfig);
+            this.emitMapEditorUpdate(command);
             this.currentCommandIndex += 1;
         } catch (e) {
             this.localCommandsHistory.splice(this.currentCommandIndex, 1);
@@ -232,13 +192,13 @@ export class MapEditorModeManager {
      * Update local map with missing commands given from the map-storage on RoomJoinedEvent. This commands
      * are applied locally and are not being send further.
      */
-    public updateMapToNewest(commands: EditMapCommandMessage[]): void {
+    public async updateMapToNewest(commands: EditMapCommandMessage[]): Promise<void> {
         if (!commands) {
             return;
         }
         for (const command of commands) {
             for (const tool of Object.values(this.editorTools)) {
-                tool.handleIncomingCommandMessage(command);
+                await tool.handleIncomingCommandMessage(command);
             }
         }
     }
@@ -276,7 +236,19 @@ export class MapEditorModeManager {
             }
             case "z": {
                 if (this.ctrlKey?.isDown) {
-                    this.shiftKey?.isDown ? this.redoCommand() : this.undoCommand();
+                    if (this.shiftKey?.isDown) {
+                        this.runningUndoRedoCommand = this.runningUndoRedoCommand
+                            .then(() => {
+                                return this.redoCommand();
+                            })
+                            .catch((e) => console.error(e));
+                    } else {
+                        this.runningUndoRedoCommand = this.runningUndoRedoCommand
+                            .then(() => {
+                                return this.undoCommand();
+                            })
+                            .catch((e) => console.error(e));
+                    }
                 }
                 break;
             }
@@ -288,17 +260,19 @@ export class MapEditorModeManager {
 
     public subscribeToRoomConnection(connection: RoomConnection): void {
         connection.editMapCommandMessageStream.subscribe((editMapCommandMessage) => {
-            if (this.pendingCommands.length > 0) {
-                if (this.pendingCommands[0].id === editMapCommandMessage.id) {
-                    this.pendingCommands.shift();
-                    return;
+            (async () => {
+                if (this.pendingCommands.length > 0) {
+                    if (this.pendingCommands[0].id === editMapCommandMessage.id) {
+                        this.pendingCommands.shift();
+                        return;
+                    }
+                    this.revertPendingCommands();
                 }
-                this.revertPendingCommands();
-            }
 
-            for (const tool of Object.values(this.editorTools)) {
-                tool.handleIncomingCommandMessage(editMapCommandMessage);
-            }
+                for (const tool of Object.values(this.editorTools)) {
+                    await tool.handleIncomingCommandMessage(editMapCommandMessage);
+                }
+            })().catch((e) => console.error(e));
         });
     }
 
@@ -306,7 +280,7 @@ export class MapEditorModeManager {
         while (this.pendingCommands.length > 0) {
             const command = this.pendingCommands.pop();
             if (command) {
-                command.undo();
+                //await command.getUndoCommand();
                 // also remove from local history of commands as this is invalid
                 const index = this.localCommandsHistory.findIndex((localCommand) => localCommand.id === command.id);
                 if (index !== -1) {
@@ -330,37 +304,12 @@ export class MapEditorModeManager {
         mapEditorSelectedToolStore.set(tool);
     }
 
-    private emitMapEditorUpdate(commandId: string, commandConfig: CommandConfig, delay = 0): void {
+    private emitMapEditorUpdate(command: FrontCommandInterface, delay = 0): void {
         const func = () => {
-            switch (commandConfig.type) {
-                case "UpdateAreaCommand": {
-                    this.scene.connection?.emitMapEditorModifyArea(commandId, commandConfig.dataToModify);
-                    break;
-                }
-                case "CreateAreaCommand": {
-                    this.scene.connection?.emitMapEditorCreateArea(commandId, commandConfig.areaObjectConfig);
-                    break;
-                }
-                case "DeleteAreaCommand": {
-                    this.scene.connection?.emitMapEditorDeleteArea(commandId, commandConfig.id);
-                    break;
-                }
-                case "UpdateEntityCommand": {
-                    this.scene.connection?.emitMapEditorModifyEntity(commandId, commandConfig.dataToModify);
-                    break;
-                }
-                case "CreateEntityCommand": {
-                    this.scene.connection?.emitMapEditorCreateEntity(commandId, commandConfig.entityData);
-                    break;
-                }
-                case "DeleteEntityCommand": {
-                    this.scene.connection?.emitMapEditorDeleteEntity(commandId, commandConfig.id);
-                    break;
-                }
-                default: {
-                    break;
-                }
+            if (this.scene.connection === undefined) {
+                throw new Error("No connection attached to room to emit map editor update");
             }
+            command.emitEvent(this.scene.connection);
         };
         if (delay === 0) {
             func();
@@ -398,12 +347,6 @@ export class MapEditorModeManager {
     private subscribeToGameMapFrontWrapperEvents(): void {
         for (const tool of Object.values(this.editorTools)) {
             tool.subscribeToGameMapFrontWrapperEvents(this.scene.getGameMapFrontWrapper());
-        }
-    }
-
-    private handleCommandExecutionByTools(commandConfig: CommandConfig, localCommand: boolean): void {
-        for (const tool of Object.values(this.editorTools)) {
-            tool.handleCommandExecution(commandConfig, localCommand);
         }
     }
 

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -153,6 +153,9 @@ export class MapEditorModeManager {
             // We do an execution instantly so there will be no lag from user's perspective
             const executedCommandConfig = command.execute();
 
+            // FIXME: in case of delete, command.execute removes the ID BEFORE handleCommandExecutionByTools is triggered. That's bad.
+            // TODO: maybe the tools should be passed in parameter of the command being created.
+
             // do any necessary changes for active tool interface
             this.handleCommandExecutionByTools(executedCommandConfig, emitMapEditorUpdate);
 

--- a/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
@@ -1,4 +1,4 @@
-import { AtLeast, CommandConfig, EntityData, EntityPrefab, WAMEntityData } from "@workadventure/map-editor";
+import { AtLeast, EntityData, EntityPrefab, WAMEntityData } from "@workadventure/map-editor";
 import { EditMapCommandMessage } from "@workadventure/messages";
 import { get, Unsubscriber } from "svelte/store";
 import {
@@ -15,6 +15,9 @@ import { CopyEntityEventData, EntitiesManager, EntitiesManagerEvent } from "../.
 import { GameMapFrontWrapper } from "../../GameMap/GameMapFrontWrapper";
 import { GameScene } from "../../GameScene";
 import { MapEditorModeManager } from "../MapEditorModeManager";
+import { CreateEntityFrontCommand } from "../Commands/Entity/CreateEntityFrontCommand";
+import { DeleteEntityFrontCommand } from "../Commands/Entity/DeleteEntityFrontCommand";
+import { UpdateEntityFrontCommand } from "../Commands/Entity/UpdateEntityFrontCommand";
 import { MapEditorTool } from "./MapEditorTool";
 
 export class EntityEditorTool extends MapEditorTool {
@@ -106,136 +109,77 @@ export class EntityEditorTool extends MapEditorTool {
         }
     }
     /**
-     * Perform actions needed to see the changes instantly
-     */
-    public handleCommandExecution(commandConfig: CommandConfig, localCommand: boolean): void {
-        switch (commandConfig.type) {
-            case "UpdateEntityCommand": {
-                this.handleEntityUpdate(commandConfig.dataToModify);
-                break;
-            }
-            case "CreateEntityCommand": {
-                this.handleEntityCreation(commandConfig.entityData).catch((e) => console.error(e));
-                break;
-            }
-            case "DeleteEntityCommand": {
-                console.log("Handle DeleteEntityCommand");
-                this.handleEntityDeletion(commandConfig.id);
-                break;
-            }
-            default: {
-                break;
-            }
-        }
-    }
-    /**
      * React on commands coming from the outside
      */
-    public handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): void {
+    public async handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void> {
         const commandId = editMapCommandMessage.id;
         switch (editMapCommandMessage.editMapMessage?.message?.$case) {
             case "createEntityMessage": {
-                (async () => {
-                    const data = editMapCommandMessage.editMapMessage?.message.createEntityMessage;
-                    const entityPrefab = await this.scene
-                        .getEntitiesCollectionsManager()
-                        .getEntityPrefab(data.collectionName, data.prefabId);
+                const data = editMapCommandMessage.editMapMessage?.message.createEntityMessage;
+                const entityPrefab = await this.scene
+                    .getEntitiesCollectionsManager()
+                    .getEntityPrefab(data.collectionName, data.prefabId);
 
-                    if (!entityPrefab) {
-                        console.warn(`NO PREFAB WAS FOUND FOR: ${data.collectionName} ${data.prefabId}`);
-                        return;
-                    }
+                if (!entityPrefab) {
+                    console.warn(`NO PREFAB WAS FOUND FOR: ${data.collectionName} ${data.prefabId}`);
+                    return;
+                }
 
-                    TexturesHelper.loadEntityImage(this.scene, entityPrefab.imagePath, entityPrefab.imagePath)
-                        .then(() => {
-                            this.entitiesManager.getEntities().get(data.id)?.setTexture(entityPrefab.imagePath);
-                        })
-                        .catch((reason) => {
-                            console.warn(reason);
-                        });
+                TexturesHelper.loadEntityImage(this.scene, entityPrefab.imagePath, entityPrefab.imagePath)
+                    .then(() => {
+                        this.entitiesManager.getEntities().get(data.id)?.setTexture(entityPrefab.imagePath);
+                    })
+                    .catch((reason) => {
+                        console.warn(reason);
+                    });
 
-                    const entityData: WAMEntityData = {
-                        x: data.x,
-                        y: data.y,
-                        id: data.id,
-                        prefabRef: {
-                            id: entityPrefab.id,
-                            collectionName: entityPrefab.collectionName,
-                        },
-                        properties: data.properties,
-                    };
-                    // execute command locally
-                    this.mapEditorModeManager.executeCommand(
-                        {
-                            type: "CreateEntityCommand",
-                            entityData,
-                        },
-                        false,
-                        false,
-                        commandId
-                    );
-                })().catch((e) => console.error(e));
+                const entityData: WAMEntityData = {
+                    x: data.x,
+                    y: data.y,
+                    id: data.id,
+                    prefabRef: {
+                        id: entityPrefab.id,
+                        collectionName: entityPrefab.collectionName,
+                    },
+                    properties: data.properties,
+                };
+                // execute command locally
+                await this.mapEditorModeManager.executeCommand(
+                    new CreateEntityFrontCommand(this.scene.getGameMap(), entityData, commandId, this.entitiesManager),
+                    false,
+                    false
+                );
                 break;
             }
             case "deleteEntityMessage": {
                 console.log("Handle deleteEntityMessage");
                 const id = editMapCommandMessage.editMapMessage?.message.deleteEntityMessage.id;
-                this.mapEditorModeManager.executeCommand(
-                    {
-                        type: "DeleteEntityCommand",
-                        id,
-                    },
+                await this.mapEditorModeManager.executeCommand(
+                    new DeleteEntityFrontCommand(this.scene.getGameMap(), id, commandId, this.entitiesManager),
                     false,
-                    false,
-                    commandId
+                    false
                 );
                 break;
             }
             case "modifyEntityMessage": {
                 const data = editMapCommandMessage.editMapMessage?.message.modifyEntityMessage;
-                this.mapEditorModeManager.executeCommand(
-                    {
-                        type: "UpdateEntityCommand",
-                        dataToModify: {
+                await this.mapEditorModeManager.executeCommand(
+                    new UpdateEntityFrontCommand(
+                        this.scene.getGameMap(),
+                        {
                             ...data,
                             properties: data.modifyProperties ? data.properties : undefined,
                         },
-                    },
+                        commandId,
+                        undefined,
+                        this.entitiesManager,
+                        this.scene
+                    ),
                     false,
-                    false,
-                    commandId
+                    false
                 );
                 break;
             }
-        }
-    }
-
-    private handleEntityUpdate(config: AtLeast<EntityData, "id">): void {
-        const entity = this.entitiesManager.getEntities().get(config.id);
-        if (!entity) {
-            return;
-        }
-        const { x: oldX, y: oldY } = entity.getOldPosition();
-        entity?.updateEntity(config);
-        this.updateCollisionGrid(entity, oldX, oldY);
-        this.scene.markDirty();
-    }
-
-    private async handleEntityCreation(config: WAMEntityData): Promise<void> {
-        await this.entitiesManager.addEntity(structuredClone(config), undefined, true);
-        return;
-    }
-
-    private handleEntityDeletion(id: string): void {
-        this.entitiesManager.deleteEntity(id);
-    }
-
-    private updateCollisionGrid(entity: Entity, oldX: number, oldY: number): void {
-        const reversedGrid = entity.getReversedCollisionGrid();
-        const grid = entity.getCollisionGrid();
-        if (reversedGrid && grid) {
-            this.scene.getGameMapFrontWrapper().modifyToCollisionsLayer(oldX, oldY, "0", reversedGrid);
-            this.scene.getGameMapFrontWrapper().modifyToCollisionsLayer(entity.x, entity.y, "0", grid);
         }
     }
 
@@ -308,16 +252,30 @@ export class EntityEditorTool extends MapEditorTool {
 
     private bindEntitiesManagerEventHandlers(): void {
         this.entitiesManager.on(EntitiesManagerEvent.DeleteEntity, (entity: Entity) => {
-            this.mapEditorModeManager.executeCommand({
-                type: "DeleteEntityCommand",
-                id: entity.getEntityData().id,
-            });
+            this.mapEditorModeManager
+                .executeCommand(
+                    new DeleteEntityFrontCommand(
+                        this.scene.getGameMap(),
+                        entity.getEntityData().id,
+                        undefined,
+                        this.entitiesManager
+                    )
+                )
+                .catch((e) => console.error(e));
         });
         this.entitiesManager.on(EntitiesManagerEvent.UpdateEntity, (entityData: AtLeast<EntityData, "id">) => {
-            this.mapEditorModeManager.executeCommand({
-                type: "UpdateEntityCommand",
-                dataToModify: entityData,
-            });
+            this.mapEditorModeManager
+                .executeCommand(
+                    new UpdateEntityFrontCommand(
+                        this.scene.getGameMap(),
+                        entityData,
+                        undefined,
+                        undefined,
+                        this.entitiesManager,
+                        this.scene
+                    )
+                )
+                .catch((e) => console.error(e));
         });
         this.entitiesManager.on(EntitiesManagerEvent.CopyEntity, (data: CopyEntityEventData) => {
             if (!CopyEntityEventData.parse(data)) {
@@ -330,10 +288,11 @@ export class EntityEditorTool extends MapEditorTool {
                 prefabRef: data.prefabRef,
                 properties: data.properties ?? [],
             };
-            this.mapEditorModeManager.executeCommand({
-                type: "CreateEntityCommand",
-                entityData,
-            });
+            this.mapEditorModeManager
+                .executeCommand(
+                    new CreateEntityFrontCommand(this.scene.getGameMap(), entityData, undefined, this.entitiesManager)
+                )
+                .catch((e) => console.error(e));
             this.cleanPreview();
         });
     }
@@ -433,10 +392,11 @@ export class EntityEditorTool extends MapEditorTool {
             prefabRef: this.entityPrefab,
             properties: get(mapEditorCopiedEntityDataPropertiesStore) ?? [],
         };
-        this.mapEditorModeManager.executeCommand({
-            entityData,
-            type: "CreateEntityCommand",
-        });
+        this.mapEditorModeManager
+            .executeCommand(
+                new CreateEntityFrontCommand(this.scene.getGameMap(), entityData, undefined, this.entitiesManager)
+            )
+            .catch((e) => console.error(e));
     }
 
     private cleanPreview(): void {

--- a/play/src/front/Phaser/Game/MapEditor/Tools/FloorEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/FloorEditorTool.ts
@@ -1,4 +1,3 @@
-import { CommandConfig } from "@workadventure/map-editor";
 import { EditMapCommandMessage } from "@workadventure/messages";
 import { GameMapFrontWrapper } from "../../GameMap/GameMapFrontWrapper";
 import { GameScene } from "../../GameScene";
@@ -34,15 +33,10 @@ export class FloorEditorTool extends MapEditorTool {
         console.log("FloorEditorTool handleKeyDownEvent");
     }
     /**
-     * Perform actions needed to see the changes instantly
-     */
-    public handleCommandExecution(commandConfig: CommandConfig, localCommand: boolean): void {
-        console.log("FloorEditorTool handleCommandExecution");
-    }
-    /**
      * React on commands coming from the outside
      */
-    public handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): void {
+    public handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void> {
         console.log("FloorEditorTool handleIncomingCommandMessage");
+        return Promise.resolve();
     }
 }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/MapEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/MapEditorTool.ts
@@ -1,4 +1,3 @@
-import type { CommandConfig } from "@workadventure/map-editor";
 import type { EditMapCommandMessage } from "@workadventure/messages";
 import type { GameMapFrontWrapper } from "../../GameMap/GameMapFrontWrapper";
 
@@ -10,11 +9,7 @@ export abstract class MapEditorTool {
     public abstract subscribeToGameMapFrontWrapperEvents(gameMapFrontWrapper: GameMapFrontWrapper): void;
     public abstract handleKeyDownEvent(event: KeyboardEvent): void;
     /**
-     * Perform actions needed to see the changes instantly
-     */
-    public abstract handleCommandExecution(commandConfig: CommandConfig, localCommand: boolean): void;
-    /**
      * React on commands coming from the outside
      */
-    public abstract handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): void;
+    public abstract handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void>;
 }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/WAMSettingsEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/WAMSettingsEditorTool.ts
@@ -1,8 +1,8 @@
-import { CommandConfig } from "@workadventure/map-editor";
 import { EditMapCommandMessage } from "@workadventure/messages";
 import { GameMapFrontWrapper } from "../../GameMap/GameMapFrontWrapper";
 import { GameScene } from "../../GameScene";
 import { MapEditorModeManager } from "../MapEditorModeManager";
+import { UpdateWAMSettingFrontCommand } from "../Commands/WAM/UpdateWAMSettingFrontCommand";
 import { MapEditorTool } from "./MapEditorTool";
 
 export class WAMSettingsEditorTool extends MapEditorTool {
@@ -34,22 +34,25 @@ export class WAMSettingsEditorTool extends MapEditorTool {
         console.log("WAMSettingsEditorTool handleKeyDownEvent");
     }
     /**
-     * Perform actions needed to see the changes instantly
-     */
-    public handleCommandExecution(commandConfig: CommandConfig, localCommand: boolean): void {
-        console.log("WAMSettingsEditorTool handleCommandExecution");
-    }
-    /**
      * React on commands coming from the outside
      */
-    public handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): void {
-        console.log("WAMSettingsEditorTool handleIncomingCommandMessage");
-        if (editMapCommandMessage.editMapMessage?.message?.$case === "updateMegaphoneSettingMessage") {
-            if (this.scene.wamFile.settings === undefined) {
-                this.scene.wamFile.settings = {};
+    public async handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void> {
+        const commandId = editMapCommandMessage.id;
+        if (editMapCommandMessage.editMapMessage?.message?.$case === "updateWAMSettingsMessage") {
+            const data = editMapCommandMessage.editMapMessage?.message.updateWAMSettingsMessage;
+
+            const wam = this.scene.getGameMap().getWam();
+            if (wam === undefined) {
+                throw new Error("WAM file is undefined");
             }
-            this.scene.wamFile.settings.megaphone =
-                editMapCommandMessage.editMapMessage.message.updateMegaphoneSettingMessage;
+
+            // execute command locally
+            await this.mapEditorModeManager.executeCommand(
+                new UpdateWAMSettingFrontCommand(wam, data, commandId),
+                false,
+                false
+            );
         }
+        return Promise.resolve();
     }
 }

--- a/play/src/pusher/models/PusherRoom.ts
+++ b/play/src/pusher/models/PusherRoom.ts
@@ -115,15 +115,20 @@ export class PusherRoom implements CustomJsonReplacerInterface {
                                     editMapCommandMessage: message.message.editMapCommandMessage,
                                 },
                             });
+                            // In case the message is updating the megaphone settings, we need to send an additional
+                            // message to update the display of the megaphone button. The Megaphone button is displayed
+                            // based on roles so we need to do this in the pusher.
                             if (
                                 message.message.editMapCommandMessage.editMapMessage?.message?.$case ===
-                                "updateMegaphoneSettingMessage"
+                                    "updateWAMSettingsMessage" &&
+                                message.message.editMapCommandMessage.editMapMessage.message.updateWAMSettingsMessage
+                                    .message?.$case === "updateMegaphoneSettingMessage"
                             ) {
                                 if (!this._wamSettings) {
                                     this._wamSettings = {};
                                 }
                                 this._wamSettings.megaphone =
-                                    message.message.editMapCommandMessage.editMapMessage.message.updateMegaphoneSettingMessage;
+                                    message.message.editMapCommandMessage.editMapMessage.message.updateWAMSettingsMessage.message.updateMegaphoneSettingMessage;
                                 listener.emitInBatch({
                                     message: {
                                         $case: "megaphoneSettingsMessage",

--- a/play/tests/pusher/UpdateWAMSettingFrontCommand.test.ts
+++ b/play/tests/pusher/UpdateWAMSettingFrontCommand.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, assert } from "vitest";
-import { UpdateWAMSettingCommand, WAMFileFormat } from "../src";
+import { describe, expect, it } from "vitest";
+import { WAMFileFormat } from "@workadventure/map-editor";
+import { UpdateWAMSettingFrontCommand } from "../../src/front/Phaser/Game/MapEditor/Commands/WAM/UpdateWAMSettingFrontCommand";
 
-describe("WAM Setting", () => {
+describe("Test UpdateWAMSettingFrontCommand", () => {
     const defaultWamFile: WAMFileFormat = {
         version: "1.0.0",
         mapUrl: "testMapUrl",
@@ -15,9 +16,10 @@ describe("WAM Setting", () => {
         rights: ["testRights"],
         scope: "testScope",
     };
-    it("should change WAM file loaded when WAMSettingCommand received", async () => {
+    it("should not change WAM file loaded when undo is used", async () => {
         const wamFile: WAMFileFormat = { ...defaultWamFile };
-        const command = new UpdateWAMSettingCommand(
+
+        const command = new UpdateWAMSettingFrontCommand(
             wamFile,
             {
                 message: {
@@ -28,21 +30,13 @@ describe("WAM Setting", () => {
             "test-uuid"
         );
         await command.execute();
+        const undoCommand = command.getUndoCommand();
+        await undoCommand.execute();
         expect(wamFile.settings).toBeDefined();
-        if (wamFile.settings) {
-            expect(wamFile.settings.megaphone).toBeDefined();
-            if (wamFile.settings.megaphone) {
-                expect(wamFile.settings.megaphone).toEqual(dataToModify);
-            } else {
-                assert.fail("wamFile.settings.megaphone is not defined");
-            }
-        } else {
-            assert.fail("wamFile.settings is not defined");
-        }
         /*expect(result.type).toBe("UpdateWAMSettingCommand");
         if (result.type === "UpdateWAMSettingCommand") {
             expect(result.name).toBe("megaphone");
-            expect(result.dataToModify).toEqual(dataToModify);
+            expect(result.dataToModify).toBeUndefined();
         } else {
             assert.fail("result.type is not UpdateWAMSettingCommand");
         }*/


### PR DESCRIPTION
Entities in WAM files now only contain a reference to the WAM collection.

Also: Refactoring map editor inner-communication

Removing the "commands" interfaces. Instead, we now only rely on command objects and pass the reference of those objects directly (instead of passing descriptors around that need to be instanciated into commands regularly)