### PR TITLE
:recycle: Early exit in isUserHasWriteAccessOnAreaForEntityCoordinates

### DIFF
--- a/libs/map-editor/src/GameMap/GameMapAreas.ts
+++ b/libs/map-editor/src/GameMap/GameMapAreas.ts
@@ -100,7 +100,6 @@ export class GameMapAreas {
         height: number,
         floating: boolean
     ): boolean {
-        const areas = this.getAreasOnPosition(entityCenterCoordinates);
         const topLeftCoordinates = {
             x: entityCenterCoordinates.x - width / 2,
             y: entityCenterCoordinates.y - height / 2,
@@ -110,22 +109,11 @@ export class GameMapAreas {
             y: entityCenterCoordinates.y + height / 2,
         };
 
-        let validAreas: AreaData[] = areas;
-
-        validAreas = areas.filter((area) => {
-            if (
+        return this.getAreasOnPosition(entityCenterCoordinates).some(
+            (area) =>
                 MathUtils.isOverlappingWithRectangle(topLeftCoordinates, area) &&
-                MathUtils.isOverlappingWithRectangle(bottomRightCoordinates, area)
-            ) {
-                return true;
-            }
-            return false;
-        });
-
-        if (validAreas?.length === 0) return false;
-        return (
-            validAreas.some((area) => this.isUserHasWriteAccessOnAreaByUserTags(area, userConnectedTags)) ||
-            validAreas.some((area) => this.isAreaOwner(area, userUUID))
+                MathUtils.isOverlappingWithRectangle(bottomRightCoordinates, area) &&
+                (this.isUserHasWriteAccessOnAreaByUserTags(area, userConnectedTags) || this.isAreaOwner(area, userUUID))
         );
     }
 


### PR DESCRIPTION
Notes:
- `npm run lint` in `libs/map-editor` raises 33 errors, maybe a CI issue
- I find that `overlapping` is a bit misleading in the name, because this checks whether a point is within a rectangle bounds (assuming horizonta and vertical sides), maybe this should be named `isPointInRectangle`
- `floating` parameter is unused
- Maybe we should not use `getAreasOnPosition` to have a dedicated `getAreasOnRectangle` 
- (not sure about the math) but as we assume rectangle with horizontal and vertical sides it is probably possible to remove the check on the center to just check for both corners, with someting along the following. Should I update the logic to avoid the extra check?
    ```typescript
        return this.getAreasOnPosition(topLeftCoordinates).some(
            (area) =>
                MathUtils.isOverlappingWithRectangle(bottomRightCoordinates, area) &&
                (this.isUserHasWriteAccessOnAreaByUserTags(area, userConnectedTags) || this.isAreaOwner(area, userUUID))
        );
    ```
- `getAreasOnPosition` could use `.filter` instead of `for` + `push`

Kind of a follow-up of #4999