### PR TITLE
Fix camera container resizing

### DIFF
--- a/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
+++ b/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
@@ -142,7 +142,7 @@
         if (resizeInProgress) {
             gap = 16;
         } else {
-            gap = 18;
+            gap = 20;
         }
 
         // Calculate maximum number of videos that can fit in one row at minimum size


### PR DESCRIPTION
When the user scroll in or out, the canvas is resize and "containerWidth" has a small jitter.