### PR TITLE
Adding a specific HTTP 404 error handler

### DIFF
--- a/play/src/pusher/app.ts
+++ b/play/src/pusher/app.ts
@@ -161,13 +161,22 @@ class App {
                 maxAge: "1h",
             })
         );
-
-        this.app.use(globalErrorHandler);
     }
 
     public async init() {
         const companionListController = new CompanionListController(this.app, jwtTokenManager);
         const wokaListController = new WokaListController(this.app, jwtTokenManager);
+
+        // Handle 404 errors with no-cache headers
+        this.app.use((req, res, _next) => {
+            // Set no-cache headers for 404 responses
+            res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0");
+            res.setHeader("Pragma", "no-cache");
+            res.setHeader("Expires", "0");
+            res.status(404).send("Not Found");
+        });
+
+        this.app.use(globalErrorHandler);
 
         try {
             const capabilities = await adminApi.initialise();


### PR DESCRIPTION
The default 404 error handler of Express does not returned no-cache headers. Cloudflare caches HTTP 404 pages for 3 minutes if there is no cache headers set. During an upgrade (with multiple play containers), one container could return the new assets to be loaded in a HTML page but another one could reply HTTP 404 to those assets, leading to a 3 minutes down-time of the app.

The new 404 page returns no-cache headers, fixing this 3 minutes downtime issue when Cloudflare is used.