### PR TITLE
fix: Persist chat sound preference when toggling checkbox

### DIFF
--- a/play/src/front/Components/Menu/ChatSubMenu.svelte
+++ b/play/src/front/Components/Menu/ChatSubMenu.svelte
@@ -35,7 +35,7 @@
                     <InputCheckbox
                         data-testid="chatSounds"
                         bind:value={chatSounds}
-                        on:change={changeChatSounds}
+                        onChange={changeChatSounds}
                         label={$LL.menu.settings.chatSounds()}
                     />
                 </div>


### PR DESCRIPTION
## Problem

Toggling the "Chat sounds" checkbox in the chat settings did not persist the value. The preference was never written to local storage because the parent was using `on:change` (Svelte event listener). `InputCheckbox` does not dispatch a `change` event; it only invokes the `onChange` prop callback.

## Solution

Use the `onChange` prop on `InputCheckbox` so that when the checkbox value changes, `changeChatSounds` is called and `localUserStore.setChatSounds(chatSounds)` runs, correctly persisting the user's choice.

## Changes

- **play/src/front/Components/Menu/ChatSubMenu.svelte**: Replaced `on:change={changeChatSounds}` with `onChange={changeChatSounds}` on the chat sounds `InputCheckbox`.