### PR TITLE
Debugging livestream spaces E2E test

### DIFF
--- a/tests/tests/scripting_spaces.spec.ts
+++ b/tests/tests/scripting_spaces.spec.ts
@@ -257,10 +257,14 @@ test.describe('Scripting space-related functions @nowebkit', () => {
             window.userCount = 0;
             window.mySpace = await WA.spaces.joinSpace("some-test-space", "streaming",[]);
             window.mySpace.userJoinedObservable.subscribe((user) => {
+                console.log("User joined:", user);
                 window.userCount++;
                 window.lastJoinedUser = user;
             });
-            window.mySpace.userLeftObservable.subscribe((user) => window.userCount--);
+            window.mySpace.userLeftObservable.subscribe((user) => {
+                console.log("User left:", user);
+                window.userCount--;
+            });
         });
 
         // Bob joins the same space


### PR DESCRIPTION
- Adding console logs to understand why E2E tests with livestream spaces fail in Helm