### PR TITLE
Upgrading to tasks-vision 0.10.32 and avoiding double init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8540,12 +8540,6 @@
       "integrity": "sha512-IxYxNhwE5VwOm52L1yoFWYLP7q9Pd+NJjzOC5tlepfvEGaY3o9hslhUrx9BgseqdfZtKSDtd/4NfCSMjNzQalA==",
       "license": "Apache-2.0"
     },
-    "node_modules/@mediapipe/tasks-vision": {
-      "version": "0.10.22-rc.20250304",
-      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.22-rc.20250304.tgz",
-      "integrity": "sha512-dElxVXMFGthshfIj+qAVm8KE2jmNo2p8oXFib8WzEjb7GNaX/ClWBc8UJfoSZwjEMVrdHJ4YUfa7P3ifl6MIWw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -40361,7 +40355,7 @@
         "@livekit/track-processors": "^0.5.8",
         "@matrix-org/olm": "^3.2.15",
         "@mediapipe/selfie_segmentation": "^0.1.1675465747",
-        "@mediapipe/tasks-vision": "^0.10.22-rc.20250304",
+        "@mediapipe/tasks-vision": "^0.10.32",
         "@sentry/browser": "^10.30.0",
         "@sentry/node": "^10.30.0",
         "@sentry/svelte": "^10.30.0",
@@ -40933,6 +40927,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "play/node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.32",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.32.tgz",
+      "integrity": "sha512-3tiAZnmKloYnRXYoO3dKltTUGnqeCwzC4lV03uY0vCsE+aveJTyEVQyZHOlQGQNsjK+gRHzkf9q08C99Qm2K0Q==",
+      "license": "Apache-2.0"
     },
     "play/node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.53.3",

--- a/play/package.json
+++ b/play/package.json
@@ -108,7 +108,7 @@
     "@livekit/track-processors": "^0.5.8",
     "@matrix-org/olm": "^3.2.15",
     "@mediapipe/selfie_segmentation": "^0.1.1675465747",
-    "@mediapipe/tasks-vision": "^0.10.22-rc.20250304",
+    "@mediapipe/tasks-vision": "^0.10.32",
     "@sentry/browser": "^10.30.0",
     "@sentry/node": "^10.30.0",
     "@sentry/svelte": "^10.30.0",

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
@@ -19,7 +19,6 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
 
     private imageSegmenter: ImageSegmenter | null = null;
     private filesetResolver: Awaited<ReturnType<typeof FilesetResolver.forVisionTasks>> | null = null;
-    private isInitialized = false;
     private backgroundImage: HTMLImageElement | null = null;
     private backgroundVideo: HTMLVideoElement | null = null;
     private outputStream: MediaStream | null = null;
@@ -68,15 +67,12 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
     }
 
     private async initialize(): Promise<void> {
-        if (this.isInitialized) return;
-
         try {
             await this.initializeMediaPipe();
             await this.loadBackgroundResources();
             // Initialize canvases for optimized rendering
             this.initializeBlurredCanvas();
             this.initializeForegroundCanvas();
-            this.isInitialized = true;
         } catch (error) {
             console.error("[MediaPipe Tasks Vision] Initialization failed:", error);
             throw error;
@@ -539,9 +535,7 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
 
     public async transform(inputStream: MediaStream): Promise<MediaStream> {
         this.frameRate = inputStream.getVideoTracks()[0]?.getSettings().frameRate || 33;
-        if (!this.isInitialized) {
-            await this.initialize();
-        }
+        await this.initPromise;
 
         if (this.config.mode === "none") {
             return inputStream;


### PR DESCRIPTION
A concurrency bug as triggering a double init of tasks-vision. Furthermore, tasks-vision as been upgraded to 0.10.32 following the fix of a NPM deployment bug (see https://github.com/google-ai-edge/mediapipe/issues/6185)