### PR TITLE
Adding links to the new upload video

### DIFF
--- a/docs/map-building/tiled-editor/publish/index.md
+++ b/docs/map-building/tiled-editor/publish/index.md
@@ -10,6 +10,8 @@ You have three ways to host your map, but only one is recommended for new projec
 
 ## Recommended (start here) 
 
+<iframe width="100%" height="480" src="https://www.youtube.com/embed/5yTB23mcnP0?si=v2flBIjYB5Qwr1uy" title="Upload your map - With the web app" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 [Upload your map to the WorkAdventure server](./wa-hosted).
 This is the easiest setup and the supported path going forward, whether you upload locally or from a CI/CD pipeline.
 

--- a/docs/map-building/tiled-editor/publish/wa-hosted.md
+++ b/docs/map-building/tiled-editor/publish/wa-hosted.md
@@ -9,10 +9,10 @@ import TabItem from '@theme/TabItem';
 # Upload your Map to WorkAdventure
 
 :::info
-As of May 2024, this is the recommended way of hosting your maps
+As of February 2026, this is the recommended way of hosting your maps
 :::
 
-<iframe width="100%" height="480" src="https://youtube.com/embed/WNcbEHm2Hlg" title="Upload your map - With the script" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen" allowfullscreen></iframe>
+<iframe width="100%" height="480" src="https://www.youtube.com/embed/5yTB23mcnP0?si=v2flBIjYB5Qwr1uy" title="Upload your map - With the web app" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 In the following sections, we will explain how to upload your maps to the WorkAdventure 'map storage' server from [the starter-kit web app](#using-the-starter-kit-web-app), from [the command line](#using-the-command-line) or [from a CI/CD pipeline](#using-github-and-a-cicd-pipeline).
 
@@ -147,6 +147,8 @@ uploaded maps (self-hosted version). You can click on any of these maps to acces
 ## Using the command line
 
 If you don't like UIs and prefer using the command line, you can also upload your maps using a command line tool.
+
+<iframe width="100%" height="480" src="https://youtube.com/embed/WNcbEHm2Hlg" title="Upload your map - With the script" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen" allowfullscreen></iframe>
 
 :::info
 Before running the commands below, please ensure you installed the required tools and followed the instructions in the [Build your Map with Tiled](../) documentation.


### PR DESCRIPTION
Adding a link to the new Youtube video showcasing how to upload a map using the built-in map starter kit web app.