### PR TITLE
Create new property for the megaphone

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -203,7 +203,7 @@ jobs:
         run: npm run pretty-check
         working-directory: "libs/map-editor"
 
-      - name: "jest"
+      - name: "vitest"
         run: npm test
         working-directory: "libs/map-editor"
 
@@ -303,7 +303,7 @@ jobs:
         run: npm run pretty-check
         working-directory: "libs/shared-utils"
 
-      - name: "jest"
+      - name: "vitest"
         run: npm test
         working-directory: "libs/shared-utils"
 

--- a/back/src/Model/Space.ts
+++ b/back/src/Model/Space.ts
@@ -282,7 +282,7 @@ export class Space implements CustomJsonReplacerInterface, ICommunicationSpace {
                 return true;
             }
             case FilterType.LIVE_STREAMING_USERS: {
-                return /*(user.screenSharingState || user.microphoneState || user.cameraState) &&*/ user.megaphoneState;
+                return user.megaphoneState;
             }
             case FilterType.LIVE_STREAMING_USERS_WITH_FEEDBACK: {
                 return true;

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -215,6 +215,7 @@ export class SocketManager {
                     room.roomGroup ?? new URL(room.roomUrl).host,
                     room.roomUrl
                 ),
+                audienceVideoFeedbackActivated: room.wamSettings?.megaphone?.audienceVideoFeedbackActivated ?? false,
             },
         };
 

--- a/docs/schema/2.0.0/wam.json
+++ b/docs/schema/2.0.0/wam.json
@@ -1054,7 +1054,7 @@
                     "type": "string"
                   }
                 },
-                "bigBrowserActivated": {
+                "audienceVideoFeedbackActivated": {
                   "type": "boolean"
                 }
               },

--- a/libs/map-editor/src/Commands/WAM/UpdateWAMSettingCommand.ts
+++ b/libs/map-editor/src/Commands/WAM/UpdateWAMSettingCommand.ts
@@ -33,9 +33,9 @@ export class UpdateWAMSettingCommand extends Command {
             title: message.updateMegaphoneSettingMessage.title ?? this.oldConfig?.megaphone?.title,
             rights: message.updateMegaphoneSettingMessage.rights ?? this.oldConfig?.megaphone?.rights,
             enabled: message.updateMegaphoneSettingMessage.enabled ?? this.oldConfig?.megaphone?.enabled ?? false,
-            bigBrowserActivated:
-                message.updateMegaphoneSettingMessage.bigBrowserActivated ??
-                this.oldConfig?.megaphone?.bigBrowserActivated ??
+            audienceVideoFeedbackActivated:
+                message.updateMegaphoneSettingMessage.audienceVideoFeedbackActivated ??
+                this.oldConfig?.megaphone?.audienceVideoFeedbackActivated ??
                 false,
         };
         /*        break;

--- a/libs/map-editor/src/types.ts
+++ b/libs/map-editor/src/types.ts
@@ -359,7 +359,7 @@ export const MegaphoneSettings = z.object({
     title: z.string().optional(),
     scope: z.string().optional(),
     rights: z.array(z.string()).optional(),
-    bigBrowserActivated: z.boolean().optional(),
+    audienceVideoFeedbackActivated: z.boolean().optional(),
 });
 
 export type MegaphoneSettings = z.infer<typeof MegaphoneSettings>;

--- a/libs/map-editor/tests/WAMMetadata.test.ts
+++ b/libs/map-editor/tests/WAMMetadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, assert } from "vitest";
-import { UpdateWAMMetadataCommand, WAMFileFormat } from "../src";
+import { UpdateWAMMetadataCommand, type WAMFileFormat } from "../src";
 
 describe("WAM Metadata", () => {
     const defaultWamFile: WAMFileFormat = {

--- a/libs/map-editor/tests/WAMSetting.test.ts
+++ b/libs/map-editor/tests/WAMSetting.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, assert } from "vitest";
-import { UpdateWAMSettingCommand, WAMFileFormat } from "../src";
+import { describe, expect, it } from "vitest";
+import { UpdateWAMSettingCommand, type WAMFileFormat } from "../src";
 
 describe("WAM Setting", () => {
     const defaultWamFile: WAMFileFormat = {
@@ -14,7 +14,7 @@ describe("WAM Setting", () => {
         title: "testTitle",
         rights: ["testRights"],
         scope: "testScope",
-        bigBrowserActivated: true,
+        audienceVideoFeedbackActivated: false,
     };
     it("should change WAM file loaded when WAMSettingCommand received", async () => {
         const wamFile: WAMFileFormat = { ...defaultWamFile };
@@ -29,23 +29,6 @@ describe("WAM Setting", () => {
             "test-uuid"
         );
         await command.execute();
-        expect(wamFile.settings).toBeDefined();
-        if (wamFile.settings) {
-            expect(wamFile.settings.megaphone).toBeDefined();
-            if (wamFile.settings.megaphone) {
-                expect(wamFile.settings.megaphone).toEqual(dataToModify);
-            } else {
-                assert.fail("wamFile.settings.megaphone is not defined");
-            }
-        } else {
-            assert.fail("wamFile.settings is not defined");
-        }
-        /*expect(result.type).toBe("UpdateWAMSettingCommand");
-        if (result.type === "UpdateWAMSettingCommand") {
-            expect(result.name).toBe("megaphone");
-            expect(result.dataToModify).toEqual(dataToModify);
-        } else {
-            assert.fail("result.type is not UpdateWAMSettingCommand");
-        }*/
+        expect(wamFile?.settings?.megaphone).toEqual(dataToModify);
     });
 });

--- a/libs/shared-utils/tests/Jitsi/slugify.spec.ts
+++ b/libs/shared-utils/tests/Jitsi/slugify.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Json } from "@workadventure/tiled-map-type-guard";
+import type { Json } from "@workadventure/tiled-map-type-guard";
 import { GameMapProperties } from "@workadventure/map-editor";
 import { slugifyJitsiRoomName } from "../../src/Jitsi/slugify";
 

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -220,7 +220,7 @@ message UpdateMegaphoneSettingMessage {
   optional string title = 2;
   optional string scope = 3;
   repeated string rights = 4;
-  optional bool bigBrowserActivated = 5;
+  optional bool audienceVideoFeedbackActivated = 5;
 }
 
 message EditMapCommandMessage {
@@ -840,6 +840,7 @@ message RoomJoinedMessage {
 message MegaphoneSettings{
   bool enabled = 1;
   optional string url = 2;
+  optional bool audienceVideoFeedbackActivated = 3;
 }
 
 message WebRtcStartMessage {

--- a/play/src/front/Components/MapEditor/ConfigureMyRoom/Megaphone.svelte
+++ b/play/src/front/Components/MapEditor/ConfigureMyRoom/Megaphone.svelte
@@ -23,8 +23,8 @@
         { value: "WORLD", label: $LL.mapEditor.settings.megaphone.inputs.world() },
     ];
 
-    let bigBrowserActivated: boolean =
-        gameManager.getCurrentGameScene().wamFile?.settings?.megaphone?.bigBrowserActivated ?? false;
+    let audienceVideoFeedbackActivated: boolean =
+        gameManager.getCurrentGameScene().wamFile?.settings?.megaphone?.audienceVideoFeedbackActivated ?? false;
 
     let loading = false;
 
@@ -71,7 +71,7 @@
                     scope,
                     title,
                     rights: (rights || []).map((right) => right.value),
-                    bigBrowserActivated: bigBrowserActivated,
+                    audienceVideoFeedbackActivated: audienceVideoFeedbackActivated,
                 }),
             });
 
@@ -133,18 +133,25 @@
                 {$LL.mapEditor.settings.megaphone.inputs.rightsHelper()}
             </p>
             <div class="flex flex-wrap gap-x-4 items-center h-fit">
-                <InputSwitch id="megaphone-bigbrowser-switch" bind:value={bigBrowserActivated} disabled={loading} />
-                <label for="megaphone-bigbrowser-switch" class="text-white font-regular peer-checked:text-white">
-                    {#if bigBrowserActivated}
-                        {$LL.mapEditor.settings.megaphone.inputs.bigBrowserActivated()}
+                <InputSwitch
+                    id="megaphone-audience-video-feedback-switch"
+                    bind:value={audienceVideoFeedbackActivated}
+                    disabled={loading}
+                />
+                <label
+                    for="megaphone-audience-video-feedback-switch"
+                    class="text-white font-regular peer-checked:text-white"
+                >
+                    {#if audienceVideoFeedbackActivated}
+                        {$LL.mapEditor.settings.megaphone.inputs.audienceVideoFeedbackActivated()}
                     {:else}
-                        {$LL.mapEditor.settings.megaphone.inputs.bigBrowserActivatedDisabled()}
+                        {$LL.mapEditor.settings.megaphone.inputs.audienceVideoFeedbackActivatedDisabled()}
                     {/if}
                 </label>
             </div>
             <p class="help-text">
                 <IconInfoCircle font-size="18" />
-                {$LL.mapEditor.settings.megaphone.inputs.bigBrowserActivatedHelper()}
+                {$LL.mapEditor.settings.megaphone.inputs.audienceVideoFeedbackActivatedHelper()}
             </p>
             <ButtonState promise={save} initialText={$LL.menu.settings.save()} loadingText="Saving" />
         {:catch error}

--- a/play/src/front/Components/Modal/GlobalCommunicationModal.svelte
+++ b/play/src/front/Components/Modal/GlobalCommunicationModal.svelte
@@ -46,7 +46,6 @@
     let broadcastToWorld = false;
     let handleSendText: { sendTextMessage(broadcast: boolean): void };
     let handleSendAudio: { sendAudioMessage(broadcast: boolean): Promise<void> };
-
     let videoElement: HTMLVideoElement;
     let stream: MediaStream | undefined;
     let aspectRatio = 1;

--- a/play/src/front/Components/Video/PictureInPicture/AudioStreamWrapper.svelte
+++ b/play/src/front/Components/Video/PictureInPicture/AudioStreamWrapper.svelte
@@ -9,7 +9,6 @@
 
     $: muteAudioStore = $streamable?.muteAudio;
     $: muteAudio = $muteAudioStore ?? false;
-    
 </script>
 
 {#if $streamable && ($streamable?.media.type === "webrtc" || $streamable?.media.type === "livekit") && !muteAudio}

--- a/play/src/front/Phaser/Game/MapEditor/Commands/WAM/UpdateWAMSettingFrontCommand.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Commands/WAM/UpdateWAMSettingFrontCommand.ts
@@ -15,7 +15,8 @@ export class UpdateWAMSettingFrontCommand extends UpdateWAMSettingCommand implem
                         ...this.wam.settings?.megaphone,
                         scope: this.wam.settings?.megaphone.scope ?? "",
                         rights: this.wam.settings?.megaphone.rights ?? [],
-                        bigBrowserActivated: this.wam.settings?.megaphone.bigBrowserActivated ?? false,
+                        audienceVideoFeedbackActivated:
+                            this.wam.settings?.megaphone.audienceVideoFeedbackActivated ?? false,
                     },
                 },
             });

--- a/play/src/front/Stores/MegaphoneStore.ts
+++ b/play/src/front/Stores/MegaphoneStore.ts
@@ -10,6 +10,12 @@ export const megaphoneCanBeUsedStore = writable<boolean>(false);
 export const requestedMegaphoneStore = writable<boolean>(false);
 
 export const megaphoneSpaceStore = writable<SpaceInterface | undefined>(undefined);
+
+/**
+ * This store indicates if the auditorium mode is enabled for the megaphone.
+ * When enabled, the speaker can see the camera feeds of all attendees.
+ */
+export const megaphoneAudienceVideoFeedbackActivatedStore = writable<boolean>(false);
 /**
  * This store is true if the user is livestreaming, i.e. if the user is a speaker or (if the user has requested the megaphone and is enabling its camera or microphone or screen)
  */

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -464,7 +464,6 @@ export class RemotePeer extends Peer implements Streamable {
         if (showVoiceIndicator && this.type === "video") {
             this.showVoiceIndicatorStore.forward(showVoiceIndicator);
         }
-
     }
 
     private sendBlockMessage(blocking: boolean) {

--- a/play/src/i18n/ar-SA/mapEditor.ts
+++ b/play/src/i18n/ar-SA/mapEditor.ts
@@ -388,9 +388,9 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 rights: "الحقوق",
                 rightsHelper:
                     "الحقوق تُحدد من يمكنه استخدام الميغافون. إن تركته فارغًا فالجميع يمكنه استخدامه. وإن وضعته فلا يمكن استخدامه إلا لمن لديه أحد هذه الوسوم.",
-                bigBrowserActivated: "وضع القاعة مفعّل",
-                bigBrowserActivatedDisabled: "وضع القاعة معطّل",
-                bigBrowserActivatedHelper:
+                audienceVideoFeedbackActivated: "وضع القاعة مفعّل",
+                audienceVideoFeedbackActivatedDisabled: "وضع القاعة معطّل",
+                audienceVideoFeedbackActivatedHelper:
                     "وضع القاعة مفعّل: استقبل تدفق الكاميرا والميكروفون لجميع المستخدمين (مع تفعيل الكاميرا والميكروفون) في الغرفة/العالم. لكن الحاضر لن يتمكن من رؤية الحاضرين الآخرين. معطّل افتراضيًا.",
                 error: {
                     title: "يرجى إدخال عنوان",

--- a/play/src/i18n/ca-ES/mapEditor.ts
+++ b/play/src/i18n/ca-ES/mapEditor.ts
@@ -26,9 +26,9 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 rights: "Drets",
                 rightsHelper:
                     "Els drets defineixen qui pot utilitzar el megàfon. Si el deixeu buit, qualsevol persona el pot utilitzar. Si el configureu, només els usuaris que tenen una d'aquestes 'etiquetes' el poden utilitzar.",
-                bigBrowserActivated: "Mode auditori activat",
-                bigBrowserActivatedDisabled: "Mode auditori desactivat",
-                bigBrowserActivatedHelper:
+                audienceVideoFeedbackActivated: "Mode auditori activat",
+                audienceVideoFeedbackActivatedDisabled: "Mode auditori desactivat",
+                audienceVideoFeedbackActivatedHelper:
                     "Mode auditori activat: Rep el flux de càmera i micròfon de tots els usuaris (amb càmera i micròfon activats) a la sala/món. Però l'assistent no podrà veure els altres assistents. Desactivat per defecte.",
                 error: {
                     title: "Siusplau, introduïu un nom",

--- a/play/src/i18n/de-DE/mapEditor.ts
+++ b/play/src/i18n/de-DE/mapEditor.ts
@@ -409,9 +409,9 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 rights: "Rechte",
                 rightsHelper:
                     "Die Rechte, die ein Benutzer haben muss, um das Megaphon zu verwenden. Wenn Sie es leer lassen, kann jeder das Megaphon verwenden.",
-                bigBrowserActivated: "Auditorium-Modus aktiviert",
-                bigBrowserActivatedDisabled: "Auditorium-Modus deaktiviert",
-                bigBrowserActivatedHelper:
+                audienceVideoFeedbackActivated: "Auditorium-Modus aktiviert",
+                audienceVideoFeedbackActivatedDisabled: "Auditorium-Modus deaktiviert",
+                audienceVideoFeedbackActivatedHelper:
                     "Auditorium-Modus aktiviert: Empfangen Sie den Kamera- und Mikrofonstream aller Benutzer (mit aktivierter Kamera und Mikrofon) im Raum/der Welt. Der Teilnehmer kann jedoch die anderen Teilnehmer nicht sehen. Standardmäßig deaktiviert.",
                 error: {
                     title: "Fehler",

--- a/play/src/i18n/dsb-DE/mapEditor.ts
+++ b/play/src/i18n/dsb-DE/mapEditor.ts
@@ -213,9 +213,9 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 rights: "Pšawa",
                 rightsHelper:
                     "Pšawa, ako wužywaŕ musy měś, aby megafon wužywał. Gaž wóstajijośo to pólo prozne, ga buźo kuždy móc megafon wužywaś.",
-                bigBrowserActivated: "Auditoriumowy modus zmóžnjony",
-                bigBrowserActivatedDisabled: "Auditoriumowy modus znjemóžnjony",
-                bigBrowserActivatedHelper:
+                audienceVideoFeedbackActivated: "Auditoriumowy modus zmóžnjony",
+                audienceVideoFeedbackActivatedDisabled: "Auditoriumowy modus znjemóžnjony",
+                audienceVideoFeedbackActivatedHelper:
                     "Auditoriumowy modus zmóžnjony: Dostawaśo pśenosowanje kamery a mikrofona wšych wužywarjow (z zmóžnjoneju kameru a mikrofonom) w rumnje/swěśe. Ale wobźělnik njamóžo drugich wobźělnikow wiźeś. Pó standardźe znjemóžnjony.",
                 error: {
                     title: "Zmólka",

--- a/play/src/i18n/en-US/mapEditor.ts
+++ b/play/src/i18n/en-US/mapEditor.ts
@@ -419,9 +419,9 @@ const mapEditor: BaseTranslation = {
                 rights: "Rights",
                 rightsHelper:
                     "The rights define who can use the megaphone. If you leave it empty, anyone can use it. If you set it, only users that have one of those 'tag' can use it.",
-                bigBrowserActivated: "Auditorium mode",
-                bigBrowserActivatedDisabled: "Auditorium mode",
-                bigBrowserActivatedHelper:
+                audienceVideoFeedbackActivated: "Auditorium mode",
+                audienceVideoFeedbackActivatedDisabled: "Auditorium mode",
+                audienceVideoFeedbackActivatedHelper:
                     "Auditorium mode activated: Receive the camera and microphone stream of all users (with camera and microphone activated) in the room/world. But the attendee will not be able to see the other attendees. Disabled by default.",
                 error: {
                     title: "Please enter a title",

--- a/play/src/i18n/fr-FR/mapEditor.ts
+++ b/play/src/i18n/fr-FR/mapEditor.ts
@@ -424,9 +424,9 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 rights: "Droits",
                 rightsHelper:
                     "Les droits définissent qui peut utiliser le megaphone. Si vous le laissez vide, tout le monde peut l'utiliser. Si vous le définissez, seuls les utilisateurs qui ont au moins l'un de ces 'tags' peuvent l'utiliser.",
-                bigBrowserActivated: "Mode auditorium activé",
-                bigBrowserActivatedDisabled: "Mode auditorium désactivé",
-                bigBrowserActivatedHelper:
+                audienceVideoFeedbackActivated: "Mode auditorium activé",
+                audienceVideoFeedbackActivatedDisabled: "Mode auditorium désactivé",
+                audienceVideoFeedbackActivatedHelper:
                     "Mode auditorium activé : Recevez le flux caméra et microphone de tous les utilisateurs (avec caméra et microphone activés) dans la salle/monde. Mais le participant ne pourra pas voir les autres participants. Désactivé par défaut.",
                 error: {
                     title: "Veuillez entrer un nom",

--- a/play/src/i18n/hsb-DE/mapEditor.ts
+++ b/play/src/i18n/hsb-DE/mapEditor.ts
@@ -215,9 +215,9 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 rights: "prawa",
                 rightsHelper:
                     "Prawa, kotrež dyrbi wužiwar měć, zo by megafon wužiwać móhł. Hdyž jón prózdny wostajiće, móže kóždy megafon wužiwać.",
-                bigBrowserActivated: "Auditoriumowy modus zmóžnjeny",
-                bigBrowserActivatedDisabled: "Auditoriumowy modus znjemóžnjeny",
-                bigBrowserActivatedHelper:
+                audienceVideoFeedbackActivated: "Auditoriumowy modus zmóžnjeny",
+                audienceVideoFeedbackActivatedDisabled: "Auditoriumowy modus znjemóžnjeny",
+                audienceVideoFeedbackActivatedHelper:
                     "Auditoriumowy modus zmóžnjeny: Dóstańće přenosowanje kamery a mikrofona wšěch wužiwarjow (z zmóžnjenej kameru a mikrofonom) w runinje/swěće. Ale wobdźělnik njemóže druhich wobdźělnikow widźeć. Po standardźe znjemóžnjeny.",
                 error: {
                     title: "zmylk",

--- a/play/src/i18n/it-IT/mapEditor.ts
+++ b/play/src/i18n/it-IT/mapEditor.ts
@@ -403,9 +403,9 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 rights: "Diritti",
                 rightsHelper:
                     "I diritti definiscono chi può usare il megafono. Se lo lasci vuoto, chiunque può usarlo. Se lo imposti, solo gli utenti che hanno uno di questi 'tag' possono usarlo.",
-                bigBrowserActivated: "Modalità auditorium attivata",
-                bigBrowserActivatedDisabled: "Modalità auditorium disattivata",
-                bigBrowserActivatedHelper:
+                audienceVideoFeedbackActivated: "Modalità auditorium attivata",
+                audienceVideoFeedbackActivatedDisabled: "Modalità auditorium disattivata",
+                audienceVideoFeedbackActivatedHelper:
                     "Modalità auditorium attivata: Ricevi il flusso di camera e microfono di tutti gli utenti (con camera e microfono attivati) nella stanza/mondo. Ma il partecipante non sarà in grado di vedere gli altri partecipanti. Disattivato per impostazione predefinita.",
                 error: {
                     title: "Per favore inserisci un titolo",

--- a/play/src/i18n/ja-JP/mapEditor.ts
+++ b/play/src/i18n/ja-JP/mapEditor.ts
@@ -401,9 +401,9 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 rights: "権限",
                 rightsHelper:
                     "権限によって、誰がメガホンを利用できるかが決まります。空白のままにしておくと、誰でも利用することができます。設定した場合、これらの「タグ」のいずれかに一致するユーザーだけが利用することができます。",
-                bigBrowserActivated: "オーディトリアムモード有効",
-                bigBrowserActivatedDisabled: "オーディトリアムモード無効",
-                bigBrowserActivatedHelper:
+                audienceVideoFeedbackActivated: "オーディトリアムモード有効",
+                audienceVideoFeedbackActivatedDisabled: "オーディトリアムモード無効",
+                audienceVideoFeedbackActivatedHelper:
                     "オーディトリアムモードが有効化されました：ルーム/ワールド内のすべてのユーザー（カメラとマイクが有効化されている）のカメラとマイクストリームを受信します。ただし、参加者は他の参加者を見ることができません。デフォルトでは無効です。",
                 error: {
                     title: "タイトルを入力してください",

--- a/play/src/i18n/ko-KR/mapEditor.ts
+++ b/play/src/i18n/ko-KR/mapEditor.ts
@@ -397,9 +397,9 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 rights: "사용 권한",
                 rightsHelper:
                     "확성기를 누가 사용할 수 있는지 정의합니다. 비워 두면 누구나 사용할 수 있고, 태그를 지정하면 해당 태그를 가진 사용자만 사용할 수 있습니다.",
-                bigBrowserActivated: "강당 모드 활성화",
-                bigBrowserActivatedDisabled: "강당 모드 비활성화",
-                bigBrowserActivatedHelper:
+                audienceVideoFeedbackActivated: "강당 모드 활성화",
+                audienceVideoFeedbackActivatedDisabled: "강당 모드 비활성화",
+                audienceVideoFeedbackActivatedHelper:
                     "강당 모드 활성화: 룸/월드의 모든 사용자(카메라 및 마이크가 활성화된)의 카메라 및 마이크 스트림을 수신합니다. 하지만 참석자는 다른 참석자를 볼 수 없습니다. 기본적으로 비활성화됩니다.",
                 error: {
                     title: "제목을 입력하세요",

--- a/play/src/i18n/nl-NL/mapEditor.ts
+++ b/play/src/i18n/nl-NL/mapEditor.ts
@@ -325,9 +325,9 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
                 rights: "Rechten",
                 rightsHelper:
                     "De rechten bepalen wie de megaphone kan gebruiken. Als je het leeg laat, kan iedereen het gebruiken. Als je het instelt, kunnen alleen gebruikers met een van die 'tags' het gebruiken.",
-                bigBrowserActivated: "Auditoriummodus geactiveerd",
-                bigBrowserActivatedDisabled: "Auditoriummodus gedeactiveerd",
-                bigBrowserActivatedHelper:
+                audienceVideoFeedbackActivated: "Auditoriummodus geactiveerd",
+                audienceVideoFeedbackActivatedDisabled: "Auditoriummodus gedeactiveerd",
+                audienceVideoFeedbackActivatedHelper:
                     "Auditoriummodus geactiveerd: Ontvang de camera- en microfoonstream van alle gebruikers (met camera en microfoon geactiveerd) in de ruimte/wereld. Maar de deelnemer kan de andere deelnemers niet zien. Standaard uitgeschakeld.",
                 error: {
                     title: "Voer een titel in",

--- a/play/src/i18n/pt-BR/mapEditor.ts
+++ b/play/src/i18n/pt-BR/mapEditor.ts
@@ -357,9 +357,9 @@ const mapEditor: BaseTranslation = {
                 rights: "Direitos",
                 rightsHelper:
                     "Os direitos definem quem pode usar o megafone. Se você deixar vazio, qualquer um pode usar. Se você definir, apenas usuários que tenham uma dessas 'tag' podem usar.",
-                bigBrowserActivated: "Modo auditório ativado",
-                bigBrowserActivatedDisabled: "Modo auditório desativado",
-                bigBrowserActivatedHelper:
+                audienceVideoFeedbackActivated: "Modo auditório ativado",
+                audienceVideoFeedbackActivatedDisabled: "Modo auditório desativado",
+                audienceVideoFeedbackActivatedHelper:
                     "Modo auditório ativado: Receba o fluxo de câmera e microfone de todos os usuários (com câmera e microfone ativados) na sala/mundo. Mas o participante não poderá ver os outros participantes. Desativado por padrão.",
                 error: {
                     title: "Por favor, digite um título",

--- a/play/src/pusher/models/PusherRoom.ts
+++ b/play/src/pusher/models/PusherRoom.ts
@@ -180,6 +180,9 @@ export class PusherRoom {
                                                     new URL(this.roomUrl).host,
                                                     this.roomUrl
                                                 ),
+                                                audienceVideoFeedbackActivated:
+                                                    this._wamSettings?.megaphone?.audienceVideoFeedbackActivated ??
+                                                    false,
                                             },
                                         },
                                     });

--- a/tests/tests/utils/map-editor/megaphone.ts
+++ b/tests/tests/utils/map-editor/megaphone.ts
@@ -67,6 +67,10 @@ class Megaphone {
   async isNotCorrectlySaved(page: Page) {
     await expect(page.getByRole('button', { name: 'Error while saving megaphone settings' })).toBeVisible();
   }
+
+  async enableAuditoriumMode(page: Page) {
+    await page.getByTestId('megaphone-audience-video-feedback-switch').click();
+  }
 }
 
 export default new Megaphone();


### PR DESCRIPTION
The speaker can view all camera streams of the user inside the world through this feature (like in meeting). The attendee couldn't see him.

⚠️ If the camera user is not opened, the camera stay closed. ⚠️ An alert will be displayed to the user to authorize camera or stream access.