### PR TITLE
feat(chat): add decline button for suggested rooms with IndexedDB persistence and refacto DraftMessageService

### DIFF
--- a/play/src/front/Chat/Components/Room/MessageInputBar.svelte
+++ b/play/src/front/Chat/Components/Room/MessageInputBar.svelte
@@ -62,7 +62,6 @@
     let applicationProperty: ApplicationProperty | undefined = undefined;
     const isProximityChatRoom = room instanceof ProximityChatRoom;
     let replyMessageId: string | null = null;
-    const draftId = `${room.id}-${localUserStore.getChatId() ?? "0"}`;
 
     const selectedChatChatMessageToReplyUnsubscriber = selectedChatMessageToReply.subscribe((chatMessage) => {
         if (chatMessage !== null) {
@@ -157,7 +156,7 @@
 
     onMount(async () => {
         fileAttachementEnabled = gameManager.getCurrentGameScene().room.isChatUploadEnabled;
-        const draft = await draftMessageService.loadDraft(draftId);
+        const draft = await draftMessageService.loadDraft(room.id, localUserStore.getChatId());
         if (draft) {
             message = draft.message ?? "";
             if (draft.replyingToMessageId) {
@@ -171,7 +170,6 @@
 
     onDestroy(() => {
         draftMessageService.saveDraft({
-            id: draftId,
             roomId: room.id,
             userId: localUserStore.getChatId(),
             message,

--- a/play/src/front/Chat/Components/Room/RoomSuggested.svelte
+++ b/play/src/front/Chat/Components/Room/RoomSuggested.svelte
@@ -6,11 +6,15 @@
     import Avatar from "../Avatar.svelte";
     import { LL } from "../../../../i18n/i18n-svelte";
     import type { PictureStore } from "../../../Stores/PictureStore";
+    import { ignoredSuggestedRoomsService } from "../../Services/IgnoredSuggestedRoomsService";
     import { IconLoader } from "@wa-icons";
 
-    export let roomInformation: { name: string; id: string; pictureStore: PictureStore };
+    export let roomInformation: { name: string; id: string; pictureStore?: PictureStore };
+    export let folderId: string | undefined = undefined;
+    export let chatId: string | undefined = undefined;
     let roomName = roomInformation.name;
     let loadingInvitation = false;
+    let declining = false;
 
     async function joinRoom() {
         loadingInvitation = true;
@@ -34,6 +38,16 @@
             warningMessageStore.addWarningMessage($LL.chat.failedToJoinRoom());
         }
     }
+
+    async function declineRoom() {
+        if (folderId === undefined || chatId === undefined) return;
+        declining = true;
+        try {
+            await ignoredSuggestedRoomsService.addIgnoredRoom(chatId, folderId, roomInformation.id);
+        } finally {
+            declining = false;
+        }
+    }
 </script>
 
 <div
@@ -52,7 +66,24 @@
         </div>
     {:else}
         <div class="flex gap-1">
+            {#if folderId !== undefined && chatId !== undefined}
+                <button
+                    type="button"
+                    class="border border-solid border-danger text-danger hover:bg-danger-400/10 rounded text-xs py-1 px-2 m-0 disabled:opacity-50"
+                    data-testid="declineSuggestedRoomButton"
+                    disabled={declining}
+                    on:click={(e) => {
+                        declineRoom().catch((error) => {
+                            warningMessageStore.addWarningMessage($LL.chat.failedToDeclineRoom());
+                            Sentry.captureException(error);
+                        });
+                    }}
+                >
+                    {$LL.chat.decline()}
+                </button>
+            {/if}
             <button
+                type="button"
                 class="border border-solid border-success text-success hover:bg-success-400/10 rounded text-xs py-1 px-2 m-0"
                 data-testid="acceptInvitationButton"
                 on:click={() => joinRoom()}

--- a/play/src/front/Chat/Components/RoomFolder.svelte
+++ b/play/src/front/Chat/Components/RoomFolder.svelte
@@ -4,12 +4,15 @@
     import LL from "../../../i18n/i18n-svelte";
     import { chatSearchBarValue } from "../Stores/ChatStore";
     import { localUserStore } from "../../Connection/LocalUserStore";
+    import { ignoredSuggestedRoomsService } from "../Services/IgnoredSuggestedRoomsService";
     import Room from "./Room/Room.svelte";
     import CreateRoomOrFolderOption from "./Room/CreateRoomOrFolderOption.svelte";
     import ShowMore from "./ShowMore.svelte";
     import RoomInvitation from "./Room/RoomInvitation.svelte";
     import RoomSuggested from "./Room/RoomSuggested.svelte";
     import { IconChevronUp } from "@wa-icons";
+
+    const ignoredByFolder = ignoredSuggestedRoomsService.getIgnoredStore();
 
     export let rootFolder: boolean;
     export let folder: RoomFolder & ChatRoomModeration;
@@ -31,6 +34,11 @@
     $: filteredJoinableRooms = $joinableRooms.filter(
         (joinable) => !$suggestedRooms.some((suggested) => suggested.id === joinable.id)
     );
+
+    const chatId = localUserStore.getChatId() ?? "";
+    $: ignoredSet = $ignoredByFolder.get(`${chatId}:${id}`) ?? new Set<string>();
+    $: filteredSuggestedRooms = $suggestedRooms.filter((r) => !ignoredSet.has(r.id));
+    $: filteredJoinableRoomsDisplay = filteredJoinableRooms.filter((r) => !ignoredSet.has(r.id));
 
     function toggleFolder() {
         isOpen = !isOpen;
@@ -79,7 +87,7 @@
     <div class="flex flex-col">
         {#if isOpen}
             <div class="flex flex-col">
-                {#if $suggestedRooms.length > 0 || filteredJoinableRooms.length > 0}
+                {#if filteredSuggestedRooms.length > 0 || filteredJoinableRoomsDisplay.length > 0}
                     <div class="mx-2 p-1 bg-secondary/30 rounded-lg mb-4 border border-solid border-secondary/80">
                         <div
                             class="group relative px-3 m-0 rounded-md text-white/75 hover:text-white h-8 hover:bg-contrast-200/10 w-full flex space-x-2 items-center"
@@ -107,19 +115,37 @@
                         </div>
                         {#if joinableRoomsOpen}
                             <div class="flex flex-col overflow-auto ps-3 pe-4 pb-3">
-                                {#if $suggestedRooms.length > 0}
+                                {#if filteredSuggestedRooms.length > 0}
                                     <div class="bg-white/10 rounded-md">
                                         <span class="text-sm opacity-80 p-2">
                                             {$LL.chat.suggestedRooms()} :
                                         </span>
-                                        <ShowMore items={$suggestedRooms} maxNumber={8} idKey="id" let:item={room}>
-                                            <RoomSuggested roomInformation={room} />
+                                        <ShowMore
+                                            items={filteredSuggestedRooms}
+                                            maxNumber={8}
+                                            idKey="id"
+                                            let:item={room}
+                                        >
+                                            <RoomSuggested
+                                                roomInformation={room}
+                                                folderId={id}
+                                                chatId={localUserStore.getChatId() ?? undefined}
+                                            />
                                         </ShowMore>
                                     </div>
                                 {/if}
-                                {#if filteredJoinableRooms.length > 0}
-                                    <ShowMore items={filteredJoinableRooms} maxNumber={8} idKey="id" let:item={room}>
-                                        <RoomSuggested roomInformation={room} />
+                                {#if filteredJoinableRoomsDisplay.length > 0}
+                                    <ShowMore
+                                        items={filteredJoinableRoomsDisplay}
+                                        maxNumber={8}
+                                        idKey="id"
+                                        let:item={room}
+                                    >
+                                        <RoomSuggested
+                                            roomInformation={room}
+                                            folderId={id}
+                                            chatId={localUserStore.getChatId() ?? undefined}
+                                        />
                                     </ShowMore>
                                 {/if}
                             </div>
@@ -147,7 +173,7 @@
                 >
                     <Room {room} />
                 </ShowMore>
-                {#if $rooms.length === 0 && $folders.length === 0 && $suggestedRooms.length === 0}
+                {#if $rooms.length === 0 && $folders.length === 0 && filteredSuggestedRooms.length === 0}
                     <p
                         class={`${
                             rootFolder

--- a/play/src/front/Chat/Services/DraftMessageService.ts
+++ b/play/src/front/Chat/Services/DraftMessageService.ts
@@ -1,7 +1,7 @@
 import { asError } from "catch-unknown";
 
 export type DraftMessage = {
-    id: string;
+    id?: string;
     roomId: string;
     userId: string | null;
     message: string;
@@ -15,13 +15,22 @@ class DraftMessageService {
         this.initDatabase();
     }
 
+    private static readonly DB_NAME = "workadventure-chat";
+    private static readonly DB_VERSION = 2;
+
     private initDatabase() {
-        const request = indexedDB.open("ChatDraftsDB", 1);
+        const request = indexedDB.open(DraftMessageService.DB_NAME, DraftMessageService.DB_VERSION);
 
         request.onupgradeneeded = (event) => {
             const db = (event.target as IDBOpenDBRequest).result;
+            if (db.objectStoreNames.contains("drafts")) {
+                db.deleteObjectStore("drafts");
+            }
             if (!db.objectStoreNames.contains("drafts")) {
-                db.createObjectStore("drafts", { keyPath: "id" });
+                db.createObjectStore("drafts", { keyPath: ["userId", "roomId"] });
+            }
+            if (!db.objectStoreNames.contains("ignoredSuggestedRooms")) {
+                db.createObjectStore("ignoredSuggestedRooms", { keyPath: ["chatId", "folderId"] });
             }
         };
 
@@ -38,11 +47,16 @@ class DraftMessageService {
         if (!this.db) return;
         const transaction = this.db.transaction("drafts", "readwrite");
         const store = transaction.objectStore("drafts");
-
-        store.put(draft);
+        const userId = draft.userId ?? "0";
+        store.put({
+            userId,
+            roomId: draft.roomId,
+            message: draft.message,
+            replyingToMessageId: draft.replyingToMessageId ?? null,
+        });
     }
 
-    public async loadDraft(id: string): Promise<DraftMessage | null> {
+    public async loadDraft(roomId: string, userId: string | null): Promise<DraftMessage | null> {
         return new Promise((resolve, reject) => {
             if (!this.db) {
                 resolve(null);
@@ -51,15 +65,22 @@ class DraftMessageService {
 
             const transaction = this.db.transaction("drafts", "readonly");
             const store = transaction.objectStore("drafts");
+            const keyUserId = userId ?? "0";
+            const request = store.get([keyUserId, roomId]);
 
-            const request = store.get(id);
             request.onsuccess = (event) => {
                 const draft = (event.target as IDBRequest).result;
                 if (!draft) {
                     resolve(null);
                     return;
                 }
-                resolve(draft);
+                resolve({
+                    id: `${roomId}-${keyUserId}`,
+                    roomId: draft.roomId,
+                    userId: draft.userId === "0" ? null : draft.userId,
+                    message: draft.message,
+                    replyingToMessageId: draft.replyingToMessageId ?? null,
+                });
             };
 
             request.onerror = (event) => {
@@ -69,13 +90,12 @@ class DraftMessageService {
         });
     }
 
-    public deleteDraft(id: string) {
+    public deleteDraft(roomId: string, userId: string | null) {
         if (!this.db) return;
 
         const transaction = this.db.transaction("drafts", "readwrite");
         const store = transaction.objectStore("drafts");
-
-        store.delete(id);
+        store.delete([userId ?? "0", roomId]);
     }
 }
 

--- a/play/src/front/Chat/Services/IgnoredSuggestedRoomsService.ts
+++ b/play/src/front/Chat/Services/IgnoredSuggestedRoomsService.ts
@@ -1,0 +1,123 @@
+import { writable, type Readable } from "svelte/store";
+import { asError } from "catch-unknown";
+
+const DB_NAME = "workadventure-chat";
+const DB_VERSION = 2;
+const STORE_NAME = "ignoredSuggestedRooms";
+
+export type IgnoredByFolderEntry = {
+    chatId: string;
+    folderId: string;
+    roomIds: string[];
+};
+
+class IgnoredSuggestedRoomsService {
+    private db: IDBDatabase | null = null;
+
+    private readonly data = writable<Map<string, Set<string>>>(new Map());
+
+    constructor() {
+        this.initDatabase();
+    }
+
+    private initDatabase(): void {
+        const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+        request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
+            const db = (event.target as IDBOpenDBRequest).result;
+            if (db.objectStoreNames.contains("drafts")) {
+                db.deleteObjectStore("drafts");
+            }
+            if (!db.objectStoreNames.contains("drafts")) {
+                db.createObjectStore("drafts", { keyPath: ["userId", "roomId"] });
+            }
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                db.createObjectStore(STORE_NAME, { keyPath: ["chatId", "folderId"] });
+            }
+        };
+
+        request.onsuccess = (event: Event) => {
+            this.db = (event.target as IDBOpenDBRequest).result;
+            this.loadAllIntoStore();
+        };
+
+        request.onerror = () => {
+            console.error("Error while opening IndexedDB for ignored suggested rooms");
+        };
+    }
+
+    private loadAllIntoStore(): void {
+        if (!this.db) return;
+        const transaction = this.db.transaction(STORE_NAME, "readonly");
+        const store = transaction.objectStore(STORE_NAME);
+        const request = store.getAll();
+
+        request.onsuccess = () => {
+            const entries = (request.result as IgnoredByFolderEntry[]) ?? [];
+            const map = new Map<string, Set<string>>();
+            for (const { chatId, folderId, roomIds } of entries) {
+                map.set(`${chatId}:${folderId}`, new Set(roomIds));
+            }
+            this.data.set(map);
+        };
+
+        request.onerror = () => {
+            console.error("Error while loading ignored suggested rooms from IndexedDB");
+        };
+    }
+
+    getIgnoredStore(): Readable<Map<string, Set<string>>> {
+        return this.data;
+    }
+
+    async addIgnoredRoom(chatId: string, folderId: string, roomId: string): Promise<void> {
+        const compositeKey = `${chatId}:${folderId}`;
+
+        this.data.update((map) => {
+            const next = new Map(map);
+            const existingSet = next.get(compositeKey) ?? new Set<string>();
+            if (existingSet.has(roomId)) return map;
+            next.set(compositeKey, new Set([...existingSet, roomId]));
+            return next;
+        });
+
+        return new Promise((resolve, reject) => {
+            if (!this.db) {
+                resolve();
+                return;
+            }
+
+            const transaction = this.db.transaction(STORE_NAME, "readwrite");
+            const store = transaction.objectStore(STORE_NAME);
+            const getRequest = store.get([chatId, folderId]);
+
+            getRequest.onsuccess = () => {
+                const existing = (getRequest.result as IgnoredByFolderEntry | undefined) ?? {
+                    chatId,
+                    folderId,
+                    roomIds: [],
+                };
+                if (existing.roomIds.includes(roomId)) {
+                    resolve();
+                    return;
+                }
+                const roomIds = [...existing.roomIds, roomId];
+                const putRequest = store.put({ chatId, folderId, roomIds });
+
+                putRequest.onsuccess = () => resolve();
+
+                putRequest.onerror = () => {
+                    console.error("Error while saving ignored suggested room");
+                    reject(asError(putRequest.error));
+                };
+            };
+
+            getRequest.onerror = () => {
+                console.error("Error while reading ignored suggested rooms");
+                reject(asError(getRequest.error));
+            };
+        });
+    }
+}
+
+export const ignoredSuggestedRoomsService = new IgnoredSuggestedRoomsService();

--- a/play/src/i18n/ar-SA/chat.ts
+++ b/play/src/i18n/ar-SA/chat.ts
@@ -485,6 +485,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "إعادة الاتصال", // Reconnect
     failedToJoinRoom: "فشل في الانضمام إلى الغرفة", // Failed to join room
     failedToLeaveRoom: "فشل في مغادرة الغرفة", // Failed to leave room
+    failedToDeclineRoom: "فشل في رفض الغرفة المقترحة",
     refreshChat: "تحديث الدردشة", // Refresh Chat
     dismiss: "رفض", // Dismiss
     whoops: "عذرًا! حدث خطأ ما", // Whoops! Something went wrong

--- a/play/src/i18n/ca-ES/chat.ts
+++ b/play/src/i18n/ca-ES/chat.ts
@@ -486,6 +486,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "Tornar a connectar",
     failedToJoinRoom: "No s'ha pogut unir a la sala",
     failedToLeaveRoom: "No s'ha pogut sortir de la sala",
+    failedToDeclineRoom: "No s'ha pogut rebutjar la sala recomanada",
     refreshChat: "Actualitzar xat",
     dismiss: "Descartar",
     whoops: "Vaja! S'ha produït un error",

--- a/play/src/i18n/de-DE/chat.ts
+++ b/play/src/i18n/de-DE/chat.ts
@@ -492,6 +492,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "Erneut verbinden",
     failedToJoinRoom: "Dem Raum konnte nicht beigetreten werden",
     failedToLeaveRoom: "Der Raum konnte nicht verlassen werden",
+    failedToDeclineRoom: "Empfohlenen Raum konnte nicht abgelehnt werden",
     refreshChat: "Chat aktualisieren",
     dismiss: "Ignorieren",
     whoops: "Ups! Ein Fehler ist aufgetreten",

--- a/play/src/i18n/dsb-DE/chat.ts
+++ b/play/src/i18n/dsb-DE/chat.ts
@@ -488,6 +488,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "Znowa zwězaś",
     failedToJoinRoom: "Njejo móžno, se k śpy pśizamknuś",
     failedToLeaveRoom: "Njejo móžno, śpu wóteś",
+    failedToDeclineRoom: "Njejo móžno, dopóruconu śpu wótpokazaś",
     refreshChat: "Chat aktualizěrowaś",
     dismiss: "Ignorěrowaś",
     whoops: "Ups! Zmólka jo nastała",

--- a/play/src/i18n/en-US/chat.ts
+++ b/play/src/i18n/en-US/chat.ts
@@ -486,6 +486,7 @@ const chat: BaseTranslation = {
     reconnect: "Reconnect",
     failedToJoinRoom: "Failed to join room",
     failedToLeaveRoom: "Failed to leave room",
+    failedToDeclineRoom: "Failed to decline suggested room",
     refreshChat: "Refresh Chat",
     dismiss: "Dismiss",
     whoops: "Whoops ! something went wrong",

--- a/play/src/i18n/es-ES/chat.ts
+++ b/play/src/i18n/es-ES/chat.ts
@@ -486,6 +486,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "Reconectar",
     failedToJoinRoom: "Error al unirse a la sala",
     failedToLeaveRoom: "Error al salir de la sala",
+    failedToDeclineRoom: "Error al rechazar la sala sugerida",
     refreshChat: "Actualizar chat",
     dismiss: "Descartar",
     whoops: "¡Ups! Algo salió mal",

--- a/play/src/i18n/fr-FR/chat.ts
+++ b/play/src/i18n/fr-FR/chat.ts
@@ -488,6 +488,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "Se reconnecter",
     failedToJoinRoom: "Impossible de rejoindre la room",
     failedToLeaveRoom: "Impossible de quitter la room",
+    failedToDeclineRoom: "Impossible de refuser le salon suggéré",
     refreshChat: "Rafraichir le chat",
     dismiss: "Ignorer",
     whoops: "Oups ! une erreur est survenue",

--- a/play/src/i18n/hsb-DE/chat.ts
+++ b/play/src/i18n/hsb-DE/chat.ts
@@ -487,6 +487,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "Hišće raz zwězać",
     failedToJoinRoom: "Njemóžno, so k rumej přizamknyć",
     failedToLeaveRoom: "Njemóžno, rum woteć",
+    failedToDeclineRoom: "Njemóžno, doporučenu rumu wotpokazać",
     refreshChat: "Chat aktualizować",
     dismiss: "Ignorować",
     whoops: "Ups! Zmylka je nastała",

--- a/play/src/i18n/it-IT/chat.ts
+++ b/play/src/i18n/it-IT/chat.ts
@@ -488,6 +488,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "Riconnetti",
     failedToJoinRoom: "Impossibile unirsi alla stanza",
     failedToLeaveRoom: "Impossibile lasciare la stanza",
+    failedToDeclineRoom: "Impossibile rifiutare la stanza suggerita",
     refreshChat: "Aggiorna chat",
     dismiss: "Ignora",
     whoops: "Ops! Si è verificato un errore",

--- a/play/src/i18n/ja-JP/chat.ts
+++ b/play/src/i18n/ja-JP/chat.ts
@@ -487,6 +487,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "再接続",
     failedToJoinRoom: "ルームに参加できませんでした",
     failedToLeaveRoom: "ルームを退出できませんでした",
+    failedToDeclineRoom: "推奨ルームを辞退できませんでした",
     refreshChat: "チャットを更新",
     dismiss: "無視",
     whoops: "おっと！エラーが発生しました",

--- a/play/src/i18n/ko-KR/chat.ts
+++ b/play/src/i18n/ko-KR/chat.ts
@@ -487,6 +487,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "다시 연결",
     failedToJoinRoom: "방 참가 실패",
     failedToLeaveRoom: "방 나가기 실패",
+    failedToDeclineRoom: "추천 방 거절 실패",
     refreshChat: "채팅 새로고침",
     dismiss: "닫기",
     whoops: "앗! 문제가 발생했습니다",

--- a/play/src/i18n/nl-NL/chat.ts
+++ b/play/src/i18n/nl-NL/chat.ts
@@ -488,6 +488,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "Opnieuw verbinden",
     failedToJoinRoom: "Kon niet deelnemen aan de kamer",
     failedToLeaveRoom: "Kon de kamer niet verlaten",
+    failedToDeclineRoom: "Aanbevolen kamer kon niet worden geweigerd",
     refreshChat: "Chat vernieuwen",
     dismiss: "Negeren",
     whoops: "Oeps! Er is een fout opgetreden",

--- a/play/src/i18n/pt-BR/chat.ts
+++ b/play/src/i18n/pt-BR/chat.ts
@@ -487,6 +487,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "Reconectar",
     failedToJoinRoom: "Falha ao entrar na sala",
     failedToLeaveRoom: "Falha ao sair da sala",
+    failedToDeclineRoom: "Falha ao recusar a sala sugerida",
     refreshChat: "Atualizar Chat",
     dismiss: "Dispensar",
     whoops: "Ops! algo deu errado",

--- a/play/src/i18n/zh-CN/chat.ts
+++ b/play/src/i18n/zh-CN/chat.ts
@@ -482,6 +482,7 @@ const chat: DeepPartial<Translation["chat"]> = {
     reconnect: "重新连接",
     failedToJoinRoom: "加入房间失败",
     failedToLeaveRoom: "离开房间失败",
+    failedToDeclineRoom: "无法拒绝推荐房间",
     refreshChat: "刷新聊天",
     dismiss: "关闭",
     whoops: "哎呀！出错了",


### PR DESCRIPTION
## Problem

Users could not hide suggested rooms they are not interested in. Suggested rooms stayed in the list with no way to dismiss them per folder or per account.

## Solution

- Add a **Decline** button on each suggested room (and in the joinable-rooms list) that records the choice in IndexedDB.
- Store is scoped by **chatId** and **folderId** so each account has its own ignored list per folder.
- Reuse the existing chat IndexedDB database **workadventure-chat** with a new object store `ignoredSuggestedRooms` (compound key `[chatId, folderId]`).
- Apply an optimistic update so the room disappears from the list immediately on click; persistence runs in the background.

## Changes

- **IgnoredSuggestedRoomsService** (new): IndexedDB read/write for ignored suggested rooms; in-memory store keyed by `chatId:folderId`; `addIgnoredRoom(chatId, folderId, roomId)` with optimistic store update.
- **DraftMessageService**: Open same DB `workadventure-chat` and create store `ignoredSuggestedRooms` with keyPath `[chatId, folderId]` when needed.
- **RoomFolder.svelte**: Subscribe to ignored store; derive `filteredSuggestedRooms` and `filteredJoinableRoomsDisplay`; pass `folderId` and `chatId` to `RoomSuggested`.
- **RoomSuggested.svelte**: New props `folderId`, `chatId`; Decline button with same style as invitation decline (`border-danger`, `text-danger`); `preventDefault`/`stopPropagation` on click; call service to add ignored room.
- **i18n**: Add `declineSuggestedRoom` in all chat locales (en-US, fr-FR, de-DE, etc.).