### PR TITLE
Fixing destroy of conversation bubble

### DIFF
--- a/play/src/front/Phaser/Components/MobileJoystick.ts
+++ b/play/src/front/Phaser/Components/MobileJoystick.ts
@@ -101,7 +101,7 @@ export class MobileJoystick extends VirtualJoystick {
     }
 
     public destroy() {
-        this.scene.scale.removeListener(Phaser.Scale.Events.RESIZE, this.resizeCallback);
+        this.scene?.scale.removeListener(Phaser.Scale.Events.RESIZE, this.resizeCallback);
         super.destroy();
         this.destroyed = true;
     }

--- a/play/src/front/Phaser/Components/RadialMenu.ts
+++ b/play/src/front/Phaser/Components/RadialMenu.ts
@@ -72,7 +72,7 @@ export class RadialMenu extends Phaser.GameObjects.Container {
     }
 
     public destroy() {
-        this.scene.scale.removeListener(Phaser.Scale.Events.RESIZE, this.resizeCallback);
+        this.scene?.scale.removeListener(Phaser.Scale.Events.RESIZE, this.resizeCallback);
         super.destroy();
     }
 }

--- a/play/src/front/Phaser/Entity/ConversationBubble.ts
+++ b/play/src/front/Phaser/Entity/ConversationBubble.ts
@@ -261,7 +261,7 @@ export class ConversationBubble extends Phaser.GameObjects.Sprite {
     /** Clean up resources when destroying the object */
     public destroy(fromScene?: boolean): void {
         // Remove the generated texture before destroying the sprite
-        if (this.generatedTextureKey && this.scene.textures.exists(this.generatedTextureKey)) {
+        if (this.generatedTextureKey && this.scene?.textures?.exists(this.generatedTextureKey)) {
             this.scene.textures.remove(this.generatedTextureKey);
         }
         super.destroy(fromScene);


### PR DESCRIPTION
In a scene that is closing, the texture key of the scene can be undefined in Phaser. This was causing the deletion of the conversation bubble to fail (for instance if you are in a bubble and asking for the "companion customize scene".