### PR TITLE
Add highlight property recalculation in AreasPropertiesListener

### DIFF
--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -370,6 +370,9 @@ export class AreasPropertiesListener {
                     console.error(e);
                     Sentry.captureException(e);
                 });
+
+                this.recalculateHighlightProperty(area);
+
                 break;
             }
             case "exit": {
@@ -490,6 +493,13 @@ export class AreasPropertiesListener {
             default: {
                 break;
             }
+        }
+    }
+
+    private recalculateHighlightProperty(area: AreaData): void {
+        const highlightProperty = area.properties?.find((property) => property.type === "highlight");
+        if (highlightProperty) {
+            this.handleHighlightPropertyOnEnter(area, highlightProperty);
         }
     }
 


### PR DESCRIPTION
This update introduces a new method to recalculate the highlight property for areas when certain events occur. The method is invoked in response to specific listener actions, ensuring that the highlight state is accurately maintained. Additionally, minor formatting adjustments were made for code clarity.