### PR TITLE
Refactor joystick visibility and touch device detection logic

### DIFF
--- a/play/src/front/Phaser/Components/MobileJoystick.ts
+++ b/play/src/front/Phaser/Components/MobileJoystick.ts
@@ -43,10 +43,10 @@ export class MobileJoystick extends VirtualJoystick {
         // Disable the joystick by default
         this.enable = false;
 
-        // Show the joeytick at the bottom middle of the screen
+        // Show the joystick at the bottom middle of the screen
         const { width, height } = this.scene.game.canvas;
         this.x = width / 2;
-        this.y = height - 200;
+        this.y = height * 0.8;
 
         // Add opacity
         this.base.setAlpha(0.3);
@@ -66,7 +66,7 @@ export class MobileJoystick extends VirtualJoystick {
         this.visible = true;
     }
 
-    public hide(): void {
+    public hide(delay: number): void {
         // The joystick is not used by the player
         this.enable = false;
 
@@ -74,7 +74,7 @@ export class MobileJoystick extends VirtualJoystick {
         if (this.setimeout) clearTimeout(this.setimeout);
         this.setimeout = setTimeout(() => {
             this.visible = false;
-        }, 30000);
+        }, delay);
     }
 
     public resize() {
@@ -86,10 +86,10 @@ export class MobileJoystick extends VirtualJoystick {
         );
 
         // TODO: change it to apply the good ratio of the canvas
-        // Show the joeytick at the bottom middle of the screen
+        // Show the joystick at the bottom middle of the screen
         const { width, height } = this.scene.game.canvas;
-        this.showAt(width / 2, height - 200);
-        this.hide();
+        this.showAt(width / 2, height * 0.8);
+        this.hide(30_000);
     }
 
     private getDisplaySizeByElement(element: integer): integer {

--- a/play/src/front/Phaser/UserInput/UserInputManager.ts
+++ b/play/src/front/Phaser/UserInput/UserInputManager.ts
@@ -97,6 +97,9 @@ export class UserInputManager {
 
     private initVirtualJoystick() {
         this.joystick = new MobileJoystick(this.scene);
+        if (!touchScreenManager.primaryTouchDevice) {
+            this.joystick.visible = false; // Hide the joystick if the device is not primarily a touch device
+        }
         this.joystick.on("update", () => {
             this.joystickForceAccuX = this.joystick?.forceX ? this.joystickForceAccuX : 0;
             this.joystickForceAccuY = this.joystick?.forceY ? this.joystickForceAccuY : 0;
@@ -323,7 +326,7 @@ export class UserInputManager {
         this.scene.input.on(
             Phaser.Input.Events.POINTER_UP,
             (pointer: Phaser.Input.Pointer, gameObjects: Phaser.GameObjects.GameObject[]) => {
-                this.joystick?.hide();
+                this.joystick?.hide(1_000); // Hide the joystick after 1 seconds of inactivity
                 this.userInputHandler.handlePointerUpEvent(pointer, gameObjects);
 
                 // Disable focus on iframe (need by Firefox)
@@ -349,7 +352,7 @@ export class UserInputManager {
                 if (pointer.event instanceof TouchEvent && pointer.event.touches.length === 1) {
                     this.joystick?.showAt(pointer.x, pointer.y);
                 } else {
-                    this.joystick?.hide();
+                    this.joystick?.hide(30_000);
                 }
             }
         );

--- a/play/src/front/Touch/TouchScreenManager.ts
+++ b/play/src/front/Touch/TouchScreenManager.ts
@@ -1,13 +1,29 @@
 class TouchScreenManager {
     readonly supportTouchScreen: boolean;
+    readonly primaryTouchDevice: boolean;
 
     constructor() {
         this.supportTouchScreen = this.detectTouchscreen();
+        this.primaryTouchDevice = this.detectPrimaryTouchDevice();
     }
 
     //found here: https://stackoverflow.com/questions/4817029/whats-the-best-way-to-detect-a-touch-screen-device-using-javascript#4819886
     detectTouchscreen(): boolean {
         return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+    }
+
+    /**
+     * Detects if the device is primarily designed for touch usage (smartphone, tablet)
+     * and not a computer with touch capability
+     */
+    detectPrimaryTouchDevice(): boolean {
+        // First check if the device has touch capability
+        const hasTouchCapability = "ontouchstart" in window || navigator.maxTouchPoints > 0;
+
+        if (!hasTouchCapability) return false;
+
+        // Detect if the primary pointer is touch
+        return window.matchMedia("(pointer: coarse)").matches;
     }
 }
 


### PR DESCRIPTION
We display the virtual joystick by default only on devices that are primarily touch devices (we do that by detecting that the primary pointer is "coarse")

Computers with a touch screen no longer display the virtual joystick on startup