### PR TITLE
In self-hosted, with map-storage, making all map belong to the same world

### DIFF
--- a/docs/developer/map-scripting/references/api-player.md
+++ b/docs/developer/map-scripting/references/api-player.md
@@ -238,6 +238,20 @@ A player variable can have 2 scopes:
 - **World** scope: the player variable is set for a given world. It is shared with all the rooms
   of this world.
 
+:::info About the notion of "world":
+
+If you are using the SAAS version (online version) of WorkAdventure, you can create your worlds from the admin dashboard
+and put your rooms in those worlds.
+
+If you are using the self-hosted version of WorkAdventure (with no custom admin API configured), there is only one world, 
+and it is shared by all the rooms defined in the map-storage (i.e. by all URLs starting with `/~/`).
+
+In both cases, any URL starting with `/_/` is **not part** of any world. Trying to set a player variable with a scope
+"world" for URLs starting with `/_/` will be the same as setting the scope to "room".
+:::
+
+
+
 
 :::info
 Player variables can be stored in 2 different places. If the player is logged, the player variables are stored on

--- a/play/src/pusher/services/LocalAdmin.ts
+++ b/play/src/pusher/services/LocalAdmin.ts
@@ -126,7 +126,7 @@ class LocalAdmin implements AdminInterface {
             authenticationMandatory: DISABLE_ANONYMOUS,
             contactPage: null,
             mucRooms: null,
-            group: null,
+            group: wamUrl ? "default" : null,
             iframeAuthentication: null,
             opidLogoutRedirectUrl: null,
             opidUsernamePolicy: opidWokaNamePolicyCheck.success ? opidWokaNamePolicyCheck.data : null,


### PR DESCRIPTION
When using maps in the map-storage, in self-hosted mode with no admin, the maps will now belong to the same world (called "default"). Maps starting from "/_/" will continue to belong to separate worlds for security reasons.

Documentation has been enhanced to make this explicit.

Closes #3520