### PR TITLE
Refactoring socketData / spaces sync in Pusher

### DIFF
--- a/play/src/pusher/models/Space.ts
+++ b/play/src/pusher/models/Space.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/node";
 import {
     SpaceUser,
     FilterType,
@@ -73,10 +74,11 @@ export class Space implements SpaceForSpaceConnectionInterface {
 
     public readonly metadata: Map<string, unknown>;
 
-    // The list of users connected to THIS pusher specifically
+    // The list of users connected to THIS pusher specifically.
+    // Note: Space._localConnectedUser, Space._localConnectedUserWithSpaceUser and SocketData.spaces must be in sync.
     public readonly _localConnectedUser: Map<string, Socket>;
-    public readonly _localWatchers: Set<string> = new Set<string>();
     public readonly _localConnectedUserWithSpaceUser = new Map<Socket, SpaceUserExtended>();
+    public readonly _localWatchers: Set<string> = new Set<string>();
     public spaceStreamToBackPromise: Promise<BackSpaceConnection> | undefined;
     public readonly forwarder: SpaceToBackForwarderInterface;
     public readonly dispatcher: SpaceToFrontDispatcherInterface;
@@ -161,27 +163,73 @@ export class Space implements SpaceForSpaceConnectionInterface {
         }
         this.destroyed = true;
 
-        // We notify the listeners and the users that the space has suffered an unexpected disconnection
-        // For normal cleanups, the list of people connected to the space is empty, so no one will receive this notification.
-        // In case cleanup() is called because of a back disconnection, the message will tell the users that the space is no longer available.
-        this.dispatcher.notifyAllIncludingNonWatchers({
-            message: {
-                $case: "spaceDestroyedMessage",
-                spaceDestroyedMessage: {
-                    spaceName: this.localName,
-                },
-            },
-        });
-
-        // Unregister the space from all local users (in case some users are still connected)
-        for (const socket of this._localConnectedUser.values()) {
-            socket.getUserData().spaces.delete(this.name);
+        try {
+            try {
+                // We notify the listeners and the users that the space has suffered an unexpected disconnection
+                // For normal cleanups, the list of people connected to the space is empty, so no one will receive this notification.
+                // In case cleanup() is called because of a back disconnection, the message will tell the users that the space is no longer available.
+                this.dispatcher.notifyAllIncludingNonWatchers({
+                    message: {
+                        $case: "spaceDestroyedMessage",
+                        spaceDestroyedMessage: {
+                            spaceName: this.localName,
+                        },
+                    },
+                });
+            } finally {
+                try {
+                    // Unregister the space from all local users (in case some users are still connected)
+                    for (const socket of this._localConnectedUser.values()) {
+                        const deleted = socket.getUserData().spaces.delete(this.name);
+                        if (!deleted) {
+                            console.warn(
+                                `Space cleanup: space not found in socket spaces for ${this.name} / ${
+                                    socket.getUserData().name
+                                }`
+                            );
+                            Sentry.captureException(
+                                new Error(
+                                    `Space cleanup: space not found in socket spaces for ${this.name} / ${
+                                        socket.getUserData().name
+                                    }`
+                                )
+                            );
+                        }
+                        const promiseDeleted = socket.getUserData().joinSpacesPromise.delete(this.name);
+                        if (!promiseDeleted) {
+                            console.warn(
+                                `Cleaning space ${this.name} : promise not found in socket joinSpacesPromise for ${
+                                    socket.getUserData().name
+                                }`
+                            );
+                            Sentry.captureException(
+                                new Error(
+                                    `Cleaning space ${this.name} : promise not found in socket joinSpacesPromise for ${
+                                        socket.getUserData().name
+                                    }`
+                                )
+                            );
+                        }
+                    }
+                } finally {
+                    try {
+                        this.forwarder.leaveSpace();
+                    } finally {
+                        try {
+                            this.spaceConnection.removeSpace(this);
+                        } finally {
+                            this.query.destroy();
+                        }
+                    }
+                }
+            }
+        } finally {
+            this._unregisterSpace(this);
         }
 
-        this.forwarder.leaveSpace();
-        this.spaceConnection.removeSpace(this);
-        this._unregisterSpace(this);
-        this.query.destroy();
+        this._localConnectedUser.clear();
+        this._localConnectedUserWithSpaceUser.clear();
+        this._localWatchers.clear();
     }
 
     public setSpaceStreamToBack(spaceStreamToBack: Promise<BackSpaceConnection>) {

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -417,11 +417,6 @@ export class SocketManager implements ZoneEventListener {
                     // The user has aborted the request, we should not add him to the space
                     throw new Error("Join space aborted by the user");
                 }
-                if (socketData.spaces.has(spaceName)) {
-                    console.warn(`User ${socketData.name} is trying to join a space he is already in.`);
-                }
-
-                socketData.spaces.add(space.name);
             } catch (e) {
                 // Deleting the promise BEFORE unregistering the user (in case unregistering fails)
                 socketData.joinSpacesPromise.delete(spaceName);

--- a/play/tests/pusher/SpaceToBackForwarder.test.ts
+++ b/play/tests/pusher/SpaceToBackForwarder.test.ts
@@ -81,6 +81,7 @@ describe("SpaceToBackForwarder", () => {
                 getUserData: vi.fn().mockReturnValue({
                     spaceUserId: "foo_1",
                     name: "foo_1",
+                    spaces: new Set<string>(),
                 }),
             });
 
@@ -146,6 +147,7 @@ describe("SpaceToBackForwarder", () => {
                 getUserData: vi.fn().mockReturnValue({
                     spaceUserId: "foo_1",
                     name: "foo_1",
+                    spaces: new Set<string>(),
                 }),
             });
 
@@ -212,6 +214,7 @@ describe("SpaceToBackForwarder", () => {
                 getUserData: vi.fn().mockReturnValue({
                     spaceUserId: "foo_1",
                     name: "foo_1",
+                    spaces: new Set<string>(),
                 }),
             });
 
@@ -451,6 +454,7 @@ describe("SpaceToBackForwarder", () => {
             const mockSocket = mock<Socket>({
                 getUserData: vi.fn().mockReturnValue({
                     spaceUserId: "foo_1",
+                    spaces: new Set<string>(),
                 }),
             });
 
@@ -499,6 +503,7 @@ describe("SpaceToBackForwarder", () => {
             const mockSocket = mock<Socket>({
                 getUserData: vi.fn().mockReturnValue({
                     spaceUserId: "foo_1",
+                    spaces: new Set<string>(),
                 }),
             });
             const cleanupMock = vi.fn();


### PR DESCRIPTION
We keep getting warnings in the Pusher about some users that have a reference to a space that does not exist anymore. This is an attempt to make sure we always keep Space._localConnectedUser, Space._localConnectedUserWithSpaceUser and SocketData.spaces in sync.