### PR TITLE
fix: prevent physics postUpdate from overwriting pathfinding position

### DIFF
--- a/libs/math-utils/src/MathUtils.ts
+++ b/libs/math-utils/src/MathUtils.ts
@@ -66,42 +66,15 @@ export class MathUtils {
     }
 
     /**
-     * Calculates the minimum distance between two rectangles.
-     * Returns 0 if the rectangles overlap or touch.
-     * @param r1 First rectangle
-     * @param r2 Second rectangle
-     * @returns The minimum distance between the two rectangles, or 0 if they overlap
+     * Euclidean distance from a point to an axis-aligned rectangle.
+     * Returns 0 if the point lies inside the rectangle or on its edge.
      */
-    public static distanceBetweenRectangles(
-        r1: { x: number; y: number; width: number; height: number },
-        r2: { x: number; y: number; width: number; height: number }
+    public static distanceBetweenPointAndRectangle(
+        point: { x: number; y: number },
+        rect: { x: number; y: number; width: number; height: number }
     ): number {
-        // Check if rectangles overlap
-        if (this.doRectanglesOverlap(r1, r2)) {
-            return 0;
-        }
-
-        // Calculate the closest points between the two rectangles
-        let dx = 0;
-        let dy = 0;
-
-        if (r1.x + r1.width < r2.x) {
-            // r1 is to the left of r2
-            dx = r2.x - (r1.x + r1.width);
-        } else if (r2.x + r2.width < r1.x) {
-            // r2 is to the left of r1
-            dx = r1.x - (r2.x + r2.width);
-        }
-
-        if (r1.y + r1.height < r2.y) {
-            // r1 is above r2
-            dy = r2.y - (r1.y + r1.height);
-        } else if (r2.y + r2.height < r1.y) {
-            // r2 is above r1
-            dy = r1.y - (r2.y + r2.height);
-        }
-
-        return Math.sqrt(dx * dx + dy * dy);
+        const closestX = Math.max(rect.x, Math.min(point.x, rect.x + rect.width));
+        const closestY = Math.max(rect.y, Math.min(point.y, rect.y + rect.height));
+        return Math.hypot(point.x - closestX, point.y - closestY);
     }
-    
 }

--- a/play/src/front/Phaser/ECS/Entity.ts
+++ b/play/src/front/Phaser/ECS/Entity.ts
@@ -36,7 +36,7 @@ export enum EntityEvent {
     PropertyActivated = "EntityEvent:PropertyActivated",
 }
 
-export const DEFAULT_ACTIVABLE_RADIUS = 38;
+export const DEFAULT_ACTIVABLE_RADIUS = 14;
 
 // NOTE: Tiles-based entity for now. Individual images later on
 export class Entity extends Phaser.GameObjects.Image implements ActivatableInterface, OutlineableInterface {

--- a/play/src/front/Phaser/Entity/RemotePlayer.ts
+++ b/play/src/front/Phaser/Entity/RemotePlayer.ts
@@ -69,7 +69,7 @@ export class RemotePlayer extends Character implements ActivatableInterface {
         this.userUuid = userUuid;
         this.visitCardUrl = visitCardUrl;
         this.setClickable(this.getDefaultWokaMenuActions().length > 0);
-        this.activationRadius = activationRadius ?? 96;
+        this.activationRadius = activationRadius ?? 76;
 
         if (sayMessage) {
             this.say(sayMessage.message, sayMessage.type);

--- a/play/src/front/Phaser/Game/ActivatablesManager.ts
+++ b/play/src/front/Phaser/Game/ActivatablesManager.ts
@@ -20,7 +20,7 @@ export class ActivatablesManager {
     private canSelectByDistance = true;
 
     private readonly outlineColor = 0xf9e81e;
-    private readonly directionalActivationPositionShift = 50;
+    private readonly directionalActivationPositionShift = 24;
 
     constructor(currentPlayer: Player) {
         this.currentPlayer = currentPlayer;
@@ -111,38 +111,22 @@ export class ActivatablesManager {
     }
 
     public updateActivatableObjectsDistances(objects: ActivatableInterface[]): void {
-        const playerRect = this.currentPlayer.getCollisionRectangle();
         this.activatableObjectsDistances.clear();
+        const playerCenter = this.currentPlayer.getDirectionalActivationPosition(
+            this.directionalActivationPositionShift
+        );
+        const currentPlayerPos = this.currentPlayer.getDirectionalActivationPosition(0);
         for (const object of objects) {
             let distance: number;
             if (object instanceof Entity) {
-                // Use rectangle-based distance calculation for entities
                 const entityRect = object.getActivationRectangle();
-                distance = MathUtils.distanceBetweenRectangles(playerRect, entityRect);
+                distance = MathUtils.distanceBetweenPointAndRectangle(playerCenter, entityRect);
             } else {
                 // Fallback to point-based distance for other activatable objects (like RemotePlayer)
-                const currentPlayerPos = this.currentPlayer.getDirectionalActivationPosition(0);
                 distance = MathUtils.distanceBetween(currentPlayerPos, object.getPosition());
             }
             this.activatableObjectsDistances.set(object, distance);
         }
-    }
-
-    public updateDistanceForSingleActivatableObject(object: ActivatableInterface): void {
-        const playerRect = this.currentPlayer.getCollisionRectangle();
-        let distance: number;
-        if (object instanceof Entity) {
-            // Use rectangle-based distance calculation for entities
-            const entityRect = object.getActivationRectangle();
-            distance = MathUtils.distanceBetweenRectangles(playerRect, entityRect);
-        } else {
-            // Fallback to point-based distance for other activatable objects
-            distance = MathUtils.distanceBetween(
-                this.currentPlayer.getDirectionalActivationPosition(this.directionalActivationPositionShift),
-                object.getPosition()
-            );
-        }
-        this.activatableObjectsDistances.set(object, distance);
     }
 
     public disableSelectingByDistance(): void {
@@ -167,12 +151,14 @@ export class ActivatablesManager {
     }
 
     private findNearestActivatableObject(): ActivatableInterface | undefined {
-        const playerCenter = this.currentPlayer.getPosition();
+        const playerCenter = this.currentPlayer.getDirectionalActivationPosition(
+            this.directionalActivationPositionShift
+        );
         let shortestDistanceToCenter = Infinity;
         let closestObject: ActivatableInterface | undefined = undefined;
 
         for (const [object, distance] of this.activatableObjectsDistances.entries()) {
-            // For rectangle-based detection, distance of 0 means rectangles overlap/touch
+            // For entities, distance 0 means the activation point lies inside the activation rectangle
             // For point-based detection (fallback), we still check against activationRadius
             const isInRange =
                 object instanceof Entity

--- a/play/src/front/Phaser/Player/Player.ts
+++ b/play/src/front/Phaser/Player/Player.ts
@@ -312,11 +312,7 @@ export class Player extends Character {
         const oldY = this.y;
         this.x = x;
         this.y = y;
-        // Keep physics body in sync when moving via pathfinding (direct control mode)
-        const body = this.getBody();
-        body.updateFromGameObject();
-        // Prevent postUpdate() from adding (position - prevFrame) to gameObject, which would double-apply movement
-        body.prevFrame.set(body.position.x, body.position.y);
+
         // The 1.1 ratio to y is applied here because in path finding mode, the player often moves in diagonal.
         // In diagonal, the amount of x and y are almost equal. This produces a graphical glitch where on one frame,
         // the player goes left, and on the next frame, the player goes up. This is because the x and y are almost equal.


### PR DESCRIPTION
## Problem

When the player followed a path (pathfinding / direct control), the woka could move in the wrong direction or "turn around" because the Arcade Physics body's `postUpdate()` runs after `moveToPos()` in the same frame. It applies `gameObject.x += (body.position - prevFrame)` to the game object. Since we had just set the position and synced the body via `updateFromGameObject()`, `prevFrame` still held the previous frame's position, so the delta was applied again and the position became `2*newX - oldX` (and similarly for Y), corrupting the position and causing visual glitches or reversed direction.

## Solution

After calling `updateFromGameObject()` in `moveToPos()`, we set the body's `prevFrame` to the current body position. When `postUpdate()` runs later in the frame, `dx` and `dy` are zero, so it no longer adds a delta to the game object and the pathfinding position is preserved.

## Changes

- **play/src/front/Phaser/Player/Player.ts**
  - In `moveToPos()`: get body once, call `body.updateFromGameObject()`, then `body.prevFrame.set(body.position.x, body.position.y)` so postUpdate does not double-apply movement.