### PR TITLE
Enabling VP9 codec for P2P video streams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13738,9 +13738,9 @@
       "link": true
     },
     "node_modules/@workadventure/simple-peer": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@workadventure/simple-peer/-/simple-peer-11.0.2.tgz",
-      "integrity": "sha512-9kDkyCVOuzoRBpm17RToInmD/vVVDd+02UYKRbmrEEl6p1RVsyfdEDYC5L8qjtdv5Z6++aS1WnAunlbbNga/5g==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@workadventure/simple-peer/-/simple-peer-12.0.0.tgz",
+      "integrity": "sha512-Op/YiVjRvssoZ2DZPGIef/VYJEZB0Ctb9Cpcx+aKJcnHdwiNY4NzoU8sQ71z7AD1+fuiGtRlinl0hkWVeX4kkQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.7",
@@ -40374,7 +40374,7 @@
         "@workadventure/math-utils": "1.0.0",
         "@workadventure/messages": "1.0.0",
         "@workadventure/shared-utils": "1.0.0",
-        "@workadventure/simple-peer": "^11.0.2",
+        "@workadventure/simple-peer": "^12.0.0",
         "@workadventure/store-utils": "1.0.0",
         "@workadventure/tailwind": "1.0.0",
         "@workadventure/tiled-map-type-guard": "^2.1.2",

--- a/play/package.json
+++ b/play/package.json
@@ -171,7 +171,7 @@
     "quill": "1.3.7",
     "quill-delta-to-html": "^0.12.0",
     "rxjs": "^6.6.3",
-    "@workadventure/simple-peer": "^11.0.2",
+    "@workadventure/simple-peer": "^12.0.0",
     "source-map-support": "^0.5.21",
     "stanza": "^12.18.0",
     "svelte-modals": "^1.3.0",

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -2,7 +2,7 @@ import { Buffer } from "buffer";
 import Debug from "debug";
 import type { Readable, Unsubscriber, Writable } from "svelte/store";
 import { derived, get, writable } from "svelte/store";
-import Peer from "@workadventure/simple-peer";
+import Peer, { type PeerOptions } from "@workadventure/simple-peer";
 import { ForwardableStore } from "@workadventure/store-utils";
 import type { IceServer } from "@workadventure/messages";
 import { z } from "zod";
@@ -240,7 +240,7 @@ export class RemotePeer extends Peer implements Streamable {
         const firefoxBrowser = isFirefox();
 
         // Firefox-specific configuration
-        const peerConfig = {
+        const peerConfig: PeerOptions = {
             initiator,
             config: {
                 iceServers,
@@ -252,6 +252,7 @@ export class RemotePeer extends Peer implements Streamable {
                 }),
             },
             sdpTransform: getSdpTransform(bandwidth === "unlimited" ? undefined : bandwidth),
+            preferredCodecs: { video: ["video/VP9", "video/VP8"] },
             // Firefox works better with trickle ICE enabled
             ...(firefoxBrowser && { trickle: true }),
         };

--- a/tests/tests/adaptive_streaming.spec.ts
+++ b/tests/tests/adaptive_streaming.spec.ts
@@ -42,7 +42,7 @@ test.describe("Adaptive streaming test @nomobile @nowebkit @nofirefox", () => {
         await page.getByRole("button", { name: "All settings" }).click();
         await page.getByText("Display video quality").click();
         await page.locator("#closeMenu").click();
-        await expect(page.getByRole("cell", { name: "video/VP8" }).first()).toBeVisible();
+        await expect(page.getByRole("cell", { name: "video/VP9" }).first()).toBeVisible();
 
         await expect(page.getByRole("cell", { name: "223x125" })).toBeVisible({ timeout: 60_000 });
         await page
@@ -53,6 +53,8 @@ test.describe("Adaptive streaming test @nomobile @nowebkit @nofirefox", () => {
         // @ts-ignore Promise.any not recognized by Playwright Typescript definitions yet
         await Promise.any([
             // In CI
+            // eslint-disable-next-line playwright/missing-playwright-await
+            expect(page.getByRole("cell", { name: "480x270" })).toBeVisible({ timeout: 60_000 }),
             // eslint-disable-next-line playwright/missing-playwright-await
             expect(page.getByRole("cell", { name: "640x360" })).toBeVisible({ timeout: 60_000 }),
             // In Real usage


### PR DESCRIPTION
Migrating @workadventure/simple-peer to the new 12.0.0 version that supports specifying preferred codec