### PR TITLE
Add support for extra volumes and volume mounts in deployment configurations

### DIFF
--- a/contrib/helm/templates/back-statefulset.yaml
+++ b/contrib/helm/templates/back-statefulset.yaml
@@ -91,6 +91,14 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.back.resources | nindent 12 }}
+          {{- with .Values.back.extraVolumeMounts }}
+          volumeMounts:
+            {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
+          {{- end }}
+      {{- with .Values.back.extraVolumes }}
+      volumes:
+        {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+      {{- end }}
       {{- with .Values.back.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/contrib/helm/templates/mapstorage-deployment.yaml
+++ b/contrib/helm/templates/mapstorage-deployment.yaml
@@ -48,6 +48,9 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- with .Values.mapstorage.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+        {{- end }}
       initContainers:
         - name: mapstorage-init
           image: busybox
@@ -104,6 +107,9 @@ spec:
           volumeMounts:
             - name: mapstorage
               mountPath: /maps
+            {{- with .Values.mapstorage.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.mapstorage.resources | nindent 12 }}
           # lifecycle:

--- a/contrib/helm/templates/play-deployment.yaml
+++ b/contrib/helm/templates/play-deployment.yaml
@@ -91,6 +91,14 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.play.resources | nindent 12 }}
+          {{- with .Values.play.extraVolumeMounts }}
+          volumeMounts:
+            {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
+          {{- end }}
+      {{- with .Values.play.extraVolumes }}
+      volumes:
+        {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+      {{- end }}
       {{- with .Values.play.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/contrib/helm/values.yaml
+++ b/contrib/helm/values.yaml
@@ -129,6 +129,33 @@ play:
 
   affinity: {}
 
+  # Additional volumes to be added to the play pod
+  extraVolumes: []
+  # Example:
+  # extraVolumes:
+  #   - name: my-config
+  #     configMap:
+  #       name: my-configmap
+  #   - name: my-secret
+  #     secret:
+  #       secretName: my-secret
+  #   - name: my-persistent-storage
+  #     persistentVolumeClaim:
+  #       claimName: my-pvc
+
+  # Additional volume mounts to be added to the play container
+  extraVolumeMounts: []
+  # Example:
+  # extraVolumeMounts:
+  #   - name: my-config
+  #     mountPath: /etc/config
+  #     readOnly: true
+  #   - name: my-secret
+  #     mountPath: /etc/secrets
+  #     readOnly: true
+  #   - name: my-persistent-storage
+  #     mountPath: /data
+
   # see configuration reference: https://github.com/workadventure/workadventure/blob/master/contrib/docker/.env.prod.template
   env:
     JITSI_PRIVATE_MODE: "false"
@@ -224,6 +251,33 @@ back:
   tolerations: []
 
   affinity: {}
+
+  # Additional volumes to be added to the back pod
+  extraVolumes: []
+  # Example:
+  # extraVolumes:
+  #   - name: my-config
+  #     configMap:
+  #       name: my-configmap
+  #   - name: my-secret
+  #     secret:
+  #       secretName: my-secret
+  #   - name: my-persistent-storage
+  #     persistentVolumeClaim:
+  #       claimName: my-pvc
+
+  # Additional volume mounts to be added to the back container
+  extraVolumeMounts: []
+  # Example:
+  # extraVolumeMounts:
+  #   - name: my-config
+  #     mountPath: /etc/config
+  #     readOnly: true
+  #   - name: my-secret
+  #     mountPath: /etc/secrets
+  #     readOnly: true
+  #   - name: my-persistent-storage
+  #     mountPath: /data
 
   # see configuration reference: https://github.com/workadventure/workadventure/blob/master/contrib/docker/.env.prod.template
   env:
@@ -525,6 +579,33 @@ mapstorage:
   tolerations: []
 
   affinity: {}
+
+  # Additional volumes to be added to the map-storage pod
+  extraVolumes: []
+  # Example:
+  # extraVolumes:
+  #   - name: my-config
+  #     configMap:
+  #       name: my-configmap
+  #   - name: my-secret
+  #     secret:
+  #       secretName: my-secret
+  #   - name: my-persistent-storage
+  #     persistentVolumeClaim:
+  #       claimName: my-pvc
+
+  # Additional volume mounts to be added to the map-storage container
+  extraVolumeMounts: []
+  # Example:
+  # extraVolumeMounts:
+  #   - name: my-config
+  #     mountPath: /etc/config
+  #     readOnly: true
+  #   - name: my-secret
+  #     mountPath: /etc/secrets
+  #     readOnly: true
+  #   - name: my-persistent-storage
+  #     mountPath: /data
 
   persistence:
     enabled: false


### PR DESCRIPTION
The Helm chart now support registering new volumes and volumeMounts in the play, back and map-storage pods.