### PR TITLE
Fixing microphone getting muted when applying virtual backgrounds

### DIFF
--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
@@ -310,7 +310,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
         this.canvas.height = this.inputVideo.videoHeight;
 
         if (this.outputStream) {
-            for (const track of this.outputStream.getTracks()) {
+            for (const track of this.outputStream.getVideoTracks()) {
                 track.stop();
             }
         }


### PR DESCRIPTION
When applying virtual background, the 2nd time, the audio is lost. This is because the call to transform was calling "stop" on all media tracks, including the source audio track.

Fixed by only closing video tracks.