### PR TITLE
Fix empty sidebar + browser console error when `ENABLE_MAP_EDITOR=false`

### DIFF
--- a/play/src/front/Components/ActionBar/MenuIcons/MapSubMenuContent.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/MapSubMenuContent.svelte
@@ -2,12 +2,7 @@
     import type { AreaData } from "@workadventure/map-editor";
     import { warningMessageStore } from "../../../Stores/ErrorStore";
     import { isInsidePersonalAreaStore, personalAreaDataStore } from "../../../Stores/PersonalDeskStore";
-    import {
-        globalMessageVisibleStore,
-        mapManagerActivated,
-        mapEditorMenuVisibleStore,
-        openedMenuStore,
-    } from "../../../Stores/MenuStore";
+    import { globalMessageVisibleStore, mapEditorMenuVisibleStore, openedMenuStore } from "../../../Stores/MenuStore";
     import { LL } from "../../../../i18n/i18n-svelte";
     import { analyticsClient } from "../../../Administration/AnalyticsClient";
     import {
@@ -117,7 +112,7 @@
         <IconMapEditor font-size="20" />
     </ActionBarButton>
 {/if}
-{#if $mapManagerActivated}
+{#if $mapEditorMenuVisibleStore}
     <ActionBarButton on:click={toggleMapExplorerMode} label={$LL.mapEditor.sideBar.exploreTheRoom()}>
         <IconMapSearch font-size="20" />
     </ActionBarButton>

--- a/play/src/front/Components/MainLayout.svelte
+++ b/play/src/front/Components/MainLayout.svelte
@@ -4,7 +4,7 @@
     import { requestVisitCardsStore } from "../Stores/GameStore";
     import { helpNotificationSettingsVisibleStore, helpWebRtcSettingsVisibleStore } from "../Stores/HelpSettingsStore";
     import { helpSettingsPopupBlockedStore } from "../Stores/HelpSettingsPopupBlockedStore";
-    import { menuVisiblilityStore, warningBannerStore } from "../Stores/MenuStore";
+    import { mapEditorActivated, menuVisiblilityStore, warningBannerStore } from "../Stores/MenuStore";
     import { showReportScreenStore, userReportEmpty } from "../Stores/ShowReportScreenStore";
     import { banMessageStore } from "../Stores/TypeMessageStore/BanMessageStore";
     import { textMessageStore } from "../Stores/TypeMessageStore/TextMessageStore";
@@ -261,7 +261,9 @@
             {/if}
             <ExternalComponents zone="centeredPopup" />
 
-            <ExplorerMenu />
+            {#if $mapEditorActivated}
+                <ExplorerMenu />
+            {/if}
         </section>
         <div class="">
             <!--<ActionBar />-->

--- a/play/src/front/Components/MapEditor/ClaimPersonalAreaDialogBox.svelte
+++ b/play/src/front/Components/MapEditor/ClaimPersonalAreaDialogBox.svelte
@@ -11,6 +11,11 @@
     let name = "";
     const mapEditorModeManager = gameManager.getCurrentGameScene().getMapEditorModeManager();
 
+    // If mapEditorModeManager is not available, close the dialog
+    if (!mapEditorModeManager) {
+        mapEditorAskToClaimPersonalAreaStore.set(undefined);
+    }
+
     // function to check key press and if it is enter key then click on yes button
     function emitKeypressEvents(event: KeyboardEvent) {
         if (event.key === "Enter") {

--- a/play/src/front/Components/PopUp/PopUpDropFileEntity.svelte
+++ b/play/src/front/Components/PopUp/PopUpDropFileEntity.svelte
@@ -104,6 +104,12 @@
 
         const mapEditorModeManager = scene.getMapEditorModeManager();
 
+        if (!mapEditorModeManager) {
+            warningMessageStore.addWarningMessage("Map editor is not available");
+            removePopup();
+            return;
+        }
+
         analyticsClient.dragDropFile();
         mapEditorModeStore.switchMode(true);
         mapEditorModeManager.equipTool(EditorToolName.EntityEditor);


### PR DESCRIPTION
## Summary

When `ENABLE_MAP_EDITOR=false`, several UI components would crash with `Cannot read properties of undefined` when trying to access `getMapEditorModeManager()`.

Fixes #5618

## Changes

- **MainLayout.svelte**: Only render `ExplorerMenu` when `mapEditorActivated` is true
- **MapSubMenuContent.svelte**: Use `mapEditorMenuVisibleStore` instead of `mapManagerActivated` for the explorer button visibility
- **ClaimPersonalAreaDialogBox.svelte**: Guard against undefined `mapEditorModeManager` and close dialog if unavailable
- **PopUpDropFileEntity.svelte**: Guard against undefined `mapEditorModeManager` and show warning message if unavailable