### PR TITLE
Improve refresh token for external module

### DIFF
--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -506,6 +506,8 @@ message ChatMembersQuery {
 
 message OauthRefreshTokenQuery {
   string tokenToRefresh = 1;
+  optional string provider = 2;
+  optional string userIdentifier = 3;
 }
 
 message  SearchTagsQuery{

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -1619,12 +1619,18 @@ export class RoomConnection implements RoomConnection {
         return answer.chatMembersAnswer;
     }
 
-    public async getOauthRefreshToken(tokenToRefresh: string): Promise<OauthRefreshToken> {
+    public async getOauthRefreshToken(
+        tokenToRefresh: string,
+        provider?: string,
+        userIdentifier?: string
+    ): Promise<OauthRefreshToken> {
         try {
             const answer = await this.query({
                 $case: "oauthRefreshTokenQuery",
                 oauthRefreshTokenQuery: {
                     tokenToRefresh,
+                    provider,
+                    userIdentifier,
                 },
             });
             if (answer.$case !== "oauthRefreshTokenAnswer") {

--- a/play/src/pusher/services/AdminApi.ts
+++ b/play/src/pusher/services/AdminApi.ts
@@ -1177,16 +1177,30 @@ class AdminApi implements AdminInterface {
      *        required: true
      *        type: "string"
      *        description: The expired refresh
+     *      - name: "provider"
+     *        in: "query"
+     *        required: false
+     *        type: "string"
+     *        description: The provider of the user
+     *        example: "google"
+     *      - name: "userIdentifier"
+     *        in: "query"
+     *        required: false
+     *        type: "string"
+     *        description: The identifier of the user
+     *        example: "998ce839-3dea-4698-8b41-ebbdf7688ad9"
      *     responses:
      *       200:
      *        schema:
      *            $ref: '#/definitions/OauthRefreshToken'
      */
-    async refreshOauthToken(token: string): Promise<OauthRefreshToken> {
+    async refreshOauthToken(token: string, provider?: string, userIdentifier?: string): Promise<OauthRefreshToken> {
         const response = await axios.post(
             `${ADMIN_URL}/api/oauth/refreshtoken`,
             {
                 accessToken: token,
+                provider: provider,
+                userIdentifier: userIdentifier,
             },
             {
                 headers: { Authorization: `${ADMIN_API_TOKEN}` },

--- a/play/src/pusher/services/AdminInterface.ts
+++ b/play/src/pusher/services/AdminInterface.ts
@@ -142,7 +142,7 @@ export interface AdminInterface {
 
     updateChatId(userIdentifier: string, chatId: string, roomUrl: string): Promise<void>;
 
-    refreshOauthToken(token: string): Promise<OauthRefreshToken>;
+    refreshOauthToken(token: string, provider?: string, userIdentifier?: string): Promise<OauthRefreshToken>;
 
     getIceServers(userId: number, userIdentifier: string, roomUrl: string): Promise<IceServer[]>;
 }

--- a/play/src/pusher/services/LocalAdmin.ts
+++ b/play/src/pusher/services/LocalAdmin.ts
@@ -426,7 +426,7 @@ class LocalAdmin implements AdminInterface {
         return Promise.resolve();
     }
 
-    refreshOauthToken(token: string): Promise<OauthRefreshToken> {
+    refreshOauthToken(token: string, provider?: string, userIdentifier?: string): Promise<OauthRefreshToken> {
         return Promise.reject(new Error("No admin backoffice set!"));
     }
 

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -1375,7 +1375,11 @@ export class SocketManager implements ZoneEventListener {
     async handleOauthRefreshTokenQuery(
         oauthRefreshTokenQuery: OauthRefreshTokenQuery
     ): Promise<OauthRefreshTokenAnswer> {
-        const { token, message } = await adminService.refreshOauthToken(oauthRefreshTokenQuery.tokenToRefresh);
+        const { token, message } = await adminService.refreshOauthToken(
+            oauthRefreshTokenQuery.tokenToRefresh,
+            oauthRefreshTokenQuery.provider,
+            oauthRefreshTokenQuery.userIdentifier
+        );
         return { message, token };
     }
 


### PR DESCRIPTION
The issue is that during token live, the token will change inside the front through the metadata of the map details. The problem is when the user is cut down or one of the service restarts, the metadata previously used is not correct and the front tries to update the token with the old token that does not exist in the database. The token cannot be used and the external module is incorrect.

To resolve the issue, we send the provider used and user ID. Using these two new parameters, it is possible to determine if the token is old or not in use in the database. By using a provider and user ID, the admin has the ability to obtain member status and refresh the token.