### PR TITLE
Stop sending stream if we are a viewer

### DIFF
--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -32,6 +32,7 @@ import {
 } from "../Stores/StreamableCollectionStore";
 import { decrementLivekitRoomCount, incrementLivekitRoomCount } from "../Utils/E2EHooks";
 import { triggerReorderStore } from "../Stores/OrderedStreamableCollectionStore";
+import { deriveSwitchStore } from "../Stores/InterruptorStore";
 import { LiveKitParticipant } from "./LivekitParticipant";
 import { LiveKitRoomInterface } from "./LiveKitRoomInterface";
 
@@ -169,8 +170,8 @@ export class LiveKitRoom implements LiveKitRoomInterface {
 
     private synchronizeMediaState() {
         this.unsubscribers.push(
-            this._localStreamStore.subscribe((localStream) => {
-                if (localStream.type !== "success" || !localStream.stream) {
+            deriveSwitchStore(this._localStreamStore, this.space.isStreamingStore).subscribe((localStream) => {
+                if (localStream === undefined || localStream.type !== "success" || !localStream.stream) {
                     this.unpublishCameraTrack().catch((err) => {
                         console.error("An error occurred while unpublishing camera track", err);
                         Sentry.captureException(err);

--- a/play/src/front/Stores/InterruptorStore.ts
+++ b/play/src/front/Stores/InterruptorStore.ts
@@ -1,0 +1,11 @@
+import { derived, Readable } from "svelte/store";
+
+/**
+ * Creates a derived store that outputs the value of the main store
+ * when the switch store is true, and undefined when the switch store is false.
+ */
+export function deriveSwitchStore<S>(mainStore: Readable<S>, switchStore: Readable<boolean>): Readable<S | undefined> {
+    return derived([mainStore, switchStore], ([$main, $interrupt]) => {
+        return $interrupt ? $main : undefined;
+    });
+}

--- a/play/src/front/WebRtc/SimplePeer.ts
+++ b/play/src/front/WebRtc/SimplePeer.ts
@@ -166,7 +166,7 @@ export class SimplePeer implements SimplePeerConnectionInterface {
         uuid: string
     ): RemotePeer | null {
         const peerConnection = this.videoPeers.get(user.userId);
-        if (peerConnection && peerConnection instanceof RemotePeer) {
+        if (peerConnection) {
             if (peerConnection.destroyed) {
                 this._streamableSubjects.videoPeerRemoved.next(peerConnection);
                 peerConnection.destroy();


### PR DESCRIPTION
If we are not publishing our stream (because we are in the audience zone or a listener of the megaphone), we should not publish our stream. Neither in WebRTC nor in Livekit.

To avoid doing that, we create a new `deriveSwitchStore` which returns the localStreamStore only if the publishStore linked to the state is true. The `deriveSwitchStore` is generic and could be used in the future for other purposes.