### PR TITLE
Adding a video quality HUD

### DIFF
--- a/play/src/front/Components/Menu/SettingsSubMenu.svelte
+++ b/play/src/front/Components/Menu/SettingsSubMenu.svelte
@@ -25,6 +25,7 @@
     import InputSwitch from "../Input/InputSwitch.svelte";
     import RangeSlider from "../Input/RangeSlider.svelte";
     import Select from "../Input/Select.svelte";
+    import { displayVideoQualityStore } from "../../Stores/DisplayVideoQualityStore";
     import {
         IconAntennaBarsLow,
         IconAntennaBarsMid,
@@ -65,6 +66,7 @@
     let previewMicrophonePrivacySettings = valueMicrophonePrivacySettings;
 
     let valueBubbleSound = localUserStore.getBubbleSound();
+    let videoQualityStats = localUserStore.getDisplayVideoQualityStats();
     const sound = new Audio();
 
     async function updateLocale() {
@@ -217,6 +219,11 @@
         localUserStore.setBubbleSound(valueBubbleSound);
         bubbleSoundStore.set(valueBubbleSound);
         playBubbleSound().catch((e) => console.error(e));
+    }
+
+    function changeVideoQualityStats() {
+        localUserStore.setDisplayVideoQualityStats(videoQualityStats);
+        displayVideoQualityStore.set(videoQualityStats);
     }
 
     async function playBubbleSound() {
@@ -543,6 +550,15 @@
                 bind:value={disableAnimations}
                 onChange={changeDisableAnimations}
                 label={$LL.menu.settings.disableAnimations()}
+            />
+        </div>
+
+        <div class="flex cursor-pointer items-center relative m-4">
+            <InputSwitch
+                id="changeVideoQualityStats"
+                bind:value={videoQualityStats}
+                onChange={changeVideoQualityStats}
+                label={$LL.menu.settings.displayVideoQualityStats()}
             />
         </div>
     </section>

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -14,10 +14,12 @@
     import { highlightFullScreen } from "../../Stores/ActionsCamStore";
     import { showFloatingUi } from "../../Utils/svelte-floatingui-show";
     import { userActivationManager } from "../../Stores/UserActivationStore";
+    import { displayVideoQualityStore } from "../../Stores/DisplayVideoQualityStore";
     import ActionMediaBox from "./ActionMediaBox.svelte";
     import UserName from "./UserName.svelte";
     import UpDownChevron from "./UpDownChevron.svelte";
     import CenteredVideo from "./CenteredVideo.svelte";
+    import WebRtcStats from "./WebRtcStatsBox.svelte";
     import { IconArrowsMinimize, IconArrowsMaximize, IconMicrophoneOff } from "@wa-icons";
 
     export let fullScreen = false;
@@ -46,6 +48,8 @@
     $: isBlockedStore = streamable?.media?.isBlocked;
     $: volumeStore = streamable?.volume;
     $: volumeMeter = $volumeMeterStore;
+    $: webRtcStatsStore = $displayVideoQualityStore ? streamable?.webrtcStats : undefined;
+    $: webRtcStats = $webRtcStatsStore;
 
     $: showVoiceIndicator = showVoiceIndicatorStore ? $showVoiceIndicatorStore : false;
 
@@ -251,6 +255,9 @@
                             />
                         {/if}
                     </div>
+                {/if}
+                {#if webRtcStats}
+                    <WebRtcStats {webRtcStats} />
                 {/if}
             </CenteredVideo>
         {/if}

--- a/play/src/front/Components/Video/WebRtcStats.ts
+++ b/play/src/front/Components/Video/WebRtcStats.ts
@@ -1,0 +1,10 @@
+export interface WebRtcStats {
+    source: string;
+    frameWidth: number;
+    frameHeight: number;
+    jitter: number;
+    mimeType?: string;
+    // Bandwidth in bytes/seconds
+    bandwidth: number;
+    fps: number;
+}

--- a/play/src/front/Components/Video/WebRtcStatsBox.svelte
+++ b/play/src/front/Components/Video/WebRtcStatsBox.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+    import type { WebRtcStats } from "./WebRtcStats";
+
+    export let webRtcStats: WebRtcStats | undefined;
+</script>
+
+{#if webRtcStats}
+    <div class="absolute bottom-0 right-0 text-green-300 p-2 bg-green-950/50 text-xs rounded-br-md rounded-tl-md">
+        <table class="m-0 p-0 border-hidden">
+            <tr>
+                <td>Jitter:</td><td>{Math.round(webRtcStats.jitter * 1000)} ms</td>
+            </tr>
+            <tr>
+                <td>Bandwidth:</td><td>{Math.round((webRtcStats.bandwidth / 1000) * 8)} kbps</td>
+            </tr>
+            <tr>
+                <td>FPS:</td><td>{Math.round(webRtcStats.fps)}</td>
+            </tr>
+            <tr>
+                <td>Resolution:</td><td>{webRtcStats.frameWidth}x{webRtcStats.frameHeight}</td>
+            </tr>
+            <tr>
+                <td>Codec:</td><td>{webRtcStats.mimeType}</td>
+            </tr>
+            <tr>
+                <td>Source:</td><td>{webRtcStats.source}</td>
+            </tr>
+        </table>
+    </div>
+{/if}

--- a/play/src/front/Connection/LocalUserStore.ts
+++ b/play/src/front/Connection/LocalUserStore.ts
@@ -24,6 +24,7 @@ const forceCowebsiteTriggerKey = "forceCowebsiteTrigger";
 const ignoreFollowRequests = "ignoreFollowRequests";
 const decreaseAudioPlayerVolumeWhileTalking = "decreaseAudioPlayerVolumeWhileTalking";
 const disableAnimations = "disableAnimations";
+const displayVideoQualityStats = "displayVideoQualityStats";
 const lastRoomUrl = "lastRoomUrl";
 const authToken = "authToken";
 const notification = "notificationPermission";
@@ -220,6 +221,14 @@ class LocalUserStore {
     }
     getDisableAnimations(): boolean {
         return localStorage.getItem(disableAnimations) === "true";
+    }
+
+    setDisplayVideoQualityStats(value: boolean): void {
+        localStorage.setItem(displayVideoQualityStats, value.toString());
+    }
+
+    getDisplayVideoQualityStats(): boolean {
+        return localStorage.getItem(displayVideoQualityStats) === "true";
     }
 
     async setLastRoomUrl(roomUrl: string): Promise<void> {

--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -63,7 +63,8 @@ export class LiveKitRoom implements LiveKitRoomInterface {
             },
             dynacast: true,
             publishDefaults: {
-                videoSimulcastLayers: [VideoPresets.h360, VideoPresets.h90],
+                // Commented out: the default simulcast layers are sufficient for our use case
+                // videoSimulcastLayers: [VideoPresets.h180, VideoPresets.h360],
                 videoCodec: "vp8",
             },
             videoCaptureDefaults: {
@@ -195,7 +196,8 @@ export class LiveKitRoom implements LiveKitRoomInterface {
                     source: Track.Source.Camera,
                     videoCodec: "vp8",
                     simulcast: true,
-                    videoSimulcastLayers: [VideoPresets.h1080, VideoPresets.h360, VideoPresets.h90],
+                    // Commented out: the default simulcast layers are sufficient for our use case
+                    //videoSimulcastLayers: [VideoPresets.h1080, VideoPresets.h360, VideoPresets.h216,  ],
                 })
                 .catch((err) => {
                     console.error("An error occurred while publishing camera track", err);
@@ -308,13 +310,14 @@ export class LiveKitRoom implements LiveKitRoomInterface {
                     if (!this.localScreenSharingVideoTrack) {
                         this.localScreenSharingVideoTrack = new LocalVideoTrack(screenShareVideoTrack);
 
-                        // Publish video track
+                        // Publish screen share track
                         this.localParticipant
                             .publishTrack(this.localScreenSharingVideoTrack, {
                                 source: Track.Source.ScreenShare,
                                 videoCodec: "vp8",
                                 simulcast: true,
-                                videoSimulcastLayers: [VideoPresets.h1080, VideoPresets.h360, VideoPresets.h90],
+                                // Commented out: the default simulcast layers are sufficient for our use case
+                                // videoSimulcastLayers: [VideoPresets.h90, VideoPresets.h360, VideoPresets.h1080],
                             })
                             .catch((err) => {
                                 console.error("An error occurred while publishing screen share video track", err);

--- a/play/src/front/Stores/DisplayVideoQualityStore.ts
+++ b/play/src/front/Stores/DisplayVideoQualityStore.ts
@@ -1,0 +1,4 @@
+import { writable } from "svelte/store";
+import { localUserStore } from "../Connection/LocalUserStore";
+
+export const displayVideoQualityStore = writable<boolean>(localUserStore.getDisplayVideoQualityStats());

--- a/play/src/front/Stores/ScreenSharingStore.ts
+++ b/play/src/front/Stores/ScreenSharingStore.ts
@@ -296,6 +296,7 @@ export const screenSharingLocalMedia = readable<Streamable | undefined>(undefine
         closeStreamable: () => {},
         volume: writable(1),
         videoType: "local_screenSharing",
+        webrtcStats: undefined,
     } satisfies Streamable;
 
     const unsubscribe = screenSharingLocalStreamStore.subscribe((screenSharingLocalStream) => {

--- a/play/src/front/Stores/ScriptingVideoStore.ts
+++ b/play/src/front/Stores/ScriptingVideoStore.ts
@@ -29,6 +29,7 @@ function createStreamableFromVideo(url: string, config: VideoConfig): Streamable
         volume: writable(1),
         closeStreamable: () => {},
         videoType: "local_scripting",
+        webrtcStats: undefined,
     };
 }
 

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -7,6 +7,7 @@ import type { VideoConfig } from "../Api/Events/Ui/PlayVideoEvent";
 import LL from "../../i18n/i18n-svelte";
 import type { VideoBox } from "../Space/Space";
 import { localSpaceUser } from "../Space/localSpaceUser";
+import type { WebRtcStats } from "../Components/Video/WebRtcStats";
 import { screenSharingLocalMedia } from "./ScreenSharingStore";
 
 import { highlightedEmbedScreen } from "./HighlightedEmbedScreenStore";
@@ -80,6 +81,7 @@ export interface Streamable {
     readonly closeStreamable: () => void;
     readonly volume: Writable<number>;
     readonly videoType: StreamOriginCategory;
+    readonly webrtcStats: Readable<WebRtcStats | undefined> | undefined;
 }
 
 // MyLocalStreamable is a streamable that is the local camera streamable
@@ -138,6 +140,7 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL]) => {
         setDisplayInPictureInPictureMode: (displayInPictureInPictureMode: boolean) => {
             streamable.displayInPictureInPictureMode = displayInPictureInPictureMode;
         },
+        webrtcStats: undefined,
     };
     return streamableToVideoBox(streamable, -2);
 });

--- a/play/src/i18n/de-DE/menu.ts
+++ b/play/src/i18n/de-DE/menu.ts
@@ -54,6 +54,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         ignoreFollowRequest: "Folgeanfragen anderer Benutzer ignorieren",
         blockAudio: "Musik und Hintergrund-Geräusche deaktivieren",
         disableAnimations: "Karten-Animationen deaktivieren",
+        displayVideoQualityStats: "Statistiken zur Videoqualität anzeigen",
     },
     invite: {
         description: "Link zu diesem Raum teilen!",

--- a/play/src/i18n/en-US/menu.ts
+++ b/play/src/i18n/en-US/menu.ts
@@ -63,6 +63,7 @@ const menu: BaseTranslation = {
             ding: "Ding",
             wobble: "Wobble",
         },
+        displayVideoQualityStats: "Display video quality statistics",
     },
     invite: {
         description: "Share the link of the room!",

--- a/play/src/i18n/es-ES/menu.ts
+++ b/play/src/i18n/es-ES/menu.ts
@@ -51,6 +51,7 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "Notificaciones",
         cowebsiteTrigger: "Preguntar siempre antes de abrir sitios web y habitaciones Jitsi Meet",
         ignoreFollowRequest: "Ignorar peticiones de seguir a otros usuarios",
+        displayVideoQualityStats: "Mostrar estadísticas de calidad de vídeo",
     },
     invite: {
         description: "¡Compartir el enlace de la habitación!",

--- a/play/src/i18n/fr-FR/menu.ts
+++ b/play/src/i18n/fr-FR/menu.ts
@@ -64,6 +64,7 @@ const menu: DeepPartial<Translation["menu"]> = {
             ding: "Ding",
             wobble: "Wobble",
         },
+        displayVideoQualityStats: "Afficher les statistiques de qualité vidéo",
     },
     invite: {
         description: "Partager le lien de la salle!",

--- a/tests/tests/livekit.spec.ts
+++ b/tests/tests/livekit.spec.ts
@@ -60,6 +60,21 @@ test.describe('Meeting actions test', () => {
         await expect(page.locator('#cameras-container').getByText("Eve")).toBeVisible({timeout: 30_000});
         await expect(page.locator('#cameras-container').getByText("Mallory")).toBeVisible({timeout: 30_000});
 
+        // Let's enable the video quality display and test it works
+        await Menu.openMenu(page);
+        await page.getByRole('button', { name: 'All settings' }).click();
+        await page.getByText('Display video quality').click();
+        await page.locator('#closeMenu').click();
+        await expect(page.getByRole('cell', { name: 'video/VP8' }).first()).toBeVisible();
+
+        // Let's disable the video quality display and test it is no longer displayed
+        await Menu.openMenu(page);
+        await page.getByRole('button', { name: 'All settings' }).click();
+        await page.getByText('Display video quality').click();
+        await page.locator('#closeMenu').click();
+        await expect(page.getByRole('cell', { name: 'video/VP8' }).first()).toBeHidden();
+
+
         // Clean up
         await page.close();
         await userBob.close();


### PR DESCRIPTION
In the settings, you can now enable displaying some video quality metrics at the bottom right of each video received.

Information include resolution, codec, bandwidth, jitter, etc...

This can be useful to debug network quality issues.

<img width="550" height="319" alt="image" src="https://github.com/user-attachments/assets/f3c80b21-6285-4f29-ba1e-112b19153fc3" />
