### PR TITLE
fix: Enable audio for remote screenshare by default

### DIFF
--- a/play/src/front/Components/Video/ActionMediaBox.svelte
+++ b/play/src/front/Components/Video/ActionMediaBox.svelte
@@ -9,17 +9,17 @@
     import type { SpaceUserExtended } from "../../Space/SpaceInterface";
     import { showReportScreenStore } from "../../Stores/ShowReportScreenStore";
     import { isListenerStore } from "../../Stores/MediaStore";
-    import type { StreamOriginCategory } from "../../Stores/StreamableCollectionStore";
+    import type { StreamCategory } from "../../Stores/StreamableCollectionStore";
     import RangeSlider from "../Input/RangeSlider.svelte";
     import { IconAlertTriangle, IconUser, IconMute, IconUnMute } from "@wa-icons";
 
     export let spaceUser: SpaceUserExtended;
     export let videoEnabled: boolean;
-    export let videoType: StreamOriginCategory | undefined;
+    export let videoType: StreamCategory | undefined;
     export let onClose: () => void;
     export let volumeStore: Writable<number> = writable(1);
 
-    const isScreenSharing = videoType === "local_screenSharing" || videoType === "remote_screenSharing";
+    const isScreenSharing = videoType === "screenSharing";
 
     const isMicrophoneEnabled = spaceUser.reactiveUser.microphoneState;
     const isVideoEnabled = spaceUser.reactiveUser.cameraState;

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -262,7 +262,7 @@
                                 cssClass="voice-meter-cam-off relative mr-0 ml-auto translate-x-0 transition-transform"
                                 barColor="white"
                             />
-                        {:else}
+                        {:else if streamable.videoType === "video"}
                             <IconMicrophoneOff
                                 aria-label={$LL.video.user_is_muted({ name: name ?? "unknown" })}
                                 data-testid={$LL.video.user_is_muted({ name: name ?? "unknown" })}

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -240,7 +240,7 @@ export class LiveKitParticipant {
             volumeStore: writable(undefined),
             volume: writable(this.defaultVolume),
             closeStreamable: () => {},
-            videoType: "remote_video",
+            videoType: "video",
             webrtcStats: this.getWebrtcStats("video"),
         };
     }
@@ -280,7 +280,7 @@ export class LiveKitParticipant {
             volumeStore: writable(undefined),
             volume: writable(this.defaultVolume),
             closeStreamable: () => {},
-            videoType: "remote_screenSharing",
+            videoType: "screenSharing",
             webrtcStats: this.getWebrtcStats("screenShare"),
         };
     }

--- a/play/src/front/Stores/ScreenSharingStore.ts
+++ b/play/src/front/Stores/ScreenSharingStore.ts
@@ -302,7 +302,7 @@ export const screenSharingLocalMedia = readable<Streamable | undefined>(undefine
         usePresentationMode: true,
         closeStreamable: () => {},
         volume: writable(1),
-        videoType: "local_screenSharing",
+        videoType: "screenSharing",
         webrtcStats: undefined,
     } satisfies Streamable;
 

--- a/play/src/front/Stores/ScriptingVideoStore.ts
+++ b/play/src/front/Stores/ScriptingVideoStore.ts
@@ -28,7 +28,7 @@ function createStreamableFromVideo(url: string, config: VideoConfig): Streamable
         usePresentationMode: false,
         volume: writable(1),
         closeStreamable: () => {},
-        videoType: "local_scripting",
+        videoType: "scripting",
         webrtcStats: undefined,
     };
 }

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -62,8 +62,6 @@ export interface ScriptingVideoStreamable {
 export type StreamOrigin = "local" | "remote";
 export type StreamCategory = "video" | "screenSharing" | "scripting";
 
-export type StreamOriginCategory = `${StreamOrigin}_${StreamCategory}`;
-
 export interface Streamable {
     readonly uniqueId: string;
     readonly media: LivekitStreamable | WebRtcStreamable | ScriptingVideoStreamable;
@@ -87,7 +85,7 @@ export interface Streamable {
     readonly spaceUserId: string | undefined;
     readonly closeStreamable: () => void;
     readonly volume: Writable<number>;
-    readonly videoType: StreamOriginCategory;
+    readonly videoType: StreamCategory;
     readonly webrtcStats: Readable<WebRtcStats | undefined> | undefined;
 }
 
@@ -146,7 +144,7 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL]) => {
         spaceUserId: undefined,
         closeStreamable: () => {},
         volume: writable(1),
-        videoType: "local_video",
+        videoType: "video",
         setDisplayInPictureInPictureMode: (displayInPictureInPictureMode: boolean) => {
             streamable.displayInPictureInPictureMode = displayInPictureInPictureMode;
         },

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -10,7 +10,7 @@ import { throttle } from "throttle-debounce";
 import type { LocalStreamStoreValue } from "../Stores/MediaStore";
 import { videoQualityStore } from "../Stores/MediaStore";
 import { SoundMeter } from "../Phaser/Components/SoundMeter";
-import type { Streamable, StreamOriginCategory, WebRtcStreamable } from "../Stores/StreamableCollectionStore";
+import type { Streamable, StreamCategory, WebRtcStreamable } from "../Stores/StreamableCollectionStore";
 import type { SpaceInterface } from "../Space/SpaceInterface";
 import { decrementWebRtcConnectionsCount, incrementWebRtcConnectionsCount } from "../Utils/E2EHooks";
 import { deriveSwitchStore } from "../Stores/InterruptorStore";
@@ -66,7 +66,7 @@ export class RemotePeer extends Peer implements Streamable {
     private readonly _isBlocked: Readable<boolean>;
     private closeStreamableTimeout: ReturnType<typeof setTimeout> | undefined;
     public readonly volume: Writable<number>;
-    public readonly videoType: StreamOriginCategory;
+    public readonly videoType: StreamCategory;
     public readonly webrtcStats: Readable<WebRtcStats | undefined>;
     private receiverMaxBitrateBps: number | undefined;
     /**
@@ -260,7 +260,7 @@ export class RemotePeer extends Peer implements Streamable {
 
         this.volume = writable(defaultVolume);
         this._hasAudio = writable<boolean>(true);
-        this.videoType = type === "video" ? "remote_video" : "remote_screenSharing";
+        this.videoType = type;
         this.displayMode = type === "video" ? "cover" : "fit";
         this.usePresentationMode = !(type === "video");
         //this.userUuid = spaceUser.uuid;


### PR DESCRIPTION
## Problem

Remote screen-sharing streams had no audio: `_hasAudio` was set from `type === "video"`, so it was `false` for screen-sharing peers and the UI/audio pipeline did not expose screenshare sound.

## Solution

Initialize `_hasAudio` to `true` for all remote peers (including screen-sharing), so shared screen audio is available by default.

## Changes

- **play/src/front/WebRtc/RemotePeer.ts**: `_hasAudio` store default changed from `type === "video"` to `true` so remote screenshare has audio.