### PR TITLE
feat(chat): sort folders and rooms by last message, muted at bottom, with full reactivity

### DIFF
--- a/play/src/front/Chat/Components/sortChatRooms.ts
+++ b/play/src/front/Chat/Components/sortChatRooms.ts
@@ -1,0 +1,30 @@
+/**
+ * Comparator: non-muted first, then by lastMessageTimestamp descending.
+ * Items without areNotificationsMuted are treated as non-muted.
+ */
+export function sortByMuteThenLastMessage<T extends { lastMessageTimestamp: number }>(
+    a: T,
+    b: T,
+    aMuted: boolean,
+    bMuted: boolean
+): number {
+    if (aMuted !== bMuted) {
+        return (aMuted ? 1 : 0) - (bMuted ? 1 : 0);
+    }
+    return b.lastMessageTimestamp - a.lastMessageTimestamp;
+}
+
+/**
+ * Same order (mute then timestamp desc) when timestamps are provided explicitly.
+ */
+export function sortByMuteThenTimestamp(
+    aMuted: boolean,
+    bMuted: boolean,
+    aTimestamp: number,
+    bTimestamp: number
+): number {
+    if (aMuted !== bMuted) {
+        return (aMuted ? 1 : 0) - (bMuted ? 1 : 0);
+    }
+    return bTimestamp - aTimestamp;
+}

--- a/play/src/front/Chat/Connection/ChatConnection.ts
+++ b/play/src/front/Chat/Connection/ChatConnection.ts
@@ -78,6 +78,8 @@ export interface ChatRoom {
     readonly stopTyping: () => Promise<object>;
     readonly isRoomFolder: boolean;
     readonly lastMessageTimestamp: number;
+    /** Mute state for notifications; implementations default to false. */
+    readonly areNotificationsMuted: Readable<boolean>;
 }
 
 export interface ChatRoomMembershipManagement {


### PR DESCRIPTION
## Problem

- Chat folders and rooms were not consistently sorted by most recent activity (last message).
- Muted conversations were not pushed to the bottom of the list.
- Sorting was not reactive: new messages or mute/unmute did not reorder the list (folders, subfolders, or rooms inside folders).

## Solution

- Introduce a single sort rule: **non-muted first** (by last message desc), then **muted** (by last message desc).
- Use Svelte derived stores so that the sorted list depends on:
  - Each folder’s mute state and messages (and, for spaces, each child room’s messages) so folder order updates when a message arrives in the folder or a child room.
  - Each room’s mute state and messages so room order inside a folder updates on new messages or mute changes.
- For Matrix spaces (folders), use an “effective” last message timestamp: max of the folder’s own timestamp and its direct child rooms’ timestamps, so a message in a child room moves the folder up.

## Changes

- **play/src/front/Chat/Components/sortChatRooms.ts** (new): Shared helpers `sortByMuteThenLastMessage` and `sortByMuteThenTimestamp`.
- **play/src/front/Chat/Components/RoomList.svelte**: Root folders sorted via a derived store (mute + folder messages + child room messages); effective last timestamp for folders; People/Rooms/Invitations lists sorted with mute-at-bottom and optional `areNotificationsMuted`.
- **play/src/front/Chat/Components/RoomFolder.svelte**: Subfolders sorted via a derived store (mute + folder messages + child room messages) with effective timestamp; rooms inside folder sorted via a derived store (rooms + search + each room’s mute and messages) so order is reactive to new messages and mute.