### PR TITLE
add query type and user context to query error logging and Sentry

### DIFF
--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -1076,10 +1076,30 @@ export class IoSocketController {
                                     }
                                 } catch (error) {
                                     const err = asError(error);
+                                    const queryType = message.message.queryMessage.query?.$case ?? "unknown";
+                                    const userData = socket.getUserData();
                                     // If the error is due to an abort, don't log it as an error
                                     if (!(err instanceof AbortError)) {
-                                        console.error("Error handling query message: ", error);
-                                        Sentry.captureException(err);
+                                        console.error(
+                                            "Error handling query message:",
+                                            {
+                                                queryType,
+                                                queryId: message.message.queryMessage.id,
+                                                userUuid: userData.userUuid,
+                                                roomId: userData.roomId,
+                                                world: userData.world,
+                                            },
+                                            error
+                                        );
+                                        Sentry.captureException(err, {
+                                            extra: {
+                                                queryType,
+                                                queryId: message.message.queryMessage.id,
+                                            },
+                                            tags: {
+                                                queryType,
+                                            },
+                                        });
                                     }
                                     const answerMessage: AnswerMessage = {
                                         id: message.message.queryMessage.id,


### PR DESCRIPTION
## Problem

When a query message failed in the pusher, the error handling gave no context: neither the type of query (e.g. `searchMemberQuery`, `joinSpaceQuery`) nor the user (room, world, userUuid). This made debugging and Sentry analysis difficult.

## Solution

Enrich the catch block for query message handling with:
- **Query type**: `message.message.queryMessage.query?.$case` (fallback to `"unknown"`).
- **User context**: `userUuid`, `roomId`, `world` from `socket.getUserData()`.

Use this context in both `console.error` (structured log) and `Sentry.captureException` (extra + tag `queryType`).

## Changes

- **play/src/pusher/controllers/IoSocketController.ts**: In the query message `catch` block, compute `queryType` and `userData`; log them in `console.error`; pass `queryType` and `queryId` to Sentry via `extra` and add a `queryType` tag for filtering.