### PR TITLE
Fixing validation of Livekit recording URL env vars

### DIFF
--- a/back/src/Enum/EnvironmentVariableValidator.ts
+++ b/back/src/Enum/EnvironmentVariableValidator.ts
@@ -156,6 +156,8 @@ Note that anonymous players don't have any TTL limit because their data is store
 
     LIVEKIT_RECORDING_S3_ENDPOINT: z
         .string()
+        .url()
+        .or(z.literal(""))
         .optional()
         .transform(emptyStringToUndefined)
         .describe("The S3 endpoint for Livekit recording."),

--- a/play/src/pusher/enums/EnvironmentVariableValidator.ts
+++ b/play/src/pusher/enums/EnvironmentVariableValidator.ts
@@ -443,15 +443,39 @@ export const EnvironmentVariables = z.object({
         .or(z.string().max(0))
         .transform((val) => toNumber(val, 20 * 1024 * 1024)) // Default to 20 MB
         .describe("The maximum size of a gRPC message. Defaults to 20 MB."),
-    LIVEKIT_RECORDING_S3_ENDPOINT: z.string().url().optional().describe("The S3 endpoint for Livekit recording."),
-    LIVEKIT_RECORDING_S3_ACCESS_KEY: z.string().optional().describe("The S3 access key for Livekit recording."),
-    LIVEKIT_RECORDING_S3_SECRET_KEY: z.string().optional().describe("The S3 secret key for Livekit recording."),
-    LIVEKIT_RECORDING_S3_BUCKET: z.string().optional().describe("The S3 bucket for Livekit recording."),
-    LIVEKIT_RECORDING_S3_REGION: z.string().optional().describe("The S3 region for Livekit recording."),
+    LIVEKIT_RECORDING_S3_ENDPOINT: z
+        .string()
+        .url()
+        .or(z.literal(""))
+        .optional()
+        .transform(emptyStringToUndefined)
+        .describe("The S3 endpoint for Livekit recording."),
+    LIVEKIT_RECORDING_S3_ACCESS_KEY: z
+        .string()
+        .optional()
+        .transform(emptyStringToUndefined)
+        .describe("The S3 access key for Livekit recording."),
+    LIVEKIT_RECORDING_S3_SECRET_KEY: z
+        .string()
+        .optional()
+        .transform(emptyStringToUndefined)
+        .describe("The S3 secret key for Livekit recording."),
+    LIVEKIT_RECORDING_S3_BUCKET: z
+        .string()
+        .optional()
+        .transform(emptyStringToUndefined)
+        .describe("The S3 bucket for Livekit recording."),
+    LIVEKIT_RECORDING_S3_REGION: z
+        .string()
+        .optional()
+        .transform(emptyStringToUndefined)
+        .describe("The S3 region for Livekit recording."),
     LIVEKIT_RECORDING_S3_CDN_ENDPOINT: z
         .string()
         .url()
+        .or(z.literal(""))
         .optional()
+        .transform(emptyStringToUndefined)
         .describe("The S3 CDN endpoint for Livekit recording."),
     BACKGROUND_TRANSFORMER_ENGINE: z
         .enum(["tasks-vision", "selfie-segmentation", ""])


### PR DESCRIPTION
Empty string URLs would cause the play container to crash.