### PR TITLE
fix(background): handle invalid video dimensions and add error handling

### DIFF
--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -14,9 +14,10 @@ import {
     type BackgroundTransformer,
     type BackgroundConfig,
 } from "../WebRtc/BackgroundProcessor/createBackgroundTransformer";
+import { LL } from "../../i18n/i18n-svelte";
 import { MediaStreamConstraintsError } from "./Errors/MediaStreamConstraintsError";
 import { BrowserTooOldError } from "./Errors/BrowserTooOldError";
-import { errorStore } from "./ErrorStore";
+import { errorStore, warningMessageStore } from "./ErrorStore";
 import { WebviewOnOldIOS } from "./Errors/WebviewOnOldIOS";
 
 import { createSilentStore } from "./SilentStore";
@@ -791,6 +792,8 @@ export const localStreamStore = derived<
         })().catch((error) => {
             console.warn("[MediaStore] Failed to transform stream:", error);
             Sentry.captureException(error);
+            warningMessageStore.addWarningMessage(get(LL).warning.backgroundProcessing.failedToApply());
+            backgroundConfigStore.reset();
         });
     }
 );

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
@@ -109,6 +109,13 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
         }
 
         const { width, height } = this.canvas;
+
+        // Skip processing if canvas has invalid dimensions
+        if (!width || !height || width === 0 || height === 0) {
+            console.warn(`[MediaPipe] Skipping frame processing: canvas dimensions are ${width}x${height}`);
+            return;
+        }
+
         this.ctx.clearRect(0, 0, width, height);
 
         if (this.config.mode === "blur") {
@@ -125,6 +132,11 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
 
     private processBlurMode(results: SelfieSegmentationResults): void {
         const { width, height } = this.canvas;
+
+        // Skip processing if canvas has invalid dimensions
+        if (!width || !height || width === 0 || height === 0) {
+            return;
+        }
 
         // Step 1: Draw the entire image with blur as background
         this.ctx.filter = `blur(${this.config.blurAmount || 15}px)`;
@@ -157,6 +169,11 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
 
     private processReplaceMode(results: SelfieSegmentationResults): void {
         const { width, height } = this.canvas;
+
+        // Skip processing if canvas has invalid dimensions
+        if (!width || !height || width === 0 || height === 0) {
+            return;
+        }
 
         // Draw background replacement (image/video)
         this.drawBackground();
@@ -298,11 +315,31 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
 
         // Setup input video
         this.inputVideo.srcObject = inputStream;
+
+        // Wait for video metadata to be loaded
+        await new Promise<void>((resolve) => {
+            if (this.inputVideo.readyState >= 2) {
+                // HAVE_CURRENT_DATA
+                resolve();
+            } else {
+                this.inputVideo.addEventListener("loadedmetadata", () => resolve(), { once: true });
+            }
+        });
+
         await this.inputVideo.play();
 
         // Setup canvas dimensions
-        this.canvas.width = this.inputVideo.videoWidth;
-        this.canvas.height = this.inputVideo.videoHeight;
+        const videoWidth = this.inputVideo.videoWidth;
+        const videoHeight = this.inputVideo.videoHeight;
+
+        // Check for invalid dimensions (0x0 or undefined)
+        if (!videoWidth || !videoHeight || videoWidth === 0 || videoHeight === 0) {
+            const errorMessage = `[MediaPipe] Invalid video dimensions: ${videoWidth}x${videoHeight}. Cannot process stream with 0x0 size.`;
+            throw new Error(errorMessage);
+        }
+
+        this.canvas.width = videoWidth;
+        this.canvas.height = videoHeight;
 
         if (this.outputStream) {
             for (const track of this.outputStream.getVideoTracks()) {
@@ -330,6 +367,19 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
                 return;
             }
 
+            // Check if video has valid dimensions before processing
+            const videoWidth = this.inputVideo.videoWidth;
+            const videoHeight = this.inputVideo.videoHeight;
+
+            if (!videoWidth || !videoHeight || videoWidth === 0 || videoHeight === 0) {
+                // Retry after a delay in case dimensions become available later
+                if (this.timeoutId) {
+                    clearTimeout(this.timeoutId);
+                }
+                this.timeoutId = setTimeout(processFrame, this.frameRate);
+                return;
+            }
+
             if (this.inputVideo.readyState >= 2 && this.selfieSegmentation) {
                 // HAVE_CURRENT_DATA
                 this.selfieSegmentation
@@ -342,7 +392,18 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
                     })
                     .catch((error) => {
                         console.warn("[MediaPipe] Segmentation error:", error);
+                        // Continue processing even if one frame fails
+                        if (this.timeoutId) {
+                            clearTimeout(this.timeoutId);
+                        }
+                        this.timeoutId = setTimeout(processFrame, this.frameRate);
                     });
+            } else {
+                // Video not ready yet, retry
+                if (this.timeoutId) {
+                    clearTimeout(this.timeoutId);
+                }
+                this.timeoutId = setTimeout(processFrame, this.frameRate);
             }
         };
 

--- a/play/src/i18n/en-US/warning.ts
+++ b/play/src/i18n/en-US/warning.ts
@@ -24,6 +24,9 @@ const warning: BaseTranslation = {
         content: "Please allow popups for this website in your browser settings.",
         done: "Ok",
     },
+    backgroundProcessing: {
+        failedToApply: "Failed to apply background effects",
+    },
 };
 
 export default warning;

--- a/play/src/i18n/fr-FR/warning.ts
+++ b/play/src/i18n/fr-FR/warning.ts
@@ -25,6 +25,9 @@ const warning: DeepPartial<Translation["warning"]> = {
         content: "Veuillez autoriser les fenêtres pop-up pour ce site dans les paramètres de votre navigateur.",
         done: "Ok",
     },
+    backgroundProcessing: {
+        failedToApply: "Échec de l'application des effets de fond",
+    },
 };
 
 export default warning;


### PR DESCRIPTION
## Problem
The background transformer was crashing when receiving video streams with 0x0 dimensions, causing `InvalidStateError` when trying to draw on canvas.

## Solution
- Added dimension validation at multiple levels (transform, processResults, processBlurMode, processReplaceMode, startProcessing)
- Return original stream as fallback when dimensions are invalid
- Added i18n warning messages (FR/EN) when background effects fail to apply
- Improved error handling with proper fallback mechanism