### PR TITLE
Fixing calling leave events when leaving map

### DIFF
--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -772,6 +772,8 @@ export class GameMapFrontWrapper {
             // We found a property that disappeared
             this.trigger(oldPropName, oldPropValue, undefined, emptyProps);
         }
+
+        this.gameMap.getGameMapAreas()?.triggerAreasChange(this.position, undefined);
     }
 
     public getRandomPositionFromLayer(layerName: string): { x: number; y: number } {
@@ -1190,6 +1192,11 @@ export class GameMapFrontWrapper {
         );
     }
 
+    /**
+     * Return properties attached to the given tile key (properties from the Tiled tile layer + properties attached
+     * to the tileset tile + properties attached to the activated entities (if any) + properties attached to the dynamic
+     * areas.
+     */
     private getProperties(key: number): Map<string, string | boolean | number> {
         const properties = new Map<string, string | boolean | number>();
         // NOTE: WE DO NOT WANT AREAS TO BE THE PART OF THE OLD PROPERTIES CHANGE SYSTEM

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -2996,7 +2996,7 @@ ${escapedMessage}
                             } else {
                                 console.warn(`Failed to add TilesetImage ${jsonTileset.name}: ${imageUrl}`);
                             }
-                            //destroy the tilemapayer because they are unique and we need to reuse their key and layerdData
+                            //destroy the tilemaplayer because they are unique and we need to reuse their key and layerData
                             for (const layer of this.Map.layers) {
                                 layer.tilemapLayer.destroy(false);
                             }


### PR DESCRIPTION
When leaving a map, the leave triggers of map-editor areas was not called, causing issues like the "silent" status not being reset when leaving a map. We now call the "exit" callback of each map-editor area properly.

Closes #5353 