### PR TITLE
Redirecting to Bitnami legacy image in chart

### DIFF
--- a/contrib/helm/values.yaml
+++ b/contrib/helm/values.yaml
@@ -679,6 +679,8 @@ ingress:
 
 redis:
   architecture: standalone
+  image:
+    repository: bitnamilegacy/redis
 
   auth:
     enabled: false


### PR DESCRIPTION
For now, redirecting the Helm chart to the Bitnami legacy image, following the removal of official bintami charts.