### PR TITLE
Rolling back dev version of Synapse to v1.141.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -483,7 +483,9 @@ services:
     # A mock server to test OpenID connect connectivity
 
   synapse:
-    image: matrixdotorg/synapse:v1.144.0
+    # Note: v1.141.0 introduces a breaking change in OIDC authentication in http with Webkit
+    # See https://github.com/element-hq/synapse/pull/19309
+    image: matrixdotorg/synapse:v1.140.0
     entrypoint: /data/start.sh
     labels:
       - "traefik.enable=true"


### PR DESCRIPTION
v1.141.0 introduces a breaking change in OIDC authentication in http with Webkit

See issue: https://github.com/element-hq/synapse/issues/19303
See PR: https://github.com/element-hq/synapse/pull/19309