### PR TITLE
MapEditor: route incoming commands by type instead of broadcasting to all tools

### DIFF
--- a/play/src/front/Phaser/Game/MapEditor/MapEditorCommandTypes.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorCommandTypes.ts
@@ -1,0 +1,23 @@
+import type { EditMapCommandMessage } from "@workadventure/messages";
+
+export type EditMapMessage = NonNullable<EditMapCommandMessage["editMapMessage"]>["message"];
+
+export type AreaEditMapMessage = Extract<
+    EditMapMessage,
+    { $case: "modifyAreaMessage" | "createAreaMessage" | "deleteAreaMessage" }
+>;
+
+export type EntityEditMapMessage = Extract<
+    EditMapMessage,
+    {
+        $case:
+            | "modifyEntityMessage"
+            | "createEntityMessage"
+            | "deleteEntityMessage"
+            | "uploadEntityMessage"
+            | "modifyCustomEntityMessage"
+            | "deleteCustomEntityMessage";
+    }
+>;
+
+export type WAMSettingsEditMapMessage = Extract<EditMapMessage, { $case: "updateWAMSettingsMessage" }>;

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorCommandTypes.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorCommandTypes.ts
@@ -1,23 +1,3 @@
 import type { EditMapCommandMessage } from "@workadventure/messages";
 
 export type EditMapMessage = NonNullable<EditMapCommandMessage["editMapMessage"]>["message"];
-
-export type AreaEditMapMessage = Extract<
-    EditMapMessage,
-    { $case: "modifyAreaMessage" | "createAreaMessage" | "deleteAreaMessage" }
->;
-
-export type EntityEditMapMessage = Extract<
-    EditMapMessage,
-    {
-        $case:
-            | "modifyEntityMessage"
-            | "createEntityMessage"
-            | "deleteEntityMessage"
-            | "uploadEntityMessage"
-            | "modifyCustomEntityMessage"
-            | "deleteCustomEntityMessage";
-    }
->;
-
-export type WAMSettingsEditMapMessage = Extract<EditMapMessage, { $case: "updateWAMSettingsMessage" }>;

--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -1,5 +1,4 @@
 import type { AreaData, AtLeast } from "@workadventure/map-editor";
-import type { EditMapCommandMessage } from "@workadventure/messages";
 import type { Unsubscriber } from "svelte/store";
 import { get } from "svelte/store";
 import { v4 as uuid } from "uuid";
@@ -20,6 +19,7 @@ import { DeleteEntityFrontCommand } from "../Commands/Entity/DeleteEntityFrontCo
 import ActionPopupOnPersonalAreaWithEntities from "../../../../Components/MapEditor/ActionPopupOnPersonalAreaWithEntities.svelte";
 import { SpeechDomElement } from "../../../Entity/SpeechDomElement";
 import { LL } from "../../../../../i18n/i18n-svelte";
+import type { AreaEditMapMessage } from "../MapEditorCommandTypes";
 import { MapEditorTool } from "./MapEditorTool";
 import type { TrashEditorTool } from "./TrashEditorTool";
 
@@ -120,11 +120,10 @@ export class AreaEditorTool extends MapEditorTool {
         this.scene.input.setDefaultCursor("auto");
     }
 
-    public async handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void> {
-        const commandId = editMapCommandMessage.id;
-        switch (editMapCommandMessage.editMapMessage?.message?.$case) {
+    public async handleIncomingAreaCommandMessage(commandId: string, message: AreaEditMapMessage): Promise<void> {
+        switch (message.$case) {
             case "modifyAreaMessage": {
-                const data = editMapCommandMessage.editMapMessage?.message.modifyAreaMessage;
+                const data = message.modifyAreaMessage;
                 // execute command locally
                 await this.mapEditorModeManager.executeLocalCommand(
                     new UpdateAreaFrontCommand(
@@ -142,7 +141,7 @@ export class AreaEditorTool extends MapEditorTool {
                 break;
             }
             case "createAreaMessage": {
-                const data = editMapCommandMessage.editMapMessage?.message.createAreaMessage;
+                const data = message.createAreaMessage;
                 const config: AreaData = {
                     ...data,
                     visible: true,
@@ -161,7 +160,7 @@ export class AreaEditorTool extends MapEditorTool {
                 break;
             }
             case "deleteAreaMessage": {
-                const data = editMapCommandMessage.editMapMessage?.message.deleteAreaMessage;
+                const data = message.deleteAreaMessage;
                 // execute command locally
                 await this.mapEditorModeManager.executeLocalCommand(
                     new DeleteAreaFrontCommand(

--- a/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/AreaEditorTool.ts
@@ -19,9 +19,14 @@ import { DeleteEntityFrontCommand } from "../Commands/Entity/DeleteEntityFrontCo
 import ActionPopupOnPersonalAreaWithEntities from "../../../../Components/MapEditor/ActionPopupOnPersonalAreaWithEntities.svelte";
 import { SpeechDomElement } from "../../../Entity/SpeechDomElement";
 import { LL } from "../../../../../i18n/i18n-svelte";
-import type { AreaEditMapMessage } from "../MapEditorCommandTypes";
+import type { EditMapMessage } from "../MapEditorCommandTypes";
 import { MapEditorTool } from "./MapEditorTool";
 import type { TrashEditorTool } from "./TrashEditorTool";
+
+type AreaEditMapMessage = Extract<
+    EditMapMessage,
+    { $case: "modifyAreaMessage" | "createAreaMessage" | "deleteAreaMessage" }
+>;
 
 export class AreaEditorTool extends MapEditorTool {
     private scene: GameScene;

--- a/play/src/front/Phaser/Game/MapEditor/Tools/CloseTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/CloseTool.ts
@@ -1,4 +1,3 @@
-import type { EditMapCommandMessage } from "@workadventure/messages";
 import type { GameMapFrontWrapper } from "../../GameMap/GameMapFrontWrapper";
 import { mapEditorModeStore, mapEditorVisibilityStore } from "../../../../Stores/MapEditorStore";
 import { gameManager } from "../../GameManager";
@@ -26,9 +25,5 @@ export class CloseTool implements MapEditorTool {
     }
     public handleKeyDownEvent(event: KeyboardEvent): void {
         // Nothing to be done
-    }
-    public handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void> {
-        // Nothing to be done
-        return Promise.resolve();
     }
 }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
@@ -1,6 +1,5 @@
 import type { AreaData, EntityData, WAMEntityData } from "@workadventure/map-editor";
 import * as Sentry from "@sentry/svelte";
-import type { EditMapCommandMessage } from "@workadventure/messages";
 import type { Unsubscriber } from "svelte/store";
 import { get } from "svelte/store";
 import { v4 as uuidv4 } from "uuid";
@@ -26,6 +25,7 @@ import type { MapEditorModeManager } from "../MapEditorModeManager";
 import { EditorToolName } from "../MapEditorModeManager";
 import { AreaPreview } from "../../../Components/MapEditor/AreaPreview";
 import { mapEditorActivated } from "../../../../Stores/MenuStore";
+import type { EntityEditMapMessage } from "../MapEditorCommandTypes";
 import { EntityRelatedEditorTool } from "./EntityRelatedEditorTool";
 
 export class EntityEditorTool extends EntityRelatedEditorTool {
@@ -84,11 +84,10 @@ export class EntityEditorTool extends EntityRelatedEditorTool {
     /**
      * React on commands coming from the outside
      */
-    public async handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void> {
-        const commandId = editMapCommandMessage.id;
-        switch (editMapCommandMessage.editMapMessage?.message?.$case) {
+    public async handleIncomingEntityCommandMessage(commandId: string, message: EntityEditMapMessage): Promise<void> {
+        switch (message.$case) {
             case "createEntityMessage": {
-                const createEntityMessage = editMapCommandMessage.editMapMessage?.message.createEntityMessage;
+                const createEntityMessage = message.createEntityMessage;
                 const entityPrefab = await this.scene
                     .getEntitiesCollectionsManager()
                     .getEntityPrefab(createEntityMessage.collectionName, createEntityMessage.prefabId);
@@ -135,14 +134,14 @@ export class EntityEditorTool extends EntityRelatedEditorTool {
                 break;
             }
             case "deleteEntityMessage": {
-                const id = editMapCommandMessage.editMapMessage?.message.deleteEntityMessage.id;
+                const id = message.deleteEntityMessage.id;
                 await this.mapEditorModeManager.executeLocalCommand(
                     new DeleteEntityFrontCommand(this.scene.getGameMap(), id, commandId, this.entitiesManager)
                 );
                 break;
             }
             case "modifyEntityMessage": {
-                const modifyEntityMessage = editMapCommandMessage.editMapMessage?.message.modifyEntityMessage;
+                const modifyEntityMessage = message.modifyEntityMessage;
                 await this.mapEditorModeManager.executeLocalCommand(
                     new UpdateEntityFrontCommand(
                         this.scene.getGameMap(),
@@ -162,7 +161,7 @@ export class EntityEditorTool extends EntityRelatedEditorTool {
                 break;
             }
             case "uploadEntityMessage": {
-                const uploadEntityMessage = editMapCommandMessage.editMapMessage?.message.uploadEntityMessage;
+                const uploadEntityMessage = message.uploadEntityMessage;
                 await this.mapEditorModeManager.executeLocalCommand(
                     new UploadEntityFrontCommand(
                         uploadEntityMessage,
@@ -173,8 +172,7 @@ export class EntityEditorTool extends EntityRelatedEditorTool {
                 break;
             }
             case "modifyCustomEntityMessage": {
-                const modifyCustomEntityMessage =
-                    editMapCommandMessage.editMapMessage?.message.modifyCustomEntityMessage;
+                const modifyCustomEntityMessage = message.modifyCustomEntityMessage;
                 await this.mapEditorModeManager.executeLocalCommand(
                     new ModifyCustomEntityFrontCommand(
                         modifyCustomEntityMessage,
@@ -186,8 +184,7 @@ export class EntityEditorTool extends EntityRelatedEditorTool {
                 break;
             }
             case "deleteCustomEntityMessage": {
-                const deleteCustomEntityMessage =
-                    editMapCommandMessage.editMapMessage?.message.deleteCustomEntityMessage;
+                const deleteCustomEntityMessage = message.deleteCustomEntityMessage;
                 await this.mapEditorModeManager.executeLocalCommand(
                     new DeleteCustomEntityFrontCommand(
                         deleteCustomEntityMessage,

--- a/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
@@ -25,9 +25,21 @@ import type { MapEditorModeManager } from "../MapEditorModeManager";
 import { EditorToolName } from "../MapEditorModeManager";
 import { AreaPreview } from "../../../Components/MapEditor/AreaPreview";
 import { mapEditorActivated } from "../../../../Stores/MenuStore";
-import type { EntityEditMapMessage } from "../MapEditorCommandTypes";
+import type { EditMapMessage } from "../MapEditorCommandTypes";
 import { EntityRelatedEditorTool } from "./EntityRelatedEditorTool";
 
+type EntityEditMapMessage = Extract<
+    EditMapMessage,
+    {
+        $case:
+            | "modifyEntityMessage"
+            | "createEntityMessage"
+            | "deleteEntityMessage"
+            | "uploadEntityMessage"
+            | "modifyCustomEntityMessage"
+            | "deleteCustomEntityMessage";
+    }
+>;
 export class EntityEditorTool extends EntityRelatedEditorTool {
     private handleUpdateEntity: (entityData: EntityData) => void;
     private handleCopyEntity: (data: CopyEntityEventData) => void;

--- a/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
@@ -1,4 +1,3 @@
-import type { EditMapCommandMessage } from "@workadventure/messages";
 import debug from "debug";
 import type { Unsubscriber } from "svelte/store";
 import { get } from "svelte/store";
@@ -283,12 +282,11 @@ export class ExplorerTool implements MapEditorTool {
     public handleKeyDownEvent(event: KeyboardEvent): void {
         logger("handleKeyDownEvent => Method not implemented.");
     }
-    public handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void> {
+    public refreshExplorationEntitiesStore(): void {
         // Refresh the entities store
         mapExplorationEntitiesStore.set(
             gameManager.getCurrentGameScene().getGameMapFrontWrapper().getEntitiesManager().getEntities()
         );
-        return Promise.resolve();
     }
 
     private setAllAreasPreviewPointedToEditColor() {

--- a/play/src/front/Phaser/Game/MapEditor/Tools/FloorEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/FloorEditorTool.ts
@@ -1,4 +1,3 @@
-import type { EditMapCommandMessage } from "@workadventure/messages";
 import type { GameMapFrontWrapper } from "../../GameMap/GameMapFrontWrapper";
 import type { GameScene } from "../../GameScene";
 import type { MapEditorModeManager } from "../MapEditorModeManager";
@@ -31,12 +30,5 @@ export class FloorEditorTool extends MapEditorTool {
     }
     public handleKeyDownEvent(event: KeyboardEvent): void {
         // To implement
-    }
-    /**
-     * React on commands coming from the outside
-     */
-    public handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void> {
-        // To implement
-        return Promise.resolve();
     }
 }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/MapEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/MapEditorTool.ts
@@ -1,4 +1,3 @@
-import type { EditMapCommandMessage } from "@workadventure/messages";
 import type { GameMapFrontWrapper } from "../../GameMap/GameMapFrontWrapper";
 
 export abstract class MapEditorTool {
@@ -8,8 +7,4 @@ export abstract class MapEditorTool {
     public abstract destroy(): void;
     public abstract subscribeToGameMapFrontWrapperEvents(gameMapFrontWrapper: GameMapFrontWrapper): void;
     public abstract handleKeyDownEvent(event: KeyboardEvent): void;
-    /**
-     * React on commands coming from the outside
-     */
-    public abstract handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void>;
 }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/TrashEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/TrashEditorTool.ts
@@ -1,5 +1,4 @@
 import type { AreaData } from "@workadventure/map-editor";
-import type { EditMapCommandMessage } from "@workadventure/messages";
 import { get } from "svelte/store";
 import { userIsAdminStore, userIsEditorStore } from "../../../../Stores/GameStore";
 import { mapEditorSelectedAreaPreviewStore, mapEditorVisibilityStore } from "../../../../Stores/MapEditorStore";
@@ -67,10 +66,6 @@ export class TrashEditorTool extends EntityRelatedEditorTool {
         this.active = false;
         this.setAreaPreviewsVisibility(false);
         this.scene.markDirty();
-    }
-
-    handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void> {
-        return Promise.resolve(undefined);
     }
 
     protected bindEventHandlers(): void {

--- a/play/src/front/Phaser/Game/MapEditor/Tools/WAMSettingsEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/WAMSettingsEditorTool.ts
@@ -1,9 +1,9 @@
-import type { EditMapCommandMessage } from "@workadventure/messages";
 import type { GameMapFrontWrapper } from "../../GameMap/GameMapFrontWrapper";
 import type { GameScene } from "../../GameScene";
 import type { MapEditorModeManager } from "../MapEditorModeManager";
 import { UpdateWAMSettingFrontCommand } from "../Commands/WAM/UpdateWAMSettingFrontCommand";
 import { mapEditorVisibilityStore } from "../../../../Stores/MapEditorStore";
+import type { WAMSettingsEditMapMessage } from "../MapEditorCommandTypes";
 import { MapEditorTool } from "./MapEditorTool";
 
 export class WAMSettingsEditorTool extends MapEditorTool {
@@ -37,19 +37,18 @@ export class WAMSettingsEditorTool extends MapEditorTool {
     /**
      * React on commands coming from the outside
      */
-    public async handleIncomingCommandMessage(editMapCommandMessage: EditMapCommandMessage): Promise<void> {
-        const commandId = editMapCommandMessage.id;
-        if (editMapCommandMessage.editMapMessage?.message?.$case === "updateWAMSettingsMessage") {
-            const data = editMapCommandMessage.editMapMessage?.message.updateWAMSettingsMessage;
+    public async handleIncomingWAMSettingsCommandMessage(
+        commandId: string,
+        message: WAMSettingsEditMapMessage
+    ): Promise<void> {
+        const data = message.updateWAMSettingsMessage;
 
-            const wam = this.scene.getGameMap().getWam();
-            if (wam === undefined) {
-                throw new Error("WAM file is undefined");
-            }
-
-            // execute command locally
-            await this.mapEditorModeManager.executeLocalCommand(new UpdateWAMSettingFrontCommand(wam, data, commandId));
+        const wam = this.scene.getGameMap().getWam();
+        if (wam === undefined) {
+            throw new Error("WAM file is undefined");
         }
-        return Promise.resolve();
+
+        // execute command locally
+        await this.mapEditorModeManager.executeLocalCommand(new UpdateWAMSettingFrontCommand(wam, data, commandId));
     }
 }

--- a/play/src/front/Phaser/Game/MapEditor/Tools/WAMSettingsEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/WAMSettingsEditorTool.ts
@@ -3,9 +3,10 @@ import type { GameScene } from "../../GameScene";
 import type { MapEditorModeManager } from "../MapEditorModeManager";
 import { UpdateWAMSettingFrontCommand } from "../Commands/WAM/UpdateWAMSettingFrontCommand";
 import { mapEditorVisibilityStore } from "../../../../Stores/MapEditorStore";
-import type { WAMSettingsEditMapMessage } from "../MapEditorCommandTypes";
+import type { EditMapMessage } from "../MapEditorCommandTypes";
 import { MapEditorTool } from "./MapEditorTool";
 
+type WAMSettingsEditMapMessage = Extract<EditMapMessage, { $case: "updateWAMSettingsMessage" }>;
 export class WAMSettingsEditorTool extends MapEditorTool {
     private scene: GameScene;
     private mapEditorModeManager: MapEditorModeManager;


### PR DESCRIPTION
Rerouted EditMapCommandMessage handling in MapEditorModeManager so each message is dispatched only to the tool that owns it, rather than looping over every MapEditorTool. This aligns behavior with how tools are scoped (area tools handle area commands, entity tools handle entity commands, etc.) and avoids unnecessary no-op handlers. The routing switch is exhaustive, so adding new message types will surface compile-time gaps, matching the request for stronger TypeScript guarantees.

To support the routing, I introduced typed unions for edit-map messages and narrowed tool APIs to accept only the command types they can handle. Area, entity, and WAM settings tools now expose specific handlers; non-command tools no longer need a placeholder method. ExplorerTool still refreshes its exploration entities store, but only when entity-related commands flow through the router. The map update catch-up path and live stream path now share the same routing logic.

Net effect: clearer ownership of command handling, less dispatch overhead, and compile-time enforcement that all edit-map command variants are accounted for in the manager.