### PR TITLE
Fixing darken effect when camera has bounds

### DIFF
--- a/play/src/front/Phaser/Components/DarkenOutsideArea/DarkenOutsideAreaEffect.ts
+++ b/play/src/front/Phaser/Components/DarkenOutsideArea/DarkenOutsideAreaEffect.ts
@@ -172,6 +172,11 @@ export class DarkenOutsideAreaEffect {
         camSx = Math.floor(camSx);
         camSy = Math.floor(camSy);
 
+        if (cam.useBounds) {
+            camSx = cam.clampX(camSx);
+            camSy = cam.clampY(camSy);
+        }
+
         const midX = camSx + halfWidth;
         const midY = camSy + halfHeight;
 


### PR DESCRIPTION
When the camera is bounded (when we are at the border of a map), the darken effect would not display at the right place.

This is fixed.