### PR TITLE
Fix privacy shutdown store activation

### DIFF
--- a/play/src/front/Stores/PrivacyShutdownStore.ts
+++ b/play/src/front/Stores/PrivacyShutdownStore.ts
@@ -27,7 +27,7 @@ function createPrivacyShutdownStore() {
     // It is ok to not unsubscribe to this store because it is a singleton.
     // eslint-disable-next-line svelte/no-ignored-unsubscribe
     videoStreamElementsStore.subscribe((peerElements) => {
-        if (peerElements.length === 0 && get(visibilityStore) === false) {
+        if (peerElements.length === 0 && get(visibilityStore) === false && !get(isLiveStreamingStore)) {
             privacyEnabled = true;
             set(true);
         }


### PR DESCRIPTION
If we are in a room that goes to 0 users, and if we our tab is not visible BUT if we are live streaming, we should not enable the privacy store. The privacy store should never be enabled when we are live streaming.