### PR TITLE
Use sec-websocket-protocol to pass the JWT token

### DIFF
--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -119,7 +119,7 @@ import { localUserStore } from "./LocalUserStore";
 const manualPingDelay = 100_000;
 
 export class RoomConnection implements RoomConnection {
-    private static websocketFactory: null | ((url: string) => any) = null; // eslint-disable-line @typescript-eslint/no-explicit-any
+    private static websocketFactory: null | ((url: string, protocols?: string[]) => any) = null; // eslint-disable-line @typescript-eslint/no-explicit-any
     public readonly socket: WebSocket;
     private userId: number | null = null;
     private closed = false;
@@ -268,9 +268,6 @@ export class RoomConnection implements RoomConnection {
 
         const params = urlObj.searchParams;
         params.set("roomId", roomUrl);
-        if (token) {
-            params.set("token", token);
-        }
         params.set("name", name);
         for (const textureId of characterTextureIds) {
             params.append("characterTextureIds", textureId);
@@ -293,10 +290,16 @@ export class RoomConnection implements RoomConnection {
         params.set("roomName", gameManager.currentStartedRoom.roomName ?? "");
 
         const url = urlObj.toString();
+        let subProtocols: string[] | undefined = undefined;
+        if (token) {
+            // We abuse the subprotocols to pass the token to the server
+            subProtocols = [token];
+        }
+
         if (RoomConnection.websocketFactory) {
-            this.socket = RoomConnection.websocketFactory(url);
+            this.socket = RoomConnection.websocketFactory(url, subProtocols);
         } else {
-            this.socket = new WebSocket(url);
+            this.socket = new WebSocket(url, subProtocols);
         }
 
         this.socket.binaryType = "arraybuffer";

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -233,7 +233,6 @@ export class IoSocketController {
                         context,
                         z.object({
                             roomId: z.string(),
-                            token: z.string().optional(),
                             name: z.string(),
                             characterTextureIds: z.union([z.string(), z.string().array()]).optional(),
                             x: z.coerce.number(),
@@ -257,13 +256,14 @@ export class IoSocketController {
 
                     const websocketKey = req.getHeader("sec-websocket-key");
                     const websocketProtocol = req.getHeader("sec-websocket-protocol");
+                    // We abuse the protocol header to pass the JWT token (to avoid sending it in the query string)
+                    const token = websocketProtocol;
                     const websocketExtensions = req.getHeader("sec-websocket-extensions");
                     const ipAddress = req.getHeader("x-forwarded-for");
                     const locale = req.getHeader("accept-language");
 
                     const {
                         roomId,
-                        token,
                         x,
                         y,
                         top,


### PR DESCRIPTION
In order to avoid passing the JWT token in the websocket query params (those could be logged and viewed by an adminsitrator), we are abusing the "sub-protocol" notion of the websockets. Instead of passing a protocol, we pass the JWT authentication token. This is agreed upon by the client and the server, so according to the specs, this should work :)