### PR TITLE
Fixing setting the speaker fallback

### DIFF
--- a/play/src/front/Components/Video/PictureInPicture/AudioStreamWrapper.svelte
+++ b/play/src/front/Components/Video/PictureInPicture/AudioStreamWrapper.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { Streamable } from "../../../Stores/StreamableCollectionStore";
     import { volumeProximityDiscussionStore } from "../../../Stores/PeerStore";
-    import { speakerSelectedStore } from "../../../Stores/MediaStore";
+    import { selectDefaultSpeaker, speakerSelectedStore } from "../../../Stores/MediaStore";
     import AudioStream from "./AudioStream.svelte";
 
     export let peer: Streamable;
@@ -13,5 +13,6 @@
         detach={peer.media.detachAudio}
         volume={$volumeProximityDiscussionStore}
         outputDeviceId={$speakerSelectedStore}
+        on:selectOutputAudioDeviceError={() => selectDefaultSpeaker()}
     />
 {/if}

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -7,7 +7,6 @@
     import type { Streamable } from "../../Stores/StreamableCollectionStore";
     import { LL } from "../../../i18n/i18n-svelte";
 
-    import { selectDefaultSpeaker } from "../../Stores/MediaStore";
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import loaderImg from "../images/loader.svg";
     import MicOffIcon from "../Icons/MicOffIcon.svelte";
@@ -193,7 +192,6 @@
                 {detachVideo}
                 {videoEnabled}
                 expectVideoOutput={videoEnabled}
-                on:selectOutputAudioDeviceError={() => selectDefaultSpeaker()}
                 verticalAlign={!inCameraContainer && !fullScreen ? "top" : "center"}
                 isTalking={showVoiceIndicator}
                 flipX={peer.flipX}

--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -480,8 +480,8 @@ class ConnectionManager {
             // The roomJoinedMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
             //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
             connection.websocketErrorStream.subscribe((error: Event) => {
-                console.info("onConnectError => An error occurred while connecting to socket server. Retrying");
-                reject(asError(event));
+                console.info("onConnectError => An error occurred while connecting to socket server. Retrying", error);
+                reject(asError(error));
             });
 
             // The roomJoinedMessageStream stream is completed in the RoomConnection. No need to unsubscribe.


### PR DESCRIPTION
When migrating the audio to the AudioStream svelte component, we forgot to backport the event triggered when the setSinkId function fails. Now, after 2 seconds, if setSinkId returns nothing, we fall back to the default speaker.