### PR TITLE
Fixing videos getting pushed to the right

### DIFF
--- a/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
+++ b/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
@@ -331,8 +331,16 @@
         id="cameras-container"
         data-testid="cameras-container"
     >
-        {#each [...$streamableCollectionStore.values()] as videoBox (videoBox.uniqueId)}
-            <VideoBox {videoBox} {isOnOneLine} {oneLineMode} {videoWidth} {videoHeight} />
+        {#each [...$streamableCollectionStore.values()] as videoBox, index (videoBox.uniqueId)}
+            <VideoBox
+                {videoBox}
+                {isOnOneLine}
+                {oneLineMode}
+                {videoWidth}
+                {videoHeight}
+                isFirst={index === 0}
+                isLast={index === $streamableCollectionStore.size - 1}
+            />
         {/each}
         <!-- in PictureInPicture, let's finish with our video feedback in small -->
         {#if isOnOneLine && oneLineMode === "vertical"}

--- a/play/src/front/Components/Video/VideoBox.svelte
+++ b/play/src/front/Components/Video/VideoBox.svelte
@@ -2,19 +2,17 @@
     import MediaBox from "../Video/MediaBox.svelte";
     import { highlightedEmbedScreen } from "../../Stores/HighlightedEmbedScreenStore";
     import { VideoBox } from "../../Space/Space";
-    import { streamableCollectionStore } from "../../Stores/StreamableCollectionStore";
 
     export let videoBox: VideoBox;
     export let isOnOneLine: boolean;
     export let oneLineMode: "vertical" | "horizontal";
     export let videoWidth: number;
     export let videoHeight: number | undefined;
+    export let isFirst: boolean = false;
+    export let isLast: boolean = false;
 
     const streamable = videoBox.streamable;
     const orderStore = videoBox.displayOrder;
-
-    $: isFirst = $orderStore === 0;
-    $: isLast = $orderStore === $streamableCollectionStore.size - 1;
 </script>
 
 {#if ($highlightedEmbedScreen !== videoBox && (!isOnOneLine || oneLineMode === "horizontal")) || (isOnOneLine && oneLineMode === "vertical" && ($streamable?.displayInPictureInPictureMode ?? false))}


### PR DESCRIPTION
When doing screensharing, the new way to order items (based on CSS order) breaks the centering of the elements. This commit fixes this issue.

Closes #5265