### PR TITLE
Removing link to BackOffice feature

### DIFF
--- a/play/src/common/FrontConfigurationInterface.ts
+++ b/play/src/common/FrontConfigurationInterface.ts
@@ -5,7 +5,6 @@ export interface FrontConfigurationInterface {
     PUSHER_URL: string;
     FRONT_URL: string;
     ADMIN_URL: string | undefined;
-    ADMIN_BO_URL: string | undefined;
     UPLOADER_URL: string;
     ICON_URL: string;
     STUN_SERVER: string | undefined;

--- a/play/src/front/Administration/AnalyticsClient.ts
+++ b/play/src/front/Administration/AnalyticsClient.ts
@@ -76,14 +76,6 @@ class AnalyticsClient {
             .catch((e) => console.error(e));
     }
 
-    openBackOffice(): void {
-        this.posthogPromise
-            ?.then((posthog) => {
-                posthog.capture("wa-opened-bo");
-            })
-            .catch((e) => console.error(e));
-    }
-
     clickOnCustomButton(id: string, label?: string, toolTip?: string, imageSrc?: string) {
         this.posthogPromise
             ?.then((posthog) => {

--- a/play/src/front/Components/ActionBar/MenuIcons/MapSubMenuContent.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/MapSubMenuContent.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import { streamingMegaphoneStore } from "../../../Stores/MediaStore";
     import {
-        backOfficeMenuVisibleStore,
         globalMessageVisibleStore,
         mapManagerActivated,
         mapEditorMenuVisibleStore,
@@ -9,7 +8,6 @@
     } from "../../../Stores/MenuStore";
     import { LL } from "../../../../i18n/i18n-svelte";
     import { liveStreamingEnabledStore, requestedMegaphoneStore } from "../../../Stores/MegaphoneStore";
-    import AdjustmentsIcon from "../../Icons/AdjustmentsIcon.svelte";
     import MessageGlobalIcon from "../../Icons/MessageGlobalIcon.svelte";
     import { analyticsClient } from "../../../Administration/AnalyticsClient";
     import {
@@ -22,7 +20,6 @@
     import { isTodoListVisibleStore } from "../../../Stores/TodoListStore";
     import { isCalendarVisibleStore } from "../../../Stores/CalendarStore";
     import { chatVisibilityStore } from "../../../Stores/ChatStore";
-    import { ADMIN_BO_URL } from "../../../Enum/EnvironmentVariable";
     import ActionBarButton from "../ActionBarButton.svelte";
     import { EditorToolName } from "../../../Phaser/Game/MapEditor/MapEditorModeManager";
     import AdditionalMenuItems from "./AdditionalMenuItems.svelte";
@@ -72,16 +69,6 @@
         gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(EditorToolName.ExploreTheRoom);
     }
 
-    function openBo() {
-        if (!ADMIN_BO_URL) {
-            throw new Error("ADMIN_BO_URL not set");
-        }
-        const url = new URL(ADMIN_BO_URL, window.location.href);
-        url.searchParams.set("playUri", window.location.href);
-        window.open(url, "_blank");
-        analyticsClient.openBackOffice();
-    }
-
     function closeMapMenu() {
         openedMenuStore.close("mapMenu");
     }
@@ -121,11 +108,6 @@
                 d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"
             /><path d="M21 21l-6 -6" /></svg
         >
-    </ActionBarButton>
-{/if}
-{#if $backOfficeMenuVisibleStore}
-    <ActionBarButton on:click={openBo} label={$LL.actionbar.bo()}>
-        <AdjustmentsIcon />
     </ActionBarButton>
 {/if}
 {#if $globalMessageVisibleStore}

--- a/play/src/front/Enum/EnvironmentVariable.ts
+++ b/play/src/front/Enum/EnvironmentVariable.ts
@@ -11,7 +11,6 @@ const env = window.env;
 export const DEBUG_MODE = env.DEBUG_MODE;
 export const PUSHER_URL = env.PUSHER_URL;
 export const ADMIN_URL = env.ADMIN_URL;
-export const ADMIN_BO_URL = env.ADMIN_BO_URL;
 export const UPLOADER_URL = env.UPLOADER_URL;
 export const ICON_URL = env.ICON_URL;
 export const STUN_SERVER = env.STUN_SERVER;

--- a/play/src/front/Stores/GameStore.ts
+++ b/play/src/front/Stores/GameStore.ts
@@ -1,5 +1,4 @@
-import { writable, derived } from "svelte/store";
-import { ADMIN_BO_URL } from "../Enum/EnvironmentVariable";
+import { writable } from "svelte/store";
 import { BannerEvent } from "./../Api/Events/Ui/BannerEvent";
 
 export const userMovingStore = writable(false);
@@ -16,13 +15,6 @@ export const userIsJitsiDominantSpeakerStore = writable(false);
 export const jitsiParticipantsCountStore = writable(0);
 
 export const limitMapStore = writable(false);
-
-export const userHasAccessToBackOfficeStore = derived(
-    [userIsAdminStore, userIsEditorStore],
-    ([$userIsAdminStore, $userIsEditorStore]) => {
-        return ADMIN_BO_URL && ($userIsAdminStore || $userIsEditorStore);
-    }
-);
 
 export const bannerStore = writable<BannerEvent | null>(null);
 

--- a/play/src/front/Stores/MenuStore.ts
+++ b/play/src/front/Stores/MenuStore.ts
@@ -16,7 +16,7 @@ import LoginMenuItem from "../Components/ActionBar/MenuIcons/LoginMenuItem.svelt
 import InviteMenuItem from "../Components/ActionBar/MenuIcons/InviteMenuItem.svelte";
 import CustomActionBarButton from "../Components/ActionBar/MenuIcons/CustomActionBarButton.svelte";
 import { analyticsClient } from "../Administration/AnalyticsClient";
-import { userHasAccessToBackOfficeStore, userIsAdminStore } from "./GameStore";
+import { userIsAdminStore } from "./GameStore";
 import { megaphoneCanBeUsedStore } from "./MegaphoneStore";
 import { chatVisibilityStore, isMatrixChatEnabledStore } from "./ChatStore";
 import { gameSceneStore } from "./GameSceneStore";
@@ -377,15 +377,11 @@ export const helpTextDisabledStore = derived(
 );
 
 export const mapEditorMenuVisibleStore = derived(
-    [mapEditorActivated, mapManagerActivated, mapEditorActivatedForThematics, getAdditionalMenuItemStore("buildMenu")],
-    ([$mapEditorActivated, $mapManagerActivated, $mapEditorActivatedForThematics, $additionalBuildMenuItems]) => {
-        return (
-            (($mapEditorActivated || $mapEditorActivatedForThematics) && $mapManagerActivated) ||
-            $additionalBuildMenuItems.size > 0
-        );
+    [mapEditorActivated, mapManagerActivated, mapEditorActivatedForThematics],
+    ([$mapEditorActivated, $mapManagerActivated, $mapEditorActivatedForThematics]) => {
+        return ($mapEditorActivated || $mapEditorActivatedForThematics) && $mapManagerActivated;
     }
 );
-export const backOfficeMenuVisibleStore = userHasAccessToBackOfficeStore;
 export const globalMessageVisibleStore = derived(
     [megaphoneCanBeUsedStore, userIsAdminStore],
     ([$megaphoneCanBeUsedStore, $userIsAdminStore]) => {
@@ -393,9 +389,9 @@ export const globalMessageVisibleStore = derived(
     }
 );
 export const mapMenuVisibleStore = derived(
-    [mapEditorMenuVisibleStore, backOfficeMenuVisibleStore, globalMessageVisibleStore],
-    ([$mapEditorMenuVisibleStore, $backOfficeMenuVisibleStore, $globalMessageVisibleStore]) => {
-        return $mapEditorMenuVisibleStore || $backOfficeMenuVisibleStore || $globalMessageVisibleStore;
+    [mapEditorMenuVisibleStore, globalMessageVisibleStore, getAdditionalMenuItemStore("buildMenu")],
+    ([$mapEditorMenuVisibleStore, $globalMessageVisibleStore, $additionalBuildMenuItems]) => {
+        return $mapEditorMenuVisibleStore || $globalMessageVisibleStore || $additionalBuildMenuItems.size > 0;
     }
 );
 

--- a/play/src/i18n/ar-SA/actionbar.ts
+++ b/play/src/i18n/ar-SA/actionbar.ts
@@ -23,7 +23,6 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     test: "اختبر إعداداتي",
     editCamMic: "تحرير الكاميرا / الميكروفون",
     allSettings: "جميع الإعدادات",
-    bo: "المكتب الخلفي",
     globalMessage: "إرسال رسالة عالمية",
     mapEditor: "محرر الخرائط",
     mapEditorMobileLocked: "محرر الخرائط مقفل في الوضع المحمول",

--- a/play/src/i18n/de-DE/actionbar.ts
+++ b/play/src/i18n/de-DE/actionbar.ts
@@ -23,7 +23,6 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     mapEditor: "Kartenmanager öffnen / schließen",
     mapEditorMobileLocked: "Karteneditor ist im mobilen Modus gesperrt",
     mapEditorLocked: "Karteneditor ist gesperrt 🔐",
-    bo: "Back Office öffnen",
     subtitle: {
         microphone: "Mikrofon",
         speaker: "Lautsprecher",

--- a/play/src/i18n/dsb-DE/actionbar.ts
+++ b/play/src/i18n/dsb-DE/actionbar.ts
@@ -6,7 +6,6 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     //menu: "Menij wótcyniś / zacyniś",
     calendar: "Kalender wótcyniś / zacyniś",
     mapEditor: "Editor kórty wótcyniś / zacyniś",
-    bo: "Běrow we slězynje wótcyniś / zacyniś",
     subtitle: {
         microphone: "Mikrofon",
         speaker: "Głosniki",

--- a/play/src/i18n/en-US/actionbar.ts
+++ b/play/src/i18n/en-US/actionbar.ts
@@ -23,7 +23,6 @@ const actionbar: BaseTranslation = {
     test: "Test my settings",
     editCamMic: "Edit cam / mic",
     allSettings: "All settings",
-    bo: "Back office",
     globalMessage: "Send global message",
     mapEditor: "Map editor",
     mapEditorMobileLocked: "Map editor is locked on mobile mode",

--- a/play/src/i18n/fr-FR/actionbar.ts
+++ b/play/src/i18n/fr-FR/actionbar.ts
@@ -25,7 +25,6 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     test: "Tester",
     editCamMic: "Camera / micro",
     allSettings: "Tous les paramètres",
-    bo: "Back office",
     globalMessage: "Envoyer un message global",
     mapEditor: "Éditer la carte",
     mapEditorMobileLocked: "L'éditeur de carte est verrouillé en mode mobile",

--- a/play/src/i18n/hsb-DE/actionbar.ts
+++ b/play/src/i18n/hsb-DE/actionbar.ts
@@ -4,7 +4,6 @@ import type { DeepPartial } from "../DeepPartial";
 const actionbar: DeepPartial<Translation["actionbar"]> = {
     //menu: "meni wočinić/začinić",
     calendar: "kalender wočinić/začinić",
-    bo: "pozadkowy běrow wočinić",
     subtitle: {
         microphone: "mikrofon",
         speaker: "wótřerěčak",

--- a/play/src/i18n/it-IT/actionbar.ts
+++ b/play/src/i18n/it-IT/actionbar.ts
@@ -11,7 +11,6 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     mapEditor: "Apri / Chiudi gestore delle mappe",
     mapEditorMobileLocked: "L'editor delle mappe è bloccato in modalità mobile",
     mapEditorLocked: "L'editor delle mappe è bloccato 🔐",
-    bo: "Apri back office",
     subtitle: {
         microphone: "Microfono",
         speaker: "Altoparlante",

--- a/play/src/i18n/ja-JP/actionbar.ts
+++ b/play/src/i18n/ja-JP/actionbar.ts
@@ -9,7 +9,6 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     mapEditor: "マップエディターの表示／非表示",
     mapEditorMobileLocked: "マップエディタ―はモバイルモードではロックされています",
     mapEditorLocked: "マップエディターはロックされています 🔐",
-    bo: "バックオフィスの表示",
     subtitle: {
         microphone: "マイク",
         speaker: "スピーカー",

--- a/play/src/i18n/nl-NL/actionbar.ts
+++ b/play/src/i18n/nl-NL/actionbar.ts
@@ -10,7 +10,6 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
     mapEditor: "Openen / Sluiten kaartbeheerder",
     mapEditorMobileLocked: "Kaarteditor is vergrendeld in mobiele modus",
     mapEditorLocked: "Kaarteditor is vergrendeld 🔐",
-    bo: "Openen backoffice",
     subtitle: {
         microphone: "Microfoon",
         speaker: "Luidspreker",

--- a/play/src/i18n/pt-BR/actionbar.ts
+++ b/play/src/i18n/pt-BR/actionbar.ts
@@ -23,7 +23,6 @@ const actionbar: BaseTranslation = {
     test: "Testar minhas configurações",
     editCamMic: "Editar câmera / microfone",
     allSettings: "Todas as configurações",
-    bo: "Back office",
     globalMessage: "Enviar mensagem global",
     mapEditor: "Editor de mapa",
     mapEditorMobileLocked: "Editor de mapa está bloqueado no modo móvel",

--- a/play/src/pusher/enums/EnvironmentVariable.ts
+++ b/play/src/pusher/enums/EnvironmentVariable.ts
@@ -149,7 +149,6 @@ export const FRONT_ENVIRONMENT_VARIABLES: FrontConfigurationInterface = {
     PUSHER_URL,
     FRONT_URL,
     ADMIN_URL,
-    ADMIN_BO_URL,
     UPLOADER_URL: env.UPLOADER_URL,
     ICON_URL: env.ICON_URL,
     STUN_SERVER: env.STUN_SERVER,


### PR DESCRIPTION
In previous versions, by configuring the ADMIN_BO_URL env var in the play container, you could add a link to an external back-office. This feature is removed (because access rights were gated by "admin" or "editor" tags which was not configurable).

If you need this feature back, you can add any kind of links in the menus simply by using the scripting API.

For instance:

```

WA.ui.actionBar.addButton({
    id: "backoffice-button",
    label: "Back office",
    location: "buildMenu",
    imageSrc: "https://example.com/backoffice.svg",
    callback: () => {
        WA.nav.openTab("https://example.com");
    }
});
```