### PR TITLE
Removing speaker selection in Safari-like browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26144,6 +26144,7 @@
       "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.15.14.tgz",
       "integrity": "sha512-q3QY1Md6+2l4LpV7OPSrKYbuMfMoEbcu+UaJL2e8Btrkh7R2wGJzWh8A852Stx4It1508IP9PK4q7U6trDzvYA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@livekit/mutex": "1.1.1",
         "@livekit/protocol": "1.42.2",
@@ -26165,6 +26166,7 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -39356,7 +39358,7 @@
         "jsonwebtoken": "^9.0.0",
         "limiter": "^3.0.0",
         "live-directory": "moufmouf/live-directory#hot_reload_param",
-        "livekit-client": "^2.15.14",
+        "livekit-client": "^2.16.0",
         "lodash": "^4.17.21",
         "marked": "^12.0.2",
         "marked-highlight": "^2.1.4",
@@ -39970,6 +39972,15 @@
         "@esbuild/win32-x64": "0.18.20"
       }
     },
+    "play/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "play/node_modules/is-fullwidth-code-point": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
@@ -40164,6 +40175,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "play/node_modules/livekit-client": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.16.0.tgz",
+      "integrity": "sha512-2iYJ4dok17yV5CGeaY1yaFvz7rMuNUmXN1+nXvhUrkxTS/RcuteWTpxwrgLG/Vl1yxkf/YquVQ7bbRwFye20CA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.42.2",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "ts-debounce": "^4.0.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
       }
     },
     "play/node_modules/p-limit": {

--- a/play/package.json
+++ b/play/package.json
@@ -149,7 +149,7 @@
     "jsonwebtoken": "^9.0.0",
     "limiter": "^3.0.0",
     "live-directory": "moufmouf/live-directory#hot_reload_param",
-    "livekit-client": "^2.15.14",
+    "livekit-client": "^2.16.0",
     "lodash": "^4.17.21",
     "marked": "^12.0.2",
     "marked-highlight": "^2.1.4",

--- a/play/src/front/Components/ActionBar/MediaSettingsList.svelte
+++ b/play/src/front/Components/ActionBar/MediaSettingsList.svelte
@@ -293,14 +293,14 @@
                     </div>
                 {/each}
             </div>
-        {:else}
+        {:else if $speakerListStore !== undefined}
             <div class="flex flex-col gap-1">
                 <div class="flex text-xxs uppercase text-white/50 px-2 pb-0.5 pt-1 relative bold">
                     {$LL.actionbar.subtitle.speaker()}
                 </div>
                 <div class="cursor-pointer group flex items-center relative z-10 py-1 px-2 font-sm justify-center">
                     <div class="text-sm italic">
-                        {#if $speakerListStore == undefined || $speakerListStore.length == 0}
+                        {#if $speakerListStore.length === 0}
                             {$LL.actionbar.speaker.noDevices()}
                         {:else}
                             {$LL.actionbar.speaker.disabled()}

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -4,7 +4,7 @@ import deepEqual from "fast-deep-equal";
 import { AvailabilityStatus } from "@workadventure/messages";
 import * as Sentry from "@sentry/svelte";
 import { localUserStore } from "../Connection/LocalUserStore";
-import { isIOS } from "../WebRtc/DeviceUtils";
+import { isIOS, isSafari } from "../WebRtc/DeviceUtils";
 import { ObtainedMediaStreamConstraints } from "../WebRtc/P2PMessages/ConstraintMessage";
 import { SoundMeter } from "../Phaser/Components/SoundMeter";
 import { RequestedStatus } from "../Rules/StatusRules/statusRules";
@@ -1041,6 +1041,15 @@ export const microphoneListStore = derived(deviceListStore, ($deviceListStore) =
 export const speakerListStore = derived(deviceListStore, ($deviceListStore) => {
     if ($deviceListStore === undefined) {
         return undefined;
+    }
+
+    // Livekit does not support audio output device selection on Safari
+    // Code: https://github.com/livekit/client-sdk-js/blob/dbaf7a9b784114728857a447734bc5d5453345b4/src/room/utils.ts#L144C1-L153C2
+    // And it seems there is no plan to support it. Issue: https://github.com/livekit/components-js/issues/1216
+    // Because the audio output selector should work in full-mesh WebRTC AND in Livekit, we have to support the same
+    // features in both modes. So we disable audio output device selection on Safari here.
+    if (isSafari() || isIOS()) {
+        return;
     }
 
     return removeDuplicateDevices($deviceListStore.filter((device) => device.kind === "audiooutput"));


### PR DESCRIPTION
Livekit does not allow selecting output devices in Safari (even on computer where setSinkId is available).

As a result, in a Livekit meeting, when we trigger an audio device change, we get this error:

> cannot switch audio output, the current browser does not support it

Livekit does not plan supporting this. See: livekit/components-js#1216

As a result, this commit is removing support for audio output selector in Safari-like browsers to align with Livekit.

Closes https://github.com/workadventure/workadventure/issues/5423