### PR TITLE
Fixing a regression on allowing iframe API

### DIFF
--- a/play/src/front/Api/IframeListener.ts
+++ b/play/src/front/Api/IframeListener.ts
@@ -284,12 +284,16 @@ class IframeListener {
                 const lookingLikeEvent = isLookingLikeIframeEventWrapper.safeParse(payload);
 
                 if (foundSrc === undefined || iframe === undefined) {
-                    if (lookingLikeEvent.success) {
+                    if (
+                        lookingLikeEvent.success ||
+                        isIframeMessagePortWrapper(payload) ||
+                        isIframeQueryWrapper(payload)
+                    ) {
                         console.warn(
                             "It seems an iFrame is trying to communicate with WorkAdventure but was not explicitly granted the permission to do so. " +
                                 "If you are looking to use the WorkAdventure Scripting API inside an iFrame, you should allow the " +
-                                'iFrame to communicate with WorkAdventure by using the "openWebsiteAllowApi" property in your map (or passing "true" as a second' +
-                                "parameter to WA.nav.openCoWebSite())"
+                                'iFrame to communicate with WorkAdventure by checking the "Allow API" checkbox (if you are using the map editor) or using the "openWebsiteAllowApi" property in your map (if you are using Tiled), or passing "true" as a second' +
+                                "parameter to WA.nav.openCoWebSite() (if you are using the scripting API)."
                         );
                     }
                     return;

--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -1105,11 +1105,16 @@ export class AreasPropertiesListener {
             console.error("Error on getWebsiteUrl: ", e);
         }
 
+        let allowAPI = false;
+        if (property.type === "openWebsite") {
+            allowAPI = property.allowAPI ?? false;
+        }
+
         // Create the co-website to be opened
         const url = new URL(urlStr, this.scene.mapUrlFile);
         const coWebsite = new SimpleCoWebsite(
             url,
-            false,
+            allowAPI ?? false,
             property.policy,
             property.width,
             property.closable,

--- a/tests/tests/map_editor.spec.ts
+++ b/tests/tests/map_editor.spec.ts
@@ -10,9 +10,10 @@ import { resetWamMaps } from "./utils/map-editor/uploader";
 import MapEditor from "./utils/mapeditor";
 import Menu from "./utils/menu";
 import { evaluateScript } from "./utils/scripting";
-import { map_storage_url, publicTestMapUrl } from "./utils/urls";
+import {map_storage_url, maps_test_url, publicTestMapUrl} from "./utils/urls";
 import { getPage } from "./utils/auth";
 import { isMobile } from "./utils/isMobile";
+import {assertLogMessage, startRecordLogs} from "./utils/log";
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -205,6 +206,44 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
         await page.context().close();
     });
+
+    test("Successfully set open website area in the map editor, with working Scripting API @nofirefox", async ({ browser, request }) => {
+        await resetWamMaps(request);
+        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+
+        //await Menu.openMapEditor(page);
+        await Menu.openMapEditor(page);
+        await MapEditor.openAreaEditor(page);
+        await AreaEditor.drawArea(page, { x: 8 * 32 * 1.5, y: 8 * 32 * 1.5 }, { x: 10 * 32 * 1.5, y: 10 * 32 * 1.5 });
+        await AreaEditor.setAreaName(page, "My app zone");
+
+        await AreaEditor.addProperty(page, "openWebsite");
+        await page.getByRole('textbox', { name: 'Link URL' }).fill(maps_test_url+'iframe.php');
+        await page.getByText('Link URL').click();
+
+        await Map.teleportToPosition(page, 9 * 32, 9 * 32);
+
+        // Let's check a warning message is displayed in the logs saying the Allow API checkbox is not checked
+        startRecordLogs(page);
+
+        await page.locator('iframe[title="Cowebsite"]').contentFrame().getByRole('button', { name: 'Send chat message' }).click();
+
+        await assertLogMessage(page, 'It seems an iFrame is trying to communicate with WorkAdventure');
+
+        await Map.teleportToPosition(page, 0, 0);
+
+        // eslint-disable-next-line playwright/no-force-option
+        await page.locator('#allowAPI').check({ force: true });
+
+        await Map.teleportToPosition(page, 9 * 32, 9 * 32);
+
+        await page.locator('iframe[title="Cowebsite"]').contentFrame().getByRole('button', { name: 'Send chat message' }).click();
+
+        await expect(page.getByText('Hello world!')).toBeVisible();
+
+        await page.context().close();
+    });
+
 
     // Test to set Klaxoon application in the area with the map editor
     test("Successfully set Klaxoon's application in the area in the map editor", async ({ browser, request }) => {

--- a/tests/tests/utils/log.ts
+++ b/tests/tests/utils/log.ts
@@ -12,9 +12,9 @@ export async function assertLogMessage(
     substring: string,
     timeout = 10000
 ): Promise<void> {
-  await expect.poll(() => logs, {
+  await expect.poll(() => logs.some((l: string) => l.includes(substring)), {
     timeout
-  }).toContain(substring);
+  }).toBeTruthy();
 }
 
 /**


### PR DESCRIPTION
From the map-editor, when creating a cowebsite, the "Allow API" button was ignored. This commit fixes the issue and adds an E2E test to prevent any future regression.