### PR TITLE
 generate a unique "tab" ID to avoid evil twins

### DIFF
--- a/back/src/Model/User.ts
+++ b/back/src/Model/User.ts
@@ -59,7 +59,9 @@ export class User implements Movable, CustomJsonReplacerInterface {
         public readonly activatedInviteUser?: boolean,
         public readonly applications?: ApplicationMessage[],
         public readonly chatID?: string,
-        private sayMessage?: SayMessage
+        private sayMessage?: SayMessage,
+        // Unique identifier for the browser tab, used to detect reconnections from the same tab
+        public readonly tabId?: string
     ) {
         this.listenedZones = new Set<Zone>();
 
@@ -89,7 +91,8 @@ export class User implements Movable, CustomJsonReplacerInterface {
         activatedInviteUser?: boolean,
         applications?: ApplicationMessage[],
         chatID?: string,
-        sayMessage?: SayMessage
+        sayMessage?: SayMessage,
+        tabId?: string
     ): Promise<User> {
         const playersVariablesRepository = await getPlayersVariablesRepository();
         const variables = new PlayerVariables(uuid, roomUrl, roomGroup, playersVariablesRepository, isLogged);
@@ -117,7 +120,8 @@ export class User implements Movable, CustomJsonReplacerInterface {
             activatedInviteUser,
             applications,
             chatID,
-            sayMessage
+            sayMessage,
+            tabId
         );
     }
 

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -1158,6 +1158,10 @@ message JoinRoomMessage {
   google.protobuf.StringValue lastCommandId = 16;
   bool canEdit = 17;
   google.protobuf.StringValue chatID = 18;
+  // Unique identifier for the browser tab, used to detect reconnections from the same tab
+  // and kill stale connections immediately instead of waiting for ping timeout
+  //TODO : remove the optional when the tabId is always present in the query string (next version of the app )
+  optional string tabId = 19;
 }
 
 message UserJoinedZoneMessage {

--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -81,6 +81,10 @@ class ConnectionManager {
     private readonly _roomConnectionStream = new Subject<RoomConnection>();
     public readonly roomConnectionStream = this._roomConnectionStream.asObservable();
 
+    // Unique identifier for this browser tab, used to detect reconnections from the same tab
+    // and kill stale connections on the server side immediately instead of waiting for ping timeout
+    private readonly _tabId: string = crypto.randomUUID();
+
     get unloading() {
         return this._unloading;
     }
@@ -471,6 +475,7 @@ class ConnectionManager {
                 viewport,
                 companionTextureId,
                 availabilityStatus,
+                this._tabId,
                 lastCommandId
             );
 
@@ -814,6 +819,10 @@ class ConnectionManager {
 
     get currentRoom() {
         return this._currentRoom;
+    }
+
+    get tabId(): string {
+        return this._tabId;
     }
 
     get klaxoonToolActivated(): boolean {

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -257,6 +257,7 @@ export class RoomConnection implements RoomConnection {
      * @param viewport
      * @param companionTextureId
      * @param availabilityStatus
+     * @param tabId Unique identifier for the browser tab, used to detect reconnections
      * @param lastCommandId
      */
     public constructor(
@@ -268,6 +269,7 @@ export class RoomConnection implements RoomConnection {
         viewport: ViewportInterface,
         companionTextureId: string | null,
         availabilityStatus: AvailabilityStatus,
+        tabId: string,
         lastCommandId?: string
     ) {
         const urlObj = new URL("ws/room", ABSOLUTE_PUSHER_URL);
@@ -299,6 +301,7 @@ export class RoomConnection implements RoomConnection {
         params.set("microphoneState", get(requestedMicrophoneState) ? "true" : "false");
         // TODO: check if the screenSharingState variable is used
         params.set("screenSharingState", get(requestedScreenSharingState) ? "true" : "false");
+        params.set("tabId", tabId);
 
         const url = urlObj.toString();
         let subProtocols: string[] | undefined = undefined;

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -256,6 +256,9 @@ export class IoSocketController {
                             roomName: z.string(),
                             cameraState: z.string().transform((val) => val === "true"),
                             microphoneState: z.string().transform((val) => val === "true"),
+                            // tabId is optional because it is not always present in the query string
+                            //TODO : remove the optional when the tabId is always present in the query string (next version of the app )
+                            tabId: z.string().optional(),
                         })
                     );
 
@@ -293,6 +296,7 @@ export class IoSocketController {
                         roomName,
                         cameraState,
                         microphoneState,
+                        tabId,
                     } = query;
 
                     const chatID = query.chatID ? query.chatID : undefined;
@@ -482,6 +486,7 @@ export class IoSocketController {
                             },
                             availabilityStatus,
                             lastCommandId,
+                            tabId,
                             messages: [],
                             tags: memberTags,
                             visitCardUrl: memberVisitCardUrl,

--- a/play/src/pusher/models/Websocket/SocketData.ts
+++ b/play/src/pusher/models/Websocket/SocketData.ts
@@ -40,6 +40,8 @@ export type SocketData = {
     viewport: ViewportInterface;
     availabilityStatus: AvailabilityStatus;
     lastCommandId?: string;
+    // Unique identifier for the browser tab, used to detect reconnections from the same tab
+    tabId: string | undefined;
     messages: unknown[];
     tags: string[];
     visitCardUrl: string | null;

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -243,6 +243,7 @@ export class SocketManager implements ZoneEventListener {
                 userRoomToken: socketData.userRoomToken ?? "", // TODO: turn this into an optional field
                 lastCommandId: socketData.lastCommandId ?? "", // TODO: turn this into an optional field
                 chatID: socketData.chatID,
+                tabId: socketData.tabId,
             };
 
             debug("Calling joinRoom '" + socketData.roomId + "'");


### PR DESCRIPTION
- Introduced a unique identifier for browser tabs (`tabId`) to manage user reconnections effectively.
- Updated GameRoom to handle stale connections by terminating them immediately upon reconnection from the same tab.
- Modified User model and related messages to include `tabId` for improved reconnection handling.
- Enhanced ConnectionManager and SocketManager to support the new `tabId` functionality, ensuring seamless user experience during network disruptions.