### PR TITLE
Displaying keys in onboarding on mainly computer devices

### DIFF
--- a/play/src/front/Components/Onboarding/Steps/MovementStep.svelte
+++ b/play/src/front/Components/Onboarding/Steps/MovementStep.svelte
@@ -104,11 +104,11 @@
                 {$LL.onboarding.movement.title()}
             </h3>
             <p class="text-sm text-white/90">
-                {touchScreenManager.supportTouchScreen
+                {touchScreenManager.primaryTouchDevice
                     ? $LL.onboarding.movement.descriptionMobile()
                     : $LL.onboarding.movement.descriptionDesktop()}
             </p>
-            {#if !touchScreenManager.supportTouchScreen}
+            {#if !touchScreenManager.primaryTouchDevice}
                 <div class="flex items-center gap-2 text-xs text-white/70 flex-wrap">
                     <kbd
                         class="px-2 py-1 bg-white/10 rounded transition-all duration-150 {$pressedKeysStore.has('KeyW')


### PR DESCRIPTION
The fact that we have a touchscreen does not mean we should not display the keys in an onboarding.

My laptop has a touchscreen and still, I use keys to move. I replaced `touchScreenManager.supportTouchScreen` with `touchScreenManager.primaryTouchDevice` to only trigger "touch" onboarding on devices that look like smartphones.