### PR TITLE
Fixing E2E test for ping

### DIFF
--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -941,7 +941,10 @@ class ConnectionManager {
                 if (isNetworkOrIdempotentRequestError(error)) {
                     return true;
                 }
-                return error.code !== "ECONNABORTED" && (!error.response || error.response.status === 429);
+                return (
+                    error.code !== "ECONNABORTED" &&
+                    (!error.response || error.response.status === 429 || error.response.status === 404)
+                );
             },
         });
 


### PR DESCRIPTION
Traefik can temporarily return 404 when restarting for the /ping endpoint. We should keep retrying in this case instead of failing.