### PR TITLE
Prevent flicker in camera

### DIFF
--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -438,7 +438,7 @@ export class LiveKitRoom implements LiveKitRoomInterface {
             priority++;
         }
 
-        // Let's trigger an update one the space's videoStreamStore to reorder the view
+        // Let's trigger an update on the space's videoStreamStore to reorder the view
         // To do so, we just take the first element of the map and put it back in the store at the same key.
         const firstEntry = this.space.allVideoStreamStore.entries().next();
         if (!firstEntry.done) {

--- a/play/src/front/Stores/OrderedStreamableCollectionStore.ts
+++ b/play/src/front/Stores/OrderedStreamableCollectionStore.ts
@@ -1,4 +1,5 @@
 import { derived, writable } from "svelte/store";
+import type { VideoBox } from "../Space/Space";
 import { streamableCollectionStore } from "./StreamableCollectionStore";
 import { stableNSort } from "./StableNSorter";
 
@@ -26,7 +27,18 @@ const currentOrderForStore: string[] = [];
 
 export const orderedStreamableCollectionStore = derived(
     [streamableCollectionStore, maxVisibleVideosStore],
-    ([$streamableCollectionStore, $maxVisibleVideosStore]) => {
-        return stableNSort($streamableCollectionStore, $maxVisibleVideosStore, currentOrderForStore);
-    }
+    ([$streamableCollectionStore, $maxVisibleVideosStore], set) => {
+        const { items, orderChanged } = stableNSort(
+            $streamableCollectionStore,
+            $maxVisibleVideosStore,
+            currentOrderForStore
+        );
+        if (orderChanged) {
+            // Only update the store if the order has changed
+            set(items);
+        }
+
+        return;
+    },
+    [] as VideoBox[]
 );

--- a/play/tests/front/Stores/StableNSorter.test.ts
+++ b/play/tests/front/Stores/StableNSorter.test.ts
@@ -22,10 +22,11 @@ describe("stableNSort", () => {
 
         const result = stableNSort(items, 2, currentOrder);
 
-        expect(result.map((i) => i.uniqueId)).toEqual(currentOrder); // returned list mirrors currentOrder
+        expect(result.items.map((i) => i.uniqueId)).toEqual(currentOrder); // returned list mirrors currentOrder
         expect(currentOrder.includes("obsolete")).toBe(false); // obsolete removed
         expect(currentOrder).toContain("b"); // missing added
         expect(new Set(currentOrder)).toEqual(new Set(["c", "a", "b"]));
+        expect(result.orderChanged).toBe(true); // order changed due to removal and addition
     });
 
     it("ensures the first n items contain exactly the n highest priority items (order not enforced)", () => {
@@ -42,11 +43,12 @@ describe("stableNSort", () => {
         const result = stableNSort(items, n, currentOrder);
 
         // d and b are swapped with a and e
-        expect(result[0].uniqueId).toBe("d");
-        expect(result[1].uniqueId).toBe("e");
-        expect(result[2].uniqueId).toBe("c");
-        expect(result[3].uniqueId).toBe("a");
-        expect(result[4].uniqueId).toBe("b");
+        expect(result.items[0].uniqueId).toBe("d");
+        expect(result.items[1].uniqueId).toBe("e");
+        expect(result.items[2].uniqueId).toBe("c");
+        expect(result.items[3].uniqueId).toBe("a");
+        expect(result.items[4].uniqueId).toBe("b");
+        expect(result.orderChanged).toBe(true);
     });
 
     it("is stable for equal priorities across multiple calls", () => {
@@ -58,16 +60,18 @@ describe("stableNSort", () => {
         const currentOrder = ["a", "b", "c"]; // original order
 
         const first = stableNSort(items, 2, currentOrder);
-        expect(first.map((i) => i.uniqueId)).toEqual(["a", "b", "c"]);
+        expect(first.items.map((i) => i.uniqueId)).toEqual(["a", "b", "c"]);
 
         // Add a new item with same priority; should appear after existing equal-priority items
         items.set("d", { uniqueId: "d", priority: 1 });
         const second = stableNSort(items, 2, currentOrder);
-        expect(second.map((i) => i.uniqueId)).toEqual(["a", "b", "c", "d"]);
+        expect(second.items.map((i) => i.uniqueId)).toEqual(["a", "b", "c", "d"]);
+        expect(second.orderChanged).toBe(true); // order changed due to addition
 
         // Re-run again to ensure stability remains
         const third = stableNSort(items, 3, currentOrder);
-        expect(third.map((i) => i.uniqueId)).toEqual(["a", "b", "c", "d"]);
+        expect(third.items.map((i) => i.uniqueId)).toEqual(["a", "b", "c", "d"]);
+        expect(third.orderChanged).toBe(false);
     });
 
     it("handles n greater than collection size", () => {
@@ -77,7 +81,7 @@ describe("stableNSort", () => {
         ]);
         const currentOrder: string[] = [];
         const result = stableNSort(items, 10, currentOrder);
-        expect(result.map((i) => i.uniqueId).sort()).toEqual(["x", "y"].sort());
+        expect(result.items.map((i) => i.uniqueId).sort()).toEqual(["x", "y"].sort());
         expect(currentOrder.sort()).toEqual(["x", "y"].sort());
     });
 
@@ -92,7 +96,8 @@ describe("stableNSort", () => {
         // Delete b
         items.delete("b");
         const res = stableNSort(items, 2, currentOrder);
-        expect(res.map((i) => i.uniqueId)).toEqual(["a", "c"]);
+        expect(res.items.map((i) => i.uniqueId)).toEqual(["a", "c"]);
         expect(currentOrder).toEqual(["a", "c"]);
+        expect(res.orderChanged).toBe(true);
     });
 });


### PR DESCRIPTION
Our own camera is flickering. This happens each time the speakers order changes in Livekit. Indeed, this triggers a camera store updates, which goes all the way up to Svelte where our own camera (only, I don't know why yet) is flickering.

This PR makes the reordered streamable collection store more stable. The orderedStreamableCollectionStore only fires an update if the order actually changed. Otherwise, the store does not move. This will make the view more stable (but is not a real true fix as we don't know why our camera is flickering when the collection store updates yet)