### PR TITLE
fix(chat): remove user from typing members when they leave proximity chat

### DIFF
--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -739,6 +739,7 @@ export class ProximityChatRoom implements ChatRoom {
                     this.soundManager.playMeetingOutSound();
                 }
             }
+            this.removeTypingUserbyID(spaceUser.spaceUserId);
         });
         await this.throwIfAborted(joinSignal, spaceForThisJoin);
 


### PR DESCRIPTION
## Problem

When a user was typing in the proximity chat and then left the conversation (e.g. closed the tab or left the bubble), they stayed in the "typing members" list. The typing indicator was not cleared for users who had already left.

## Solution

1. **`removeTypingUser`** no longer depends on `this.users`. It always removes the user from `typingMembers` by `senderUserId`. Previously, if the user had already left, `this.users.get(senderUserId)` was undefined and the method returned without removing them (e.g. when a "stop typing" event arrived after they had left).

2. **`observeUserLeft`** now explicitly calls `removeTypingUserbyID(spaceUser.spaceUserId)` when a user leaves the space, so they are removed from the typing list as soon as they leave.

## Changes

- **`play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts`**
  - `removeTypingUser(senderUserId)`: removed early return and lookup in `this.users`; always filter `typingMembers` by `user.id !== senderUserId`.
  - In the `observeUserLeft` subscription: call `removeTypingUserbyID(spaceUser.spaceUserId)` so users who leave are removed from the typing members list.