### PR TITLE
Making action bar button isGradient really optional

### DIFF
--- a/play/src/front/Api/Events/Ui/ButtonActionBarEvent.ts
+++ b/play/src/front/Api/Events/Ui/ButtonActionBarEvent.ts
@@ -7,7 +7,7 @@ export const isAddActionBarButtonEvent = z.object({
     bgColor: z.string().optional(),
     textColor: z.string().optional(),
     imageSrc: z.string().optional(),
-    isGradient: z.boolean().optional().default(false),
+    isGradient: z.boolean().optional(),
 });
 
 export type AddButtonActionBarEvent = z.infer<typeof isAddActionBarButtonEvent>;


### PR DESCRIPTION
In scripting, the isGradient property was not really optional because Zod forgot about it because it has a default value.