### PR TITLE
Fixing webcam / microphone requested state

### DIFF
--- a/play/src/front/Components/ActionBar/MenuIcons/CameraMenuItem.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/CameraMenuItem.svelte
@@ -49,7 +49,7 @@
     state={$cameraButtonStateStore}
     dataTestId="camera-button"
     on:mouseenter={() => {
-        if ($availabilityStatusStore == AvailabilityStatus.ONLINE) mouseIsHoveringCameraButton.set(true);
+        if ($availabilityStatusStore === AvailabilityStatus.ONLINE) mouseIsHoveringCameraButton.set(true);
         else mouseIsHoveringCameraButton.set(false);
     }}
     on:mouseleave={() => mouseIsHoveringCameraButton.set(false)}

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -652,12 +652,16 @@ export const rawLocalStreamStore = derived<[typeof mediaStreamConstraintsStore],
                             type: "success",
                             stream: currentStream,
                         });
+                        batchGetUserMediaStore.startBatch();
                         if (currentStream.getVideoTracks().length > 0) {
                             usedCameraDeviceIdStore.set(currentStream.getVideoTracks()[0]?.getSettings().deviceId);
                             obtainedMediaConstraintStore.update((c) => {
                                 c.video = true;
                                 return c;
                             });
+                            // Also, let's switch the webcam back on if it was off (because some code or the user might have turned it off while we were waiting for getUserMedia,
+                            // but we need to show the user that the webcam is on because we just got a stream)
+                            requestedCameraState.enableWebcam();
                         }
                         if (currentStream.getAudioTracks().length > 0) {
                             usedMicrophoneDeviceIdStore.set(currentStream.getAudioTracks()[0]?.getSettings().deviceId);
@@ -665,7 +669,11 @@ export const rawLocalStreamStore = derived<[typeof mediaStreamConstraintsStore],
                                 c.audio = true;
                                 return c;
                             });
+                            // Also, let's switch the microphone back on if it was off (because some code or the user might have turned it off while we were waiting for getUserMedia,
+                            // but we need to show the user that the microphone is on because we just got a stream)
+                            requestedMicrophoneState.enableMicrophone();
                         }
+                        batchGetUserMediaStore.commitChanges();
                         hideHelpCameraSettings();
                         return stream;
                     } catch (e) {


### PR DESCRIPTION
When going through the webcam selection screen, if the user does not allow webcam/microphone right away and goes into the game, the app would turn the requested state to false.
If afterwards, the webcam authorisation was granted, we would switch in a weird state where there is a stream (especially an audio one in bubbles), despite the app displaying a "no sound" icon.

We fix this by explicitly setting the requested cam/mic to true as soon as the user grants cam/mic access in the browser.