### PR TITLE
feat(chat): use interlocutor profile picture for Matrix DM conversation avatar

### DIFF
--- a/play/src/front/Chat/Components/Avatar.svelte
+++ b/play/src/front/Chat/Components/Avatar.svelte
@@ -14,7 +14,7 @@
     <img
         src={$pictureStore}
         alt="User avatar"
-        class="rounded-sm h-full w-full object-contain bg-white"
+        class="rounded-sm object-contain bg-white h-10 w-10"
         draggable="false"
         style:background-color={`${color ? color : `${getColorByString(fallbackName)}`}`}
         on:error={(event) => {

--- a/play/src/front/Chat/Connection/ChatConnection.ts
+++ b/play/src/front/Chat/Connection/ChatConnection.ts
@@ -58,6 +58,7 @@ export interface ChatRoomMember {
     name: Readable<string>;
     membership: Readable<ChatRoomMembership>;
     permissionLevel: Readable<ChatPermissionLevel>;
+    pictureStore?: PictureStore;
 }
 export interface ChatRoom {
     readonly id: string;

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -118,7 +118,9 @@ export class MatrixChatRoom
         this.type = this.getMatrixRoomType();
         this.hasUnreadMessages = writable(matrixRoom.getUnreadNotificationCount() > 0);
         this.unreadNotificationCount = writable(matrixRoom.getUnreadNotificationCount());
-        this.pictureStore = readable(matrixRoom.getAvatarUrl(matrixRoom.client.baseUrl, 24, 24, "scale") ?? undefined);
+        const roomAvatarStore: PictureStore = readable(
+            matrixRoom.getAvatarUrl(matrixRoom.client.baseUrl, 24, 24, "scale") ?? undefined
+        );
         this.messages = new SearchableArrayStore((item: MatrixChatMessage) => item.id);
         this.sendMessage = this.sendMessage.bind(this);
         this.myMembership = writable(matrixRoom.getMyMembership());
@@ -128,6 +130,19 @@ export class MatrixChatRoom
                 .getMembers()
                 .map((member) => new MatrixChatRoomMember(member, this.matrixRoom.client.baseUrl)),
         ]);
+
+        if (this.type === "direct") {
+            this.pictureStore = derived(this.members, (members) => {
+                const myUserId = this.matrixRoom.client.getUserId();
+                const other = members.find((m) => m.id !== myUserId);
+                if (other?.pictureStore) {
+                    return get(other.pictureStore);
+                }
+                return get(roomAvatarStore);
+            });
+        } else {
+            this.pictureStore = roomAvatarStore;
+        }
 
         this.hasPreviousMessage = writable(false);
 

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoomMember.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoomMember.ts
@@ -17,7 +17,7 @@ export class MatrixChatRoomMember implements ChatRoomMember {
     readonly permissionLevel: Writable<ChatPermissionLevel>;
     readonly isTypingInformation: Writable<{ id: string; name: string | null; pictureStore: PictureStore } | null> =
         writable(null);
-    private pictureStore: PictureStore;
+    readonly pictureStore: PictureStore;
 
     constructor(private roomMember: RoomMember, baseUrl: string) {
         this.id = roomMember.userId;


### PR DESCRIPTION
## Problem

For Matrix one-to-one (DM) conversations and invitations, the conversation avatar in the chat list always used the room avatar. DM rooms typically have no room avatar set, so the UI fell back to the initial letter of the name instead of showing the other person's profile picture.

## Solution

For rooms of type `"direct"`, the conversation avatar is now derived from the **other interlocutor's** profile picture (the member who is not the current user). For DM invitations, that member is the inviter, so their photo is shown. Group rooms (`"multiple"`) keep using the room avatar. No changes were needed in the UI components (Room.svelte, RoomInvitation.svelte), which already use `room.pictureStore`.

## Changes

- **ChatConnection.ts**: Add optional `pictureStore` to `ChatRoomMember` so implementations can expose a member avatar.
- **MatrixChatRoomMember.ts**: Expose `pictureStore` as public `readonly` (was private) so `MatrixChatRoom` can use it for the "other" member in DMs.
- **MatrixChatRoom.ts**: Introduce `roomAvatarStore` for the room avatar (used for group rooms and as fallback). For `type === "direct"`, set `pictureStore` to a `derived` store from `members` that resolves the other member and uses their `pictureStore` (or `roomAvatarStore` when no other member is present).