### PR TITLE
Fixing manifest merging following new Docker BuildX version

### DIFF
--- a/.github/workflows/build-single-image.yml
+++ b/.github/workflows/build-single-image.yml
@@ -110,6 +110,8 @@ jobs:
           build-args: |
             FAST_BUILD=${{ inputs.fast_build == true && 'true' || '' }}
           outputs: ${{ inputs.push-to-registry != true && format('type=docker,dest=/tmp/{0}.tar', inputs.short_name) || '' }}
+          provenance: false # Disable provenance attestation generation to not generate a manifest list (so we can merge later)
+          sbom: false # Disable SBOM generation to not generate a manifest list (so we can merge later)
 
       - name: Zip image
         if: ${{ inputs.push-to-registry != true }}


### PR DESCRIPTION
Fixes ghcr.io/workadventure/back-dev-build:amd64-4e20682756d5b50db55693d5bec97b6daec23dfc is a manifest list