### PR TITLE
Downloading a recording is shutting down Livekit room

### DIFF
--- a/play/src/front/Components/PopUp/Recording/RecordingContextMenuContent.svelte
+++ b/play/src/front/Components/PopUp/Recording/RecordingContextMenuContent.svelte
@@ -38,6 +38,9 @@
             const link = document.createElement("a");
             link.href = downloadUrl;
             link.download = filename;
+            // Target _blank is needed, otherwise the click triggers a "onleave" event on the page that can cause issues (space left, etc...)
+            link.target = "_blank";
+            link.rel = "noopener noreferrer";
             link.style.display = "none"; // Hide the link element
             document.body.appendChild(link);
             link.click();


### PR DESCRIPTION
The "download" button was triggering a "onleave" page event, that was detected by spaces that triggered a "space leave" event. We are now targetting "_blank" with the download link to avoid the roghe "onleave" page event.