### PR TITLE
Fix some visual issues on the OICD profile screen

### DIFF
--- a/play/src/pusher/controllers/OpenIdProfileController.ts
+++ b/play/src/pusher/controllers/OpenIdProfileController.ts
@@ -52,7 +52,7 @@ export class OpenIdProfileController extends BaseHttpController {
                             }
                             body{
                                 text-align: center;
-                                                            }
+                            }
                             section{
                                 margin: 20px;
                             }
@@ -68,18 +68,21 @@ export class OpenIdProfileController extends BaseHttpController {
                             </section>
                             <section>
                                 ${
-                                    email != undefined &&
-                                    `<p style="margin: 0;font-size: 12px;">Your email or application id:</p><p style="margin: 0 0 5px 0;font-weight: bold;">${email}</p>`
+                                    email != undefined
+                                        ? `<p style="margin: 0;font-size: 12px;">Your email or application id:</p><p style="margin: 0 0 5px 0;font-weight: bold;">${email}</p>`
+                                        : ""
                                 }
                                 ${
-                                    name != undefined &&
-                                    `<p style="margin: 0;font-size: 12px;">Your name:</p><p style="margin: 0 0 5px 0;font-weight: bold;">${name}</p>`
+                                    name != undefined
+                                        ? `<p style="margin: 0;font-size: 12px;">Your name:</p><p style="margin: 0 0 5px 0;font-weight: bold;">${name}</p>`
+                                        : ""
                                 }
                                 ${
-                                    tags != undefined &&
-                                    `<p style="margin: 0;font-size: 12px;">Your access right:</p><p style="margin: 0 0 5px 0;font-weight: bold;">${tags?.join(
-                                        ", "
-                                    )}</p>`
+                                    tags != undefined
+                                        ? `<p style="margin: 0;font-size: 12px;">Your access right:</p><p style="margin: 0 0 5px 0;font-weight: bold;">${tags?.join(
+                                              ", "
+                                          )}</p>`
+                                        : ""
                                 }
                                 ${
                                     email == undefined && name == undefined && tags == undefined


### PR DESCRIPTION
The text was forced to white, but the background was not specified. So with a default white background from the browser, the text was only visible when selecting it (see screenshot). Also, the text `false` was inserted by mistakes for empty values.

<img width="242" height="300" alt="The profile screen, with some selected white on white text" src="https://github.com/user-attachments/assets/ff8a94f4-71ee-4d9a-a96e-ae8bfd9c5ed5" />
