### PR TITLE
Improve MapEditor UX

### DIFF
--- a/play/src/front/Components/Modal/ObjectDetails.svelte
+++ b/play/src/front/Components/Modal/ObjectDetails.svelte
@@ -44,10 +44,24 @@
         // Make sure that if the user click on another object, the previous one is not selected anymore
         oldEntity = $mapExplorationObjectSelectedStore;
         mapExplorationObjectSelectedStoreSubscription = mapExplorationObjectSelectedStore.subscribe((value) => {
-            if (oldEntity instanceof Entity) oldEntity.setPointedToEditColor(0x000000);
+            if (oldEntity instanceof Entity) {
+                if (oldEntity.searchable === true) {
+                    oldEntity.setPointedToEditColor(0x000000);
+                } else {
+                    // Remove pointed to edit color
+                    oldEntity.removePointedToEditColor();
+                }
+            }
             if (oldEntity instanceof AreaPreview) oldEntity.setStrokeStyle(2, 0x000000);
             oldEntity = value;
-            if (value instanceof Entity) value.setPointedToEditColor(0xf9e82d);
+            if (value instanceof Entity) {
+                if (value.searchable === true) {
+                    value.setPointedToEditColor(0xf9e82d);
+                } else {
+                    // Remove pointed to edit color
+                    value.removePointedToEditColor();
+                }
+            }
             if (value instanceof AreaPreview) value.setStrokeStyle(2, 0xf9e82d);
 
             initPropertyComponents();
@@ -99,11 +113,24 @@
     }
 
     function close() {
-        if ($mapExplorationObjectSelectedStore instanceof Entity)
-            $mapExplorationObjectSelectedStore.setPointedToEditColor(0x000000);
+        if ($mapExplorationObjectSelectedStore instanceof Entity) {
+            if ($mapExplorationObjectSelectedStore.searchable === true) {
+                $mapExplorationObjectSelectedStore.setPointedToEditColor(0x000000);
+            } else {
+                // Remove pointed to edit color
+                $mapExplorationObjectSelectedStore.removePointedToEditColor();
+            }
+        }
         if ($mapExplorationObjectSelectedStore instanceof AreaPreview)
             $mapExplorationObjectSelectedStore.setStrokeStyle(2, 0x000000);
-        if (oldEntity instanceof Entity) oldEntity.setPointedToEditColor(0x000000);
+        if (oldEntity instanceof Entity) {
+            if (oldEntity.searchable === true) {
+                oldEntity.setPointedToEditColor(0x000000);
+            } else {
+                // Remove pointed to edit color
+                oldEntity.removePointedToEditColor();
+            }
+        }
         if (oldEntity instanceof AreaPreview) oldEntity.setStrokeStyle(2, 0x000000);
         mapExplorationObjectSelectedStore.set(undefined);
     }

--- a/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/EntitiesManager.ts
@@ -362,20 +362,22 @@ export class EntitiesManager extends Phaser.Events.EventEmitter {
                 return;
             }
 
+            // If the entity is not editable and the entity editor tool is not active, switch automatically to entity editor tool
             if (
                 get(mapEditorModeStore) &&
-                this.isEntityEditorToolActive() &&
-                !get(mapEditorSelectedEntityPrefabStore)
+                get(mapEditorSelectedToolStore) != EditorToolName.ExploreTheRoom &&
+                this.isEntityEditorToolActive() == false
             ) {
+                // Activate entity editor tool
+                this.scene.getMapEditorModeManager().equipTool(EditorToolName.EntityEditor);
+            }
+
+            if (get(mapEditorModeStore) && !get(mapEditorSelectedEntityPrefabStore)) {
                 if (document.activeElement instanceof HTMLElement) {
                     document.activeElement.blur();
                 }
 
                 if (this.isTrashEditorToolActive()) {
-                    return;
-                }
-
-                if (!entity.canEdit) {
                     return;
                 }
 

--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -107,6 +107,7 @@ export class AreaEditorTool extends MapEditorTool {
         this.setAreaPreviewsVisibility(true);
         this.bindEventHandlers();
         this.changeAreaMode("ADD");
+        this.makeAllEntitiesInteractive();
         this.scene.markDirty();
     }
 
@@ -739,5 +740,10 @@ export class AreaEditorTool extends MapEditorTool {
 
     private isSizeAlteringSquare(obj: Phaser.GameObjects.GameObject): obj is SizeAlteringSquare {
         return obj instanceof SizeAlteringSquare;
+    }
+
+    private makeAllEntitiesInteractive() {
+        const entitiesManager = this.scene.getGameMapFrontWrapper().getEntitiesManager();
+        entitiesManager.makeAllEntitiesInteractive(false);
     }
 }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
@@ -11,6 +11,7 @@ import {
     mapEditorEntityUploadEventStore,
     mapEditorModifyCustomEntityEventStore,
     mapEditorSelectedEntityStore,
+    mapEditorSelectedToolStore,
 } from "../../../../Stores/MapEditorStore";
 import { TexturesHelper } from "../../../Helpers/TexturesHelper";
 import { CopyEntityEventData, EntitiesManagerEvent } from "../../GameMap/EntitiesManager";
@@ -20,7 +21,7 @@ import { DeleteEntityFrontCommand } from "../Commands/Entity/DeleteEntityFrontCo
 import { ModifyCustomEntityFrontCommand } from "../Commands/Entity/ModifyCustomEntityFrontCommand";
 import { UpdateEntityFrontCommand } from "../Commands/Entity/UpdateEntityFrontCommand";
 import { UploadEntityFrontCommand } from "../Commands/Entity/UploadEntityFrontCommand";
-import { MapEditorModeManager } from "../MapEditorModeManager";
+import { EditorToolName, MapEditorModeManager } from "../MapEditorModeManager";
 import { AreaPreview } from "../../../Components/MapEditor/AreaPreview";
 import { EntityRelatedEditorTool } from "./EntityRelatedEditorTool";
 
@@ -353,6 +354,11 @@ export class EntityEditorTool extends EntityRelatedEditorTool {
         }
 
         if (!this.entityPrefabPreview || !this.entityPrefab) {
+            // Check if the object selected is an area
+            const areaEditorToolObjects = gameObjects.filter((obj) => obj instanceof AreaPreview);
+            if (areaEditorToolObjects.length > 0 && get(mapEditorSelectedToolStore) !== EditorToolName.AreaEditor) {
+                this.scene.getMapEditorModeManager().equipTool(EditorToolName.AreaEditor);
+            }
             return;
         }
 


### PR DESCRIPTION
Selecting an entity or area while in editor mode causes an automatic change in the entity or area edition in the map editor.


https://github.com/user-attachments/assets/ed85db64-2c2f-4d89-99bf-59959ebec794

