### PR TITLE
fix(chat): set Matrix room alias only for public rooms and make it unique

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -31,16 +31,8 @@ import { MapStore } from "@workadventure/store-utils";
 import { KnownMembership } from "matrix-js-sdk/lib/@types/membership";
 import { defaultWoka } from "@workadventure/shared-utils";
 import { slugify } from "@workadventure/shared-utils/src/Jitsi/slugify";
+import { shortHash } from "@workadventure/shared-utils/src/String/shortHash";
 
-/**
- * Returns a unique room alias local part (no domain) for public rooms/folders.
- * Ensures multiple rooms with the same name get distinct aliases.
- */
-function uniqueRoomAliasName(baseName: string): string {
-    const slug = slugify(baseName) || "room";
-    const uuid = crypto.randomUUID().replace(/-/g, "");
-    return `${slug}-${uuid}`;
-}
 import { AvailabilityStatus } from "@workadventure/messages";
 import type { VerificationRequest } from "matrix-js-sdk/lib/crypto-api";
 import { canAcceptVerificationRequest } from "matrix-js-sdk/lib/crypto-api";
@@ -461,6 +453,16 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             wokaImageSrc: get(currentPlayerWokaStore),
             forceSync,
         });
+    }
+
+    /**
+     * Returns a unique room alias local part (no domain) for public rooms/folders.
+     * Ensures multiple rooms with the same name get distinct aliases.
+     */
+    private uniqueRoomAliasName(baseName: string): string {
+        const slug = slugify(baseName) || "room";
+        const hash = shortHash(crypto.randomUUID());
+        return `${slug}-${hash}`;
     }
 
     private setPresence(status: AvailabilityStatus): void {
@@ -1061,7 +1063,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         return {
             name: roomName.trim(),
             visibility: roomOptions.visibility as Visibility | undefined,
-            ...(roomOptions.visibility === "public" && { room_alias_name: uniqueRoomAliasName(roomName) }),
+            ...(roomOptions.visibility === "public" && { room_alias_name: this.uniqueRoomAliasName(roomName) }),
             invite:
                 roomOptions.invite
                     ?.map((invitation) => invitation.value)
@@ -1085,7 +1087,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         return {
             name: roomName.trim(),
             visibility: (roomOptions.visibility === "public" ? "public" : "private") as Visibility | undefined,
-            ...(roomOptions.visibility === "public" && { room_alias_name: uniqueRoomAliasName(roomName) }),
+            ...(roomOptions.visibility === "public" && { room_alias_name: this.uniqueRoomAliasName(roomName) }),
             invite:
                 roomOptions.invite
                     ?.map((invitation) => invitation.value)

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -31,6 +31,16 @@ import { MapStore } from "@workadventure/store-utils";
 import { KnownMembership } from "matrix-js-sdk/lib/@types/membership";
 import { defaultWoka } from "@workadventure/shared-utils";
 import { slugify } from "@workadventure/shared-utils/src/Jitsi/slugify";
+
+/**
+ * Returns a unique room alias local part (no domain) for public rooms/folders.
+ * Ensures multiple rooms with the same name get distinct aliases.
+ */
+function uniqueRoomAliasName(baseName: string): string {
+    const slug = slugify(baseName) || "room";
+    const uuid = crypto.randomUUID().replace(/-/g, "");
+    return `${slug}-${uuid}`;
+}
 import { AvailabilityStatus } from "@workadventure/messages";
 import type { VerificationRequest } from "matrix-js-sdk/lib/crypto-api";
 import { canAcceptVerificationRequest } from "matrix-js-sdk/lib/crypto-api";
@@ -1045,10 +1055,13 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             throw new Error("Room name is undefined");
         }
 
+        // When MSC4362 (encrypted state events) is supported: for rooms created with state encryption
+        // enabled, omit `name` here and call client.setRoomName(room_id, name) after creation so the
+        // client can send the name as an encrypted state event. Currently we send the name in createRoom.
         return {
             name: roomName.trim(),
             visibility: roomOptions.visibility as Visibility | undefined,
-            room_alias_name: slugify(roomName),
+            ...(roomOptions.visibility === "public" && { room_alias_name: uniqueRoomAliasName(roomName) }),
             invite:
                 roomOptions.invite
                     ?.map((invitation) => invitation.value)
@@ -1072,7 +1085,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         return {
             name: roomName.trim(),
             visibility: (roomOptions.visibility === "public" ? "public" : "private") as Visibility | undefined,
-            room_alias_name: slugify(roomName),
+            ...(roomOptions.visibility === "public" && { room_alias_name: uniqueRoomAliasName(roomName) }),
             invite:
                 roomOptions.invite
                     ?.map((invitation) => invitation.value)


### PR DESCRIPTION
## Problem

- Room alias (`room_alias_name`) was sent for every room and folder, so two rooms with the same name caused an alias conflict (Matrix requires alias uniqueness per server).
- This effectively prevented creating multiple rooms with the same name, although the Matrix spec allows duplicate room names.

## Solution

- Send `room_alias_name` only when `visibility === "public"` (for both rooms and folders), matching the spec that aliases are mainly for public rooms.
- For public rooms and folders, generate a unique alias with `uniqueRoomAliasName()` (slug + UUID) so multiple public rooms with the same name can coexist without alias conflicts.

## Changes

- **`play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts`**
  - `mapCreateRoomOptionsToMatrixCreateRoomOptions`: add `room_alias_name` only if `roomOptions.visibility === "public"`, using `uniqueRoomAliasName(roomName)`.
  - `mapCreateRoomOptionsToMatrixCreateFolderOptions`: same for folders (spaces).
  - New helper `uniqueRoomAliasName(baseName)`: returns `slugify(baseName) || "room"` + `-` + `crypto.randomUUID().replace(/-/g, "")` for a unique alias local part.
  - Comment added for future MSC4362 (encrypted state events) and optional `setRoomName` after creation.