### PR TITLE
Fixing Darken effect when we zoom out

### DIFF
--- a/play/src/front/Phaser/Components/DarkenOutsideArea/DarkenOutsideAreaPipeline.ts
+++ b/play/src/front/Phaser/Components/DarkenOutsideArea/DarkenOutsideAreaPipeline.ts
@@ -33,7 +33,7 @@ export class DarkenOutsideAreaPipeline extends Phaser.Renderer.WebGL.Pipelines.P
 
       void main() {
         vec4 color = texture2D(uMainSampler, outTexCoord);
-        vec2 p = vec2(gl_FragCoord.x, gl_FragCoord.y);
+        vec2 p = gl_FragCoord.xy;
 
         vec2 rMin = uRect.xy;
         vec2 rMax = uRect.xy + uRect.zw;


### PR DESCRIPTION
The camera coordinates are now correctly computed when we perform a zoom (the darken effect stays on the defined zone) and the darken effect is no more seeming to follow the camera a bit late.