### PR TITLE
feat(chat): add image preview modal and fix file attachments list overflow

### DIFF
--- a/play/src/front/Chat/Components/ChatImagePreviewModal.svelte
+++ b/play/src/front/Chat/Components/ChatImagePreviewModal.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+    import { onDestroy } from "svelte";
+    import { closeModal } from "svelte-modals";
+    import ButtonClose from "../../Components/Input/ButtonClose.svelte";
+    import LL from "../../../i18n/i18n-svelte";
+    import { IconExternalLink } from "@wa-icons";
+
+    export let url: string;
+    export let alt: string | undefined = undefined;
+
+    let containerRef: HTMLDivElement;
+
+    function handleKeydown(event: KeyboardEvent) {
+        if (event.key === "Escape") {
+            event.preventDefault();
+            closeModal();
+        }
+    }
+
+    onDestroy(() => {
+        document.removeEventListener("keydown", handleKeydown);
+    });
+
+    document.addEventListener("keydown", handleKeydown);
+</script>
+
+<div
+    bind:this={containerRef}
+    class="fixed inset-0 z-[2001] flex items-center justify-center p-4 pointer-events-auto bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    aria-label={$LL.chat.imagePreview.close()}
+>
+    <!-- Click outside closes the modal -->
+    <button
+        type="button"
+        class="absolute inset-0 w-full h-full cursor-default"
+        aria-label={$LL.chat.imagePreview.close()}
+        on:click={() => closeModal()}
+    />
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <div
+        class="relative flex flex-col bg-contrast/75 backdrop-blur-md text-white rounded-3xl max-w-3xl w-full max-h-[90vh] overflow-hidden pointer-events-auto shadow-xl"
+        on:click|stopPropagation
+    >
+        <div class="relative flex items-center justify-center min-h-0 p-2">
+            <img
+                src={url}
+                alt={alt ?? ""}
+                class="max-w-full max-h-[90vh] w-auto h-auto object-contain rounded-lg"
+                draggable="false"
+            />
+            <div
+                class="absolute top-2 right-2 flex items-center justify-end gap-2 rounded-lg bg-black/40 p-1.5"
+                aria-label="Image actions"
+            >
+                <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="flex items-center justify-center rounded-lg p-2 hover:bg-white/20 text-white transition-colors"
+                    title={$LL.chat.imagePreview.openInNewTab()}
+                >
+                    <IconExternalLink class="h-6 w-6" />
+                </a>
+                <ButtonClose dataTestId="close-image-preview-modal" size="sm" on:click={() => closeModal()} />
+            </div>
+        </div>
+    </div>
+</div>

--- a/play/src/front/Chat/Components/Room/Message/MessageImage.svelte
+++ b/play/src/front/Chat/Components/Room/Message/MessageImage.svelte
@@ -1,15 +1,30 @@
 <script lang="ts">
     import type { Readable } from "svelte/store";
+    import { openModal } from "svelte-modals";
     import type { ChatMessageContent } from "../../../Connection/ChatConnection";
+    import ChatImagePreviewModal from "../../ChatImagePreviewModal.svelte";
 
     export let content: Readable<ChatMessageContent>;
+
+    function openImagePreview(url: string, alt: string | undefined) {
+        openModal(ChatImagePreviewModal, { url, alt });
+    }
 </script>
 
-<a href={$content.url} target="_blank" class="cursor-pointer relative group block p-1 pb-0">
+<div class="cursor-pointer relative group block p-1 pb-0">
     <div
-        class="bg-contrast/50 p-1 rounded absolute top-2 right-2 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all h-fit w-fit"
+        class="bg-contrast/50 p-1 rounded absolute top-2 right-2 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all h-fit w-fit z-10"
+        role="group"
+        aria-label="Image actions"
     >
-        <div class="hover:bg-white/10 rounded-sm p-1">
+        <a
+            href={$content.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="hover:bg-white/10 rounded-sm p-1"
+            on:click|stopPropagation
+            title="Open in new tab"
+        >
             <svg
                 xmlns="http://www.w3.org/2000/svg"
                 class="block"
@@ -27,9 +42,29 @@
                 <path d="M11 13l9 -9" />
                 <path d="M15 4h5v5" />
             </svg>
-        </div>
+        </a>
     </div>
     {#if $content.url}
-        <img class="w-full object-cover max-h-52 rounded" src={$content.url} alt={$content.body} draggable="false" />
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <div
+            class="block"
+            role="button"
+            tabindex="0"
+            on:click={() => openImagePreview($content.url ?? "", $content.body)}
+            on:keydown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    openImagePreview($content.url ?? "", $content.body);
+                }
+            }}
+        >
+            <img
+                class="w-full object-cover max-h-52 rounded"
+                src={$content.url}
+                alt={$content.body}
+                draggable="false"
+            />
+        </div>
     {/if}
-</a>
+</div>

--- a/play/src/front/Chat/Components/Room/MessageInputBar.svelte
+++ b/play/src/front/Chat/Components/Room/MessageInputBar.svelte
@@ -425,11 +425,13 @@
 </script>
 
 {#if files.length > 0 && !(room instanceof ProximityChatRoom)}
-    <div class="w-full p-1">
-        <div class="flex flex-row gap-2 w-full overflow-visible no-scroll-bar rounded-lg p-2 bg-contrast/80">
+    <div class="w-full min-w-0 p-1">
+        <div
+            class="flex flex-row flex-nowrap gap-2 w-full min-w-[200px] overflow-x-auto no-scroll-bar rounded-lg p-2 bg-contrast/80"
+        >
             {#each filesPreview as preview (preview.id)}
                 <div
-                    class="relative content-center {preview.type.includes('image')
+                    class="relative shrink-0 content-center {preview.type.includes('image')
                         ? 'w-20'
                         : 'w-28'} h-20 rounded-md backdrop-opacity-10 bg-white p-0.5"
                 >

--- a/play/src/i18n/ar-SA/chat.ts
+++ b/play/src/i18n/ar-SA/chat.ts
@@ -44,6 +44,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "المستخدم",
         limitReached: "لقد أرسلت الكثير من دعوات الاجتماعات. يرجى المحاولة مرة أخرى لاحقاً.",
     },
+    imagePreview: {
+        close: "إغلاق",
+        openInNewTab: "فتح في علامة تبويب جديدة",
+    },
     join: "انضمام",
     search: "بحث",
     closeSearch: "إغلاق البحث",

--- a/play/src/i18n/ca-ES/chat.ts
+++ b/play/src/i18n/ca-ES/chat.ts
@@ -45,6 +45,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "L'usuari",
         limitReached: "Has enviat massa invitacions a reunions. Si us plau, torna-ho a provar més tard.",
     },
+    imagePreview: {
+        close: "Tancar",
+        openInNewTab: "Obrir en una nova pestanya",
+    },
     join: "Unir-se",
     search: "Cercar",
     closeSearch: "Tancar cerca",

--- a/play/src/i18n/de-DE/chat.ts
+++ b/play/src/i18n/de-DE/chat.ts
@@ -46,6 +46,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "Der Benutzer",
         limitReached: "Sie haben zu viele Meeting-Einladungen gesendet. Bitte versuchen Sie es später erneut.",
     },
+    imagePreview: {
+        close: "Schließen",
+        openInNewTab: "In neuem Tab öffnen",
+    },
     join: "Beitreten",
     search: "Suchen",
     closeSearch: "Suche schließen",

--- a/play/src/i18n/dsb-DE/chat.ts
+++ b/play/src/i18n/dsb-DE/chat.ts
@@ -46,6 +46,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "Wužywaŕ",
         limitReached: "Sćo pósłali pśewjele pśepšosowanjow. Pšosym wopytajśo pózdźej hyšći raz.",
     },
+    imagePreview: {
+        close: "Zacyniś",
+        openInNewTab: "W nowem rejtarku wócyniś",
+    },
     join: "Pśizamknuś",
     search: "Pytaś",
     closeSearch: "Pytaś zacyniś",

--- a/play/src/i18n/en-US/chat.ts
+++ b/play/src/i18n/en-US/chat.ts
@@ -44,6 +44,10 @@ const chat: BaseTranslation = {
         defaultResponderName: "The user",
         limitReached: "You have sent too many meeting invitations. Please try again later.",
     },
+    imagePreview: {
+        close: "Close",
+        openInNewTab: "Open in new tab",
+    },
     join: "Join",
     search: "Search",
     closeSearch: "Close search",

--- a/play/src/i18n/es-ES/chat.ts
+++ b/play/src/i18n/es-ES/chat.ts
@@ -45,6 +45,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "El usuario",
         limitReached: "Has enviado demasiadas invitaciones a reuniones. Por favor, inténtalo más tarde.",
     },
+    imagePreview: {
+        close: "Cerrar",
+        openInNewTab: "Abrir en nueva pestaña",
+    },
     join: "Unirse",
     search: "Buscar",
     closeSearch: "Cerrar búsqueda",

--- a/play/src/i18n/fr-FR/chat.ts
+++ b/play/src/i18n/fr-FR/chat.ts
@@ -46,6 +46,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "L'utilisateur",
         limitReached: "Vous avez envoyé trop d'invitations à des réunions. Veuillez réessayer plus tard.",
     },
+    imagePreview: {
+        close: "Fermer",
+        openInNewTab: "Ouvrir dans un nouvel onglet",
+    },
     join: "Rejoindre",
     search: "Rechercher",
     closeSearch: "Fermer recherche",

--- a/play/src/i18n/hsb-DE/chat.ts
+++ b/play/src/i18n/hsb-DE/chat.ts
@@ -46,6 +46,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "Wužiwar",
         limitReached: "Sće přewjele přeprošenjow pósłali. Prošu spytajće pozdźišo hišće raz.",
     },
+    imagePreview: {
+        close: "Začinić",
+        openInNewTab: "W nowym rajtarku woteworić",
+    },
     join: "Přizamknyć",
     search: "Pytać",
     closeSearch: "Pytać začinić",

--- a/play/src/i18n/it-IT/chat.ts
+++ b/play/src/i18n/it-IT/chat.ts
@@ -46,6 +46,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "L'utente",
         limitReached: "Hai inviato troppe inviti alla riunione. Riprova più tardi.",
     },
+    imagePreview: {
+        close: "Chiudi",
+        openInNewTab: "Apri in una nuova scheda",
+    },
     join: "Unisciti",
     search: "Cerca",
     closeSearch: "Chiudi ricerca",

--- a/play/src/i18n/ja-JP/chat.ts
+++ b/play/src/i18n/ja-JP/chat.ts
@@ -46,6 +46,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "ユーザー",
         limitReached: "ミーティングへの招待を送りすぎました。しばらくしてからもう一度お試しください。",
     },
+    imagePreview: {
+        close: "閉じる",
+        openInNewTab: "新しいタブで開く",
+    },
     join: "参加",
     search: "検索",
     closeSearch: "検索を閉じる",

--- a/play/src/i18n/ko-KR/chat.ts
+++ b/play/src/i18n/ko-KR/chat.ts
@@ -45,6 +45,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "해당 사용자",
         limitReached: "회의 초대를 너무 많이 보냈습니다. 나중에 다시 시도해 주세요.",
     },
+    imagePreview: {
+        close: "닫기",
+        openInNewTab: "새 탭에서 열기",
+    },
     join: "참가",
     search: "검색",
     closeSearch: "검색 닫기",

--- a/play/src/i18n/nl-NL/chat.ts
+++ b/play/src/i18n/nl-NL/chat.ts
@@ -46,6 +46,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "De gebruiker",
         limitReached: "Je hebt te veel vergaderuitnodigingen verzonden. Probeer het later opnieuw.",
     },
+    imagePreview: {
+        close: "Sluiten",
+        openInNewTab: "Openen in nieuw tabblad",
+    },
     join: "Lid worden",
     search: "Zoeken",
     closeSearch: "Zoeken sluiten",

--- a/play/src/i18n/pt-BR/chat.ts
+++ b/play/src/i18n/pt-BR/chat.ts
@@ -45,6 +45,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "O usuário",
         limitReached: "Você enviou muitos convites para reuniões. Tente novamente mais tarde.",
     },
+    imagePreview: {
+        close: "Fechar",
+        openInNewTab: "Abrir em nova guia",
+    },
     join: "Entrar",
     search: "Pesquisar",
     closeSearch: "Fechar pesquisa",

--- a/play/src/i18n/zh-CN/chat.ts
+++ b/play/src/i18n/zh-CN/chat.ts
@@ -43,6 +43,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         defaultResponderName: "该用户",
         limitReached: "您发送的会议邀请过多，请稍后再试。",
     },
+    imagePreview: {
+        close: "关闭",
+        openInNewTab: "在新标签页中打开",
+    },
     join: "加入",
     search: "搜索",
     closeSearch: "关闭搜索",


### PR DESCRIPTION
## Problem

- Clicking an image in the chat opened it in a new tab instead of offering an in-app preview.
- When many files were attached before sending, the preview list had no minimum width and no horizontal scroll, leading to layout and UX issues.

## Solution

- **Image preview**: Clicking a chat image now opens an in-app modal (lightbox) with the same style as the chat (colors, backdrop, close on outside click). The "Open in new tab" action is kept as a separate control so users can still open the image in a new tab.
- **File attachments list**: The list of files to be sent now has a minimum width and horizontal overflow (scroll) so that with many documents the list stays usable and does not break the layout.

## Changes

- **New**: `play/src/front/Chat/Components/ChatImagePreviewModal.svelte` — Modal for image preview (overlay, close button, "Open in new tab" link, Escape and backdrop close).
- **Modified**: `play/src/front/Chat/Components/Room/Message/MessageImage.svelte` — Replaced direct link with click handler that opens `ChatImagePreviewModal`; kept "Open in new tab" icon with `stopPropagation`.
- **Modified**: `play/src/front/Chat/Components/Room/MessageInputBar.svelte` — File preview list: `min-w-0` on wrapper, `flex-nowrap`, `min-w-[200px]`, `overflow-x-auto` on container, `shrink-0` on each preview card so the list scrolls horizontally when there are many files.
- **i18n**: Added `chat.imagePreview.close` and `chat.imagePreview.openInNewTab` (and locale equivalents) for the image preview modal.

<img width="1580" height="930" alt="image" src="https://github.com/user-attachments/assets/10c4d12c-8692-4a47-a137-62ac6f270840" />

