### PR TITLE
Reduce flicker of the user's webcam

### DIFF
--- a/contrib/docker/docker-compose.prod.yaml
+++ b/contrib/docker/docker-compose.prod.yaml
@@ -237,7 +237,7 @@ services:
     restart: ${RESTART_POLICY}
 
   icon:
-    image: matthiasluedtke/iconserver:v3.15.0
+    image: matthiasluedtke/iconserver:v3.21.0
     labels:
       traefik.enable: "true"
       traefik.http.middlewares.strip-icon-prefix.stripprefix.prefixes: "/icon"

--- a/contrib/helm/values.yaml
+++ b/contrib/helm/values.yaml
@@ -472,7 +472,7 @@ icon:
     repository: matthiasluedtke/iconserver
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is appVersion.
-    tag: "v3.16.0"
+    tag: "v3.21.0"
 
   podAnnotations: {}
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -353,7 +353,7 @@ services:
       - "traefik.http.services.redisinsight.loadbalancer.server.port=8001"
 
   icon:
-    image: matthiasluedtke/iconserver:v3.15.0
+    image: matthiasluedtke/iconserver:v3.21.0
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.icon.rule=Host(`icon.workadventure.localhost`)"

--- a/play/src/front/Components/Video/VideoBox.svelte
+++ b/play/src/front/Components/Video/VideoBox.svelte
@@ -14,19 +14,17 @@
 </script>
 
 {#if ($highlightedEmbedScreen !== videoBox && (!isOnOneLine || oneLineMode === "horizontal")) || (isOnOneLine && oneLineMode === "vertical" && ($streamable?.displayInPictureInPictureMode ?? false))}
-    {#key videoBox.uniqueId}
-        <div
-            style={`order: ${$orderStore}; width: ${videoWidth}px; max-width: ${videoWidth}px;${
-                videoHeight ? `height: ${videoHeight}px; max-height: ${videoHeight}px;` : ""
-            }`}
-            class={isOnOneLine
-                ? oneLineMode === "horizontal"
-                    ? "pointer-events-auto basis-40 shrink-0 min-w-40 grow camera-box first-of-type:ml-auto last-of-type:mr-auto"
-                    : "pointer-events-auto basis-40 shrink-0 min-h-24 grow camera-box"
-                : "pointer-events-auto shrink-0 camera-box"}
-            class:aspect-video={videoHeight === undefined}
-        >
-            <MediaBox {videoBox} />
-        </div>
-    {/key}
+    <div
+        style={`order: ${$orderStore}; width: ${videoWidth}px; max-width: ${videoWidth}px;${
+            videoHeight ? `height: ${videoHeight}px; max-height: ${videoHeight}px;` : ""
+        }`}
+        class={isOnOneLine
+            ? oneLineMode === "horizontal"
+                ? "pointer-events-auto basis-40 shrink-0 min-w-40 grow camera-box first-of-type:ml-auto last-of-type:mr-auto"
+                : "pointer-events-auto basis-40 shrink-0 min-h-24 grow camera-box"
+            : "pointer-events-auto shrink-0 camera-box"}
+        class:aspect-video={videoHeight === undefined}
+    >
+        <MediaBox {videoBox} />
+    </div>
 {/if}

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -28,6 +28,7 @@ import { screenShareStreamElementsStore, videoStreamElementsStore } from "./Peer
 import { windowSize } from "./CoWebsiteStore";
 import { muteMediaStreamStore } from "./MuteMediaStreamStore";
 import { isLiveStreamingStore } from "./IsStreamingStore";
+import { createDelayedUnsubscribeStore } from "./Utils/createDelayedUnsubscribeStore";
 
 //export type Streamable = RemotePeer | ScreenSharingLocalMedia | JitsiTrackStreamWrapper;
 
@@ -98,7 +99,7 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL]) => {
         uniqueId: "-1",
         media: {
             type: "webrtc" as const,
-            streamStore: mutedLocalStream,
+            streamStore: createDelayedUnsubscribeStore(mutedLocalStream, 1000),
             isBlocked: writable(false),
         },
         volumeStore: localVolumeStore,

--- a/play/src/front/Stores/Utils/createDelayedUnsubscribeStore.ts
+++ b/play/src/front/Stores/Utils/createDelayedUnsubscribeStore.ts
@@ -1,0 +1,161 @@
+import type { Readable, Unsubscriber } from "svelte/store";
+
+/**
+ * Creates a store wrapper that delays unsubscription by a specified amount of time.
+ *
+ * This utility is designed to prevent unnecessary store deinitialization and reinitialization
+ * when the last unsubscription is quickly followed by a new subscription. This is particularly
+ * useful for stores that have expensive initialization logic (e.g., acquiring media streams,
+ * establishing network connections, loading heavy resources).
+ *
+ * ## How it works:
+ *
+ * 1. When a subscriber subscribes to the delayed store, it immediately subscribes to the
+ *    underlying store and passes through all values.
+ *
+ * 2. When a subscriber unsubscribes, instead of immediately unsubscribing from the underlying
+ *    store, a timer is started.
+ *
+ * 3. If a new subscription occurs before the timer expires, the timer is cancelled and the
+ *    existing subscription to the underlying store is reused.
+ *
+ * 4. If the timer expires without any new subscriptions, the store finally unsubscribes from
+ *    the underlying store.
+ *
+ * ## Use cases:
+ *
+ * - **Media streams**: Avoid repeatedly requesting camera/microphone permissions
+ * - **WebRTC connections**: Prevent connection churn during rapid mount/unmount cycles
+ * - **Network requests**: Avoid redundant API calls when components rapidly mount/unmount
+ * - **Heavy computations**: Preserve computed state during navigation transitions
+ *
+ * ## Example:
+ *
+ * ```typescript
+ * import { readable } from "svelte/store";
+ * import { createDelayedUnsubscribeStore } from "./createDelayedUnsubscribeStore";
+ *
+ * // Create an expensive store (e.g., media stream acquisition)
+ * const expensiveMediaStore = readable<MediaStream | null>(null, (set) => {
+ *     console.log("Initializing media stream (expensive!)");
+ *
+ *     navigator.mediaDevices.getUserMedia({ video: true, audio: true })
+ *         .then(stream => set(stream))
+ *         .catch(err => console.error(err));
+ *
+ *     return () => {
+ *         console.log("Cleaning up media stream");
+ *         // Cleanup logic here
+ *     };
+ * });
+ *
+ * // Wrap it with delayed unsubscribe (2 second delay)
+ * const delayedMediaStore = createDelayedUnsubscribeStore(expensiveMediaStore, 2000);
+ *
+ * // Now rapid subscribe/unsubscribe cycles won't trigger reinitialization
+ * const unsubscribe1 = delayedMediaStore.subscribe(stream => console.log("Stream:", stream));
+ * unsubscribe1(); // Starts 2 second timer
+ *
+ * // If we subscribe again within 2 seconds, no reinitialization occurs
+ * const unsubscribe2 = delayedMediaStore.subscribe(stream => console.log("Stream:", stream));
+ * ```
+ *
+ * @template T The type of value emitted by the store
+ * @param store The underlying Readable store to wrap
+ * @param delayForUnsubscribe The delay in milliseconds before actually unsubscribing from the underlying store
+ * @returns A new Readable store with delayed unsubscription behavior
+ *
+ * @throws {Error} If delayForUnsubscribe is negative
+ */
+export function createDelayedUnsubscribeStore<T>(store: Readable<T>, delayForUnsubscribe: number): Readable<T> {
+    if (delayForUnsubscribe < 0) {
+        throw new Error("delayForUnsubscribe must be a non-negative number");
+    }
+
+    // Track the underlying store subscription
+    let underlyingUnsubscribe: Unsubscriber | null = null;
+
+    // Track the number of active subscribers
+    let subscriberCount = 0;
+
+    // Track the pending unsubscription timer
+    let unsubscribeTimer: ReturnType<typeof setTimeout> | null = null;
+
+    // Store the last known value from the underlying store
+    let currentValue: T | undefined = undefined;
+    let hasValue = false;
+
+    // Track all active subscriber callbacks
+    const subscribers = new Set<(value: T) => void>();
+
+    /**
+     * Actually unsubscribe from the underlying store
+     */
+    const performUnsubscribe = () => {
+        if (underlyingUnsubscribe) {
+            underlyingUnsubscribe();
+            underlyingUnsubscribe = null;
+            hasValue = false;
+        }
+    };
+
+    /**
+     * Cancel any pending unsubscription
+     */
+    const cancelPendingUnsubscribe = () => {
+        if (unsubscribeTimer !== null) {
+            clearTimeout(unsubscribeTimer);
+            unsubscribeTimer = null;
+        }
+    };
+
+    /**
+     * Subscribe to the underlying store if not already subscribed
+     */
+    const ensureSubscribed = () => {
+        if (!underlyingUnsubscribe) {
+            underlyingUnsubscribe = store.subscribe((value: T) => {
+                currentValue = value;
+                hasValue = true;
+                // Notify all subscribers
+                subscribers.forEach((callback) => {
+                    callback(value);
+                });
+            });
+        }
+    };
+
+    return {
+        subscribe: (run: (value: T) => void): Unsubscriber => {
+            // Cancel any pending unsubscription
+            cancelPendingUnsubscribe();
+
+            // Ensure we're subscribed to the underlying store
+            ensureSubscribed();
+
+            // Add this subscriber to our set
+            subscribers.add(run);
+            subscriberCount++;
+
+            // If we already have a value, immediately call the subscriber with it
+            if (hasValue && currentValue !== undefined) {
+                run(currentValue);
+            }
+
+            // Return unsubscriber function
+            return () => {
+                // Remove this subscriber
+                subscribers.delete(run);
+                subscriberCount--;
+
+                // If this was the last subscriber, start the delayed unsubscribe timer
+                if (subscriberCount === 0) {
+                    unsubscribeTimer = setTimeout(() => {
+                        performUnsubscribe();
+                        unsubscribeTimer = null;
+                    }, delayForUnsubscribe);
+                }
+            };
+        },
+    };
+}

--- a/play/tests/front/Stores/Utils/createDelayedUnsubscribeStore.test.ts
+++ b/play/tests/front/Stores/Utils/createDelayedUnsubscribeStore.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readable, writable } from "svelte/store";
+import { createDelayedUnsubscribeStore } from "../../../../src/front/Stores/Utils/createDelayedUnsubscribeStore";
+
+describe("createDelayedUnsubscribeStore", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it("should throw an error if delayForUnsubscribe is negative", () => {
+        const store = writable(0);
+        expect(() => createDelayedUnsubscribeStore(store, -100)).toThrow(
+            "delayForUnsubscribe must be a non-negative number"
+        );
+    });
+
+    it("should immediately subscribe to the underlying store on first subscription", () => {
+        let subscribed = false;
+        const store = readable(42, () => {
+            subscribed = true;
+            return () => {
+                subscribed = false;
+            };
+        });
+
+        const delayedStore = createDelayedUnsubscribeStore(store, 1000);
+        expect(subscribed).toBe(false);
+        const unsubscribe = delayedStore.subscribe(() => {});
+        expect(subscribed).toBe(true);
+        unsubscribe();
+    });
+
+    it("should pass through values from the underlying store", () => {
+        const store = writable(10);
+        const delayedStore = createDelayedUnsubscribeStore(store, 1000);
+        const values: number[] = [];
+        const unsubscribe = delayedStore.subscribe((value) => {
+            values.push(value);
+        });
+        store.set(20);
+        store.set(30);
+        expect(values).toEqual([10, 20, 30]);
+        unsubscribe();
+    });
+
+    it("should delay unsubscription from the underlying store", () => {
+        let subscribed = false;
+        const store = readable(42, () => {
+            subscribed = true;
+            return () => {
+                subscribed = false;
+            };
+        });
+        const delayedStore = createDelayedUnsubscribeStore(store, 2000);
+        const unsubscribe = delayedStore.subscribe(() => {});
+        expect(subscribed).toBe(true);
+        unsubscribe();
+        expect(subscribed).toBe(true);
+        vi.advanceTimersByTime(1000);
+        expect(subscribed).toBe(true);
+        vi.advanceTimersByTime(1000);
+        expect(subscribed).toBe(false);
+    });
+
+    it("should cancel delayed unsubscription if a new subscription occurs", () => {
+        let subscribeCount = 0;
+        let unsubscribeCount = 0;
+        const store = readable(42, () => {
+            subscribeCount++;
+            return () => {
+                unsubscribeCount++;
+            };
+        });
+        const delayedStore = createDelayedUnsubscribeStore(store, 1000);
+        const unsubscribe1 = delayedStore.subscribe(() => {});
+        expect(subscribeCount).toBe(1);
+        expect(unsubscribeCount).toBe(0);
+        unsubscribe1();
+        expect(unsubscribeCount).toBe(0);
+        vi.advanceTimersByTime(500);
+        const unsubscribe2 = delayedStore.subscribe(() => {});
+        expect(subscribeCount).toBe(1);
+        expect(unsubscribeCount).toBe(0);
+        vi.advanceTimersByTime(1000);
+        expect(subscribeCount).toBe(1);
+        expect(unsubscribeCount).toBe(0);
+        unsubscribe2();
+        vi.advanceTimersByTime(1000);
+        expect(unsubscribeCount).toBe(1);
+    });
+
+    it("should handle multiple simultaneous subscribers", () => {
+        let subscribeCount = 0;
+        let unsubscribeCount = 0;
+        const store = readable(100, () => {
+            subscribeCount++;
+            return () => {
+                unsubscribeCount++;
+            };
+        });
+        const delayedStore = createDelayedUnsubscribeStore(store, 1000);
+        const unsubscribe1 = delayedStore.subscribe(() => {});
+        const unsubscribe2 = delayedStore.subscribe(() => {});
+        const unsubscribe3 = delayedStore.subscribe(() => {});
+        expect(subscribeCount).toBe(1);
+        unsubscribe1();
+        unsubscribe2();
+        vi.advanceTimersByTime(2000);
+        expect(unsubscribeCount).toBe(0);
+        unsubscribe3();
+        vi.advanceTimersByTime(1000);
+        expect(unsubscribeCount).toBe(1);
+    });
+
+    it("should deliver the current value to new subscribers immediately", () => {
+        const store = writable(5);
+        const delayedStore = createDelayedUnsubscribeStore(store, 1000);
+        const values1: number[] = [];
+        const unsubscribe1 = delayedStore.subscribe((value) => {
+            values1.push(value);
+        });
+        expect(values1).toEqual([5]);
+        store.set(10);
+        expect(values1).toEqual([5, 10]);
+        unsubscribe1();
+        vi.advanceTimersByTime(500);
+        store.set(15);
+        const values2: number[] = [];
+        const unsubscribe2 = delayedStore.subscribe((value) => {
+            values2.push(value);
+        });
+        expect(values2).toEqual([15]);
+        unsubscribe2();
+    });
+
+    it("should work with zero delay", () => {
+        let subscribed = false;
+        const store = readable(42, () => {
+            subscribed = true;
+            return () => {
+                subscribed = false;
+            };
+        });
+        const delayedStore = createDelayedUnsubscribeStore(store, 0);
+        const unsubscribe = delayedStore.subscribe(() => {});
+        expect(subscribed).toBe(true);
+        unsubscribe();
+        expect(subscribed).toBe(true);
+        vi.advanceTimersByTime(0);
+        expect(subscribed).toBe(false);
+    });
+
+    it("should handle rapid subscribe/unsubscribe cycles", () => {
+        let subscribeCount = 0;
+        let unsubscribeCount = 0;
+        const store = readable("test", () => {
+            subscribeCount++;
+            return () => {
+                unsubscribeCount++;
+            };
+        });
+        const delayedStore = createDelayedUnsubscribeStore(store, 1000);
+        for (let i = 0; i < 10; i++) {
+            const unsub = delayedStore.subscribe(() => {});
+            unsub();
+            vi.advanceTimersByTime(100);
+        }
+        expect(subscribeCount).toBe(1);
+        expect(unsubscribeCount).toBe(0);
+        vi.advanceTimersByTime(1000);
+        expect(unsubscribeCount).toBe(1);
+    });
+
+    it("should properly clean up when multiple subscribers unsubscribe at different times", () => {
+        const store = writable(0);
+        const delayedStore = createDelayedUnsubscribeStore(store, 1000);
+        const values1: number[] = [];
+        const values2: number[] = [];
+        const unsubscribe1 = delayedStore.subscribe((v) => values1.push(v));
+        const unsubscribe2 = delayedStore.subscribe((v) => values2.push(v));
+        store.set(1);
+        expect(values1).toEqual([0, 1]);
+        expect(values2).toEqual([0, 1]);
+        unsubscribe1();
+        store.set(2);
+        expect(values1).toEqual([0, 1]);
+        expect(values2).toEqual([0, 1, 2]);
+        unsubscribe2();
+        vi.advanceTimersByTime(1000);
+        const values3: number[] = [];
+        const unsubscribe3 = delayedStore.subscribe((v) => values3.push(v));
+        expect(values3).toEqual([2]);
+        unsubscribe3();
+    });
+});


### PR DESCRIPTION
The user's webcam was tied to a store that could be quickly subscribed and unsubscribed (because of attached Svelte components). When unsubscribing and resubscribing to the store, that would produce a nasty flicker.

We solve the issue by adding a utility function: "createDelayedUnsubscribeStore" It wraps a Svelte store and delays the last unsubscribe. This way, if a resubscribe happens just after, the store can serve the stored value.

Unrelated: upgrading iconserver to 3.21.0 because the pevious 3.15.0 was only available on ARM processors.