### PR TITLE
Returning a stable "MediaStream" in muteMediaStreamStore()

### DIFF
--- a/play/src/front/Space/Space.ts
+++ b/play/src/front/Space/Space.ts
@@ -355,7 +355,7 @@ export class Space implements SpaceInterface {
     ): NonNullable<PublicEventsObservables[K]> {
         const observable = this.publicEventsObservables[key];
         if (!observable) {
-            return (this.publicEventsObservables[key] = new Subject());
+            return (this.publicEventsObservables[key] = new Subject() as NonNullable<PublicEventsObservables[K]>);
         }
         return observable;
     }
@@ -364,7 +364,7 @@ export class Space implements SpaceInterface {
     ): NonNullable<PrivateEventsObservables[K]> {
         const observable = this.privateEventsObservables[key];
         if (!observable) {
-            return (this.privateEventsObservables[key] = new Subject());
+            return (this.privateEventsObservables[key] = new Subject() as NonNullable<PrivateEventsObservables[K]>);
         }
         return observable;
     }

--- a/play/src/pusher/models/SpaceToFrontDispatcher.ts
+++ b/play/src/pusher/models/SpaceToFrontDispatcher.ts
@@ -152,7 +152,7 @@ export class SpaceToFrontDispatcher implements SpaceToFrontDispatcherInterface {
                     `During init... user ${spaceUser.spaceUserId} already exists in space ${this._space.name}`
                 );
             }
-            this._space.users.set(spaceUser.spaceUserId, user);
+            this._space.users.set(spaceUser.spaceUserId, user as SpaceUserExtended);
             debug(`${this._space.name} : user added during init ${spaceUser.spaceUserId}.`);
         }
         debug(`${this._space.name} : init done. User count ${this._space.users.size}`);
@@ -168,7 +168,7 @@ export class SpaceToFrontDispatcher implements SpaceToFrontDispatcherInterface {
             console.warn(`User ${spaceUser.spaceUserId} already exists in space ${this._space.name}`); // Probably already added
             return;
         }
-        this._space.users.set(spaceUser.spaceUserId, user);
+        this._space.users.set(spaceUser.spaceUserId, user as SpaceUserExtended);
         debug(`${this._space.name} : user added ${spaceUser.spaceUserId}. User count ${this._space.users.size}`);
 
         const subMessage: SubMessage = {


### PR DESCRIPTION
The side effect is not triggering a MediaStream refresh in WebRtcVideo when we switch from PiP to non PiP with a screensharing enabled. Due to a bug, the "NoVideo" message got displayed. Now that the MediasStream is stable, the "NoVideo" detector does not get triggered when switching out of PiP.