### PR TITLE
Fixing 2 race conditions with disable controls

### DIFF
--- a/play/src/front/Api/IframeListener.ts
+++ b/play/src/front/Api/IframeListener.ts
@@ -541,7 +541,9 @@ class IframeListener {
         this.iframes.set(iframe, id);
         iframe.addEventListener("load", () => {
             if (iframe.contentWindow) {
-                this.iframeCloseCallbacks.set(iframe.contentWindow, new Set());
+                if (!this.iframeCloseCallbacks.has(iframe.contentWindow)) {
+                    this.iframeCloseCallbacks.set(iframe.contentWindow, new Set());
+                }
             } else {
                 console.error('Could not register "iframeCloseCallbacks". No contentWindow.');
             }

--- a/play/src/front/Components/Modal/Modal.svelte
+++ b/play/src/front/Components/Modal/Modal.svelte
@@ -38,9 +38,12 @@
     });
 
     onDestroy(() => {
-        if ($modalIframeStore?.allowApi) {
-            iframeListener.unregisterIframe(modalIframe);
-        }
+        // Note: we are running unregisterIframe every time and not only when allowApi is true,
+        // because of a possible race condition where the $modalIframeStore store is emptied before onDestroy is called,
+        // which would lead to an error in unregisterIframe.
+        //if ($modalIframeStore?.allowApi) {
+        iframeListener.unregisterIframe(modalIframe);
+        //}
     });
 
     let modalUrl = $modalIframeStore


### PR DESCRIPTION
When disabling controls via the scripting API and restoring controls when the iframe is closed, there was 2 race conditions.

One when the iframe was fully loaded AFTER the disableControls() call was done. The other when the Modal was destroyed by Svelte.