### PR TITLE
Refactoring output device selection

### DIFF
--- a/play/src/front/Components/Video/PictureInPicture/AudioStream.svelte
+++ b/play/src/front/Components/Video/PictureInPicture/AudioStream.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { createEventDispatcher, onDestroy, onMount } from "svelte";
-    import CancelablePromise from "cancelable-promise";
     import Debug from "debug";
+    import * as Sentry from "@sentry/svelte";
 
     export let attach: (container: HTMLAudioElement) => void;
     export let detach: (container: HTMLAudioElement) => void;
@@ -22,89 +22,80 @@
         }
     }
 
-    // TODO: check the race condition when setting sinkId is solved.
-    // Also, read: https://github.com/nwjs/nw.js/issues/4340
+    let lastRequestedDeviceId: string | undefined;
+
+    async function safeSetSinkId(deviceId: string, el: HTMLAudioElement) {
+        if (destroyed) {
+            return false;
+        }
+        if (lastRequestedDeviceId === deviceId) {
+            return true;
+        }
+        if (typeof el.setSinkId !== "function") {
+            return false;
+        }
+        lastRequestedDeviceId = deviceId;
+        try {
+            debug("Setting output device to ", deviceId);
+            await el.setSinkId(deviceId);
+            debug("Output device set to ", deviceId);
+            return true;
+        } catch (e) {
+            if (destroyed) {
+                return false;
+            }
+
+            Sentry.captureException(e);
+            if (e instanceof DOMException && e.name === "AbortError") {
+                // An error occurred while setting the sinkId. Let's fall back to default.
+                console.warn("Error setting the audio output device. We fallback to default.");
+
+                try {
+                    lastRequestedDeviceId = "";
+                    await el.setSinkId("");
+                } catch (e) {
+                    console.error("Error resetting the audio output device: ", e);
+                }
+
+                dispatch("selectOutputAudioDeviceError");
+                return false;
+            }
+            console.error("Error setting the audio output device: ", e);
+            return false;
+        }
+    }
 
     $: {
         if (outputDeviceId && audioElement) {
-            setAudioOutput(outputDeviceId, audioElement);
+            safeSetSinkId(outputDeviceId, audioElement).catch((e) => {
+                console.error("Error setting the audio output device: ", e);
+                Sentry.captureException(e);
+            });
         }
     }
 
-    // A promise to chain calls to setSinkId and setting the srcObject
-    // setSinkId must be resolved before setting the srcObject. See Chrome bug, according to https://bugs.chromium.org/p/chromium/issues/detail?id=971947&q=setsinkid&can=2
-    let sinkIdPromise = CancelablePromise.resolve();
-    let currentDeviceId: string | undefined;
     let destroyed = false;
 
-    //sets the ID of the audio device to use for output
-    function setAudioOutput(deviceId: string, audioElement: HTMLAudioElement) {
-        if (destroyed) {
-            // In case this function is called in a promise that resolves after the component is destroyed,
-            // let's ignore the call.
-            console.warn("setAudioOutput called after the component was destroyed. Call is ignored.");
-            return;
-        }
-
-        if (currentDeviceId === deviceId) {
-            // No need to change the audio output if it's already the one we want.
-            debug("setAudioOutput on already set deviceId. Ignoring call.");
-            return;
-        }
-        currentDeviceId = deviceId;
-
-        // The sinkId does not work for screensharing.
-        // Check if the mediaStream has an audio track (if not it's a screensharing)
-        //if (mediaStream?.getAudioTracks().length === 0) return;
-
-        // Check HTMLMediaElement.setSinkId() compatibility for browser => https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId
-        debug("Awaiting to set sink id to ", deviceId);
-        sinkIdPromise = sinkIdPromise.then(async () => {
-            debug("Setting Sink Id to ", deviceId);
-
-            const timeOutPromise = new Promise((resolve) => {
-                setTimeout(resolve, 2000, "timeout");
-            });
-
-            try {
-                const setSinkIdRacePromise = Promise.race([timeOutPromise, audioElement.setSinkId?.(deviceId)]);
-
-                let result = await setSinkIdRacePromise;
-                if (result === "timeout") {
-                    // In some rare case, setSinkId can NEVER return. I've seen this in Firefox on Linux with a Jabra.
-                    // Let's fallback to default speaker if this happens.
-                    console.warn("setSinkId timed out. Calling setSinkId again on default speaker.");
-                    dispatch("selectOutputAudioDeviceError");
-                    return;
-                } else {
-                    // eslint-disable-next-line require-atomic-updates
-                    audioElement.volume = volume;
-                    debug("Audio output device set to ", deviceId, "with volume", volume);
-                    // Trying to set the stream again after setSinkId is set (for Chrome, according to https://bugs.chromium.org/p/chromium/issues/detail?id=971947&q=setsinkid&can=2)
-                    /*if (videoElement && $streamStore) {
-                        videoElement.srcObject = $streamStore;
-                    }*/
-                }
-            } catch (e) {
-                if (e instanceof DOMException && e.name === "AbortError") {
-                    // An error occurred while setting the sinkId. Let's fallback to default.
-                    console.warn("Error setting the audio output device. We fallback to default.");
-                    dispatch("selectOutputAudioDeviceError");
-                    return;
-                }
-                console.info("Error setting the audio output device: ", e);
-            }
-        });
-    }
-
     onMount(() => {
-        attach(audioElement);
-        audioElement.volume = volume;
+        (async () => {
+            if (outputDeviceId) {
+                // Because of a bug in Chrome, we need to wait for setSinkId to resolve before setting the srcObject.
+                await safeSetSinkId(outputDeviceId, audioElement);
+                if (destroyed || !audioElement) {
+                    return;
+                }
+                attach(audioElement);
+                audioElement.volume = volume;
+            }
+        })().catch((e) => {
+            console.error(e);
+            Sentry.captureException(e);
+        });
     });
 
     onDestroy(() => {
+        destroyed = true;
         detach(audioElement);
-        sinkIdPromise.cancel();
     });
 </script>
 

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -857,7 +857,7 @@ export const selectDefaultSpeaker = () => {
     if (devices !== undefined && devices.length > 0) {
         speakerSelectedStore.set(devices[0].deviceId);
     } else {
-        speakerSelectedStore.set(undefined);
+        speakerSelectedStore.set("");
     }
 };
 


### PR DESCRIPTION
The calls to setSinkId have been refactored.
We are making sure the call to setSinkId has been resolved before attaching the video element. Also, we removed the weird 2 seconds timeout detection that happened rarely in Firefox. Hopefully, the Firefox bug might have been resolved.