### PR TITLE
Adding a fallback for the display of avatars

### DIFF
--- a/play/src/front/Chat/Components/Avatar.svelte
+++ b/play/src/front/Chat/Components/Avatar.svelte
@@ -6,15 +6,21 @@
     export let fallbackName = "A";
     export let color: string | null = null;
     export let isChatAvatar = false;
+
+    let forceFallback = false;
 </script>
 
-{#if $pictureStore}
+{#if $pictureStore && !forceFallback}
     <img
         src={$pictureStore}
         alt="User avatar"
         class="rounded-sm h-full w-full object-contain bg-white"
         draggable="false"
         style:background-color={`${color ? color : `${getColorByString(fallbackName)}`}`}
+        on:error={(event) => {
+            console.warn(`Failed to load avatar image for ${fallbackName}`, event);
+            forceFallback = true;
+        }}
     />
 {:else}
     <div

--- a/play/src/front/Chat/Components/Room/Reaction.svelte
+++ b/play/src/front/Chat/Components/Room/Reaction.svelte
@@ -3,7 +3,7 @@
 
     export let reaction: ChatMessageReaction;
 
-    const { reacted, key, users } = reaction;
+    const { reacted, key, users, component } = reaction;
 </script>
 
 {#if $users.size > 0}
@@ -15,7 +15,7 @@
         data-testid={`${key}_reactionButton`}
     >
         <div class="group-hover:scale-[2] group-hover:rotate-3 transition-all text-xs p-0 m-0 hover:cursor-pointer">
-            {key}
+            <svelte:component this={component.component} {...component.props} />
         </div>
         <div class="text-xs p-0 m-0 hover:cursor-pointer text-white" class:font-extrabold={$reacted}>
             {$users.size}

--- a/play/src/front/Chat/Components/Room/ReactionIcon.svelte
+++ b/play/src/front/Chat/Components/Room/ReactionIcon.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+    import type { MatrixClient } from "matrix-js-sdk";
+
+    // A valid Matrix reaction key is either a Unicode emoji or an mxc URI pointing to an image, or even some text.
+    export let key: string;
+    export let matrixClient: MatrixClient;
+
+    let imageUrl: string | null = null;
+
+    if (key.startsWith("mxc://")) {
+        imageUrl = matrixClient.mxcUrlToHttp(key, 40, 40);
+    }
+
+    function handleError(event: Event) {
+        console.warn(`Failed to load reaction image for key ${key}`, event);
+        imageUrl = null;
+        key = "❓";
+    }
+</script>
+
+{#if imageUrl}
+    <img src={imageUrl} alt="Reaction" class="w-5 h-5" on:error={handleError} />
+{:else if [...key].length > 1}
+    <span title={key}>{key.substring(0, 1)}</span>
+{:else}
+    {key}
+{/if}

--- a/play/src/front/Chat/Connection/ChatConnection.ts
+++ b/play/src/front/Chat/Connection/ChatConnection.ts
@@ -2,6 +2,7 @@ import type { Readable, Writable } from "svelte/store";
 import type { AvailabilityStatus } from "@workadventure/messages";
 import type { MapStore } from "@workadventure/store-utils";
 import type { StateEvents } from "matrix-js-sdk";
+import type { ComponentType, SvelteComponent } from "svelte";
 import type { RoomConnection } from "../../Connection/RoomConnection";
 import type { PictureStore } from "../../Stores/PictureStore";
 
@@ -126,10 +127,11 @@ export interface ChatMessage {
 }
 
 export interface ChatMessageReaction {
-    key: string;
-    users: MapStore<string, ChatUser>;
-    react: () => void;
-    reacted: Readable<boolean>;
+    readonly key: string;
+    readonly users: MapStore<string, ChatUser>;
+    readonly react: () => void;
+    readonly reacted: Readable<boolean>;
+    readonly component: { component: ComponentType<SvelteComponent>; props: Record<string, unknown> };
 }
 
 export type ChatMessageType = "proximity" | "text" | "incoming" | "outcoming" | "image" | "file" | "audio" | "video";

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatMessageReaction.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatMessageReaction.ts
@@ -3,7 +3,9 @@ import { EventType, RelationType } from "matrix-js-sdk";
 import { MapStore } from "@workadventure/store-utils";
 import type { Writable } from "svelte/store";
 import { get, writable } from "svelte/store";
+import type { ComponentType, SvelteComponent } from "svelte";
 import type { ChatMessageReaction, ChatUser } from "../ChatConnection";
+import ReactionIcon from "../../Components/Room/ReactionIcon.svelte";
 import { chatUserFactory } from "./MatrixChatUser";
 
 type EventId = string;
@@ -85,5 +87,15 @@ export class MatrixChatMessageReaction implements ChatMessageReaction {
         } catch (error) {
             console.error(error);
         }
+    }
+
+    public get component(): { component: ComponentType<SvelteComponent>; props: Record<string, unknown> } {
+        return {
+            component: ReactionIcon,
+            props: {
+                key: this.key,
+                matrixClient: this.matrixRoom.client,
+            },
+        };
     }
 }


### PR DESCRIPTION
In case the Matrix resource loading fails, adding fallbacks.

Also, in the case of reactions, adding support for reactions that are: MXC resources, or long text messages.