### PR TITLE
Fixing repository URL in room-api package.json

### DIFF
--- a/libs/room-api-clients/room-api-client-js/package.json
+++ b/libs/room-api-clients/room-api-client-js/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/thecodingmachine/workadventure.git#master"
+    "url": "git+https://github.com/workadventure/workadventure.git"
   },
   "keywords": [
     "workadventure",


### PR DESCRIPTION
A correct repository URL is needed to publish the packages with the new authentication method.