### PR TITLE
fix: Restore action bar after exiting screenshare fullscreen

### DIFF
--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -81,7 +81,6 @@
 
     function exitFullScreen() {
         highlightedEmbedScreen.removeHighlight();
-        highlightFullScreen.set(false);
     }
 
     let userMenuButton: HTMLDivElement;

--- a/play/src/front/Stores/HighlightedEmbedScreenStore.ts
+++ b/play/src/front/Stores/HighlightedEmbedScreenStore.ts
@@ -1,6 +1,7 @@
 import { writable } from "svelte/store";
 import type { Unsubscriber } from "svelte/store";
 import type { VideoBox } from "../Space/Space";
+import { highlightFullScreen } from "./ActionsCamStore";
 
 function createHighlightedEmbedScreenStore() {
     const { subscribe, set } = writable<VideoBox | undefined>(undefined);
@@ -41,6 +42,7 @@ function createHighlightedEmbedScreenStore() {
                         }
                         if (!hasVideo) {
                             // If hasVideo becomes false, remove the highlight
+                            highlightFullScreen.set(false);
                             set(undefined);
                             if (streamableUnsubscriber) {
                                 streamableUnsubscriber();
@@ -65,6 +67,7 @@ function createHighlightedEmbedScreenStore() {
                 hasVideoUnsubscriber();
                 hasVideoUnsubscriber = undefined;
             }
+            highlightFullScreen.set(false);
             set(undefined);
         },
     };

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -12,7 +12,7 @@ import { screenSharingLocalMedia } from "./ScreenSharingStore";
 
 import { highlightedEmbedScreen } from "./HighlightedEmbedScreenStore";
 import { embedScreenLayoutStore } from "./EmbedScreenLayoutStore";
-import { highlightFullScreen } from "./ActionsCamStore";
+
 import { scriptingVideoStore } from "./ScriptingVideoStore";
 import { myCameraStore } from "./MyMediaStore";
 import {
@@ -234,7 +234,6 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
 
             if ($highlightedEmbedScreen && !peers.has($highlightedEmbedScreen.uniqueId)) {
                 highlightedEmbedScreen.removeHighlight();
-                highlightFullScreen.set(false);
             }
 
             return peers;
@@ -300,6 +299,5 @@ streamableCollectionStore.subscribe((streamableCollection) => {
     const $highlightedEmbedScreen = get(highlightedEmbedScreen);
     if ($highlightedEmbedScreen && !streamableCollection.has($highlightedEmbedScreen.uniqueId)) {
         highlightedEmbedScreen.removeHighlight();
-        highlightFullScreen.set(false);
     }
 });


### PR DESCRIPTION
## Problem
When putting a screenshare in fullscreen then exiting (or when the stream ended / peer left), the action bar stayed hidden instead of reappearing.

## Solution
Centralize the `highlightFullScreen` reset in `HighlightedEmbedScreenStore`:
- Call `highlightFullScreen.set(false)` when the highlighted embed is cleared (in the `hasVideo` subscription and in `removeHighlight()`).
- Remove duplicate `highlightFullScreen.set(false)` from `VideoMediaBox.svelte` (exitFullScreen) and `StreamableCollectionStore.ts`, so a single source of truth drives the action bar visibility.

## Changes
- **HighlightedEmbedScreenStore.ts**: Set `highlightFullScreen` to `false` when removing the highlight (video gone or explicit remove).
- **VideoMediaBox.svelte**: No longer sets `highlightFullScreen` in `exitFullScreen()` (handled by the store).
- **StreamableCollectionStore.ts**: Removed redundant `highlightFullScreen.set(false)` when the highlighted peer leaves the collection.