### PR TITLE
fix: register new game scene on reconnection and add E2E hook to trigger server disconnect

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1510,10 +1510,12 @@ export class GameScene extends DirtyScene {
             reconnecting: reconnecting,
         });
 
-        //If new gameScene doesn't start automatically then we change the gameScene in gameManager so that it can start the new gameScene
-        if (!autostart) {
+        // Register the new scene as current when not autostarting (so GameManager can start it) or when
+        // reconnecting (so getCurrentGameScene() returns the new scene during teardown and store subscriptions work).
+        if (!autostart || reconnecting) {
             gameManager.gameSceneIsCreated(game);
         }
+
         this.scene.stop(this.scene.key);
         this.scene.remove(this.scene.key);
     }

--- a/play/src/front/Utils/E2EHooks.ts
+++ b/play/src/front/Utils/E2EHooks.ts
@@ -36,6 +36,28 @@ function testWebRtcRetry(): { spaceName: string; userId: string; triggered: bool
 }
 
 /**
+ * [DEBUG] Forces a server disconnected event to test the reconnection flow (connection issue toast, wait for pusher, reload scene).
+ * Emits on the current RoomConnection's serverDisconnected subject so the same handlers as a real disconnect run.
+ * @returns { triggered: true } if the event was emitted, or null if not in a game scene or no connection
+ */
+function triggerServerDisconnected(): { triggered: true } | null {
+    try {
+        const scene = gameManager.getCurrentGameScene();
+        const connection = scene.connection;
+        if (!connection) {
+            console.warn("[DEBUG] No room connection available to trigger serverDisconnected");
+            return null;
+        }
+        connection._serverDisconnected.next();
+        console.info("[DEBUG] serverDisconnected event triggered for E2E test");
+        return { triggered: true };
+    } catch (error) {
+        console.error("[DEBUG] Error while triggering serverDisconnected:", error);
+        return null;
+    }
+}
+
+/**
  * [DEBUG] Forces a LiveKit WebSocket close to test the reconnection mechanism.
  * This function finds the first space with an active LiveKit connection and closes the WebSocket.
  * @returns Information about the triggered close, or null if no LiveKit connection found
@@ -117,4 +139,8 @@ export const e2eHooks = {
      * [DEBUG] Forces a LiveKit WebSocket close to test the reconnection mechanism.
      */
     testLivekitRetry,
+    /**
+     * [DEBUG] Forces a server disconnected event to test the reconnection flow.
+     */
+    triggerServerDisconnected,
 };


### PR DESCRIPTION
## Problem

On reconnection after a lost connection ("Pusher reachable again. Reloading scene"), the new `GameScene` was created and started with `autostart: true`, but `gameManager.gameSceneIsCreated(game)` was only called when `!autostart`. So `GameManager.currentGameSceneName` kept pointing at the old scene, which was then stopped and removed. Any code calling `getCurrentGameScene()` (e.g. store subscriptions, map editor) saw the wrong or removed scene and threw "Not the Game Scene", and the reconnection flow appeared to do nothing.

## Solution

- Register the new scene as the current one in `GameManager` when reconnecting as well, by calling `gameManager.gameSceneIsCreated(game)` when `!autostart || reconnecting` in `createSuccessorGameScene`. This way `getCurrentGameScene()` returns the new scene during and after teardown.
- Add an E2E hook `triggerServerDisconnected()` that emits on the current `RoomConnection`’s `serverDisconnected` subject so tests can trigger the same reconnection flow (toast, wait for pusher, reload scene) without a real network drop.

## Changes

- **play/src/front/Phaser/Game/GameScene.ts**: In `createSuccessorGameScene`, call `gameManager.gameSceneIsCreated(game)` when `!autostart || reconnecting` (not only when `!autostart`), with an updated comment.
- **play/src/front/Utils/E2EHooks.ts**: Add `triggerServerDisconnected()` and expose it on `e2eHooks` for E2E tests.