### PR TITLE
fix(chat): delete chat drafts on send and room leave, sync input on room change

### DIFF
--- a/play/src/front/Chat/Components/Room/RoomMenu/RoomMenu.svelte
+++ b/play/src/front/Chat/Components/Room/RoomMenu/RoomMenu.svelte
@@ -12,10 +12,11 @@
         ChatUser,
     } from "../../../Connection/ChatConnection";
     import { notificationPlayingStore } from "../../../../Stores/NotificationStore";
+    import { localUserStore } from "../../../../Connection/LocalUserStore";
+    import { draftMessageService } from "../../../Services/DraftMessageService";
     import LL from "../../../../../i18n/i18n-svelte";
     import ManageParticipantsModal from "../ManageParticipantsModal.svelte";
     import { gameManager } from "../../../../Phaser/Game/GameManager";
-    import { localUserStore } from "../../../../Connection/LocalUserStore";
     import { analyticsClient } from "../../../../Administration/AnalyticsClient";
     import { scriptUtils } from "../../../../Api/ScriptUtils";
     import type { UserProviderMerger } from "../../../UserProviderMerger/UserProviderMerger";
@@ -82,8 +83,10 @@
 
     function closeMenuAndLeaveRoom() {
         toggleRoomOptions();
+        const roomId = room.id;
         room.leaveRoom()
             .then(() => {
+                draftMessageService.deleteDraft(`${roomId}-${localUserStore.getChatId() ?? "0"}`);
                 notificationPlayingStore.playNotification($LL.chat.roomMenu.leaveRoom.notification());
             })
             .catch(() => console.error("Failed to leave room"));

--- a/play/src/front/Chat/Components/Room/RoomTimeline.svelte
+++ b/play/src/front/Chat/Components/Room/RoomTimeline.svelte
@@ -396,8 +396,9 @@
         {#if $typingMembers.length > 0}
             <TypingUsers typingMembers={$typingMembers} />
         {/if}
-
-        <MessageInputBar disabled={$shouldRetrySendingEvents} {room} bind:this={messageInputBarRef} />
+        {#key room}
+            <MessageInputBar disabled={$shouldRetrySendingEvents} {room} bind:this={messageInputBarRef} />
+        {/key}
     {/if}
 </div>
 


### PR DESCRIPTION
## Problem

- Drafts were never removed when sending a message or when leaving a room (Matrix leave), so old drafts stayed in IndexedDB.
- In two-column layout, switching conversations did not update the message input: the previous room’s text stayed visible and the current room’s draft was not loaded.

## Solution

- Call `draftMessageService.deleteDraft(draftId)` when a message is successfully sent and when the user leaves a room (menu leave, decline invitation, leave folder).
- Make draft handling reactive to `room.id` in `MessageInputBar`: on room change, save the previous room’s draft, reset the input state, then load the new room’s draft so the input always matches the selected conversation.

## Changes

- **MessageInputBar.svelte**: Reactive `draftId`; call `deleteDraft(draftId)` after sending a message; reactive block on `room.id` to save previous draft, reset state (message, reply, files, etc.), and load new room draft via `pendingDraftLoad`; draft load moved from `onMount` to reactive flow; `onDestroy` still saves draft on close.
- **RoomMenu.svelte**: After successful `room.leaveRoom()`, call `draftMessageService.deleteDraft(roomId-userId)`.
- **RoomInvitation.svelte**: After successful `room.leaveRoom()` (decline), call `draftMessageService.deleteDraft(roomId-userId)`.
- **CreateRoomOrFolderOption.svelte**: After successful `folder.leaveRoom()`, call `draftMessageService.deleteDraft(folderId-userId)`.