### PR TITLE
Moving character offset to the feet

### DIFF
--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -26,7 +26,7 @@ import Container = Phaser.GameObjects.Container;
 import Sprite = Phaser.GameObjects.Sprite;
 import DOMElement = Phaser.GameObjects.DOMElement;
 
-const playerNameY = -25;
+const playerNameY = -41;
 const interactiveRadius = 35;
 
 export abstract class Character extends Container implements OutlineableInterface {
@@ -182,8 +182,8 @@ export abstract class Character extends Container implements OutlineableInterfac
         this.megaphoneIcon = new MegaphoneIcon(scene, 0, playerNameY - 1);
         this.statusDot.visible = false;
         this.megaphoneIcon.visible = false;
-        this.talkIcon = new TalkIcon(scene, 0, -45);
-        this.speakerIcon = new SpeakerIcon(scene, 0, -45);
+        this.talkIcon = new TalkIcon(scene, 0, -61);
+        this.speakerIcon = new SpeakerIcon(scene, 0, -61);
         this.add([this.talkIcon, this.speakerIcon, this.statusDot, this.megaphoneIcon]);
 
         if (isClickable) {
@@ -203,7 +203,7 @@ export abstract class Character extends Container implements OutlineableInterfac
         this.getBody().setCollideWorldBounds(true);
         this.setSize(16, 16);
         this.getBody().setSize(16, 16); //edit the hitbox to better match the character model
-        this.getBody().setOffset(0, 8);
+        this.getBody().setOffset(0, -8);
         this.setDepth(0);
     }
 
@@ -308,6 +308,7 @@ export abstract class Character extends Container implements OutlineableInterfac
                 throw new CharacterTextureError(`Texture "${texture}" not found`);
             }
             const sprite = new Sprite(this.scene, 0, 0, texture, frame);
+            sprite.setOrigin(0.5, 1);
             this.add(sprite);
             getPlayerAnimations(texture).forEach((d) => {
                 if (!this.scene.anims.exists(d.key)) {
@@ -375,7 +376,7 @@ export abstract class Character extends Container implements OutlineableInterfac
         }
         this.playAnimation(this._lastDirection, true);
 
-        this.setDepth(this.y + 16);
+        this.setDepth(this.y);
 
         if (this.companion) {
             this.companion.setTarget(this.x, this.y, this._lastDirection);

--- a/play/src/front/Phaser/Helpers/TexturesHelper.ts
+++ b/play/src/front/Phaser/Helpers/TexturesHelper.ts
@@ -9,7 +9,7 @@ export class TexturesHelper {
                 if (frame) {
                     sprite.setFrame(frame);
                 }
-                rt.draw(sprite, sprite.displayWidth * 0.5, sprite.displayHeight * 0.5);
+                rt.draw(sprite, sprite.displayWidth * 0.5, sprite.displayHeight);
             }
             return new Promise<string>((resolve, reject) => {
                 try {

--- a/tests/tests/map_editor.spec.ts
+++ b/tests/tests/map_editor.spec.ts
@@ -265,7 +265,7 @@ test.describe('Map editor', () => {
     await Menu.closeMapEditor(page);
 
     // walk on the area position and open the popup
-    await Map.walkToPosition(page, 9 * 32, 9 * 32);
+    await Map.walkToPosition(page, 9 * 32 + 16, 9 * 32 + 16);
 
     // check if the iframe was opened and button thumbnail is visible
     await expect(page.locator('#cowebsite-thumbnail-0')).toBeVisible();


### PR DESCRIPTION
**Important change!**

The Woka "origin" is now set at the bottom of the sprite (16, 32), instead of the center of the sprite. This makes more sense as we consider someone enters a zone when the FEET actually enter the zone (and not the center of the body).

Though the new behaviour is the expected behaviour by most users, this will impact zone entry detection and scripting API position fetching.