### PR TITLE
Fix remote companion memory leek

### DIFF
--- a/play/src/front/Phaser/Entity/RemotePlayer.ts
+++ b/play/src/front/Phaser/Entity/RemotePlayer.ts
@@ -57,7 +57,7 @@ export class RemotePlayer extends Character implements ActivatableInterface {
         direction: PositionMessage_Direction,
         moving: boolean,
         visitCardUrl: string | null,
-        companionTexturePromise: CancelablePromise<string>,
+        companionTexturePromise: CancelablePromise<string> | undefined,
         activationRadius?: number,
         private chatID: string | undefined = undefined,
         sayMessage?: SayMessage

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -3667,11 +3667,9 @@ ${escapedMessage}
                 addPlayerData.position.direction,
                 addPlayerData.position.moving,
                 addPlayerData.visitCardUrl,
-                addPlayerData.companionTexture
+                addPlayerData.companionTexture != undefined
                     ? lazyLoadPlayerCompanionTexture(this.superLoad, addPlayerData.companionTexture)
-                    : new CancelablePromise<string>((_, reject) =>
-                          reject(new CompanionTextureError("No companion texture"))
-                      ),
+                    : undefined,
                 undefined,
                 addPlayerData.chatID,
                 addPlayerData.sayMessage


### PR DESCRIPTION
We see that the companion was all time defined and used whenever the remote player has no set companion.