### PR TITLE
Fixing audio getting cut when exiting Livekit

### DIFF
--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -71,7 +71,6 @@ export class LiveKitRoom implements LiveKitRoomInterface {
             publishDefaults: {
                 videoSimulcastLayers: [VideoPresets.h360, VideoPresets.h90],
                 videoCodec: "vp8",
-                stopMicTrackOnMute: true,
             },
             videoCaptureDefaults: {
                 resolution: VideoPresets.h720,
@@ -545,20 +544,6 @@ export class LiveKitRoom implements LiveKitRoomInterface {
             this.room?.off(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected.bind(this));
             this.room?.off(RoomEvent.ActiveSpeakersChanged, this.handleActiveSpeakersChanged.bind(this));
 
-            this.localParticipant?.setMicrophoneEnabled(false).catch((err) => {
-                console.error("An error occurred while disabling microphone", err);
-                Sentry.captureException(err);
-            });
-            // Clean up custom video tracks
-            this.unpublishCameraTrack().catch((err) => {
-                console.error("An error occurred while unpublishing camera track during destroy", err);
-                Sentry.captureException(err);
-            });
-            // Clean up screen share tracks (video and audio)
-            this.unpublishAllScreenShareTrack().catch((err) => {
-                console.error("An error occurred while unpublishing screen share tracks during destroy", err);
-                Sentry.captureException(err);
-            });
             this.leaveRoom();
         } finally {
             this._livekitRoomCounter.decrement();


### PR DESCRIPTION
When a Livekit room was destroyed, we were calling `this.localParticipant?.setMicrophoneEnabled(false)`.

This was actually a lost call of the time when we used `setMicrophoneEnabled` to enable/disable the microphone. But we don't do like this nowadays. Instead, we provide Livekit with a stream. As a result, Livekit would "stop" the local audio stream we provided when quitting Livekit.

We fix this by... doing nothing! When we leave the room, Livekit cleans up resources, and we already take care of local resources.