### PR TITLE
fix video layout with screenshare

### DIFF
--- a/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
+++ b/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
@@ -332,13 +332,7 @@
         data-testid="cameras-container"
     >
         {#each [...$streamableCollectionStore.values()] as videoBox (videoBox.uniqueId)}
-            <VideoBox 
-                {videoBox} 
-                {isOnOneLine} 
-                {oneLineMode} 
-                {videoWidth} 
-                {videoHeight}
-            />
+            <VideoBox {videoBox} {isOnOneLine} {oneLineMode} {videoWidth} {videoHeight} />
         {/each}
         <!-- in PictureInPicture, let's finish with our video feedback in small -->
         {#if isOnOneLine && oneLineMode === "vertical"}

--- a/play/src/front/Components/Video/VideoBox.svelte
+++ b/play/src/front/Components/Video/VideoBox.svelte
@@ -12,7 +12,7 @@
 
     const streamable = videoBox.streamable;
     const orderStore = videoBox.displayOrder;
-    
+
     $: isFirst = $orderStore === 0;
     $: isLast = $orderStore === $streamableCollectionStore.size - 1;
 </script>
@@ -24,7 +24,9 @@
         }`}
         class={isOnOneLine
             ? oneLineMode === "horizontal"
-                ? `pointer-events-auto basis-40 shrink-0 min-w-40 grow camera-box ${isFirst ? 'ml-auto' : ''} ${isLast ? 'mr-auto' : ''}`
+                ? `pointer-events-auto basis-40 shrink-0 min-w-40 grow camera-box ${isFirst ? "ml-auto" : ""} ${
+                      isLast ? "mr-auto" : ""
+                  }`
                 : "pointer-events-auto basis-40 shrink-0 min-h-24 grow camera-box"
             : "pointer-events-auto shrink-0 camera-box"}
         class:aspect-video={videoHeight === undefined}


### PR DESCRIPTION
The bug comes from the fact that we changed how videos are displayed. We now use the CSS order property to define their position, and apply ml-auto and mr-auto to the first and last elements. However, the :first-of-type and :last-of-type selectors don’t take the order property into account — they’re applied before the elements are visually reordered.

close #5265 