### PR TITLE
Properly cleaning the throttled calls to setViewport

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -343,7 +343,7 @@ export class GameScene extends DirtyScene {
     private playersEventDispatcher = new IframeEventDispatcher();
     private playersMovementEventDispatcher = new IframeEventDispatcher();
     private remotePlayersRepository = new RemotePlayersRepository();
-    private throttledSendViewportToServer!: () => void;
+    private throttledSendViewportToServer!: throttle<() => void>;
     private playersDebugLogAlreadyDisplayed = false;
     private hideTimeout: ReturnType<typeof setTimeout> | undefined;
     // The promise that will resolve to the current player textures. This will be available only after connection is established.
@@ -1199,6 +1199,7 @@ export class GameScene extends DirtyScene {
             this.localVolumeStoreUnsubscriber();
             this.localVolumeStoreUnsubscriber = undefined;
         }
+        this.throttledSendViewportToServer?.cancel();
 
         this._focusFx?.destroy();
 


### PR DESCRIPTION
Calls to setViewport are throttled. When the GameScene was deleted, a throttled call to setViewport could still be sent after the connection was closed. Now fixed.