### PR TITLE
Enable auto-gain control

### DIFF
--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -244,7 +244,7 @@ export const videoConstraintStore = derived(
 export const audioConstraintStore = derived(requestedMicrophoneDeviceIdStore, ($microphoneDeviceIdStore) => {
     let constraints = {
         //TODO: make these values configurable in the game settings menu and store them in localstorage
-        autoGainControl: false,
+        autoGainControl: true,
         echoCancellation: true,
         noiseSuppression: true,
     } as boolean | MediaTrackConstraints;


### PR DESCRIPTION
Turning auto-gain control on.

This was previously turned off on a feat of bad audio quality on some computers, but it is also the source of very low audio on MacOS (especially compared to Jitsi that has the feature enabled by default)