### PR TITLE
Fixing jumping from one bubble to a meeting room

### DIFF
--- a/play/src/front/Space/Space.ts
+++ b/play/src/front/Space/Space.ts
@@ -985,4 +985,8 @@ export class Space implements SpaceInterface {
             return blockedByUsers;
         });
     }
+
+    public get destroyed(): boolean {
+        return this._isDestroyed;
+    }
 }

--- a/play/src/front/Space/SpaceInterface.ts
+++ b/play/src/front/Space/SpaceInterface.ts
@@ -116,6 +116,8 @@ export interface SpaceInterface {
     readonly filterType: FilterType;
     get mySpaceUserId(): SpaceUser["spaceUserId"];
     getUsers(options?: { signal: AbortSignal }): Promise<Map<string, Readonly<SpaceUserExtended>>>;
+
+    readonly destroyed: boolean;
 }
 
 export type ReactiveSpaceUser = {


### PR DESCRIPTION
When jumping from one bubble to a meeting room, a race condition would prevent joining the meeting room (because the message to leave to bubble is sent by the server and received by the front AFTER the front tries to join the new space)