### PR TITLE
fix(map-editor): return parsed WAM result in fetchWamFile after migration

### DIFF
--- a/libs/map-editor/src/MapFetcher.ts
+++ b/libs/map-editor/src/MapFetcher.ts
@@ -35,11 +35,13 @@ class MapFetcher {
     ): Promise<WAMFileFormat> {
         try {
             const result = await this.fetchFile(wamUrl, true, true, internalMapStorageUrl, stripPrefix);
-            const parseResult = WAMFileFormat.safeParse(wamFileMigration.migrate(result.data));
-            if (!parseResult) {
+            const migratedResult = wamFileMigration.migrate(result.data);
+            const parseResult = WAMFileFormat.safeParse(migratedResult);
+
+            if (!parseResult.success) {
                 throw new LocalUrlError(`Invalid wam file format for: ${wamUrl}`);
             }
-            return result.data as WAMFileFormat;
+            return parseResult.data;
         } catch {
             throw new LocalUrlError(`Invalid wam file format for: ${wamUrl}`);
         }


### PR DESCRIPTION
## Problem

`MapFetcher.fetchWamFile` was applying migrations and parsing the WAM file with `WAMFileFormat.safeParse(wamFileMigration.migrate(result.data))`, but it returned `result.data as WAMFileFormat` instead of the parse result. Callers therefore received the raw response data instead of the migrated and validated WAM format, so migrations and validation had no effect on the returned value.

## Solution

- Run migration then parse in two steps and keep the parse result.
- Return `parseResult.data` so callers receive the migrated and schema-validated WAM format.

## Changes

- **libs/map-editor/src/MapFetcher.ts**: Store `migratedResult` from `wamFileMigration.migrate(result.data)`, run `WAMFileFormat.safeParse(migratedResult)`, and return `parseResult.data` instead of `result.data`.
- **libs/map-editor/src/GameMap/WamFile.ts**: Debug logging of WAM property IDs in constructor (can be removed before merge if temporary).
- **libs/map-editor/src/Migrations/WamFileMigration.ts**: Debug logging and a TODO for `allowedTags` on `lockableAreaPropertyData`.