### PR TITLE
Delaying loader hiding until everything is loaded

### DIFF
--- a/play/src/front/Phaser/Game/EmbeddedWebsiteManager.ts
+++ b/play/src/front/Phaser/Game/EmbeddedWebsiteManager.ts
@@ -205,9 +205,13 @@ height,*/
         }
         domElement.setVisible(visible);
 
-        this.gameScene.load.once("complete", () => {
-            iframe.style.visibility = "visible";
-        });
+        this.gameScene.sceneReadyToStartPromise
+            .then(() => {
+                iframe.style.visibility = "visible";
+            })
+            .catch((e) => {
+                console.error(e);
+            });
 
         switch (embeddedWebsiteEvent.origin) {
             case "player":

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -207,6 +207,8 @@ export class GameScene extends DirtyScene {
     private connectionAnswerPromiseDeferred: Deferred<RoomJoinedMessageInterface>;
     // A promise that will resolve when the "create" method is called (signaling loading is ended)
     private createPromiseDeferred: Deferred<void>;
+    // A promise that will resolve when the scene is ready to start (all assets have been loaded and the connection to the room is established)
+    private sceneReadyToStartDeferred: Deferred<void> = new Deferred<void>();
     private iframeSubscriptionList!: Array<Subscription>;
     private gameMapChangedSubscription!: Subscription;
     private messageSubscription: Subscription | null = null;
@@ -877,6 +879,7 @@ export class GameScene extends DirtyScene {
         ])
             .then(() => {
                 this.hide(false);
+                this.sceneReadyToStartDeferred.resolve();
             })
             .catch((e) =>
                 console.error(
@@ -3291,5 +3294,9 @@ ${escapedMessage}
 
     get room(): Room {
         return this._room;
+    }
+
+    get sceneReadyToStartPromise(): Promise<void> {
+        return this.sceneReadyToStartDeferred.promise;
     }
 }

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -393,7 +393,7 @@ export class GameScene extends DirtyScene {
             //if SpriteSheetFile (WOKA file) don't display error and give an access for user
             if (this.preloading && !(file instanceof SpriteSheetFile)) {
                 //remove loader in progress
-                this.loader.removeLoader();
+                this.loader.hideLoader();
 
                 errorScreenStore.setError(
                     ErrorScreenMessage.fromPartial({
@@ -424,7 +424,7 @@ export class GameScene extends DirtyScene {
                     (key: string, type: string, wamFile: unknown) => {
                         const wamFileResult = WAMFileFormat.safeParse(wamFile);
                         if (!wamFileResult.success) {
-                            this.loader.removeLoader();
+                            this.loader.hideLoader();
                             errorScreenStore.setError(
                                 ErrorScreenMessage.fromPartial({
                                     type: "error",
@@ -879,6 +879,7 @@ export class GameScene extends DirtyScene {
         ])
             .then(() => {
                 this.hide(false);
+                this.loader.hideLoader();
                 this.sceneReadyToStartDeferred.resolve();
             })
             .catch((e) =>


### PR DESCRIPTION
Previously, loader was supposed to hide when ressources were loaded. In practice, because of a buggy test on the gameScene type, it remained until the game scene was marked dirty.

Now, we instead explicitly call the loader to remove itself when everything is up (i.e.: up until all scripts are loaded, connection is established, etc...)