### PR TITLE
fix: use "turn off video" instead of "mute video" in camera menu labels

### DIFF
--- a/play/src/i18n/en-US/camera.ts
+++ b/play/src/i18n/en-US/camera.ts
@@ -56,9 +56,9 @@ const camera: BaseTranslation = {
         muteAudioUser: "Mute audio",
         askToMuteAudioUser: "Ask to mute audio",
         muteAudioEveryBody: "Mute audio for everybody",
-        muteVideoUser: "Mute video",
-        askToMuteVideoUser: "Ask to mute video",
-        muteVideoEveryBody: "Mute video for everybody",
+        muteVideoUser: "Turn off video",
+        askToMuteVideoUser: "Ask to turn off video",
+        muteVideoEveryBody: "Turn off video for everybody",
         blockOrReportUser: "Moderation",
     },
     backgroundEffects: {

--- a/tests/tests/meeting.spec.ts
+++ b/tests/tests/meeting.spec.ts
@@ -59,7 +59,7 @@ test.describe("Meeting actions test @nomobile @nowebkit", () => {
         await page.click("#cameras-container .camera-box .video-media-box .user-menu-btn");
 
         // Click on the mute button
-        await page.getByRole("button", { name: "Ask to mute video", exact: true }).click();
+        await page.getByRole("button", { name: "Ask to turn off video", exact: true }).click();
 
         // Check if "Bob" user receive the request to be muted
         await expect(userBob.locator("div").filter({ hasText: /^Can I mute your camera\?$/ })).toBeVisible();
@@ -244,7 +244,7 @@ test.describe("Meeting actions test @nomobile @nowebkit", () => {
 
     // Click on the mute video button
     await page.locator('.video-media-box:has-text("Bob")').getByRole('button').first().click();
-    await page.getByRole('button', { name: 'Mute video', exact: true }).click();
+    await page.getByRole('button', { name: 'Turn off video', exact: true }).click();
 
     // Check if "Bob" user receive the request to be muted
     // Because Alice is admin, Bob is directly muted.


### PR DESCRIPTION
## Problem

Camera menu labels used "Mute video" / "Ask to mute video" / "Mute video for everybody", while the same screen uses "Turn off your camera" for disabling the camera. The mixed "mute" vs "turn off" wording was inconsistent and could confuse users.

## Solution

Align video-related menu labels with the existing camera terminology by using "turn off video" instead of "mute video" in the English locale.

## Changes

- **play/src/i18n/en-US/camera.ts**: Updated `muteVideoUser`, `askToMuteVideoUser`, and `muteVideoEveryBody` to "Turn off video", "Ask to turn off video", and "Turn off video for everybody".
- **tests/tests/meeting.spec.ts**: Updated E2E selectors to use the new button names ("Ask to turn off video", "Turn off video") so meeting tests still pass.