### PR TITLE
replace icons in MapSubMenuContent and MapEditorSideBar

### DIFF
--- a/play/src/front/Components/ActionBar/MenuIcons/MapSubMenuContent.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/MapSubMenuContent.svelte
@@ -20,7 +20,7 @@
     import ActionBarButton from "../ActionBarButton.svelte";
     import { EditorToolName } from "../../../Phaser/Game/MapEditor/MapEditorModeManager";
     import AdditionalMenuItems from "./AdditionalMenuItems.svelte";
-    import { IconSearch, IconSpeakerPhone, IconMapEditor } from "@wa-icons";
+    import { IconMapSearch, IconSpeakerPhone, IconMapEditor } from "@wa-icons";
 
     function resetChatVisibility() {
         chatVisibilityStore.set(false);
@@ -76,7 +76,7 @@
 {/if}
 {#if $mapManagerActivated}
     <ActionBarButton on:click={toggleMapExplorerMode} label={$LL.mapEditor.sideBar.exploreTheRoom()}>
-        <IconSearch font-size="20" />
+        <IconMapSearch font-size="20" />
     </ActionBarButton>
 {/if}
 {#if $globalMessageVisibleStore}

--- a/play/src/front/Components/MapEditor/MapEditorSideBar.svelte
+++ b/play/src/front/Components/MapEditor/MapEditorSideBar.svelte
@@ -10,7 +10,7 @@
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import { mapEditorActivated, mapEditorActivatedForThematics } from "../../Stores/MenuStore";
     import { isMediaBreakpointUp } from "../../Utils/BreakpointsUtils";
-    import { IconX, IconTexture, IconLamp, IconMapSearch, IconSettingsFilled, IconTrash } from "@wa-icons";
+    import { IconX, IconTexture, IconLamp, IconMapSearch, IconSettings, IconTrash } from "@wa-icons";
 
     const availableTools: { toolName: EditorToolName; iconComponent: ComponentType; tooltiptext: LocalizedString }[] =
         [];
@@ -46,7 +46,7 @@
         availableTools.push(entityEditorTool);
         availableTools.push({
             toolName: EditorToolName.WAMSettingsEditor,
-            iconComponent: IconSettingsFilled,
+            iconComponent: IconSettings,
             tooltiptext: $LL.mapEditor.sideBar.configureMyRoom(),
         });
         availableTools.push(trashEditorTool);


### PR DESCRIPTION
- Replaced IconSearch with IconMapSearch in MapSubMenuContent.svelte.
- Updated IconSettingsFilled to IconSettings in MapEditorSideBar.svelte.
- Ensured consistency in icon usage across components.