### PR TITLE
Fixing publish of @workadventure/iframe-api-typings

### DIFF
--- a/.github/workflows/iframe-api-push-to-npm.yml
+++ b/.github/workflows/iframe-api-push-to-npm.yml
@@ -21,7 +21,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Replace version number

--- a/.github/workflows/room-api-push-to-npm.yml
+++ b/.github/workflows/room-api-push-to-npm.yml
@@ -21,7 +21,8 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '24.x'
+
           registry-url: 'https://registry.npmjs.org'
 
       - name: Replace version number

--- a/play/packages/iframe-api-typings/package.json
+++ b/play/packages/iframe-api-typings/package.json
@@ -4,7 +4,10 @@
   "description": "Typescript typings for WorkAdventure iFrame API",
   "main": "iframe_api.js",
   "types": "iframe_api.d.ts",
-  "repository": "https://github.com/thecodingmachine/workadventure/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/workadventure/workadventure.git"
+  },
   "author": "David Négrier <d.negrier@thecodingmachine.com>",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
The new authentication system (https://docs.npmjs.com/trusted-publishers) requires NPM 11.5.1 or later. Upgrading Node to get a newer NPM version.