### PR TITLE
fix: Video relay server error popup displayed after wake up

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1194,6 +1194,7 @@ export class GameScene extends DirtyScene {
         this.gameMapFrontWrapper?.close();
         this.followManager?.close();
         this.spaceScriptingBridgeService?.destroy();
+        iceServersManager.finalize();
 
         this._focusFx?.destroy();
 

--- a/play/src/front/WebRtc/IceServersManager.ts
+++ b/play/src/front/WebRtc/IceServersManager.ts
@@ -48,6 +48,16 @@ class IceServersManager {
         }
     }
 
+    public finalize() {
+        if (this.renewalTimer) {
+            clearTimeout(this.renewalTimer);
+            this.renewalTimer = undefined;
+        }
+        this.iceServersConfigPromise = undefined;
+        this.roomConnection = undefined;
+        this.retryCount = 0;
+    }
+
     public async getIceServersConfig(): Promise<IceServersConfig> {
         if (!this.iceServersConfigPromise) {
             return this.renewNow();


### PR DESCRIPTION
The iceServersManager was not properly uninitialized when leaving a room. As a result, the TURN credentials would stay in memory. If a user was putting a laptop in sleep mode for more than 4 hours and opening it again, the old TURN credentials would be reused by the TURN connection checker (and would fail). We now clean things up properly.