### PR TITLE
Fixing clickability of the user action menu

### DIFF
--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -150,7 +150,7 @@
         class:justify-center={$statusStore === "connecting" || $statusStore === "error"}
     >
         {#if $statusStore === "connecting" && showAfterDelay}
-            <div class="absolute w-full h-full z-50 overflow-hidden">
+            <div class="absolute w-full h-full overflow-hidden">
                 <div
                     class="flex w-8 h-8 justify-center items-center absolute right-2 top-2 @[22rem]/videomediabox:w-full @[22rem]/videomediabox:right-auto @[22rem]/videomediabox:top-auto @[22rem]/videomediabox:h-full @[22rem]/videomediabox:justify-center @[22rem]/videomediabox:items-center @[22rem]/videomediabox:right-none @[22rem]/videomediabox:top-none"
                 >
@@ -159,7 +159,7 @@
                 </div>
             </div>
         {:else if $statusStore === "error"}
-            <div class="absolute w-full h-full z-50">
+            <div class="absolute w-full h-full">
                 <div class="w-full h-full flex justify-center items-end">
                     <div class="text-lg text-white bold mb-4">{$LL.video.connection_issue()}</div>
                 </div>


### PR DESCRIPTION
The arrow of the menu was not clickable if an error or waiting message was displayed due to a transparent div positioned above.