### PR TITLE
feat(chat): add pending file attachments with preview before send

### DIFF
--- a/play/src/front/Chat/Components/Room/Message/MessageFileInput.svelte
+++ b/play/src/front/Chat/Components/Room/Message/MessageFileInput.svelte
@@ -8,23 +8,21 @@
     import { IconLoader, IconPaperclip, IconX } from "@wa-icons";
 
     const dispatch = createEventDispatcher<{
+        filesSelected: FileList;
         fileUploaded: void;
     }>();
 
     let files: FileList | undefined = undefined;
+    let fileInputElement: HTMLInputElement;
     export let room: ChatRoom;
     const isProximityChatRoom = room instanceof ProximityChatRoom;
 
     $: {
-        if (files) {
-            room.sendFiles(files)
-                .then(() => {
-                    // Infinite loop is not possible because the first thing we do in the reactive statement is test for "files" not undefined.
-                    // eslint-disable-next-line svelte/infinite-reactive-loop
-                    files = undefined;
-                    unselectChatMessageToReplyIfSelected();
-                })
-                .catch((error) => console.error(error));
+        if (files && files.length > 0) {
+            dispatch("filesSelected", files);
+            dispatch("fileUploaded");
+            files = undefined;
+            fileInputElement.value = "";
         }
     }
 
@@ -59,6 +57,7 @@
         type="file"
         multiple
         bind:files
+        bind:this={fileInputElement}
         data-testid="uploadChatCustomAsset"
         on:focusin={focusChatInput}
         on:focusout={unfocusChatInput}

--- a/play/src/front/Chat/Components/Room/MessageInputBar.svelte
+++ b/play/src/front/Chat/Components/Room/MessageInputBar.svelte
@@ -20,6 +20,7 @@
     import type { ChatRoom } from "../../Connection/ChatConnection";
     import { selectedChatMessageToReply } from "../../Stores/ChatStore";
     import { chatInputFocusStore, shouldDisableChatInProximityRoomStore } from "../../../Stores/ChatStore";
+    import { warningMessageStore } from "../../../Stores/ErrorStore";
     import LL from "../../../../i18n/i18n-svelte";
     import { ProximityChatRoom } from "../../Connection/Proximity/ProximityChatRoom";
     import { gameManager } from "../../../Phaser/Game/GameManager";
@@ -97,11 +98,11 @@
             // message contains HTML tags. Actually, the only tags we allow are for the new line, ie. <br> tags.
             // We can turn those back into carriage returns.
             const messageToSend = message.replace(/<br>/g, "\n");
-            sendMessage(messageToSend);
+            sendMessage(messageToSend).catch((error) => console.error(error));
         }
     }
 
-    function sendMessage(messageToSend: string) {
+    async function sendMessage(messageToSend: string) {
         if (applicationProperty && applicationProperty.link.length !== 0) {
             room?.sendMessage(applicationProperty.link);
         }
@@ -112,14 +113,22 @@
         // send files
         if (files && files.length > 0) {
             if (!(room instanceof ProximityChatRoom)) {
+                const idsToSend = files.map((f) => f.id);
                 const fileList: FileList = files.reduce((fileListAcc, currentFile) => {
                     fileListAcc.items.add(currentFile.file);
                     return fileListAcc;
                 }, new DataTransfer()).files;
 
-                room.sendFiles(fileList).catch((error) => console.error(error));
-                files = [];
-                filesPreview = [];
+                try {
+                    await room.sendFiles(fileList);
+                    files = files.filter((f) => !idsToSend.includes(f.id));
+                    filesPreview = filesPreview.filter((p) => !idsToSend.includes(p.id));
+                } catch (error) {
+                    console.error(error);
+                    warningMessageStore.addWarningMessage($LL.chat.failedToSendAttachments(), {
+                        closable: true,
+                    });
+                }
             }
         }
 
@@ -664,7 +673,14 @@
     </div>
 {/if}
 {#if fileAttachmentComponentOpened}
-    <MessageFileInput {room} on:fileUploaded={() => closeFileAttachmentComponent()} />
+    <MessageFileInput
+        {room}
+        on:filesSelected={(e) => {
+            handleFiles(e);
+            closeFileAttachmentComponent();
+        }}
+        on:fileUploaded={() => closeFileAttachmentComponent()}
+    />
 {/if}
 <div
     class="flex w-full flex-none items-center border border-solid border-b-0 border-x-0 border-t-1 border-white/10 bg-contrast/50 relative"
@@ -731,7 +747,7 @@
             data-testid="sendMessageButton"
             class="disabled:opacity-30 disabled:!cursor-none disabled:text-white py-0 px-3 m-0 bg-secondary h-full rounded-none"
             disabled={applicationPropertyInProcessing}
-            on:click={() => sendMessage(message)}
+            on:click={() => sendMessage(message).catch((error) => console.error(error))}
         >
             <IconSend />
         </button>

--- a/play/src/i18n/ar-SA/chat.ts
+++ b/play/src/i18n/ar-SA/chat.ts
@@ -489,6 +489,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "رفض", // Dismiss
     whoops: "عذرًا! حدث خطأ ما", // Whoops! Something went wrong
     failedToOpenRoom: "فشل في فتح الغرفة: {roomId}", // Failed to open room: {roomId}
+    failedToSendAttachments: "فشل إرسال المرفقات. يرجى المحاولة مرة أخرى.", // Failed to send attachments. Please try again.
     refreshChatError: "فشل في تحديث الدردشة", // Failed to refresh chat
     discord: {
         chatBand: {

--- a/play/src/i18n/ca-ES/chat.ts
+++ b/play/src/i18n/ca-ES/chat.ts
@@ -490,6 +490,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "Descartar",
     whoops: "Vaja! S'ha produït un error",
     failedToOpenRoom: "No s'ha pogut obrir la sala: {roomId}",
+    failedToSendAttachments: "No s'han pogut enviar els fitxers adjunts. Torna-ho a provar.",
     refreshChatError: "No s'ha pogut actualitzar el xat",
     discord: {
         chatBand: {

--- a/play/src/i18n/de-DE/chat.ts
+++ b/play/src/i18n/de-DE/chat.ts
@@ -496,6 +496,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "Ignorieren",
     whoops: "Ups! Ein Fehler ist aufgetreten",
     failedToOpenRoom: "Raum konnte nicht geöffnet werden: {roomId}",
+    failedToSendAttachments: "Anhänge konnten nicht gesendet werden. Bitte versuchen Sie es erneut.",
     refreshChatError: "Chat konnte nicht aktualisiert werden",
     discord: {
         chatBand: {

--- a/play/src/i18n/dsb-DE/chat.ts
+++ b/play/src/i18n/dsb-DE/chat.ts
@@ -492,6 +492,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "Ignorěrowaś",
     whoops: "Ups! Zmólka jo nastała",
     failedToOpenRoom: "Njejo móžno, śpu wócyniś: {roomId}",
+    failedToSendAttachments: "Njejo móžno, pśidanki pósłaś. Pšosym wopytaj hyšći raz.",
     refreshChatError: "Njejo móžno, chat aktualizěrowaś",
     discord: {
         chatBand: {

--- a/play/src/i18n/en-US/chat.ts
+++ b/play/src/i18n/en-US/chat.ts
@@ -490,6 +490,7 @@ const chat: BaseTranslation = {
     dismiss: "Dismiss",
     whoops: "Whoops ! something went wrong",
     failedToOpenRoom: "Failed to open room : {roomId}",
+    failedToSendAttachments: "Failed to send attachments. Please try again.",
     refreshChatError: "Failed to refresh chat",
     discord: {
         chatBand: {

--- a/play/src/i18n/es-ES/chat.ts
+++ b/play/src/i18n/es-ES/chat.ts
@@ -490,6 +490,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "Descartar",
     whoops: "¡Ups! Algo salió mal",
     failedToOpenRoom: "Error al abrir la sala: {roomId}",
+    failedToSendAttachments: "No se han podido enviar los archivos adjuntos. Inténtalo de nuevo.",
     refreshChatError: "Error al actualizar el chat",
     discord: {
         chatBand: {

--- a/play/src/i18n/fr-FR/chat.ts
+++ b/play/src/i18n/fr-FR/chat.ts
@@ -492,6 +492,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "Ignorer",
     whoops: "Oups ! une erreur est survenue",
     failedToOpenRoom: "Impossible d'ouvrir la room : {roomId}",
+    failedToSendAttachments: "Échec de l'envoi des pièces jointes. Veuillez réessayer.",
     refreshChatError: "Impossible de rafraichir le chat",
     discord: {
         chatBand: {

--- a/play/src/i18n/hsb-DE/chat.ts
+++ b/play/src/i18n/hsb-DE/chat.ts
@@ -491,6 +491,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "Ignorować",
     whoops: "Ups! Zmylka je nastała",
     failedToOpenRoom: "Njemóžno, rum wočinić: {roomId}",
+    failedToSendAttachments: "Njemóžno, přiwěški pósłać. Prošu wopytajće hišće raz.",
     refreshChatError: "Njemóžno, chat aktualizować",
     discord: {
         chatBand: {

--- a/play/src/i18n/it-IT/chat.ts
+++ b/play/src/i18n/it-IT/chat.ts
@@ -492,6 +492,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "Ignora",
     whoops: "Ops! Si è verificato un errore",
     failedToOpenRoom: "Impossibile aprire la stanza: {roomId}",
+    failedToSendAttachments: "Impossibile inviare gli allegati. Riprova.",
     refreshChatError: "Impossibile aggiornare la chat",
     discord: {
         chatBand: {

--- a/play/src/i18n/ja-JP/chat.ts
+++ b/play/src/i18n/ja-JP/chat.ts
@@ -491,6 +491,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "無視",
     whoops: "おっと！エラーが発生しました",
     failedToOpenRoom: "ルームを開けませんでした: {roomId}",
+    failedToSendAttachments: "添付ファイルを送信できませんでした。もう一度お試しください。",
     refreshChatError: "チャットを更新できませんでした",
     discord: {
         chatBand: {

--- a/play/src/i18n/ko-KR/chat.ts
+++ b/play/src/i18n/ko-KR/chat.ts
@@ -491,6 +491,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "닫기",
     whoops: "앗! 문제가 발생했습니다",
     failedToOpenRoom: "방 열기 실패: {roomId}",
+    failedToSendAttachments: "첨부파일을 보낼 수 없습니다. 다시 시도해 주세요.",
     refreshChatError: "채팅 새로고침 실패",
     discord: {
         chatBand: {

--- a/play/src/i18n/nl-NL/chat.ts
+++ b/play/src/i18n/nl-NL/chat.ts
@@ -492,6 +492,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "Negeren",
     whoops: "Oeps! Er is een fout opgetreden",
     failedToOpenRoom: "Kon kamer niet openen: {roomId}",
+    failedToSendAttachments: "Bijlagen verzenden is mislukt. Probeer het opnieuw.",
     refreshChatError: "Kon chat niet vernieuwen",
     discord: {
         chatBand: {

--- a/play/src/i18n/pt-BR/chat.ts
+++ b/play/src/i18n/pt-BR/chat.ts
@@ -491,6 +491,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "Dispensar",
     whoops: "Ops! algo deu errado",
     failedToOpenRoom: "Falha ao abrir sala: {roomId}",
+    failedToSendAttachments: "Falha ao enviar anexos. Tente novamente.",
     refreshChatError: "Falha ao atualizar chat",
     discord: {
         chatBand: {

--- a/play/src/i18n/zh-CN/chat.ts
+++ b/play/src/i18n/zh-CN/chat.ts
@@ -486,6 +486,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     dismiss: "关闭",
     whoops: "哎呀！出错了",
     failedToOpenRoom: "打开房间失败: {roomId}",
+    failedToSendAttachments: "发送附件失败。请重试。",
     refreshChatError: "刷新聊天失败",
     discord: {
         chatBand: {

--- a/synapse/homeserver.template.yaml
+++ b/synapse/homeserver.template.yaml
@@ -83,6 +83,7 @@ enable_registration: true
 enable_registration_without_verification: true
 turn_allow_guests: true
 allow_guest_access: true
+enable_authenticated_media: false
 
 # Development server only: we allow creating publicly visible rooms to anyone.
 room_list_publication_rules:


### PR DESCRIPTION
## Problem

When sending documents in the Matrix chat (via the attachment button), files were sent immediately upon selection. Users could not:
- See documents in a pending state before sending
- Add multiple documents and send them together
- Remove documents from the selection before sending
- Add a text message alongside the attachments and send everything at once

## Solution

Unify file import flows so that files selected via the attachment picker go through the same pipeline as drag-and-drop and paste: they are added to a pending list with previews. The user can then add or remove attachments, optionally add a message, and send everything with the send button.

## Changes

- **MessageFileInput.svelte**: Stop sending files directly via `room.sendFiles()`. Dispatch a `filesSelected` event with the selected `FileList` to the parent, then `fileUploaded` to close the panel. Reset the file input after dispatch so the same files can be selected again if needed.
- **MessageInputBar.svelte**: Listen for `filesSelected` on `MessageFileInput`; call `handleFiles()` to add selected files to `files` and `filesPreview`, then close the attachment panel. Pending files are shown in the existing preview strip (same as drag-and-drop and paste); send happens only when the user clicks the send button.