### PR TITLE
feat(chat): allow all users to access Matrix room user list

### DIFF
--- a/play/src/front/Chat/Components/Room/CreateRoomOrFolderOption.svelte
+++ b/play/src/front/Chat/Components/Room/CreateRoomOrFolderOption.svelte
@@ -55,7 +55,8 @@
 
     function openManageParticipantsModal() {
         if (!folder) return;
-        openModal(ManageParticipantsModal, { room: folder });
+        const canManageUsers = $hasPermissionToInvite || $hasPermissionToKick || $hasPermissionToBan;
+        openModal(ManageParticipantsModal, { room: folder, canManageUsers });
     }
 </script>
 

--- a/play/src/front/Chat/Components/Room/ManageParticipantsModal.svelte
+++ b/play/src/front/Chat/Components/Room/ManageParticipantsModal.svelte
@@ -11,6 +11,8 @@
     import { IconLoader } from "@wa-icons";
     export let isOpen: boolean;
     export let room: ChatRoomMembershipManagement & ChatRoomModeration;
+    export let canManageUsers: boolean;
+
     const members = room.members;
 
     let invitations: { value: string; label: string }[] = [];
@@ -40,7 +42,9 @@
 </script>
 
 <Popup {isOpen}>
-    <h1 slot="title">{$LL.chat.manageRoomUsers.title()}</h1>
+    <h1 slot="title">
+        {canManageUsers ? $LL.chat.manageRoomUsers.title.manageUsers() : $LL.chat.manageRoomUsers.title.userList()}
+    </h1>
     <div slot="content" class="w-full flex flex-col gap-2" data-testid="inviteParticipantsModalContent">
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-static-element-interactions -->

--- a/play/src/front/Chat/Components/Room/ManageParticipantsModal.svelte
+++ b/play/src/front/Chat/Components/Room/ManageParticipantsModal.svelte
@@ -65,11 +65,13 @@
                     {$LL.chat.manageRoomUsers.error()} : <b><i>{invitationToRoomError}</i></b>
                 </div>
             {/if}
-            <SelectMatrixUser
-                on:error={handleSelectMatrixUserError}
-                bind:value={invitations}
-                placeholder={$LL.chat.createRoom.users()}
-            />
+            {#if canManageUsers}
+                <SelectMatrixUser
+                    on:error={handleSelectMatrixUserError}
+                    bind:value={invitations}
+                    placeholder={$LL.chat.createRoom.users()}
+                />
+            {/if}
             <div class="table-container max-h-96 overflow-auto bg-white/10 rounded-lg">
                 <table class="w-full border-separate border-spacing-2 border-none">
                     <thead>

--- a/play/src/front/Chat/Components/Room/RoomMenu/RoomMenu.svelte
+++ b/play/src/front/Chat/Components/Room/RoomMenu/RoomMenu.svelte
@@ -45,8 +45,6 @@
 
     const { connection } = gameManager.getCurrentGameScene();
 
-    $: shouldDisplayManageParticipantButton = $hasPermissionToInvite || $hasPermissionToKick || $hasPermissionToBan;
-
     onMount(() => {
         document.addEventListener("click", closeRoomOptionsOnClickOutside);
         // Initialize usersByRoomStore
@@ -90,7 +88,8 @@
     }
 
     function openManageParticipantsModal() {
-        openModal(ManageParticipantsModal, { room });
+        const canManageUsers = $hasPermissionToInvite || $hasPermissionToKick || $hasPermissionToBan;
+        openModal(ManageParticipantsModal, { room, canManageUsers });
     }
 
     function closeMenuAndSetMuteStatus() {
@@ -219,14 +218,13 @@
             disabled={chatUser == undefined || chatUser.uuid == undefined}
         />
     {/if}
-    {#if shouldDisplayManageParticipantButton}
-        <RoomOption
-            dataTestId="manageParticipantOption"
-            IconComponent={IconUserEdit}
-            title={$LL.chat.manageRoomUsers.roomOption()}
-            on:click={openManageParticipantsModal}
-        />
-    {/if}
+
+    <RoomOption
+        dataTestId="manageParticipantOption"
+        IconComponent={IconUserEdit}
+        title={$LL.chat.manageRoomUsers.roomOption()}
+        on:click={openManageParticipantsModal}
+    />
 
     <RoomOption
         IconComponent={$areNotificationsMuted ? IconUnMute : IconMute}

--- a/play/src/i18n/ar-SA/chat.ts
+++ b/play/src/i18n/ar-SA/chat.ts
@@ -295,7 +295,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "المشاركون",
         error: "تعذر إرسال الدعوات",
-        title: "إدارة المشاركين",
+        title: {
+            manageUsers: "إدارة المشاركين",
+            userList: "قائمة المشاركين",
+        },
         invitations: "الدعوات",
         participants: "المشاركون",
         join: "انضم",

--- a/play/src/i18n/ca-ES/chat.ts
+++ b/play/src/i18n/ca-ES/chat.ts
@@ -296,7 +296,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "Participants",
         error: "No s'han pogut enviar les invitacions",
-        title: "Gestionar participants",
+        title: {
+            manageUsers: "Gestionar participants",
+            userList: "Llista de participants",
+        },
         invitations: "Invitacions",
         participants: "Participants",
         join: "S'ha unit",

--- a/play/src/i18n/de-DE/chat.ts
+++ b/play/src/i18n/de-DE/chat.ts
@@ -299,7 +299,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "Teilnehmer",
         error: "Einladungen konnten nicht gesendet werden",
-        title: "Teilnehmer verwalten",
+        title: {
+            manageUsers: "Teilnehmer verwalten",
+            userList: "Teilnehmerliste",
+        },
         invitations: "Einladungen",
         participants: "Teilnehmer",
         roomID: "Raum-ID: {roomId}",

--- a/play/src/i18n/dsb-DE/chat.ts
+++ b/play/src/i18n/dsb-DE/chat.ts
@@ -297,7 +297,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "Wobźělniki",
         error: "Njejo móžno, pśepšosynki pósłaś",
-        title: "Wobźělnikow zastojaś",
+        title: {
+            manageUsers: "Wobźělnikow zastojaś",
+            userList: "Lisćina wobźělnikow",
+        },
         invitations: "Pśepšosynki",
         participants: "Wobźělniki",
         roomID: "ID śpy: {roomId}",

--- a/play/src/i18n/en-US/chat.ts
+++ b/play/src/i18n/en-US/chat.ts
@@ -296,7 +296,10 @@ const chat: BaseTranslation = {
     manageRoomUsers: {
         roomOption: "Participants",
         error: "Unable send invitations",
-        title: "Manage participants",
+        title: {
+            manageUsers: "Manage participants",
+            userList: "Participants list",
+        },
         invitations: "Invitations",
         participants: "Participants",
         join: "Joined",

--- a/play/src/i18n/es-ES/chat.ts
+++ b/play/src/i18n/es-ES/chat.ts
@@ -296,7 +296,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "Participantes",
         error: "No se pudieron enviar las invitaciones",
-        title: "Gestionar participantes",
+        title: {
+            manageUsers: "Gestionar participantes",
+            userList: "Lista de participantes",
+        },
         invitations: "Invitaciones",
         participants: "Participantes",
         join: "Se unió",

--- a/play/src/i18n/fr-FR/chat.ts
+++ b/play/src/i18n/fr-FR/chat.ts
@@ -297,7 +297,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "Participants",
         error: "Impossible d'envoyer les invitations",
-        title: "Gérer les participants",
+        title: {
+            manageUsers: "Gérer les participants",
+            userList: "Liste des participants",
+        },
         invitations: "Invitations",
         participants: "Participants",
         roomID: "ID du salon : {roomId}",

--- a/play/src/i18n/hsb-DE/chat.ts
+++ b/play/src/i18n/hsb-DE/chat.ts
@@ -297,7 +297,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "Wobdźělnicy",
         error: "Njemóžno, přeprošenja pósłać",
-        title: "Wobdźělnikow zastojować",
+        title: {
+            manageUsers: "Wobdźělnikow zastojać",
+            userList: "Lisćina wobdźělnikow",
+        },
         invitations: "Přeprošenja",
         participants: "Wobdźělnicy",
         roomID: "ID ruma: {roomId}",

--- a/play/src/i18n/it-IT/chat.ts
+++ b/play/src/i18n/it-IT/chat.ts
@@ -297,7 +297,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "Partecipanti",
         error: "Impossibile inviare inviti",
-        title: "Gestisci i partecipanti",
+        title: {
+            manageUsers: "Gestisci partecipanti",
+            userList: "Elenco partecipanti",
+        },
         invitations: "Inviti",
         participants: "Partecipanti",
         roomID: "ID stanza: {roomId}",

--- a/play/src/i18n/ja-JP/chat.ts
+++ b/play/src/i18n/ja-JP/chat.ts
@@ -297,7 +297,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "参加者",
         error: "招待を送信できません",
-        title: "参加者の管理",
+        title: {
+            manageUsers: "参加者を管理",
+            userList: "参加者リスト",
+        },
         invitations: "招待",
         participants: "参加者",
         roomID: "ルームID: {roomId}",

--- a/play/src/i18n/ko-KR/chat.ts
+++ b/play/src/i18n/ko-KR/chat.ts
@@ -298,7 +298,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "참가자",
         error: "초대를 보낼 수 없습니다",
-        title: "참가자 관리",
+        title: {
+            manageUsers: "참가자 관리",
+            userList: "참가자 목록",
+        },
         invitations: "초대",
         participants: "참가자",
         join: "참가함",

--- a/play/src/i18n/nl-NL/chat.ts
+++ b/play/src/i18n/nl-NL/chat.ts
@@ -297,7 +297,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "Deelnemers",
         error: "Uitnodigingen konden niet worden verzonden",
-        title: "Deelnemers beheren",
+        title: {
+            manageUsers: "Deelnemers beheren",
+            userList: "Deelnemerslijst",
+        },
         invitations: "Uitnodigingen",
         participants: "Deelnemers",
         roomID: "Kamer-ID: {roomId}",

--- a/play/src/i18n/pt-BR/chat.ts
+++ b/play/src/i18n/pt-BR/chat.ts
@@ -297,7 +297,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "Participantes",
         error: "Não foi possível enviar convites",
-        title: "Gerenciar participantes",
+        title: {
+            manageUsers: "Gerenciar participantes",
+            userList: "Lista de participantes",
+        },
         invitations: "Convites",
         participants: "Participantes",
         join: "Entrou",

--- a/play/src/i18n/zh-CN/chat.ts
+++ b/play/src/i18n/zh-CN/chat.ts
@@ -294,7 +294,10 @@ const chat: DeepPartial<Translation["chat"]> = {
     manageRoomUsers: {
         roomOption: "参与者",
         error: "无法发送邀请",
-        title: "管理参与者",
+        title: {
+            manageUsers: "管理参与者",
+            userList: "参与者列表",
+        },
         invitations: "邀请",
         participants: "参与者",
         join: "已加入",

--- a/tests/tests/chat/matrixChatArea.spec.ts
+++ b/tests/tests/chat/matrixChatArea.spec.ts
@@ -155,10 +155,10 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
         await page.getByTestId("chatBackward").click();
         await page.getByTestId("name of new room").hover();
         await page.getByTestId("name of new room").getByTestId("toggleRoomMenu").click();
+        await expect(page.getByTestId("manageParticipantOption")).toBeVisible();
         await page.getByTestId("manageParticipantOption").click();
-        await expect(page.getByText("Manage participants")).toBeVisible({
-            timeout: 60000,
-        });
+
+        await expect(page.getByRole("heading", { name: "Manage participants" })).toBeVisible();
 
         await page.context().close();
     });
@@ -196,6 +196,10 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
         await page2.getByTestId("chatBackward").click();
         await page2.getByTestId("name of new room").hover();
         await page2.getByTestId("name of new room").getByTestId("toggleRoomMenu").click();
-        await expect(page2.getByTestId("manageParticipantOption")).not.toBeAttached();
+        await expect(page2.getByTestId("manageParticipantOption")).toBeVisible();
+        await page2.getByTestId("manageParticipantOption").click();
+        await expect(page2.getByRole("heading", { name: "Participants list" })).toBeVisible();
+
+        await page2.context().close();
     });
 });


### PR DESCRIPTION
TODO : 

- [ ]  Review the popup UX and UI before merging
- [ ] review Matrix E2E tests related to moderation

## Problem

The list of users (participants) in a Matrix room was only available to a restricted set of users (e.g. admins or moderators). Regular participants could not see who was in the room, which limited transparency and discoverability.

## Solution

Grant all users access to the Matrix room user list. Any participant can now view the list of users in the room, aligning with expectations for a shared chat space and improving usability.

## Changes

- **Chat / Matrix room**: Permission or visibility logic updated so the room user list is available to every participant (not only admins/moderators).
- **UI**: "Manage participants" / "Participants list" (or equivalent) is shown and accessible to all users when viewing a room.