### PR TITLE
feat: validate microphone to reduce no-sound warning false positives

### DIFF
--- a/play/src/front/Components/Toasts/NoMicrophoneSoundToast.svelte
+++ b/play/src/front/Components/Toasts/NoMicrophoneSoundToast.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+    import { get } from "svelte/store";
     import { LL } from "../../../i18n/i18n-svelte";
     import { mediaSettingsOpenStore } from "../../Stores/MenuStore";
+    import { usedMicrophoneDeviceIdStore } from "../../Stores/MediaStore";
+    import { microphoneValidatedForDeviceIdStore } from "../../Stores/MicrophoneValidatedForDeviceIdStore";
     import { toastStore } from "../../Stores/ToastStore";
     import ToastContainer from "./ToastContainer.svelte";
 
@@ -12,6 +15,7 @@
     }
 
     function closeToast(): void {
+        microphoneValidatedForDeviceIdStore.set(get(usedMicrophoneDeviceIdStore));
         // Remove toast on next tick so the store update is flushed and the settings panel can open first
         setTimeout(() => {
             toastStore.removeToast(toastUuid);

--- a/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
+++ b/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
@@ -16,6 +16,7 @@ import { nbSoundPlayedInBubbleStore } from "../../Stores/ApparentMediaContraintS
 import { bindMuteEventsToSpace } from "../Utils/BindMuteEvents";
 import { recordingSchema } from "../SpaceMetadataValidator";
 import { CommunicationType } from "../../Livekit/LivekitConnection";
+import { microphoneValidatedForDeviceIdStore } from "../../Stores/MicrophoneValidatedForDeviceIdStore";
 import { notificationPlayingStore } from "../../Stores/NotificationStore";
 import { audioContextManager } from "../../WebRtc/AudioContextManager";
 import LL, { locale } from "../../../i18n/i18n-svelte";
@@ -164,6 +165,8 @@ export class SpacePeerManager {
                 }
                 this._toFinalizeState = this._communicationState;
                 this._toFinalizeState.shutdown();
+
+                // create factory for the new state instead of creating the state directly ?
                 if (message.switchMessage.strategy === CommunicationType.WEBRTC) {
                     this._communicationState = new WebRTCState(this.space, this._streamableSubjects, blockedUsersStore);
                 } else if (message.switchMessage.strategy === CommunicationType.LIVEKIT) {
@@ -177,6 +180,7 @@ export class SpacePeerManager {
                     Sentry.captureMessage("Unknown communication strategy: " + message.switchMessage.strategy);
                 }
 
+                microphoneValidatedForDeviceIdStore.set(undefined);
                 this.setState(this._communicationState);
             })
         );

--- a/play/src/front/Stores/MicrophoneValidatedForDeviceIdStore.ts
+++ b/play/src/front/Stores/MicrophoneValidatedForDeviceIdStore.ts
@@ -1,0 +1,10 @@
+import type { Writable } from "svelte/store";
+import { writable } from "svelte/store";
+
+/**
+ * Device ID for which the microphone is considered working (validated).
+ * Set when sound is detected from the mic or when the user dismisses the "no sound" warning.
+ * Reset when switching between WebRTC and LiveKit so the new path must reconfirm the mic works.
+ * When set and matching usedMicrophoneDeviceIdStore, the "no microphone sound" toast is not shown.
+ */
+export const microphoneValidatedForDeviceIdStore: Writable<string | undefined> = writable(undefined);

--- a/play/src/front/Stores/NoMicrophoneSoundWarningVisibleStore.ts
+++ b/play/src/front/Stores/NoMicrophoneSoundWarningVisibleStore.ts
@@ -1,23 +1,49 @@
 import { derived } from "svelte/store";
 import { myMicrophoneStore } from "./MyMediaStore";
 import { isLiveStreamingStore } from "./IsStreamingStore";
-import { localVolumeStore, silentStore } from "./MediaStore";
+import { localVolumeStore, silentStore, usedMicrophoneDeviceIdStore } from "./MediaStore";
+import { microphoneValidatedForDeviceIdStore } from "./MicrophoneValidatedForDeviceIdStore";
 
-const ZERO_SAMPLES_FOR_NO_SOUND_WARNING = 30; // 3 seconds at 100ms (localVolumeStore updates every 100ms)
+const ZERO_SAMPLES_FOR_NO_SOUND_WARNING = 50; // 5 seconds at 100ms (localVolumeStore updates every 100ms)
+const MIN_SOUND_SAMPLES_BEFORE_VALIDATION = 10; // 1 second of sustained sound on current device before we validate (avoids validating a new mic with residual sound from the previous one)
 
 function isVolumeZero(volume: number[] | undefined): boolean {
     return volume !== undefined && volume.length > 0 && volume.every((v) => v === 0);
 }
 
 let noSoundWarningZeroCount = 0;
+let soundValidationSampleCount = 0;
+let lastDeviceIdForSoundValidation: string | undefined;
 
 export const noMicrophoneSoundWarningVisibleStore = derived(
-    [localVolumeStore, myMicrophoneStore, isLiveStreamingStore, silentStore],
-    ([volume, myMic, isLiveStreaming, silent], set) => {
+    [
+        localVolumeStore,
+        myMicrophoneStore,
+        isLiveStreamingStore,
+        silentStore,
+        usedMicrophoneDeviceIdStore,
+        microphoneValidatedForDeviceIdStore,
+    ],
+    ([volume, myMic, isLiveStreaming, silent, usedDeviceId, validatedDeviceId], set) => {
         const isStreamingContext = isLiveStreaming;
         const shouldDetect = myMic && isStreamingContext && !silent;
+        const isCurrentDeviceValidated =
+            validatedDeviceId !== undefined && usedDeviceId !== undefined && usedDeviceId === validatedDeviceId;
 
-        if (shouldDetect && isVolumeZero(volume)) {
+        if (shouldDetect && usedDeviceId !== undefined && !isVolumeZero(volume)) {
+            if (lastDeviceIdForSoundValidation !== usedDeviceId) {
+                lastDeviceIdForSoundValidation = usedDeviceId;
+                soundValidationSampleCount = 0;
+            }
+            soundValidationSampleCount += 1;
+            if (soundValidationSampleCount >= MIN_SOUND_SAMPLES_BEFORE_VALIDATION) {
+                microphoneValidatedForDeviceIdStore.set(usedDeviceId);
+            }
+        } else {
+            soundValidationSampleCount = 0;
+        }
+
+        if (shouldDetect && !isCurrentDeviceValidated && isVolumeZero(volume)) {
             noSoundWarningZeroCount += 1;
             if (noSoundWarningZeroCount >= ZERO_SAMPLES_FOR_NO_SOUND_WARNING) {
                 set(true);
@@ -25,7 +51,7 @@ export const noMicrophoneSoundWarningVisibleStore = derived(
             }
         } else {
             noSoundWarningZeroCount = 0;
-            if (!shouldDetect || !isVolumeZero(volume)) {
+            if (!shouldDetect || !isVolumeZero(volume) || isCurrentDeviceValidated) {
                 set(false);
             }
         }


### PR DESCRIPTION
## Problem

The "no microphone sound" popup appears when the mic is on but volume stays at zero for a few seconds. With noise-cancelling mics or when not speaking during a meeting, this triggers false positives and is disruptive.

## Solution

- Introduce a **validation store** per device: once the mic is considered "working" (sound detected or user dismisses the toast), the warning is not shown again for that device until the user changes microphone or the communication strategy (WebRTC ↔ LiveKit) changes.
- **Sound-based validation** requires 1 second of sustained sound on the current device before validating, so switching to a broken mic while still speaking does not validate the new device with residual audio.
- **Timing**: 5 seconds without sound before showing the popup; 1 second of sustained sound to auto-validate the device.

## Changes

- **New** `MicrophoneValidatedForDeviceIdStore.ts`: writable store holding the device ID for which the mic is validated (set on sound or dismiss; reset on strategy switch).
- **`NoMicrophoneSoundWarningVisibleStore.ts`**: depends on `usedMicrophoneDeviceIdStore` and `microphoneValidatedForDeviceIdStore`; only shows warning when the current device is not validated; validates on 1 s sustained sound (with reset on device change to avoid validating on residual sound).
- **`NoMicrophoneSoundToast.svelte`**: on "Ignore" or "Open settings", sets the validated store to the current microphone device ID.
- **`SpacePeerManager.ts`**: resets `microphoneValidatedForDeviceIdStore` when receiving a WebRTC/LiveKit strategy switch message so the new path must reconfirm the mic.