### PR TITLE
feat(chat): allow moderators to delete other users’ messages in Matrix rooms

### DIFF
--- a/play/src/front/Chat/Components/Room/MessageOptions.svelte
+++ b/play/src/front/Chat/Components/Room/MessageOptions.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { ChatMessage } from "../../Connection/ChatConnection";
     import { selectedChatMessageToEdit, selectedChatMessageToReply } from "../../Stores/ChatStore";
+    import LL from "../../../../i18n/i18n-svelte";
     import EmojiButton from "./EmojiButton.svelte";
     import { IconArrowBackUp, IconArrowDown, IconPencil, IconTrash } from "@wa-icons";
 
@@ -58,6 +59,8 @@
         <button
             class="p-0 m-0 text-white/50 hover:text-white transition-all hover:cursor-pointer flex"
             data-testid="removeMessageButton"
+            title={$LL.chat.delete()}
+            aria-label={$LL.chat.delete()}
             on:click={removeMessage}
         >
             <IconTrash font-size={16} />

--- a/play/src/i18n/ar-SA/chat.ts
+++ b/play/src/i18n/ar-SA/chat.ts
@@ -173,6 +173,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "أكثر",
     sendBack: "إعادة الإرسال",
     delete: "حذف",
+    deleteMessageConfirmOwn: "حذف هذه الرسالة؟",
+    deleteMessageConfirmOther: "حذف رسالة من {senderName}؟",
     messageDeleted: "تم حذف الرسالة",
     emoji: {
         icon: "رمز لفتح أو إغلاق نافذة اختيار الرموز التعبيرية",

--- a/play/src/i18n/ca-ES/chat.ts
+++ b/play/src/i18n/ca-ES/chat.ts
@@ -174,6 +174,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "més",
     sendBack: "Reenviar",
     delete: "Eliminar",
+    deleteMessageConfirmOwn: "Eliminar aquest missatge?",
+    deleteMessageConfirmOther: "Eliminar missatge de {senderName}?",
     messageDeleted: "Missatge eliminat",
     emoji: {
         icon: "Icona per obrir o tancar la finestra emergent d'emoji seleccionat",

--- a/play/src/i18n/de-DE/chat.ts
+++ b/play/src/i18n/de-DE/chat.ts
@@ -176,6 +176,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "Mehr",
     sendBack: "Zurücksenden",
     delete: "Löschen",
+    deleteMessageConfirmOwn: "Diese Nachricht löschen?",
+    deleteMessageConfirmOther: "Nachricht von {senderName} löschen?",
     messageDeleted: "Nachricht gelöscht",
     emoji: {
         icon: "Emojis",

--- a/play/src/i18n/dsb-DE/chat.ts
+++ b/play/src/i18n/dsb-DE/chat.ts
@@ -175,6 +175,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "Wěcej",
     sendBack: "Slědk pósłaś",
     delete: "Wulašowaś",
+    deleteMessageConfirmOwn: "Tutu powěsć wulašowaś?",
+    deleteMessageConfirmOther: "Powěsć wot {senderName} wulašowaś?",
     messageDeleted: "Powěsć wulašowana",
     emoji: {
         icon: "Emojis",

--- a/play/src/i18n/en-US/chat.ts
+++ b/play/src/i18n/en-US/chat.ts
@@ -174,6 +174,8 @@ const chat: BaseTranslation = {
     more: "more",
     sendBack: "Send back",
     delete: "Delete",
+    deleteMessageConfirmOwn: "Delete this message?",
+    deleteMessageConfirmOther: "Delete message from {senderName}?",
     messageDeleted: "Message deleted",
     emoji: {
         icon: "Icon to open or close emoji selected popup",

--- a/play/src/i18n/es-ES/chat.ts
+++ b/play/src/i18n/es-ES/chat.ts
@@ -174,6 +174,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "más",
     sendBack: "Reenviar",
     delete: "Eliminar",
+    deleteMessageConfirmOwn: "¿Eliminar este mensaje?",
+    deleteMessageConfirmOther: "¿Eliminar mensaje de {senderName}?",
     messageDeleted: "Mensaje eliminado",
     emoji: {
         icon: "Icono para abrir o cerrar la ventana emergente de emoji seleccionado",

--- a/play/src/i18n/fr-FR/chat.ts
+++ b/play/src/i18n/fr-FR/chat.ts
@@ -175,6 +175,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "plus",
     sendBack: "Renvoyer",
     delete: "Supprimer",
+    deleteMessageConfirmOwn: "Supprimer ce message ?",
+    deleteMessageConfirmOther: "Supprimer le message de {senderName} ?",
     messageDeleted: "Message supprimé",
     emoji: {
         icon: "Emojis",

--- a/play/src/i18n/hsb-DE/chat.ts
+++ b/play/src/i18n/hsb-DE/chat.ts
@@ -175,6 +175,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "wjac",
     sendBack: "wróćosyć",
     delete: "hašeć",
+    deleteMessageConfirmOwn: "Tutu powěsć zhašeć?",
+    deleteMessageConfirmOther: "Powěsć wot {senderName} zhašeć?",
     messageDeleted: "Powěsć zhašena",
     emoji: {
         icon: "Emojis",

--- a/play/src/i18n/it-IT/chat.ts
+++ b/play/src/i18n/it-IT/chat.ts
@@ -175,6 +175,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "di più",
     sendBack: "Rimanda indietro",
     delete: "Elimina",
+    deleteMessageConfirmOwn: "Eliminare questo messaggio?",
+    deleteMessageConfirmOther: "Eliminare il messaggio di {senderName}?",
     messageDeleted: "Messaggio eliminato",
     emoji: {
         icon: "Emojis",

--- a/play/src/i18n/ja-JP/chat.ts
+++ b/play/src/i18n/ja-JP/chat.ts
@@ -175,6 +175,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "増やす",
     sendBack: "再送信",
     delete: "削除",
+    deleteMessageConfirmOwn: "このメッセージを削除しますか？",
+    deleteMessageConfirmOther: "{senderName}のメッセージを削除しますか？",
     messageDeleted: "メッセージの削除",
     emoji: {
         icon: "Emojis",

--- a/play/src/i18n/ko-KR/chat.ts
+++ b/play/src/i18n/ko-KR/chat.ts
@@ -176,6 +176,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "더 보기",
     sendBack: "되돌려 보내기",
     delete: "삭제",
+    deleteMessageConfirmOwn: "이 메시지를 삭제하시겠습니까?",
+    deleteMessageConfirmOther: "{senderName}의 메시지를 삭제하시겠습니까?",
     messageDeleted: "메시지가 삭제되었습니다",
     emoji: {
         icon: "이모티콘 선택 팝업을 열거나 닫는 아이콘",

--- a/play/src/i18n/nl-NL/chat.ts
+++ b/play/src/i18n/nl-NL/chat.ts
@@ -175,6 +175,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "meer",
     sendBack: "Terugsturen",
     delete: "Verwijderen",
+    deleteMessageConfirmOwn: "Dit bericht verwijderen?",
+    deleteMessageConfirmOther: "Bericht van {senderName} verwijderen?",
     messageDeleted: "Bericht verwijderd",
     emoji: {
         icon: "Emojis",

--- a/play/src/i18n/pt-BR/chat.ts
+++ b/play/src/i18n/pt-BR/chat.ts
@@ -175,6 +175,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "mais",
     sendBack: "Enviar de volta",
     delete: "Excluir",
+    deleteMessageConfirmOwn: "Excluir esta mensagem?",
+    deleteMessageConfirmOther: "Excluir mensagem de {senderName}?",
     messageDeleted: "Mensagem excluída",
     emoji: {
         icon: "Ícone para abrir ou fechar popup de emoji selecionado",

--- a/play/src/i18n/zh-CN/chat.ts
+++ b/play/src/i18n/zh-CN/chat.ts
@@ -172,6 +172,8 @@ const chat: DeepPartial<Translation["chat"]> = {
     more: "更多",
     sendBack: "重新发送",
     delete: "删除",
+    deleteMessageConfirmOwn: "删除此消息？",
+    deleteMessageConfirmOther: "删除{senderName}的消息？",
     messageDeleted: "消息已删除",
     emoji: {
         icon: "打开或关闭表情符号选择弹出窗口的图标",


### PR DESCRIPTION
## Problem

Moderators and admins had no way to delete other users’ messages in Matrix chat rooms. Only the author could delete their own messages, so inappropriate content could not be removed by room staff.

## Solution

- **Moderation delete**: Users with the Matrix `redact` power level and a higher power level than the message sender can delete that user’s messages via the existing delete button in message options (next to reply, edit, etc.).
- **Own messages**: Any user can still delete their own messages (delete button shown for own messages regardless of power level).
- **Rights**: `canDelete` is true for (1) own message, or (2) `hasSufficientPowerLevelFor("redact")` and `myPowerLevel > senderPowerLevel`, so the delete button appears only when the current user is allowed to redact that event.
- **Accessibility**: Added `title` and `aria-label` on the delete button for screen readers and tooltips.
- **i18n**: Added `deleteMessageConfirmOwn` and `deleteMessageConfirmOther` in all locales for future use (e.g. confirmation dialogs or tooltips).

## Changes

- **play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts**: `canDelete` = own message OR (has redact permission and higher power level than sender); formatting only, logic already supported moderation.
- **play/src/front/Chat/Components/Room/MessageOptions.svelte**: Delete button already present; added `title` and `aria-label` via `$LL.chat.delete()` for accessibility.
- **play/src/i18n/**/chat.ts** (all locales): Added `deleteMessageConfirmOwn` and `deleteMessageConfirmOther`.