### PR TITLE
fix: Refresh listener zone when associated speaker zone is updated

### DIFF
--- a/libs/map-editor/src/GameMap/GameMapAreas.ts
+++ b/libs/map-editor/src/GameMap/GameMapAreas.ts
@@ -9,10 +9,18 @@ export type AreaChangeCallback = (
     allAreasOnNewPosition: Array<AreaData>
 ) => void;
 
+/**
+ * Optional context passed when triggering an area update (e.g. precomputed associated area ids).
+ */
+export interface AreaUpdateContext {
+    associatedAreaIds?: string[];
+}
+
 export type AreaUpdateCallback = (
     area: AreaData,
     oldProperties: AreaDataProperties | undefined,
-    newProperties: AreaDataProperties | undefined
+    newProperties: AreaDataProperties | undefined,
+    context?: AreaUpdateContext
 ) => void;
 
 export class GameMapAreas {
@@ -303,10 +311,11 @@ export class GameMapAreas {
     public triggerSpecificAreaOnUpdate(
         area: AreaData,
         oldProperties: AreaDataProperties | undefined,
-        newProperties: AreaDataProperties | undefined
+        newProperties: AreaDataProperties | undefined,
+        context?: AreaUpdateContext
     ): void {
         for (const callback of this.updateAreaCallbacks) {
-            callback(area, oldProperties, newProperties);
+            callback(area, oldProperties, newProperties, context);
         }
     }
 

--- a/play/src/front/Phaser/Game/GameMap/AreasManager.ts
+++ b/play/src/front/Phaser/Game/GameMap/AreasManager.ts
@@ -122,4 +122,15 @@ export class AreasManager {
         }
         return this.gameMapAreas.getCollidingAreas(this.userConnectedTags);
     }
+
+    /**
+     * Returns true if the current player is inside the area with the given id.
+     */
+    public isCurrentPlayerInArea(areaId: string): boolean {
+        const position = this.scene.getGameMapFrontWrapper().getPlayerPosition();
+        if (!position) {
+            return false;
+        }
+        return this.gameMapAreas.isPlayerInsideArea(areaId, position);
+    }
 }

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -1,6 +1,7 @@
 import type {
     AreaChangeCallback,
     AreaData,
+    AreaDataProperty,
     AtLeast,
     GameMap,
     AreaDataProperties,
@@ -120,6 +121,15 @@ export class GameMapFrontWrapper {
     private leaveDynamicAreaCallbacks = Array<DynamicAreaChangeCallback>();
 
     public areasManager: AreasManager | undefined;
+
+    /**
+     * Registry of resolvers that return associated area ids for a given area, keyed by area property type.
+     * Used to trigger onUpdate only when the player is (or was) in the updated zone or in an associated zone.
+     */
+    private associatedAreasResolvers = new Map<
+        AreaDataProperty["type"],
+        (area: AreaData, getAreas: () => Map<string, AreaData>) => string[]
+    >();
 
     /**
      * Firing on map change, containing newest collision grid array
@@ -886,6 +896,33 @@ export class GameMapFrontWrapper {
         return this.gameMap.getWamFile()?.getGameMapAreas().getArea(id);
     }
 
+    /**
+     * Registers a resolver that returns associated area ids for areas having the given property type.
+     * Enables filtering triggerSpecificAreaOnUpdate to only run when the player is in the zone or in an associated zone.
+     */
+    public registerAssociatedAreasResolver(
+        propertyType: AreaDataProperty["type"],
+        resolver: (area: AreaData, getAreas: () => Map<string, AreaData>) => string[]
+    ): void {
+        this.associatedAreasResolvers.set(propertyType, resolver);
+    }
+
+    /**
+     * Returns the set of area ids that are "associated" to the given area, based on registered resolvers
+     * (e.g. speaker zone → listener zones that reference it; listener zone → its speaker zone).
+     */
+    public getAssociatedAreaIds(area: AreaData): string[] {
+        const getAreas = (): Map<string, AreaData> => this.getAreas() ?? new Map();
+        const ids: string[] = [];
+        for (const property of area.properties ?? []) {
+            const resolver = this.associatedAreasResolvers.get(property.type);
+            if (resolver) {
+                ids.push(...resolver(area, getAreas));
+            }
+        }
+        return [...new Set(ids)];
+    }
+
     public getDynamicArea(name: string): DynamicArea | undefined {
         return this.dynamicAreas.get(name);
     }
@@ -943,8 +980,13 @@ export class GameMapFrontWrapper {
 
         const propertiesChanged = JSON.stringify(oldConfig.properties) !== JSON.stringify(newConfig.properties);
 
-        if (isPlayerWasInsideArea && isPlayerInsideArea) {
-            if (propertiesChanged) {
+        if (propertiesChanged) {
+            const isPlayerInOrWasInUpdatedZone = isPlayerWasInsideArea || isPlayerInsideArea;
+            const associatedAreaIds = this.getAssociatedAreaIds(area);
+            const isPlayerInAssociatedZone =
+                this.areasManager !== undefined &&
+                associatedAreaIds.some((id) => this.areasManager?.isCurrentPlayerInArea(id));
+            if (isPlayerInOrWasInUpdatedZone || isPlayerInAssociatedZone) {
                 this.triggerSpecificAreaOnUpdate(area, oldConfig.properties, newConfig.properties);
             }
         } else if (isPlayerWasInsideArea && !isPlayerInsideArea) {
@@ -953,10 +995,6 @@ export class GameMapFrontWrapper {
         } else if (!isPlayerWasInsideArea && isPlayerInsideArea) {
             this.triggerSpecificAreaOnEnter(area);
             return;
-        } else if (propertiesChanged) {
-            // Player is not in the updated area (e.g. in a listener zone while speaker zone is edited).
-            // Still notify so listener refresh can run when speaker name/seeAttendees changes.
-            this.triggerSpecificAreaOnUpdate(area, oldConfig.properties, newConfig.properties);
         }
         if (!this.areasManager) {
             throw new Error("AreasManager is not initialized. Are you on a public map?");

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -2,6 +2,7 @@ import type {
     AreaChangeCallback,
     AreaData,
     AreaDataProperty,
+    AreaUpdateContext,
     AtLeast,
     GameMap,
     AreaDataProperties,
@@ -879,7 +880,8 @@ export class GameMapFrontWrapper {
     public triggerSpecificAreaOnUpdate(
         area: AreaData,
         oldProperties: AreaDataProperties | undefined,
-        newProperties: AreaDataProperties | undefined
+        newProperties: AreaDataProperties | undefined,
+        context?: AreaUpdateContext
     ): void {
         this.gameMap.getWamFile()?.getGameMapAreas().triggerSpecificAreaOnUpdate(area, oldProperties, newProperties);
     }
@@ -987,7 +989,9 @@ export class GameMapFrontWrapper {
                 this.areasManager !== undefined &&
                 associatedAreaIds.some((id) => this.areasManager?.isCurrentPlayerInArea(id));
             if (isPlayerInOrWasInUpdatedZone || isPlayerInAssociatedZone) {
-                this.triggerSpecificAreaOnUpdate(area, oldConfig.properties, newConfig.properties);
+                this.triggerSpecificAreaOnUpdate(area, oldConfig.properties, newConfig.properties, {
+                    associatedAreaIds,
+                });
             }
         } else if (isPlayerWasInsideArea && !isPlayerInsideArea) {
             this.triggerSpecificAreaOnLeave(area);

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -77,6 +77,13 @@ export class GameMapFrontWrapper {
     private position: { x: number; y: number } | undefined;
 
     /**
+     * Returns the current player position (in pixels), or undefined if not yet set.
+     */
+    public getPlayerPosition(): { x: number; y: number } | undefined {
+        return this.position;
+    }
+
+    /**
      * Manager for renderable, interactive objects that players can work with.
      */
     private entitiesManager: EntitiesManager;
@@ -934,8 +941,10 @@ export class GameMapFrontWrapper {
         const isPlayerWasInsideArea = this.isPlayerInsideAreaByCoordinates(oldAreaCoordinates, this.position);
         const isPlayerInsideArea = this.isPlayerInsideAreaByCoordinates(newAreaCoordinates, this.position);
 
+        const propertiesChanged = JSON.stringify(oldConfig.properties) !== JSON.stringify(newConfig.properties);
+
         if (isPlayerWasInsideArea && isPlayerInsideArea) {
-            if (JSON.stringify(oldConfig.properties) !== JSON.stringify(newConfig.properties)) {
+            if (propertiesChanged) {
                 this.triggerSpecificAreaOnUpdate(area, oldConfig.properties, newConfig.properties);
             }
         } else if (isPlayerWasInsideArea && !isPlayerInsideArea) {
@@ -944,6 +953,10 @@ export class GameMapFrontWrapper {
         } else if (!isPlayerWasInsideArea && isPlayerInsideArea) {
             this.triggerSpecificAreaOnEnter(area);
             return;
+        } else if (propertiesChanged) {
+            // Player is not in the updated area (e.g. in a listener zone while speaker zone is edited).
+            // Still notify so listener refresh can run when speaker name/seeAttendees changes.
+            this.triggerSpecificAreaOnUpdate(area, oldConfig.properties, newConfig.properties);
         }
         if (!this.areasManager) {
             throw new Error("AreasManager is not initialized. Are you on a public map?");

--- a/play/src/front/Phaser/Game/MapEditor/AreaPropertyUpdateHandlerRegistry.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreaPropertyUpdateHandlerRegistry.ts
@@ -1,0 +1,188 @@
+import type { AreaData, AreaDataProperty, SpeakerMegaphonePropertyData } from "@workadventure/map-editor";
+import * as Sentry from "@sentry/svelte";
+import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
+import {
+    buildListenerEntriesFromAssociatedIds,
+    getListenerAreasReferencingSpeakerWherePlayerIs,
+    getSpeakerPropertyForAreaId,
+} from "./MegaphoneAssociatedZonesAndUpdateHelpers";
+import type { ListenerEntry } from "./MegaphoneAssociatedZonesAndUpdateHelpers";
+
+/**
+ * Context passed to property-update callbacks when an area property is updated.
+ * precomputedAssociatedAreaIds is set when the update was triggered from listenAreaChanges
+ * so handlers can avoid re-computing associated zones.
+ * megaphoneDeps is provided by the caller at invoke time (dependency inversion).
+ */
+export interface AreaPropertyUpdateContext<T extends AreaDataProperty = AreaDataProperty> {
+    area: AreaData;
+    oldProperty: T;
+    newProperty: T;
+    /** When present, associated area ids were already computed by the trigger path. */
+    precomputedAssociatedAreaIds?: string[];
+    /** Dependencies for megaphone handlers, passed at invoke time by the listener. */
+    megaphoneDeps?: MegaphoneUpdateHandlerDeps;
+}
+
+/**
+ * Handler for property updates of a given type. Registered per property type;
+ * optional hasRelevantChange avoids running onUpdate when the change is not meaningful.
+ */
+export interface AreaPropertyUpdateHandler<T extends AreaDataProperty = AreaDataProperty> {
+    hasRelevantChange?(oldProperty: T, newProperty: T): boolean;
+    onUpdate(context: AreaPropertyUpdateContext<T>): void | Promise<void>;
+}
+
+/**
+ * Dependencies required to run the megaphone property update handlers
+ * (speaker/listener zone refresh when properties change).
+ */
+export interface MegaphoneUpdateHandlerDeps {
+    getAreas(): Map<string, AreaData> | undefined;
+    getAreasManager(): { isCurrentPlayerInArea(areaId: string): boolean } | undefined;
+    refreshListenerZonesForSpeakerChange(
+        oldSpeakerProperty: SpeakerMegaphonePropertyData,
+        newSpeakerProperty: SpeakerMegaphonePropertyData,
+        listenerEntries: ListenerEntry[]
+    ): Promise<void>;
+}
+
+/**
+ * Registry of property-update handlers, with built-in registration for megaphone (speaker/listener) handlers.
+ * Decouples the "invoke handler by property type" mechanism and megaphone-specific logic from AreasPropertiesListener.
+ */
+export class AreaPropertyUpdateHandlerRegistry {
+    private readonly handlers = new Map<AreaDataProperty["type"], AreaPropertyUpdateHandler>();
+
+    /**
+     * Registers a handler for a given property type.
+     */
+    public register<T extends AreaDataProperty>(type: T["type"], handler: AreaPropertyUpdateHandler<T>): void {
+        this.handlers.set(type, handler as AreaPropertyUpdateHandler);
+    }
+
+    /**
+     * Registers the built-in listenerMegaphone and speakerMegaphone update handlers.
+     * Megaphone deps are passed at invoke time by the caller.
+     */
+    public registerMegaphoneHandlers(): void {
+        this.register("listenerMegaphone", {
+            onUpdate: (context) => this.onListenerMegaphonePropertyUpdated(context),
+        });
+        this.register("speakerMegaphone", {
+            hasRelevantChange(oldProp: SpeakerMegaphonePropertyData, newProp: SpeakerMegaphonePropertyData): boolean {
+                return (
+                    oldProp.name !== newProp.name ||
+                    oldProp.seeAttendees !== newProp.seeAttendees ||
+                    oldProp.chatEnabled !== newProp.chatEnabled
+                );
+            },
+            onUpdate: (context) => this.onSpeakerMegaphonePropertyUpdated(context),
+        });
+    }
+
+    /**
+     * Invokes the handler for the given property update, if one is registered.
+     * megaphoneDeps must be provided when the updated property is megaphone-related.
+     */
+    public invoke(
+        area: AreaData,
+        oldProperty: AreaDataProperty,
+        newProperty: AreaDataProperty,
+        precomputedAssociatedAreaIds?: string[],
+        megaphoneDeps?: MegaphoneUpdateHandlerDeps
+    ): void {
+        const handler = this.handlers.get(newProperty.type);
+        if (!handler) {
+            return;
+        }
+        if (handler.hasRelevantChange && !handler.hasRelevantChange(oldProperty, newProperty)) {
+            return;
+        }
+        const result = handler.onUpdate({
+            area,
+            oldProperty,
+            newProperty,
+            precomputedAssociatedAreaIds,
+            megaphoneDeps,
+        });
+        if (result instanceof Promise) {
+            result.catch((e) => {
+                if (e instanceof AbortError) {
+                    return;
+                }
+                console.error(e);
+                Sentry.captureException(e);
+            });
+        }
+    }
+
+    private onSpeakerMegaphonePropertyUpdated(context: AreaPropertyUpdateContext): void {
+        if (context.newProperty.type !== "speakerMegaphone" || context.oldProperty.type !== "speakerMegaphone") {
+            return;
+        }
+        const deps = context.megaphoneDeps;
+        if (!deps) {
+            return;
+        }
+        const { area, oldProperty, newProperty, precomputedAssociatedAreaIds } = context;
+        const areas = deps.getAreas();
+        const areasManager = deps.getAreasManager();
+        const listenerEntries =
+            areas && areasManager
+                ? precomputedAssociatedAreaIds?.length
+                    ? buildListenerEntriesFromAssociatedIds(
+                          areas,
+                          (id) => areasManager.isCurrentPlayerInArea(id),
+                          area.id,
+                          precomputedAssociatedAreaIds
+                      )
+                    : getListenerAreasReferencingSpeakerWherePlayerIs(
+                          areas,
+                          (id) => areasManager.isCurrentPlayerInArea(id),
+                          area.id
+                      )
+                : [];
+        if (listenerEntries.length === 0) {
+            return;
+        }
+        deps.refreshListenerZonesForSpeakerChange(oldProperty, newProperty, listenerEntries).catch((e) => {
+            if (e instanceof AbortError) {
+                return;
+            }
+            console.error(e);
+            Sentry.captureException(e);
+        });
+    }
+
+    private onListenerMegaphonePropertyUpdated(context: AreaPropertyUpdateContext): void {
+        if (context.newProperty.type !== "listenerMegaphone") {
+            return;
+        }
+        const deps = context.megaphoneDeps;
+        if (!deps) {
+            return;
+        }
+        const { area } = context;
+        const listenerProperty = context.newProperty;
+        const areasManager = deps.getAreasManager();
+        if (!areasManager?.isCurrentPlayerInArea(area.id)) {
+            return;
+        }
+        const listenerEntries = [{ listenerArea: area, listenerProperty }];
+        const areas = deps.getAreas();
+        const speakerProperty = areas
+            ? getSpeakerPropertyForAreaId(areas, listenerProperty.speakerZoneName)
+            : undefined;
+        if (!speakerProperty) {
+            return;
+        }
+        deps.refreshListenerZonesForSpeakerChange(speakerProperty, speakerProperty, listenerEntries).catch((e) => {
+            if (e instanceof AbortError) {
+                return;
+            }
+            console.error(e);
+            Sentry.captureException(e);
+        });
+    }
+}

--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -214,6 +214,13 @@ export class AreasPropertiesListener {
                 propertiesTreated.add(oldProperty.id);
             }
         }
+
+        for (const newProperty of newProperties) {
+            if (propertiesTreated.has(newProperty.id)) {
+                continue;
+            }
+            this.addPropertyFilter(newProperty, area, undefined);
+        }
     }
 
     /**
@@ -300,7 +307,8 @@ export class AreasPropertiesListener {
             newSpeakerProperty.seeAttendees
                 ? FilterType.LIVE_STREAMING_USERS_WITH_FEEDBACK
                 : FilterType.LIVE_STREAMING_USERS,
-            !listenerProperty.chatEnabled
+            !listenerProperty.chatEnabled,
+            signal
         );
 
         if (signal.aborted) {
@@ -312,7 +320,7 @@ export class AreasPropertiesListener {
         currentLiveStreamingSpaceStore.set(space);
         isListenerStore.set(true);
         listenerWaitingMediaStore.set(listenerProperty.waitingLink);
-        listenerSharingCameraStore.set(true);
+        listenerSharingCameraStore.set(newSpeakerProperty.seeAttendees);
         if (newSpeakerProperty.seeAttendees) {
             space.startListenerStreaming();
         }

--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -143,7 +143,7 @@ export class AreasPropertiesListener {
      */
     private getMegaphoneDeps(): MegaphoneUpdateHandlerDeps {
         return {
-            getAreas: () => this.scene.getGameMap().getGameMapAreas()?.getAreas(),
+            getAreas: () => this.scene.getGameMapFrontWrapper().getGameMap().getWamFile()?.getGameMapAreas().getAreas(),
             getAreasManager: () => this.scene.getGameMapFrontWrapper().areasManager,
             refreshListenerZonesForSpeakerChange: (oldProp, newProp, entries) =>
                 this.refreshListenerZonesForSpeakerChange(oldProp, newProp, entries),

--- a/play/src/front/Phaser/Game/MapEditor/MegaphoneAssociatedZonesAndUpdateHelpers.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MegaphoneAssociatedZonesAndUpdateHelpers.ts
@@ -1,0 +1,91 @@
+import type { AreaData, ListenerMegaphonePropertyData, SpeakerMegaphonePropertyData } from "@workadventure/map-editor";
+import type { GameMapFrontWrapper } from "../GameMap/GameMapFrontWrapper";
+
+export type ListenerEntry = { listenerArea: AreaData; listenerProperty: ListenerMegaphonePropertyData };
+
+/**
+ * Returns the speaker megaphone property for a given speaker area id, or undefined if not found.
+ */
+export function getSpeakerPropertyForAreaId(
+    areas: Map<string, AreaData>,
+    speakerAreaId: string
+): SpeakerMegaphonePropertyData | undefined {
+    const speakerArea = areas.get(speakerAreaId);
+    if (!speakerArea) {
+        return undefined;
+    }
+    const prop = speakerArea.properties.find((p): p is SpeakerMegaphonePropertyData => p.type === "speakerMegaphone");
+    return prop;
+}
+
+/**
+ * Builds listener entries from precomputed associated area ids (avoids scanning all areas).
+ * Use when the trigger path already computed associatedAreaIds for the updated speaker zone.
+ */
+export function buildListenerEntriesFromAssociatedIds(
+    areas: Map<string, AreaData>,
+    isPlayerInArea: (areaId: string) => boolean,
+    speakerAreaId: string,
+    associatedAreaIds: string[]
+): ListenerEntry[] {
+    const entries: ListenerEntry[] = [];
+    for (const areaId of associatedAreaIds) {
+        const listenerArea = areas.get(areaId);
+        if (!listenerArea || !isPlayerInArea(areaId)) {
+            continue;
+        }
+        const listenerProperty = listenerArea.properties.find(
+            (p): p is ListenerMegaphonePropertyData =>
+                p.type === "listenerMegaphone" && p.speakerZoneName === speakerAreaId
+        );
+        if (listenerProperty) {
+            entries.push({ listenerArea, listenerProperty });
+        }
+    }
+    return entries;
+}
+
+/**
+ * Returns listener areas that reference the given speaker area id and where the current player is inside.
+ */
+export function getListenerAreasReferencingSpeakerWherePlayerIs(
+    areas: Map<string, AreaData>,
+    isPlayerInArea: (areaId: string) => boolean,
+    speakerAreaId: string
+): ListenerEntry[] {
+    const entries: ListenerEntry[] = [];
+    for (const listenerArea of areas.values()) {
+        const listenerProperty = listenerArea.properties.find(
+            (p): p is ListenerMegaphonePropertyData =>
+                p.type === "listenerMegaphone" && p.speakerZoneName === speakerAreaId
+        );
+        if (listenerProperty && isPlayerInArea(listenerArea.id)) {
+            entries.push({ listenerArea, listenerProperty });
+        }
+    }
+    return entries;
+}
+
+/**
+ * Registers the megaphone-associated-areas resolvers on the given wrapper.
+ * Speaker zone → listener zones that reference it; listener zone → its speaker zone.
+ */
+export function registerMegaphoneAssociatedAreasResolvers(
+    wrapper: Pick<GameMapFrontWrapper, "registerAssociatedAreasResolver" | "getAreas">
+): void {
+    wrapper.registerAssociatedAreasResolver("speakerMegaphone", (area, getAreas) => {
+        const areas = getAreas();
+        return Array.from(areas.values())
+            .filter((a) =>
+                a.properties?.some(
+                    (p): p is ListenerMegaphonePropertyData =>
+                        p.type === "listenerMegaphone" && p.speakerZoneName === area.id
+                )
+            )
+            .map((a) => a.id);
+    });
+    wrapper.registerAssociatedAreasResolver("listenerMegaphone", (area, _getAreas) => {
+        const prop = area.properties?.find((p): p is ListenerMegaphonePropertyData => p.type === "listenerMegaphone");
+        return prop ? [prop.speakerZoneName] : [];
+    });
+}

--- a/play/src/front/Phaser/Game/MapEditor/propertyUpdateHandlerRegistryInstance.ts
+++ b/play/src/front/Phaser/Game/MapEditor/propertyUpdateHandlerRegistryInstance.ts
@@ -1,0 +1,12 @@
+import { AreaPropertyUpdateHandlerRegistry } from "./AreaPropertyUpdateHandlerRegistry";
+
+/**
+ * Single shared instance of the property-update handler registry with megaphone handlers
+ * (listenerMegaphone, speakerMegaphone) already registered.
+ * Injected into AreasPropertiesListener via constructor (dependency inversion).
+ * Megaphone deps are passed at invoke time by the listener.
+ */
+const propertyUpdateHandlerRegistry = new AreaPropertyUpdateHandlerRegistry();
+propertyUpdateHandlerRegistry.registerMegaphoneHandlers();
+
+export const propertyUpdateHandlerRegistryInstance = propertyUpdateHandlerRegistry;


### PR DESCRIPTION
## Problem

When a **speaker** zone was updated , users standing in a **listener** zone that references this speaker did not get the new settings: the listener zone was not refreshed. In addition, the code ran speaker zone leave/enter even when the user was only in the listener zone, which was incorrect.

## Solution

- **Refresh listener zone on speaker update**: When the speaker zone is updated, we now refresh every listener zone that references it and where the current player is (re-join the space with the new speaker settings via `refreshListenerZonesForSpeakerChange`), so the listener experience is updated without leaving the zone.
- **Property-update callbacks**: A generic callback system (`AreaPropertyUpdateHandler`, `invokePropertyUpdateHandlers`) runs per property type on update; the **speaker** callback is responsible for refreshing those listener zones when the speaker changes.
- **No speaker enter/leave when only in listener**: In `updatePropertyFilter`, we run speaker leave/enter only when the player is actually in the speaker area (`isCurrentPlayerInArea(area.id)`). If the player is only in a listener zone, we skip speaker enter/leave and rely on the callback to refresh the listener zone.
- **Support**: `AreasManager.isCurrentPlayerInArea(areaId)` and `GameMapFrontWrapper.getPlayerPosition()` were added so we can tell whether the player is in a given area.

## Changes

- **play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts**: Generic property-update handler registry; speaker and listener callbacks (speaker callback refreshes listener zones when speaker is updated); in `updatePropertyFilter` for `speakerMegaphone`, run speaker leave/enter only when the player is in the speaker area.
- **play/src/front/Phaser/Game/GameMap/AreasManager.ts**: Added `isCurrentPlayerInArea(areaId)` using player position and `gameMapAreas.isPlayerInsideArea`.
- **play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts**: Added `getPlayerPosition()` to expose the current player position.