### PR TITLE
Making video box "Svelte immutable" and refactoring volume stores

### DIFF
--- a/play/src/front/Components/Video/CenteredVideo.svelte
+++ b/play/src/front/Components/Video/CenteredVideo.svelte
@@ -1,3 +1,5 @@
+<svelte:options immutable={true} />
+
 <script lang="ts">
     import LL from "../../../i18n/i18n-svelte";
     import type { Streamable } from "../../Stores/StreamableCollectionStore";

--- a/play/src/front/Components/Video/MediaBox.svelte
+++ b/play/src/front/Components/Video/MediaBox.svelte
@@ -1,3 +1,5 @@
+<svelte:options immutable={true} />
+
 <script lang="ts">
     import { fly } from "svelte/transition";
     import type { Readable } from "svelte/store";

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -1,3 +1,5 @@
+<svelte:options immutable={true} />
+
 <script lang="ts">
     //STYLE: Classes factorizing tailwind's ones are defined in video-ui.scss
 

--- a/play/src/front/Components/Video/VideoTags/LivekitVideo.svelte
+++ b/play/src/front/Components/Video/VideoTags/LivekitVideo.svelte
@@ -1,3 +1,5 @@
+<svelte:options immutable={true} />
+
 <script lang="ts">
     import { createEventDispatcher, onDestroy } from "svelte";
     import type { Readable } from "svelte/store";

--- a/play/src/front/Components/Video/VideoTags/ScriptingVideo.svelte
+++ b/play/src/front/Components/Video/VideoTags/ScriptingVideo.svelte
@@ -1,3 +1,5 @@
+<svelte:options immutable={true} />
+
 <script lang="ts">
     import type { ScriptingVideoStreamable } from "../../../Stores/StreamableCollectionStore";
 

--- a/play/src/front/Components/Video/VideoTags/WebRtcVideo.svelte
+++ b/play/src/front/Components/Video/VideoTags/WebRtcVideo.svelte
@@ -1,3 +1,5 @@
+<svelte:options immutable={true} />
+
 <script lang="ts">
     import { createEventDispatcher, onDestroy, onMount } from "svelte";
     import type { WebRtcStreamable } from "../../../Stores/StreamableCollectionStore";

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -886,28 +886,24 @@ export const obtainedMediaConstraintStore = writable<ObtainedMediaStreamConstrai
     video: false,
 });
 
-export const localVolumeStore = readable<number[] | undefined>(undefined, (set) => {
-    let timeout: ReturnType<typeof setTimeout>;
-    let soundMeter: SoundMeter;
-    const unsubscribe = localStreamStore.subscribe((localStreamStoreValue) => {
-        clearInterval(timeout);
-        if (soundMeter) {
-            soundMeter.stop();
-        }
-        if (localStreamStoreValue.type === "error") {
+export const localVolumeStore = derived<typeof localStreamStore, number[] | undefined>(
+    localStreamStore,
+    ($localStreamStoreValue, set) => {
+        if ($localStreamStoreValue.type === "error") {
             set(undefined);
             return;
         }
-        const mediaStream = localStreamStoreValue.stream;
+        const mediaStream = $localStreamStoreValue.stream;
 
         if (mediaStream === undefined || mediaStream.getAudioTracks().length <= 0) {
             set(undefined);
             return;
         }
-        soundMeter = new SoundMeter(mediaStream);
+
+        const soundMeter = new SoundMeter(mediaStream);
         let error = false;
 
-        timeout = setInterval(() => {
+        const timeout = setInterval(() => {
             try {
                 set(soundMeter.getVolume());
             } catch (err) {
@@ -917,16 +913,14 @@ export const localVolumeStore = readable<number[] | undefined>(undefined, (set) 
                 }
             }
         }, 100);
-    });
 
-    return () => {
-        unsubscribe();
-        clearInterval(timeout);
-        if (soundMeter) {
+        return () => {
+            clearInterval(timeout);
             soundMeter.stop();
-        }
-    };
-});
+        };
+    },
+    undefined
+);
 
 const talkIconVolumeThreshold = 10;
 


### PR DESCRIPTION
Making Video box related elements "immutable".
This is interesting to avoid triggering "$:" if the prop reference did not change. This is making much less subscribe triggers which is a very good thing.

Also: refactoring volume stores from readable+subscribe to an easier to understand *derived*.