### PR TITLE
feat(chat): allow multiple user-list groups open and add collapse/expand all icon

### DIFF
--- a/play/src/front/Chat/Components/UserList/RoomUserList.svelte
+++ b/play/src/front/Chat/Components/UserList/RoomUserList.svelte
@@ -7,7 +7,7 @@
     import type { UserProviderMerger } from "../../UserProviderMerger/UserProviderMerger";
     import ChatHeader from "../ChatHeader.svelte";
     import UserList from "./UserList.svelte";
-    import { IconChevronUp } from "@wa-icons";
+    import { IconChevronUp, IconCollapseMinus, IconCollapsePlus } from "@wa-icons";
 
     export let userProviderMerger: UserProviderMerger;
 
@@ -17,7 +17,7 @@
     const isMatrixChatEnabled = gameScene.room.isMatrixChatEnabled;
 
     onMount(() => {
-        if ($shownRoomListStore === "") shownRoomListStore.set($LL.chat.userList.isHere());
+        if ($shownRoomListStore.size === 0) shownRoomListStore.set(new Set([$LL.chat.userList.isHere()]));
     });
 
     $: usersByRoom = userProviderMerger.usersByRoomStore;
@@ -60,16 +60,54 @@
 
             return aKey.localeCompare(bKey);
         });
+
+    $: allGroupsOpen =
+        roomsWithUsers.length > 0 && roomsWithUsers.every(([roomName]) => $shownRoomListStore.has(roomName));
+
+    function toggleRoom(roomName: string) {
+        shownRoomListStore.update((open) => {
+            const next = new Set(open);
+            if (next.has(roomName)) next.delete(roomName);
+            else next.add(roomName);
+            return next;
+        });
+    }
+
+    function collapseAll() {
+        shownRoomListStore.set(new Set());
+    }
+
+    function expandAll() {
+        shownRoomListStore.set(new Set(roomsWithUsers.map(([roomName]) => roomName)));
+    }
 </script>
 
 <div class="flex flex-col h-full">
     <ChatHeader />
     <div class="max-h-full overflow-x-hidden overflow-y-auto">
+        {#if roomsWithUsers.length > 0}
+            <div class="flex items-center justify-end shrink-0 h-11 px-3">
+                <button
+                    class="p-1.5 rounded text-white/75 hover:text-white hover:bg-contrast-200/10 outline-none border-0 appearance-none m-0"
+                    on:click={() => (allGroupsOpen ? collapseAll() : expandAll())}
+                    type="button"
+                    title={allGroupsOpen ? $LL.chat.userList.collapseAll() : $LL.chat.userList.expandAll()}
+                    aria-label={allGroupsOpen ? $LL.chat.userList.collapseAll() : $LL.chat.userList.expandAll()}
+                >
+                    {#if allGroupsOpen}
+                        <IconCollapseMinus class="w-5 h-5" />
+                    {:else}
+                        <IconCollapsePlus class="w-5 h-5" />
+                    {/if}
+                </button>
+            </div>
+        {/if}
         {#each roomsWithUsers as [roomName, userInRoom] (roomName)}
             <div class=" users flex flex-col shrink-0 relative first:pt-[12px]">
                 <button
                     class="group relative px-3 gap-2 rounded-none text-white/75 hover:text-white h-11 hover:bg-contrast-200/10 w-full flex space-x-2 items-center border border-solid border-x-0 border-t border-b-0 border-white/10 text-white outline-none border-y-0 appearance-none m-0"
-                    on:click={() => shownRoomListStore.set($shownRoomListStore === roomName ? "" : roomName)}
+                    on:click={() => toggleRoom(roomName)}
+                    type="button"
                 >
                     {#if roomName !== $LL.chat.userList.disconnected()}
                         <div
@@ -87,11 +125,11 @@
                         class="transition-all group-hover:bg-white/10 p-1 rounded aspect-square flex items-center justify-center text-white"
                     >
                         <IconChevronUp
-                            class={`transform transition ${$shownRoomListStore === roomName ? "" : "rotate-180"}`}
+                            class={`transform transition ${$shownRoomListStore.has(roomName) ? "" : "rotate-180"}`}
                         />
                     </div>
                 </button>
-                {#if $shownRoomListStore === roomName}
+                {#if $shownRoomListStore.has(roomName)}
                     <div class="flex flex-col flex-1 h-fit">
                         <UserList userList={userInRoom} {isMatrixChatEnabled} />
                     </div>

--- a/play/src/front/Chat/Stores/ChatStore.ts
+++ b/play/src/front/Chat/Stores/ChatStore.ts
@@ -49,7 +49,7 @@ function createNavChatStore() {
 
 export const navChat = createNavChatStore();
 
-export const shownRoomListStore = writable<string>("");
+export const shownRoomListStore = writable<Set<string>>(new Set());
 export const chatSearchBarValue = writable<string>("");
 
 export function initializeChatVisibilitySubscription() {

--- a/play/src/front/Components/Icons.ts
+++ b/play/src/front/Components/Icons.ts
@@ -140,3 +140,6 @@ export { default as IconLink } from "~icons/tabler/link";
 export { default as IconMapEditor } from "~icons/tabler/augmented-reality";
 export { default as IconSPlayertop } from "~icons/tabler/player-stop";
 export { default as IconNetworkOff } from "~icons/tabler/network-off";
+export { default as IconSquareMinus } from "~icons/tabler/square-minus";
+export { default as IconCollapsePlus } from "~icons/tabler/library-plus";
+export { default as IconCollapseMinus } from "~icons/tabler/library-minus";

--- a/play/src/i18n/ar-SA/chat.ts
+++ b/play/src/i18n/ar-SA/chat.ts
@@ -33,6 +33,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "بطاقة العمل",
         sendMessage: "إرسال رسالة",
         follow: "تحديد الموقع",
+        collapseAll: "طي الكل",
+        expandAll: "توسيع الكل",
     },
     accept: "قبول",
     decline: "رفض",

--- a/play/src/i18n/ca-ES/chat.ts
+++ b/play/src/i18n/ca-ES/chat.ts
@@ -34,6 +34,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "Targeta de visita",
         sendMessage: "Enviar missatge",
         follow: "Localitzar",
+        collapseAll: "Replegar tot",
+        expandAll: "Expandir tot",
     },
     accept: "Acceptar",
     decline: "Rebutjar",

--- a/play/src/i18n/de-DE/chat.ts
+++ b/play/src/i18n/de-DE/chat.ts
@@ -35,6 +35,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "Visitenkarte",
         sendMessage: "Nachricht senden",
         follow: "Lokalisieren",
+        collapseAll: "Alle einklappen",
+        expandAll: "Alle aufklappen",
     },
     accept: "Akzeptieren",
     decline: "Ablehnen",

--- a/play/src/i18n/dsb-DE/chat.ts
+++ b/play/src/i18n/dsb-DE/chat.ts
@@ -35,6 +35,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "Wizitna kórtka",
         sendMessage: "Powěsć pósłaś",
         follow: "Lokalizěrowaś",
+        collapseAll: "Wšykno złožyś",
+        expandAll: "Wšykno wótcyniś",
     },
     accept: "Akceptěrowaś",
     decline: "Wótpokazaś",

--- a/play/src/i18n/en-US/chat.ts
+++ b/play/src/i18n/en-US/chat.ts
@@ -33,6 +33,8 @@ const chat: BaseTranslation = {
         businessCard: "Business Card",
         sendMessage: "Send Message",
         follow: "Locate",
+        collapseAll: "Collapse all",
+        expandAll: "Expand all",
     },
     accept: "Accept",
     decline: "Decline",

--- a/play/src/i18n/es-ES/chat.ts
+++ b/play/src/i18n/es-ES/chat.ts
@@ -34,6 +34,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "Tarjeta de visita",
         sendMessage: "Enviar mensaje",
         follow: "Localizar",
+        collapseAll: "Contraer todo",
+        expandAll: "Expandir todo",
     },
     accept: "Aceptar",
     decline: "Rechazar",

--- a/play/src/i18n/fr-FR/chat.ts
+++ b/play/src/i18n/fr-FR/chat.ts
@@ -35,6 +35,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "Carte de visite",
         sendMessage: "Envoyer un message",
         follow: "Localiser",
+        collapseAll: "Tout replier",
+        expandAll: "Tout ouvrir",
     },
     accept: "Accepter",
     decline: "Refuser",

--- a/play/src/i18n/hsb-DE/chat.ts
+++ b/play/src/i18n/hsb-DE/chat.ts
@@ -35,6 +35,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "wizitka",
         sendMessage: "Powěsć pósłać",
         follow: "Lokalizować",
+        collapseAll: "Wšitko złožić",
+        expandAll: "Wšitko wotcynić",
     },
     accept: "Akceptować",
     decline: "Wotpokazać",

--- a/play/src/i18n/it-IT/chat.ts
+++ b/play/src/i18n/it-IT/chat.ts
@@ -35,6 +35,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "Biglietto da visita",
         sendMessage: "Invia messaggio",
         follow: "Localizza",
+        collapseAll: "Comprimi tutto",
+        expandAll: "Espandi tutto",
     },
     accept: "Accetta",
     decline: "Rifiuta",

--- a/play/src/i18n/ja-JP/chat.ts
+++ b/play/src/i18n/ja-JP/chat.ts
@@ -35,6 +35,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "名刺",
         sendMessage: "メッセージを送信",
         follow: "位置を特定",
+        collapseAll: "すべて折りたたむ",
+        expandAll: "すべて展開",
     },
     accept: "承諾",
     decline: "拒否",

--- a/play/src/i18n/ko-KR/chat.ts
+++ b/play/src/i18n/ko-KR/chat.ts
@@ -34,6 +34,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "명함",
         sendMessage: "메시지 보내기",
         follow: "위치 찾기",
+        collapseAll: "모두 접기",
+        expandAll: "모두 펼치기",
     },
     accept: "수락",
     decline: "거절",

--- a/play/src/i18n/nl-NL/chat.ts
+++ b/play/src/i18n/nl-NL/chat.ts
@@ -35,6 +35,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "Visitekaartje",
         sendMessage: "Bericht verzenden",
         follow: "Lokaliseren",
+        collapseAll: "Alles inklappen",
+        expandAll: "Alles uitklappen",
     },
     accept: "Accepteren",
     decline: "Weigeren",

--- a/play/src/i18n/pt-BR/chat.ts
+++ b/play/src/i18n/pt-BR/chat.ts
@@ -34,6 +34,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "Cartão de Visita",
         sendMessage: "Enviar Mensagem",
         follow: "Localizar",
+        collapseAll: "Recolher tudo",
+        expandAll: "Expandir tudo",
     },
     accept: "Aceitar",
     decline: "Recusar",

--- a/play/src/i18n/zh-CN/chat.ts
+++ b/play/src/i18n/zh-CN/chat.ts
@@ -32,6 +32,8 @@ const chat: DeepPartial<Translation["chat"]> = {
         businessCard: "名片",
         sendMessage: "发送消息",
         follow: "定位",
+        collapseAll: "全部折叠",
+        expandAll: "全部展开",
     },
     accept: "接受",
     decline: "拒绝",


### PR DESCRIPTION
## Problem

In the user list, people are grouped by world and "disconnected", but only one group could be open at a time. There was no way to collapse or expand all groups at once.

## Solution

- Store which groups are open in a `Set<string>` so multiple groups can be open simultaneously.
- Add a single icon button (collapse/expand) that toggles between "collapse all" and "expand all" depending on state, using `IconCollapseMinus` and `IconCollapsePlus`.
- Keep default behavior: "Is on this map" is open on first load.

## Changes

- **play/src/front/Chat/Stores/ChatStore.ts**: `shownRoomListStore` changed from `writable<string>("")` to `writable<Set<string>>(new Set())`.
- **play/src/front/Chat/Components/UserList/RoomUserList.svelte**: Toggle logic per group (add/remove from set), reactive `allGroupsOpen`, collapse/expand all handlers, icon-only button on the right with `title`/`aria-label` for accessibility.
- **play/src/i18n/**/chat.ts** (en-US + 13 locales): Added `collapseAll` and `expandAll` under `userList`.
- **play/src/front/Components/Icons.ts**: Exports for `IconCollapsePlus` and `IconCollapseMinus` (if not already present).