### PR TITLE
fix(chat): clear chat search bar when closing chat

### DIFF
--- a/play/src/front/Chat/Components/ChatHeader.svelte
+++ b/play/src/front/Chat/Components/ChatHeader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+    import { onDestroy } from "svelte";
     import { chatInputFocusStore } from "../../Stores/ChatStore";
-
     let searchActive = false;
     import { chatSearchBarValue, navChat, joignableRoom } from "../Stores/ChatStore";
     import LoadingSmall from "../images/loading-small.svelte";
@@ -77,6 +77,20 @@
         // Enable input manager to allow the game to receive the input
         chatInputFocusStore.set(false);
     }
+
+    onDestroy(() => {
+        if (typingTimer) {
+            clearTimeout(typingTimer);
+        }
+        chatSearchBarValue.set("");
+        joignableRoom.set([]);
+
+        userProviderMergerPromise
+            .then((userProviderMerger) => {
+                return userProviderMerger.setFilter("");
+            })
+            .catch((e) => console.error(e));
+    });
 </script>
 
 <div class=" relative p-2 flex items-center w-full z-40">


### PR DESCRIPTION
## Problem

When the user closed the chat, the search bar kept its previous value. Reopening the chat showed the old search term, which was confusing and could affect filtering/behavior.

## Solution

Clear the chat search bar whenever the chat is hidden. The existing `initializeChatVisibilitySubscription` in `ChatStore` already reacts to chat visibility; we now reset `chatSearchBarValue` to an empty string when the chat becomes not visible, so the search bar is blank next time the chat is opened.

## Changes

- **`play/src/front/Chat/Stores/ChatStore.ts`**: In `initializeChatVisibilitySubscription`, when `chatVisibilityStore` becomes not visible, call `chatSearchBarValue.set("")` so the search bar is cleared on close.