### PR TITLE
Fixing camera turned off in live streaming when changing tab

### DIFF
--- a/play/src/front/Stores/PrivacyShutdownStore.ts
+++ b/play/src/front/Stores/PrivacyShutdownStore.ts
@@ -1,9 +1,10 @@
 import { get, writable } from "svelte/store";
 import { videoStreamElementsStore } from "./PeerStore";
 import { visibilityStore } from "./VisibilityStore";
+import { isLiveStreamingStore } from "./IsStreamingStore";
 
 /**
- * A store that contains "true" if the webcam should be stopped for privacy reasons - i.e. if the the user left the the page while not in a discussion.
+ * A store that contains "true" if the webcam should be stopped for privacy reasons - i.e. if the user leaves the page while not in a discussion.
  */
 function createPrivacyShutdownStore() {
     let privacyEnabled = false;
@@ -13,7 +14,7 @@ function createPrivacyShutdownStore() {
     // It is ok to not unsubscribe to this store because it is a singleton.
     // eslint-disable-next-line svelte/no-ignored-unsubscribe
     visibilityStore.subscribe((isVisible) => {
-        if (!isVisible && get(videoStreamElementsStore).length === 0) {
+        if (!isVisible && get(videoStreamElementsStore).length === 0 && !get(isLiveStreamingStore)) {
             privacyEnabled = true;
             set(true);
         }


### PR DESCRIPTION
The "PrivacyShutdownStore" was previously triggered despite the fact the user was in a live streaming zone. We now take this into account to prevent the privacy shutdown store from triggering.