### PR TITLE
fix: guard markAsIntentionalClose when peer is undefined in onAbort

### DIFF
--- a/play/src/front/WebRtc/SimplePeer.ts
+++ b/play/src/front/WebRtc/SimplePeer.ts
@@ -288,7 +288,7 @@ export class SimplePeer implements SimplePeerConnectionInterface {
         const onAbort = () => {
             this.videoPeers.delete(user.userId);
             if (abortController.signal.reason === "intentional") {
-                peer.markAsIntentionalClose();
+                peer?.markAsIntentionalClose();
             }
         };
 


### PR DESCRIPTION
## Problem

A race condition in `createPeerConnection` caused a `TypeError: Cannot read properties of undefined (reading 'markAsIntentionalClose')`. The `onAbort` listener is registered before `peer` is assigned (from `await peerPromise`). When the connection is aborted intentionally before the peer is created (e.g. user leaves or `closeConnection` is called during connection setup), the callback runs with `peer` still undefined.

## Solution

Use optional chaining when calling `markAsIntentionalClose()` in the first `onAbort` callback. If the abort happens before the peer exists, the call is skipped; behavior is unchanged when the peer is already assigned.

## Changes

- **play/src/front/WebRtc/SimplePeer.ts**: In the `onAbort` callback of `createPeerConnection`, replace `peer.markAsIntentionalClose()` with `peer?.markAsIntentionalClose()`.