### PR TITLE
Fixing missing audio in full screen mode

### DIFF
--- a/play/src/front/Components/MainLayout.svelte
+++ b/play/src/front/Components/MainLayout.svelte
@@ -125,12 +125,6 @@
         <div class="w-full h-full fixed start-0 end-0">
             <MediaBox videoBox={$highlightedEmbedScreen} isHighlighted={true} />
         </div>
-        <!-- If we are in fullscreen, the other streams are not displayed. We should therefore play the audio of hidden streams -->
-        {#each [...$streamableCollectionStore.values()] as videoBox (videoBox.uniqueId)}
-            {#if videoBox.uniqueId !== $highlightedEmbedScreen.uniqueId}
-                <AudioStreamWrapper {videoBox} />
-            {/if}
-        {/each}
     {/if}
 
     <AudioPlayer />
@@ -209,6 +203,12 @@
                     <PresentationLayout {inPictureInPicture} />
                 </PictureInPicture>
             {/if}
+
+            <!-- Because of a bug in PIP, new content cannot play sound (it does not inherit UserActivation) -->
+            <!-- So we need to split the audio playing (played in the main frame) from the video streams (that can be embedded in PiP) -->
+            {#each [...$streamableCollectionStore.values()] as videoBox (videoBox.uniqueId)}
+                <AudioStreamWrapper {videoBox} />
+            {/each}
 
             {#if $uiWebsitesStore}
                 <UiWebsiteContainer />

--- a/play/src/front/Components/Video/PictureInPicture.svelte
+++ b/play/src/front/Components/Video/PictureInPicture.svelte
@@ -3,11 +3,10 @@
     import { Unsubscriber } from "svelte/store";
     import { z } from "zod";
     import Debug from "debug";
-    import { streamableCollectionStore, streamablePictureInPictureStore } from "../../Stores/StreamableCollectionStore";
+    import { streamablePictureInPictureStore } from "../../Stores/StreamableCollectionStore";
     import { activePictureInPictureStore } from "../../Stores/PeerStore";
     import { visibilityStore } from "../../Stores/VisibilityStore";
     import { localUserStore } from "../../Connection/LocalUserStore";
-    import AudioStreamWrapper from "./PictureInPicture/AudioStreamWrapper.svelte";
     import {} from "./PictureInPicture/PictureInPictureWindow";
 
     const debug = Debug("app:PictureInPicture");
@@ -184,9 +183,4 @@
     <div bind:this={divElement} class="h-full w-full bg-contrast-1100">
         <slot inPictureInPicture={$activePictureInPictureStore} />
     </div>
-    <!-- Because of a bug in PIP, new content cannot play sound (it does not inherit UserActivation) -->
-    <!-- So we need to play audio out of the PIP slot. -->
-    {#each [...$streamableCollectionStore.values()] as videoBox (videoBox.uniqueId)}
-        <AudioStreamWrapper {videoBox} />
-    {/each}
 </div>


### PR DESCRIPTION
We are moving the audio wrapper one step up (in the MainLayout)