### PR TITLE
fix: Construct entity collection and file URLs relative to map-storage

### DIFF
--- a/play/src/front/Components/MapEditor/PropertyEditor/FileUpload/FileUpload.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/FileUpload/FileUpload.svelte
@@ -78,9 +78,14 @@
         const fileName = selectedFile.name.slice(0, lastDot);
         const fileExt = selectedFile.name.slice(lastDot + 1);
 
-        const fileUrl = `${get(gameSceneStore)?.room.mapStorageUrl?.toString()}private/files/${fileName}-${
-            property.id
-        }.${fileExt}`;
+        const mapStorageUrl = get(gameSceneStore)?.room.mapStorageUrl;
+        if (!mapStorageUrl) {
+            throw new Error("Map storage URL is not available");
+        }
+        // Files are stored at map-storage root, not relative to WAM file
+        // Construct URL relative to map-storage origin
+        const filePath = `private/files/${fileName}-${property.id}.${fileExt}`;
+        const fileUrl = new URL(filePath, `${mapStorageUrl.protocol}//${mapStorageUrl.host}`).toString();
 
         property.name = selectedFile.name;
         property.link = fileUrl;

--- a/play/src/front/Components/PopUp/PopUpDropFileEntity.svelte
+++ b/play/src/front/Components/PopUp/PopUpDropFileEntity.svelte
@@ -67,9 +67,15 @@
         const lastDot = file.name.lastIndexOf(".");
         const name = file.name.slice(0, lastDot);
         const fileExt = file.name.slice(lastDot + 1);
-        const fileUrl = `${get(
-            gameSceneStore
-        )?.room.mapStorageUrl?.toString()}private/files/${name}-${propertyId}.${fileExt}`;
+
+        const mapStorageUrl = get(gameSceneStore)?.room.mapStorageUrl;
+        if (!mapStorageUrl) {
+            throw new Error("Map storage URL is not available");
+        }
+        // Files are stored at map-storage root, not relative to WAM file
+        // Construct URL relative to map-storage origin
+        const filePath = `private/files/${name}-${propertyId}.${fileExt}`;
+        const fileUrl = new URL(filePath, `${mapStorageUrl.protocol}//${mapStorageUrl.host}`).toString();
 
         const fileBuffer = await file.arrayBuffer();
         const fileAsUint8Array = new Uint8Array(fileBuffer);

--- a/play/src/front/Connection/Room.ts
+++ b/play/src/front/Connection/Room.ts
@@ -280,8 +280,19 @@ export class Room {
         if (!this._wamUrl) {
             return undefined;
         }
-        const mapStoragePath = `${PUBLIC_MAP_STORAGE_PREFIX}`;
-        return new URL(mapStoragePath, this._wamUrl);
+        // mapStorageUrl should point to the root of the map-storage service, not the WAM file
+        // Extract the origin (protocol + host) from the WAM URL
+        const wamUrlObj = new URL(this._wamUrl);
+        const origin = `${wamUrlObj.protocol}//${wamUrlObj.host}`;
+
+        // If PUBLIC_MAP_STORAGE_PREFIX is set (e.g., "/map-storage" for reverse proxy setups),
+        // append it to the origin to get the correct map-storage root URL
+        if (PUBLIC_MAP_STORAGE_PREFIX) {
+            return new URL(PUBLIC_MAP_STORAGE_PREFIX, origin);
+        }
+
+        // Otherwise, just return the origin (no path prefix)
+        return new URL(origin);
     }
 
     get authenticationMandatory(): boolean {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -24,7 +24,7 @@ import { z } from "zod";
 import type { ITiledMap, ITiledMapLayer, ITiledMapObject, ITiledMapTileset } from "@workadventure/tiled-map-type-guard";
 import type { AreaData, EntityPrefabType } from "@workadventure/map-editor";
 import {
-    ENTITIES_FOLDER_PATH_NO_PREFIX,
+    ENTITIES_FOLDER_PATH,
     ENTITY_COLLECTION_FILE,
     EntityPermissions,
     GameMap,
@@ -55,7 +55,6 @@ import {
     ENABLE_OPENID,
     MAX_PER_GROUP,
     POSITION_DELAY,
-    PUBLIC_MAP_STORAGE_PREFIX,
     WOKA_SPEED,
 } from "../../Enum/EnvironmentVariable";
 import { Room } from "../../Connection/Room";
@@ -601,8 +600,15 @@ export class GameScene extends DirtyScene {
     }
 
     public getCustomEntityCollectionUrl() {
-        const mapStoragePath = `${PUBLIC_MAP_STORAGE_PREFIX}${ENTITIES_FOLDER_PATH_NO_PREFIX}/${ENTITY_COLLECTION_FILE}`;
-        return new URL(mapStoragePath, this.wamUrlFile).toString();
+        if (!this.wamUrlFile) {
+            throw new Error("WAM URL is not available");
+        }
+
+        const wamUrl = new URL(this.wamUrlFile);
+        // Entity collection is stored at map-storage root, not relative to WAM file
+        // Construct URL relative to map-storage origin
+        const entityCollectionPath = `${ENTITIES_FOLDER_PATH}/${ENTITY_COLLECTION_FILE}`;
+        return new URL(entityCollectionPath, `${wamUrl.protocol}//${wamUrl.host}`).toString();
     }
 
     //hook initialisation

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -600,15 +600,14 @@ export class GameScene extends DirtyScene {
     }
 
     public getCustomEntityCollectionUrl() {
-        if (!this.wamUrlFile) {
-            throw new Error("WAM URL is not available");
+        const mapStorageUrl = this.room.mapStorageUrl;
+        if (!mapStorageUrl) {
+            throw new Error("Map storage URL is not available");
         }
-
-        const wamUrl = new URL(this.wamUrlFile);
         // Entity collection is stored at map-storage root, not relative to WAM file
-        // Construct URL relative to map-storage origin
+        // Use room.mapStorageUrl which correctly handles path prefixes for reverse proxy setups
         const entityCollectionPath = `${ENTITIES_FOLDER_PATH}/${ENTITY_COLLECTION_FILE}`;
-        return new URL(entityCollectionPath, `${wamUrl.protocol}//${wamUrl.host}`).toString();
+        return new URL(entityCollectionPath, mapStorageUrl.toString()).toString();
     }
 
     //hook initialisation


### PR DESCRIPTION
Entity collection is stored at map-storage root, not relative to WAM file.

Previously, entity collection and file upload URLs were constructed relative to the WAM file path, causing errors when WAM and entities are on different paths (Admin API). Files are stored at the map-storage root, not relative to the WAM file location.

This fix:
- Constructs entity collection URL relative to map-storage origin
- Constructs file upload URLs relative to map-storage origin
- Works with both default setup and Admin API setup
- Works with USE_DOMAIN_NAME_IN_PATH=true or false
- Works with both S3 and local storage