### PR TITLE
Add FPS standard deviation to WebRTC stats

### DIFF
--- a/play/src/front/Components/Video/WebRtcStats.ts
+++ b/play/src/front/Components/Video/WebRtcStats.ts
@@ -7,6 +7,7 @@ export interface WebRtcStats {
     // Bandwidth in bytes/seconds
     bandwidth: number;
     fps: number;
+    fpsStdDev?: number;
     // Whether the selected ICE route is TURN relayed
     relay?: boolean;
     // Protocol used with TURN when relayed (browser-dependent)

--- a/play/src/front/Components/Video/WebRtcStatsBox.svelte
+++ b/play/src/front/Components/Video/WebRtcStatsBox.svelte
@@ -2,11 +2,19 @@
     import type { WebRtcStats } from "./WebRtcStats";
 
     export let webRtcStats: WebRtcStats | undefined;
+
+    $: fpsStdDevDisplay = webRtcStats?.fpsStdDev === undefined ? "-" : Math.round(webRtcStats.fpsStdDev * 100) / 100;
+    $: statsColorClass =
+        webRtcStats?.fpsStdDev !== undefined && webRtcStats.fpsStdDev > 10
+            ? "text-red-300 bg-red-950/50"
+            : webRtcStats?.fpsStdDev !== undefined && webRtcStats.fpsStdDev > 4
+            ? "text-yellow-300 bg-yellow-950/50"
+            : "text-green-300 bg-green-950/50";
 </script>
 
 {#if webRtcStats}
     <div
-        class="absolute bottom-0 right-0 text-green-300 p-2 bg-green-950/50 text-[0.6rem] @[20rem]/videomediabox:text-[0.75rem] rounded-br-md rounded-tl-md"
+        class={`absolute bottom-0 right-0 p-2 text-[0.6rem] @[20rem]/videomediabox:text-[0.75rem] rounded-br-md rounded-tl-md ${statsColorClass}`}
     >
         <table class="m-0 p-0 border-hidden">
             <tr>
@@ -17,6 +25,10 @@
             </tr>
             <tr>
                 <td>FPS:</td><td>{Math.round(webRtcStats.fps)}</td>
+            </tr>
+            <tr>
+                <td>FPS Variability:</td>
+                <td>{fpsStdDevDisplay}</td>
             </tr>
             <tr>
                 <td>Resolution:</td><td>{webRtcStats.frameWidth}x{webRtcStats.frameHeight}</td>


### PR DESCRIPTION
## Summary

- track FPS sample standard deviation in WebRTC stats (compute standard deviation on the last 8 FPS sample)
- reset FPS window on resolution changes (because FPS could change when resolution change)
- color stats box based on FPS std dev