### PR TITLE
Improve end to end test

### DIFF
--- a/tests/tests/report_issue.spec.ts
+++ b/tests/tests/report_issue.spec.ts
@@ -4,7 +4,7 @@ import { publicTestMapUrl } from "./utils/urls";
 import menu from "./utils/menu";
 
 test.describe("Report issue", () => {
-    test("Should display the report issue button", async ({ browser }) => {
+    test("Should display the report issue button @local", async ({ browser }) => {
         // Create two browser contexts for Alice and Bob
         await using alicePage = await getPage(browser, 'Alice',
             publicTestMapUrl("tests/E2E/empty.json", "report_issue")


### PR DESCRIPTION
The report test can be ok only if the SENTRY_DNS environment file is defined. Tag in @local to not execute the test for Kubernetes.