### PR TITLE
feat: Closable option for modals

### DIFF
--- a/play/src/front/Api/Events/ModalEvent.ts
+++ b/play/src/front/Api/Events/ModalEvent.ts
@@ -7,6 +7,7 @@ export const isModalEvent = z.object({
     position: z.enum(["right", "left", "center"]).optional().default("right"),
     allowApi: z.boolean().optional().default(false),
     allowFullScreen: z.boolean().optional().default(true),
+    closable: z.boolean().optional().default(true),
 });
 
 /**

--- a/play/src/front/Components/Modal/Modal.svelte
+++ b/play/src/front/Components/Modal/Modal.svelte
@@ -91,14 +91,16 @@
                     </button>
                 {/if}
             {/if}
-            <button
-                on:click|preventDefault|stopPropagation={close}
-                class="btn btn-danger rounded m-0"
-                style={isFullScreened == true ? "" : "margin: 0px;"}
-                data-testid="close-modal-button"
-            >
-                <IconX font-size="20" class="text-white" />
-            </button>
+            {#if $modalIframeStore?.closable == undefined || $modalIframeStore?.closable == true}
+                <button
+                    on:click|preventDefault|stopPropagation={close}
+                    class="btn btn-danger rounded m-0"
+                    style={isFullScreened == true ? "" : "margin: 0px;"}
+                    data-testid="close-modal-button"
+                >
+                    <IconX font-size="20" class="text-white" />
+                </button>
+            {/if}
         </div>
         {#if modalUrl != undefined}
             <iframe


### PR DESCRIPTION
Add `closable` property to control the display of modal close button. Defaults to `true` to maintain current behavior.