### PR TITLE
Remove room creation and deletion logic in favor of LiveKit server handling

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -60,6 +60,7 @@ import { VariableError } from "../Services/VariableError";
 import { VariablesManager } from "../Services/VariablesManager";
 import type { AreaPropertyVariable } from "../Services/AreaPropertyVariablesManager";
 import { AreaPropertyVariablesManager } from "../Services/AreaPropertyVariablesManager";
+import { clientEventsEmitter } from "../Services/ClientEventsEmitter";
 import { AreaZoneTracker } from "./AreaZoneTracker";
 import type { BrothersFinder } from "./BrothersFinder";
 import { Group } from "./Group";
@@ -333,6 +334,8 @@ export class GameRoom implements BrothersFinder {
             admin.sendUserJoin(user.uuid, user.name, user.IPAddress);
         }
 
+        clientEventsEmitter.clientJoinSubject.next({ clientUUid: user.uuid, roomId: this._roomUrl });
+
         return user;
     }
 
@@ -385,6 +388,7 @@ export class GameRoom implements BrothersFinder {
         }
 
         this._userLeaveStream.next(user);
+        clientEventsEmitter.clientLeaveSubject.next({ clientUUid: user.uuid, roomId: this._roomUrl });
     }
 
     public isEmpty(): boolean {

--- a/back/src/Model/Services/LivekitService.ts
+++ b/back/src/Model/Services/LivekitService.ts
@@ -1,8 +1,7 @@
 import crypto from "crypto";
 import type { SpaceUser } from "@workadventure/messages";
-import type { CreateOptions, EgressInfo, EncodedOutputs } from "livekit-server-sdk";
+import type { EgressInfo, EncodedOutputs } from "livekit-server-sdk";
 import {
-    RoomServiceClient,
     AccessToken,
     TrackSource,
     EgressClient,
@@ -23,25 +22,16 @@ import {
 
 const debug = Debug("LivekitService");
 
-const defaultRoomServiceClient = (livekitHost: string, livekitApiKey: string, livekitApiSecret: string) =>
-    new RoomServiceClient(livekitHost, livekitApiKey, livekitApiSecret);
-
 const defaultEgressClient = (livekitHost: string, livekitApiKey: string, livekitApiSecret: string) =>
     new EgressClient(livekitHost, livekitApiKey, livekitApiSecret);
 
 export class LiveKitService {
-    private roomServiceClient: RoomServiceClient;
     private egressClient: EgressClient;
     constructor(
         private livekitHost: string,
         private livekitApiKey: string,
         private livekitApiSecret: string,
         private livekitFrontendUrl: string,
-        createRoomServiceClient: (
-            livekitHost: string,
-            livekitApiKey: string,
-            livekitApiSecret: string
-        ) => RoomServiceClient = defaultRoomServiceClient,
         createEgressClient: (
             livekitHost: string,
             livekitApiKey: string,
@@ -52,30 +42,10 @@ export class LiveKitService {
             debug("Livekit host, api key or secret is not set");
             throw new Error("Livekit host, api key or secret is not set");
         }
-        this.roomServiceClient = createRoomServiceClient(this.livekitHost, this.livekitApiKey, this.livekitApiSecret);
         this.egressClient = createEgressClient(this.livekitHost, this.livekitApiKey, this.livekitApiSecret);
     }
 
     private currentRecordingInformation: EgressInfo | null = null;
-
-    async createRoom(roomName: string): Promise<void> {
-        // First check if the room already exists
-        const rooms = await this.roomServiceClient.listRooms([roomName]);
-        if (rooms && rooms.length > 0) {
-            return;
-        }
-
-        const hashedRoomName =
-            roomName.length > 250
-                ? crypto.createHash("sha256").update(roomName).digest("hex").substring(0, 250)
-                : roomName;
-        // Room doesn't exist, create it
-        const createOptions: CreateOptions = {
-            name: hashedRoomName,
-        };
-
-        await this.roomServiceClient.createRoom(createOptions);
-    }
 
     async generateToken(roomName: string, user: SpaceUser): Promise<string> {
         const hashedRoomName = this.getHashedRoomName(roomName);
@@ -110,16 +80,6 @@ export class LiveKitService {
         return roomName.length > 250
             ? crypto.createHash("sha256").update(roomName).digest("hex").substring(0, 250)
             : roomName;
-    }
-
-    async deleteRoom(roomName: string): Promise<void> {
-        try {
-            await this.roomServiceClient.deleteRoom(this.getHashedRoomName(roomName));
-        } catch (error) {
-            console.error(`Error deleting room ${roomName}:`, error);
-            // Comment this out to avoid spamming Sentry with errors when rooms are deleted
-            // Sentry.captureException(error);
-        }
     }
 
     private getParticipantIdentity(participantName: string): string {

--- a/back/src/Model/Strategies/LivekitCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/LivekitCommunicationStrategy.ts
@@ -176,7 +176,7 @@ export class LivekitCommunicationStrategy implements IRecordableStrategy {
             this.receivingUsers.set(user.spaceUserId, user);
 
             // Let's only send the invitation if the user is not already streaming in the room
-            if (!this.streamingUsers.has(user.spaceUserId)) {
+            if (!this.streamingUsers.has(user.spaceUserId) && this.streamingUsers.size > 0) {
                 await this.sendLivekitInvitationMessage(user);
             }
         });

--- a/back/src/Model/Strategies/LivekitCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/LivekitCommunicationStrategy.ts
@@ -6,7 +6,6 @@ import type { LiveKitService } from "../Services/LivekitService";
 
 export class LivekitCommunicationStrategy implements IRecordableStrategy {
     private usersReady: Set<string> = new Set();
-    private createRoomPromise: Promise<void> | null = null;
 
     private streamingUsers: Map<string, SpaceUser> = new Map<string, SpaceUser>();
     private receivingUsers: Map<string, SpaceUser> = new Map<string, SpaceUser>();
@@ -51,20 +50,13 @@ export class LivekitCommunicationStrategy implements IRecordableStrategy {
     }
 
     async addUser(user: SpaceUser): Promise<void> {
-        return this.queueUserOperation(user.spaceUserId, async () => {
+        return this.queueUserOperation(user.spaceUserId, () => {
             // Check if the user is already streaming
             if (this.streamingUsers.has(user.spaceUserId)) {
                 console.warn("User already streaming in the room", user.spaceUserId);
                 Sentry.captureMessage(`User already streaming in the room ${user.spaceUserId}`);
-                return;
+                return Promise.resolve();
             }
-
-            // Ensure the Livekit room is created (only once)
-            if (!this.createRoomPromise) {
-                this.createRoomPromise = this.livekitService.createRoom(this.space.getSpaceName());
-            }
-
-            await this.createRoomPromise;
 
             // Send invitation to all receiving users if this is the first room creation
             if (this.receivingUsers.size > 0 && this.streamingUsers.size === 0) {
@@ -88,6 +80,7 @@ export class LivekitCommunicationStrategy implements IRecordableStrategy {
                     Sentry.captureException(error);
                 });
             }
+            return Promise.resolve();
         });
     }
 
@@ -111,7 +104,7 @@ export class LivekitCommunicationStrategy implements IRecordableStrategy {
     }
 
     deleteUser(user: SpaceUser): void {
-        this.queueUserOperation(user.spaceUserId, async () => {
+        this.queueUserOperation(user.spaceUserId, () => {
             const deleted = this.streamingUsers.delete(user.spaceUserId);
 
             if (!deleted) {
@@ -124,13 +117,11 @@ export class LivekitCommunicationStrategy implements IRecordableStrategy {
             }
 
             if (this.streamingUsers.size === 0) {
-                this.createRoomPromise = null;
                 for (const receivingUser of this.receivingUsers.values()) {
                     this.sendLivekitDisconnectMessage(receivingUser);
                 }
-
-                await this.livekitService.deleteRoom(this.space.getSpaceName());
             }
+            return Promise.resolve();
         }).catch((error) => {
             console.error(`Error in deleteUser for ${user.spaceUserId}:`, error);
             Sentry.captureException(error);
@@ -183,11 +174,6 @@ export class LivekitCommunicationStrategy implements IRecordableStrategy {
             }
 
             this.receivingUsers.set(user.spaceUserId, user);
-
-            if (!this.createRoomPromise) {
-                return;
-            }
-            await this.createRoomPromise;
 
             // Let's only send the invitation if the user is not already streaming in the room
             if (!this.streamingUsers.has(user.spaceUserId)) {
@@ -255,19 +241,8 @@ export class LivekitCommunicationStrategy implements IRecordableStrategy {
         for (const user of this.receivingUsers.values()) {
             this.deleteUserFromNotify(user);
         }
-        this.livekitService.deleteRoom(this.space.getSpaceName()).catch((error) => {
-            console.error(error);
-            Sentry.captureException(error);
-        });
     }
     async startRecording(user: SpaceUser): Promise<void> {
-        if (!this.createRoomPromise) {
-            console.warn("Room not created yet");
-            Sentry.captureMessage("[LivekitCommunicationStrategy] Room not created yet when starting recording");
-            return;
-        }
-
-        await this.createRoomPromise;
         await this.livekitService.startRecording(this.space.getSpaceName(), user, user.uuid);
     }
     async stopRecording(): Promise<void> {

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -317,8 +317,9 @@ export class SocketManager {
             //user leave previous world
             room.leave(user);
             this.cleanupRoomIfEmpty(room);
-        } finally {
-            clientEventsEmitter.clientLeaveSubject.next({ clientUUid: user.uuid, roomId: room.roomUrl });
+        } catch (e) {
+            console.error("Error while leaving room", e);
+            Sentry.captureException(e);
         }
     }
 
@@ -384,8 +385,6 @@ export class SocketManager {
 
         //join world
         const user = await room.join(socket, joinRoomMessage);
-
-        clientEventsEmitter.clientJoinSubject.next({ clientUUid: user.uuid, roomId: roomId });
 
         return { room, user };
     }


### PR DESCRIPTION
This PR removes the existing createRoom and deleteRoom functions from the codebase. These responsibilities are now delegated to the LiveKit server, which natively manages room lifecycle operations.

By relying on LiveKit’s built-in handling, we simplify our application logic, reduce redundancy, and ensure more consistent room management aligned with LiveKit’s standards.
