### PR TITLE
feat(livekit): check LiveKit connection when joining the room

### DIFF
--- a/back/src/Model/Services/LivekitService.ts
+++ b/back/src/Model/Services/LivekitService.ts
@@ -23,6 +23,8 @@ import {
     LIVEKIT_RECORDING_S3_REGION,
 } from "../../Enum/EnvironmentVariable";
 
+import type { LivekitCredentialsResponse } from "../../Services/Repository/LivekitCredentialsResponse";
+
 const defaultRoomServiceClient = (livekitHost: string, livekitApiKey: string, livekitApiSecret: string) =>
     new RoomServiceClient(livekitHost, livekitApiKey, livekitApiSecret);
 
@@ -105,6 +107,35 @@ export class LiveKitService {
         this.roomServiceClient = createRoomServiceClient(this.livekitHost, this.livekitApiKey, this.livekitApiSecret);
         this.egressClient = createEgressClient(this.livekitHost, this.livekitApiKey, this.livekitApiSecret);
         this.webhookReceiver = createWebhookReceiver(this.livekitApiKey, this.livekitApiSecret);
+    }
+
+    static createTokenForTestOfConnection(livekitCredentials: LivekitCredentialsResponse): Promise<string> {
+        const uuid = crypto.randomUUID();
+        const hashedRoomName = getLivekitRoomName(uuid);
+
+        const { livekitApiKey, livekitApiSecret } = livekitCredentials;
+
+        const token = new AccessToken(livekitApiKey, livekitApiSecret, {
+            identity: uuid,
+            name: uuid,
+            // This token is only used for a one-shot connection test right after joining, so keep it short-lived.
+            ttl: "5m",
+        });
+        token.addGrant({
+            room: hashedRoomName,
+            // Note: everyone can publish in Livekit, moderation is handled at application level. If a user should
+            // not have published, its VideoBox will never be visible by anyone anyway.
+            canPublish: true,
+            canSubscribe: true,
+            roomJoin: true,
+            canPublishSources: [
+                TrackSource.CAMERA,
+                TrackSource.MICROPHONE,
+                TrackSource.SCREEN_SHARE,
+                TrackSource.SCREEN_SHARE_AUDIO,
+            ],
+        });
+        return token.toJwt();
     }
 
     async createRoom(roomName: string): Promise<void> {

--- a/back/src/Model/States/StateFactory.ts
+++ b/back/src/Model/States/StateFactory.ts
@@ -1,17 +1,12 @@
 import type { SpaceUser } from "@workadventure/messages";
-import { getCapability } from "../../Services/Capabilities";
-import { adminApi } from "../../Services/AdminApi";
-import { LIVEKIT_API_KEY, LIVEKIT_API_SECRET, LIVEKIT_HOST } from "../../Enum/EnvironmentVariable";
 import type { ICommunicationSpace } from "../Interfaces/ICommunicationSpace";
 import type { ICommunicationState } from "../Interfaces/ICommunicationState";
 import { CommunicationType } from "../Types/CommunicationTypes";
 import type { ICommunicationStrategy } from "../Interfaces/ICommunicationStrategy";
+import { getLivekitCredentials } from "../../Utils/livekitCredentials";
 import { LivekitState } from "./LivekitState";
 import { WebRTCState } from "./WebRTCState";
 import { VoidState } from "./VoidState";
-
-const LIVEKIT_CREDENTIALS_CAPABILITY = "api/livekit/credentials";
-const LIVKEIT_CREDENTIALS_VERSION = "v1";
 
 export interface StateFactoryOptions {
     playUri?: string;
@@ -51,26 +46,7 @@ export class StateFactory {
         usersToNotify: ReadonlyMap<string, SpaceUser>,
         playUri?: string,
     ): Promise<LivekitState> {
-        if (getCapability(LIVEKIT_CREDENTIALS_CAPABILITY) === LIVKEIT_CREDENTIALS_VERSION) {
-            if (!playUri) {
-                throw new Error("playUri is required when using AdminAPI for Livekit credentials");
-            }
-            const credentials = await adminApi.fetchLivekitCredentials(space.getSpaceName(), playUri);
-            return new LivekitState(space, credentials, users, usersToNotify);
-        } else {
-            if (!LIVEKIT_HOST || !LIVEKIT_API_KEY || !LIVEKIT_API_SECRET) {
-                throw new Error("Livekit credentials are not set in environment variables");
-            }
-            return new LivekitState(
-                space,
-                {
-                    livekitHost: LIVEKIT_HOST,
-                    livekitApiKey: LIVEKIT_API_KEY,
-                    livekitApiSecret: LIVEKIT_API_SECRET,
-                },
-                users,
-                usersToNotify,
-            );
-        }
+        const credentials = await getLivekitCredentials(playUri);
+        return new LivekitState(space, credentials, users, usersToNotify);
     }
 }

--- a/back/src/Model/User.ts
+++ b/back/src/Model/User.ts
@@ -18,10 +18,12 @@ import type { PositionNotifier } from "../Model/PositionNotifier";
 import type { Zone } from "../Model/Zone";
 import { PlayerVariables } from "../Services/PlayersRepository/PlayerVariables";
 import { getPlayersVariablesRepository } from "../Services/PlayersRepository/PlayersVariablesRepository";
+import { getLivekitCredentials, isLivekitAvailable } from "../Utils/livekitCredentials";
 import type { BrothersFinder } from "./BrothersFinder";
-import type { CustomJsonReplacerInterface } from "./CustomJsonReplacerInterface";
 import type { Group } from "./Group";
+import type { CustomJsonReplacerInterface } from "./CustomJsonReplacerInterface";
 import type { PointInterface } from "./Websocket/PointInterface";
+import { LiveKitService } from "./Services/LivekitService";
 
 export type UserSocket = ServerDuplexStream<PusherToBackMessage, ServerToClientMessage>;
 
@@ -344,6 +346,28 @@ export class User implements Movable, CustomJsonReplacerInterface {
                 });
             }
         }
+    }
+
+    public async sendLivekitCredentialsForTestOfConnection(roomUrl: string): Promise<void> {
+        // Only run the LiveKit connection test when LiveKit is actually available in this deployment.
+        // On WebRTC-only deployments (no admin capability and no LIVEKIT_* env vars) this would throw
+        // and report an error on every single join, so we skip it entirely.
+        if (!isLivekitAvailable()) {
+            return;
+        }
+
+        const credentials = await getLivekitCredentials(roomUrl);
+        const token = await LiveKitService.createTokenForTestOfConnection(credentials);
+
+        this.socket.write({
+            message: {
+                $case: "livekitCredentialsMessage",
+                livekitCredentialsMessage: {
+                    token,
+                    url: credentials.livekitHost.replace("http", "ws"),
+                },
+            },
+        });
     }
 
     public customJsonReplacer(key: unknown, value: unknown): string | undefined {

--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -96,6 +96,16 @@ const roomManager = {
                         const myUser = await socketManager.handleJoinRoom(call, room, message.message.joinRoomMessage);
                         if (call.writable) {
                             setUser(myUser);
+
+                            if (room) {
+                                myUser.sendLivekitCredentialsForTestOfConnection(room.roomUrl).catch((e) => {
+                                    console.error(
+                                        "Error sending livekit credentials to the pusher for the test of connection livekit: ",
+                                        e,
+                                    );
+                                    Sentry.captureException(e);
+                                });
+                            }
                         } else {
                             // Connection may have been closed before the init was finished, so we have to manually disconnect the user.
                             if (room) {

--- a/back/src/Services/AdminApi.ts
+++ b/back/src/Services/AdminApi.ts
@@ -6,7 +6,7 @@ import { ADMIN_API_TOKEN, ADMIN_API_URL } from "../Enum/EnvironmentVariable";
 import { LivekitCredentialsResponse } from "./Repository/LivekitCredentialsResponse";
 
 class AdminApi {
-    async fetchLivekitCredentials(spaceId: string, playUri: string): Promise<LivekitCredentialsResponse> {
+    async fetchLivekitCredentials(playUri: string): Promise<LivekitCredentialsResponse> {
         if (!ADMIN_API_URL) {
             return Promise.reject(new Error("No admin backoffice set!"));
         }

--- a/back/src/Utils/livekitCredentials.ts
+++ b/back/src/Utils/livekitCredentials.ts
@@ -1,0 +1,38 @@
+import { LIVEKIT_API_KEY, LIVEKIT_API_SECRET, LIVEKIT_HOST } from "../Enum/EnvironmentVariable";
+import { adminApi } from "../Services/AdminApi";
+import { getCapability } from "../Services/Capabilities";
+import type { LivekitCredentialsResponse } from "../Services/Repository/LivekitCredentialsResponse";
+
+const LIVEKIT_CREDENTIALS_CAPABILITY = "api/livekit/credentials";
+const LIVEKIT_CREDENTIALS_VERSION = "v1";
+
+/**
+ * Returns true if LiveKit can be used in this deployment, either through the admin API
+ * (capability "api/livekit/credentials") or through environment variables.
+ * Used to avoid running LiveKit-specific logic (e.g. the connection test) on deployments
+ * that rely on WebRTC only and have no LiveKit configured.
+ */
+export const isLivekitAvailable = (): boolean => {
+    if (getCapability(LIVEKIT_CREDENTIALS_CAPABILITY) === LIVEKIT_CREDENTIALS_VERSION) {
+        return true;
+    }
+    return Boolean(LIVEKIT_HOST && LIVEKIT_API_KEY && LIVEKIT_API_SECRET);
+};
+
+export const getLivekitCredentials = async (playUri?: string): Promise<LivekitCredentialsResponse> => {
+    if (getCapability(LIVEKIT_CREDENTIALS_CAPABILITY) === LIVEKIT_CREDENTIALS_VERSION) {
+        if (!playUri) {
+            throw new Error("playUri is required when using the admin API for LiveKit credentials");
+        }
+        return adminApi.fetchLivekitCredentials(playUri);
+    }
+
+    if (!LIVEKIT_HOST || !LIVEKIT_API_KEY || !LIVEKIT_API_SECRET) {
+        throw new Error("Livekit credentials are not set in environment variables");
+    }
+    return {
+        livekitHost: LIVEKIT_HOST,
+        livekitApiKey: LIVEKIT_API_KEY,
+        livekitApiSecret: LIVEKIT_API_SECRET,
+    };
+};

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -1147,6 +1147,12 @@ message MeetingInvitationRequestTooHighMessage {
 message MeetingInvitationRequestClosedMessage {
 }
 
+/** Send by the server to send the livekit credentials for the test of connection livekit */
+message LivekitCredentialsMessage {
+  string token = 1;
+  string url = 2;
+}
+
 // A request sent within a space to mute the audio of a specific user
 message MuteAudioPrivateMessage {
   // The "force" field is filled by the pusher server if the user is an admin
@@ -1365,6 +1371,7 @@ message ServerToClientMessage {
     MeetingInvitationRequestClosedMessage meetingInvitationRequestClosedMessage = 40;
     DuplicateUserConnectedMessage duplicateUserConnectedMessage = 41;
     BackConnectionCloseReasonMessage backConnectionCloseReasonMessage = 42;
+    LivekitCredentialsMessage livekitCredentialsMessage = 43;
   }
 }
 

--- a/play/src/front/Components/PopUp/LivekitConnectionCheckerPopup.svelte
+++ b/play/src/front/Components/PopUp/LivekitConnectionCheckerPopup.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+    import LL from "../../../i18n/i18n-svelte";
+    import { LivekitConnectionStatus } from "../../Livekit/utils/LivekitConnectionChecker";
+    import PopUpContainer from "./PopUpContainer.svelte";
+    import { IconNetworkOff } from "@wa-icons";
+
+    interface Props {
+        status?: LivekitConnectionStatus;
+        onclose?: () => void;
+    }
+
+    const { status = LivekitConnectionStatus.Critical, onclose }: Props = $props();
+
+    function reload() {
+        window.location.reload();
+    }
+</script>
+
+<PopUpContainer reduceOnSmallScreen={true}>
+    <div class="flex flex-col items-center gap-2 pointer-events-auto">
+        <IconNetworkOff font-size="28" color="rgb(234, 110, 83)" />
+        <p class="mt-0 mb-0">
+            {#if status === LivekitConnectionStatus.Critical}
+                {$LL.warning.livekitConnection.critical()}
+            {:else}
+                {$LL.warning.livekitConnection.warning()}
+            {/if}
+        </p>
+    </div>
+    {#snippet buttons()}
+        <button type="button" class="btn btn-secondary w-1/2 justify-center" onclick={reload}>
+            {$LL.error.errorDialog.reload()}
+        </button>
+        <button type="button" class="btn btn-light btn-ghost w-1/2 justify-center" onclick={() => onclose?.()}>
+            {$LL.error.errorDialog.close()}
+        </button>
+    {/snippet}
+</PopUpContainer>

--- a/play/src/front/Components/Toasts/LivekitConnectionCheckerToast.svelte
+++ b/play/src/front/Components/Toasts/LivekitConnectionCheckerToast.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+    import LL from "../../../i18n/i18n-svelte";
+    import { LivekitConnectionStatus } from "../../Livekit/utils/LivekitConnectionChecker";
+    import { toastStore } from "../../Stores/ToastStoreSingleton";
+    import ToastContainer from "./ToastContainer.svelte";
+    import { IconNetworkOff, IconAlertTriangle, IconX } from "@wa-icons";
+
+    interface Props {
+        toastUuid?: string;
+        status: LivekitConnectionStatus;
+        duration?: number;
+    }
+
+    let { toastUuid = "", status, duration = undefined }: Props = $props();
+
+    const theme = $derived(status === LivekitConnectionStatus.Critical ? ("error" as const) : ("secondary" as const));
+
+    function close() {
+        toastStore.removeToast(toastUuid);
+    }
+</script>
+
+<ToastContainer {theme} extraClasses="" {toastUuid} {duration}>
+    <div class="px-1 flex items-center gap-2">
+        {#if status === LivekitConnectionStatus.Critical}
+            <IconNetworkOff color="rgb(234, 110, 83)" />
+            {$LL.warning.livekitConnection.critical()}
+        {:else}
+            <IconAlertTriangle color="rgb(255, 204, 0)" />
+            {$LL.warning.livekitConnection.warning()}
+        {/if}
+    </div>
+    {#snippet buttons()}
+        <button
+            class="flex items-center justify-center p-2 hover:bg-white/10 rounded-full transition-colors"
+            onclick={close}
+            title={$LL.error.errorDialog.close()}
+        >
+            <IconX font-size="18" />
+        </button>
+    {/snippet}
+</ToastContainer>

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -78,6 +78,7 @@ import type {
     MeetingInvitationResponseReceivedMessage,
     MeetingInvitationRequestClosedMessage,
     MeetingInvitationRequestTooHighMessage,
+    LivekitCredentialsMessage,
     VideoQualityReportMessage,
     ClientToServerMessage as ClientToServerMessageTsProto,
     ServerToClientMessage as ServerToClientMessageTsProto,
@@ -263,6 +264,8 @@ export class RoomConnection implements RoomConnection {
     public readonly externalModuleMessage = this._externalModuleMessage.asObservable();
     private readonly _spaceDestroyedMessage = new Subject<SpaceDestroyedMessage>();
     public readonly spaceDestroyedMessage = this._spaceDestroyedMessage.asObservable();
+    private readonly _livekitCredentialsMessageStream = new Subject<LivekitCredentialsMessage>();
+    public readonly livekitCredentialsMessageStream = this._livekitCredentialsMessageStream.asObservable();
 
     private queries = new Map<
         number,
@@ -755,6 +758,12 @@ export class RoomConnection implements RoomConnection {
                 }
                 case "backConnectionCloseReasonMessage": {
                     console.warn("Received an internal back connection close reason message on the front.");
+                    break;
+                }
+                case "livekitCredentialsMessage": {
+                    // Transport layer only forwards the message; the connection test and the
+                    // user-facing UI are handled by the consumer (GameScene).
+                    this._livekitCredentialsMessageStream.next(message.livekitCredentialsMessage);
                     break;
                 }
                 default: {
@@ -2149,6 +2158,7 @@ export class RoomConnection implements RoomConnection {
         this._leaveSpaceRequestMessage.complete();
         this._externalModuleMessage.complete();
         this._spaceDestroyedMessage.complete();
+        this._livekitCredentialsMessageStream.complete();
     }
 
     private goToSelectYourWokaScene(): void {

--- a/play/src/front/Livekit/utils/LivekitConnectionChecker.ts
+++ b/play/src/front/Livekit/utils/LivekitConnectionChecker.ts
@@ -1,0 +1,89 @@
+import { ConnectionCheck, CheckStatus, type CheckInfo } from "livekit-client";
+import { Subject, type Observable } from "rxjs";
+
+export enum LivekitConnectionStatus {
+    Success = "Success",
+    Warning = "Warning",
+    Critical = "Critical",
+}
+
+export interface LivekitCheckSummary {
+    status: LivekitConnectionStatus;
+    failedChecks: string[];
+}
+
+/**
+ * The subset of LiveKit connection checks we rely on to decide what to tell the user.
+ * We keep our own labels instead of using `CheckInfo.name`, which is the check's runtime class
+ * name (`constructor.name`) and gets mangled by the production minifier.
+ */
+export interface LivekitCheckResults {
+    websocket: CheckInfo;
+    webRTC: CheckInfo;
+    turn: CheckInfo;
+    publishAudio: CheckInfo;
+    publishVideo: CheckInfo;
+}
+
+/**
+ * Turns the raw LiveKit check results into a user-facing severity.
+ * Pure function (no I/O) so it can be unit-tested in isolation.
+ * - A failing signaling websocket means the user cannot communicate at all -> Critical.
+ * - A degraded media path (webRTC/TURN/publish) only reduces audio/video quality -> Warning.
+ */
+export function classifyLivekitChecks(results: LivekitCheckResults): LivekitCheckSummary {
+    const isFailed = (check: CheckInfo): boolean => check.status === CheckStatus.FAILED;
+
+    const failedChecks = (
+        [
+            ["websocket", results.websocket],
+            ["webRTC", results.webRTC],
+            ["turn", results.turn],
+            ["publishAudio", results.publishAudio],
+            ["publishVideo", results.publishVideo],
+        ] as const
+    )
+        .filter(([, result]) => isFailed(result))
+        .map(([label]) => label);
+
+    let status = LivekitConnectionStatus.Success;
+    if (isFailed(results.websocket)) {
+        status = LivekitConnectionStatus.Critical;
+    } else if ([results.webRTC, results.turn, results.publishAudio, results.publishVideo].some(isFailed)) {
+        status = LivekitConnectionStatus.Warning;
+    }
+
+    return { status, failedChecks };
+}
+
+export class LivekitConnectionChecker {
+    private _connectionCheck: ConnectionCheck;
+
+    private readonly _statusStream = new Subject<LivekitCheckSummary>();
+    public readonly statusStream: Observable<LivekitCheckSummary> = this._statusStream.asObservable();
+
+    constructor(url: string, token: string) {
+        this._connectionCheck = new ConnectionCheck(url, token);
+    }
+
+    public async runConnectionCheck(): Promise<void> {
+        try {
+            // Run the checks sequentially: livekit-client's ConnectionCheck shares internal state between
+            // checks and each check opens its own connection, so running them in parallel is unreliable.
+            // We only run the checks needed to decide the severity shown to the user.
+            const websocket = await this._connectionCheck.checkWebsocket();
+            const webRTC = await this._connectionCheck.checkWebRTC();
+            const turn = await this._connectionCheck.checkTURN();
+            const publishAudio = await this._connectionCheck.checkPublishAudio();
+            const publishVideo = await this._connectionCheck.checkPublishVideo();
+
+            this._statusStream.next(classifyLivekitChecks({ websocket, webRTC, turn, publishAudio, publishVideo }));
+        } catch (e) {
+            console.error("Error during global Livekit connection check", e);
+            this._statusStream.next({
+                status: LivekitConnectionStatus.Critical,
+                failedChecks: ["GlobalFailure"],
+            });
+        }
+    }
+}

--- a/play/src/front/Livekit/utils/livekitConnectionCheckHandler.ts
+++ b/play/src/front/Livekit/utils/livekitConnectionCheckHandler.ts
@@ -1,0 +1,56 @@
+import * as Sentry from "@sentry/svelte";
+import { toastStore } from "../../Stores/ToastStoreSingleton";
+import { popupStore } from "../../Stores/PopupStore";
+import LivekitConnectionCheckerToast from "../../Components/Toasts/LivekitConnectionCheckerToast.svelte";
+import LivekitConnectionCheckerPopup from "../../Components/PopUp/LivekitConnectionCheckerPopup.svelte";
+import { LivekitConnectionChecker, LivekitConnectionStatus } from "./LivekitConnectionChecker";
+
+const LIVEKIT_CONNECTION_CHECK_POPUP_ID = "livekit-connection-check";
+const WARNING_TOAST_DURATION = 20000;
+
+/**
+ * Runs the LiveKit connection test (using the credentials the server sent right after joining)
+ * and surfaces the result to the user:
+ * - Success: nothing shown.
+ * - Warning (degraded media path): a transient toast.
+ * - Critical (cannot communicate at all): a persistent popup with a reload action.
+ */
+export function runLivekitConnectionCheck(url: string, token: string): void {
+    const checker = new LivekitConnectionChecker(url, token);
+
+    const subscription = checker.statusStream.subscribe((summary) => {
+        subscription.unsubscribe();
+
+        if (summary.status === LivekitConnectionStatus.Success) {
+            return;
+        }
+
+        console.warn(
+            `[Livekit Connection Check] Status: ${summary.status}. Failed checks: ${summary.failedChecks.join(", ")}`,
+        );
+
+        // Report to Sentry so we can measure how often users hit LiveKit connectivity issues in the field.
+        Sentry.captureMessage(`LiveKit connection check ${summary.status}: ${summary.failedChecks.join(", ")}`, {
+            level: summary.status === LivekitConnectionStatus.Critical ? "error" : "warning",
+            extra: { status: summary.status, failedChecks: summary.failedChecks },
+        });
+
+        if (summary.status === LivekitConnectionStatus.Critical) {
+            popupStore.addPopup(
+                LivekitConnectionCheckerPopup,
+                { status: summary.status },
+                LIVEKIT_CONNECTION_CHECK_POPUP_ID,
+            );
+        } else {
+            toastStore.addToast(
+                LivekitConnectionCheckerToast,
+                { status: summary.status, duration: WARNING_TOAST_DURATION },
+                undefined,
+            );
+        }
+    });
+
+    checker.runConnectionCheck().catch((err) => {
+        console.error("Error during Livekit connection check", err);
+    });
+}

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -121,6 +121,7 @@ import NoMicrophoneSoundToast from "../../Components/Toasts/NoMicrophoneSoundToa
 import { LL, locale } from "../../../i18n/i18n-svelte";
 import { toastStore } from "../../Stores/ToastStoreSingleton";
 import { audioInterruptedStore } from "../../Stores/AudioInterruptedStore";
+import { runLivekitConnectionCheck } from "../../Livekit/utils/livekitConnectionCheckHandler";
 import { GameSceneUserInputHandler } from "../UserInput/GameSceneUserInputHandler";
 import { followUsersColorStore, followUsersStore } from "../../Stores/FollowStore";
 import { axiosWithRetry, hideConnectionIssueMessage, showConnectionIssueMessage } from "../../Connection/AxiosUtils";
@@ -2097,6 +2098,12 @@ export class GameScene extends DirtyScene {
                 //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
                 this.connection.deleteMapMessageStream.subscribe(() => {
                     mapDeletedPromptStore.set(true);
+                });
+
+                // The livekitCredentialsMessageStream stream is completed in the RoomConnection. No need to unsubscribe.
+                //eslint-disable-next-line rxjs/no-ignored-subscription, svelte/no-ignored-unsubscribe
+                this.connection.livekitCredentialsMessageStream.subscribe((message) => {
+                    runLivekitConnectionCheck(message.url, message.token);
                 });
 
                 // The playerDetailsUpdatedMessageStream stream is completed in the RoomConnection. No need to unsubscribe.

--- a/play/src/i18n/ar-SA/warning.ts
+++ b/play/src/i18n/ar-SA/warning.ts
@@ -23,6 +23,10 @@ const warning: DeepPartial<Translation["warning"]> = {
     backgroundProcessing: {
         failedToApply: "فشل في تطبيق تأثيرات الخلفية",
     },
+    livekitConnection: {
+        critical: "قد تواجه مشكلات في التواصل مع المستخدمين الآخرين.",
+        warning: "قد تنخفض جودة الصوت أو الفيديو لديك.",
+    },
     popupBlocked: {
         title: "تم حظر النوافذ المنبثقة", // "Popup blocked"
         content: "يرجى السماح بالنوافذ المنبثقة لهذا الموقع في إعدادات متصفحك.", // "Please allow popups for this site in your browser settings."

--- a/play/src/i18n/ca-ES/warning.ts
+++ b/play/src/i18n/ca-ES/warning.ts
@@ -24,6 +24,10 @@ const warning: DeepPartial<Translation["warning"]> = {
     backgroundProcessing: {
         failedToApply: "Error en aplicar els efectes de fons",
     },
+    livekitConnection: {
+        critical: "És possible que tinguis problemes de comunicació amb altres usuaris.",
+        warning: "La qualitat d'àudio o vídeo es podria veure reduïda.",
+    },
     popupBlocked: {
         title: "Bloqueig de finestres emergents",
         content:

--- a/play/src/i18n/de-DE/warning.ts
+++ b/play/src/i18n/de-DE/warning.ts
@@ -36,6 +36,10 @@ const warning: DeepPartial<Translation["warning"]> = {
         confirmContinue: "Verstanden, fortfahren",
         dontRemindAgain: "Diese Meldung nicht mehr anzeigen",
     },
+    livekitConnection: {
+        critical: "Es könnten Kommunikationsprobleme mit anderen Benutzern auftreten.",
+        warning: "Die Audio- oder Videoqualität könnte beeinträchtigt sein.",
+    },
     browserNotSupported: {
         title: "😢 Browser wird nicht unterstützt",
         message: "Ihr Browser ({browserName}) wird von WorkAdventure nicht mehr unterstützt.",

--- a/play/src/i18n/dsb-DE/warning.ts
+++ b/play/src/i18n/dsb-DE/warning.ts
@@ -23,6 +23,10 @@ const warning: DeepPartial<Translation["warning"]> = {
     backgroundProcessing: {
         failedToApply: "Zastosowanje pozadkowych efektow jo se njeraźiło",
     },
+    livekitConnection: {
+        critical: "You might encounter communication problems with other users.",
+        warning: "Your audio or video quality might be reduced.",
+    },
     popupBlocked: {
         title: "Pop-up-bloker",
         content: "Zwól pop-upy za ten webbok we nastajenjach browsera.",

--- a/play/src/i18n/en-US/warning.ts
+++ b/play/src/i18n/en-US/warning.ts
@@ -34,6 +34,10 @@ const warning: BaseTranslation = {
         confirmContinue: "I understand, continue",
         dontRemindAgain: "Don't show this message again",
     },
+    livekitConnection: {
+        critical: "You might encounter communication problems with other users.",
+        warning: "Your audio or video quality might be reduced.",
+    },
     browserNotSupported: {
         title: "😢 Browser Not Supported",
         message: "Your browser ({browserName}) is no longer supported by WorkAdventure.",

--- a/play/src/i18n/es-ES/warning.ts
+++ b/play/src/i18n/es-ES/warning.ts
@@ -23,6 +23,10 @@ const warning: DeepPartial<Translation["warning"]> = {
     backgroundProcessing: {
         failedToApply: "Error al aplicar los efectos de fondo",
     },
+    livekitConnection: {
+        critical: "Es posible que experimente problemas de comunicación con otros usuarios.",
+        warning: "La calidad de audio o video podría verse reducida.",
+    },
     popupBlocked: {
         title: "Bloqueo de ventanas emergentes",
         content: "Por favor, permita ventanas emergentes para este sitio web en la configuración de su navegador.",

--- a/play/src/i18n/fr-FR/warning.ts
+++ b/play/src/i18n/fr-FR/warning.ts
@@ -35,6 +35,10 @@ const warning: DeepPartial<Translation["warning"]> = {
         confirmContinue: "J'ai compris, continuer",
         dontRemindAgain: "Ne plus afficher ce message",
     },
+    livekitConnection: {
+        critical: "Vous pourriez rencontrer des problèmes de communication avec les autres utilisateurs.",
+        warning: "La qualité de votre audio ou de votre vidéo pourrait être réduite.",
+    },
     browserNotSupported: {
         title: "😢 Navigateur non supporté",
         message: "Votre navigateur ({browserName}) n'est plus supporté par WorkAdventure.",

--- a/play/src/i18n/hsb-DE/warning.ts
+++ b/play/src/i18n/hsb-DE/warning.ts
@@ -25,6 +25,10 @@ const warning: DeepPartial<Translation["warning"]> = {
     backgroundProcessing: {
         failedToApply: "Nałoženje pozadkowych efektow je so njeporadźiło",
     },
+    livekitConnection: {
+        critical: "You might encounter communication problems with other users.",
+        warning: "Your audio or video quality might be reduced.",
+    },
     popupBlocked: {
         title: "Blokěrowanje wuskakowaceho wokna",
         content: "Prošu w browseru wuskakowace wokna za tutu stronu dowolić.",

--- a/play/src/i18n/it-IT/warning.ts
+++ b/play/src/i18n/it-IT/warning.ts
@@ -36,6 +36,10 @@ const warning: DeepPartial<Translation["warning"]> = {
         confirmContinue: "Ho capito, continua",
         dontRemindAgain: "Non mostrare più questo messaggio",
     },
+    livekitConnection: {
+        critical: "Potresti riscontrare problemi di comunicazione con altri utenti.",
+        warning: "La qualità audio o video potrebbe essere ridotta.",
+    },
     browserNotSupported: {
         title: "😢 Browser non supportato",
         message: "Il tuo browser ({browserName}) non è più supportato da WorkAdventure.",

--- a/play/src/i18n/ja-JP/warning.ts
+++ b/play/src/i18n/ja-JP/warning.ts
@@ -36,6 +36,10 @@ const warning: DeepPartial<Translation["warning"]> = {
         confirmContinue: "理解しました、続ける",
         dontRemindAgain: "このメッセージを再表示しない",
     },
+    livekitConnection: {
+        critical: "他のユーザーとの通信に問題が発生する可能性があります。",
+        warning: "オーディオまたはビデオの品質が低下する可能性があります。",
+    },
     browserNotSupported: {
         title: "😢 サポートされていないブラウザ",
         message: "お使いのブラウザ（{browserName}）は、WorkAdventureでサポートされなくなりました。",

--- a/play/src/i18n/ko-KR/warning.ts
+++ b/play/src/i18n/ko-KR/warning.ts
@@ -35,6 +35,10 @@ const warning: DeepPartial<Translation["warning"]> = {
         confirmContinue: "이해했습니다, 계속",
         dontRemindAgain: "이 메시지를 다시 표시하지 않음",
     },
+    livekitConnection: {
+        critical: "다른 사용자와의 통신 문제가 발생할 수 있습니다.",
+        warning: "오디오 또는 비디오 품질이 저하될 수 있습니다.",
+    },
     browserNotSupported: {
         title: "😢 지원되지 않는 브라우저",
         message: "사용 중인 브라우저({browserName})는 더 이상 WorkAdventure에서 지원되지 않습니다.",

--- a/play/src/i18n/nl-NL/warning.ts
+++ b/play/src/i18n/nl-NL/warning.ts
@@ -23,6 +23,10 @@ const warning: DeepPartial<Translation["warning"]> = {
     backgroundProcessing: {
         failedToApply: "Achtergrondeffecten toepassen mislukt",
     },
+    livekitConnection: {
+        critical: "U kunt communicatieproblemen ervaren met andere gebruikers.",
+        warning: "De audio- of videokwaliteit kan verminderd zijn.",
+    },
     popupBlocked: {
         title: "Popup geblokkeerd",
         content: "Sta popups toe voor deze website in je browserinstellingen.",

--- a/play/src/i18n/pt-BR/warning.ts
+++ b/play/src/i18n/pt-BR/warning.ts
@@ -22,6 +22,10 @@ const warning: BaseTranslation = {
     backgroundProcessing: {
         failedToApply: "Falha ao aplicar efeitos de fundo",
     },
+    livekitConnection: {
+        critical: "Você pode encontrar problemas de comunicação com outros usuários.",
+        warning: "A qualidade do áudio ou vídeo pode ser reduzida.",
+    },
     popupBlocked: {
         title: "Bloqueador de pop-up",
         content: "Por favor, permita pop-ups para este site nas configurações do seu navegador.",

--- a/play/src/i18n/zh-CN/warning.ts
+++ b/play/src/i18n/zh-CN/warning.ts
@@ -23,6 +23,10 @@ const warning: DeepPartial<Translation["warning"]> = {
     backgroundProcessing: {
         failedToApply: "应用背景效果失败",
     },
+    livekitConnection: {
+        critical: "您可能会遇到与其他用户的通信问题。",
+        warning: "您的音视频质量可能会降低。",
+    },
     popupBlocked: {
         title: "弹出窗口被阻止",
         content: "请在您的浏览器设置中允许此网站的弹出窗口。",

--- a/play/src/i18n/zh-TW/warning.ts
+++ b/play/src/i18n/zh-TW/warning.ts
@@ -23,6 +23,10 @@ const warning: DeepPartial<Translation["warning"]> = {
     backgroundProcessing: {
         failedToApply: "套用背景效果失敗",
     },
+    livekitConnection: {
+        critical: "您可能會遇到與其他使用者的通訊問題。",
+        warning: "您的音訊或視訊品質可能會降低。",
+    },
     popupBlocked: {
         title: "彈出視窗被封鎖",
         content: "請在您的瀏覽器設定中允許此網站的彈出視窗。",

--- a/play/tests/front/Livekit/LivekitConnectionChecker.test.ts
+++ b/play/tests/front/Livekit/LivekitConnectionChecker.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { CheckStatus, type CheckInfo } from "livekit-client";
+import {
+    classifyLivekitChecks,
+    LivekitConnectionStatus,
+    type LivekitCheckResults,
+} from "../../../src/front/Livekit/utils/LivekitConnectionChecker";
+
+function check(status: CheckStatus): CheckInfo {
+    // `name`/`description` are irrelevant to the classification (that's the whole point of the fix:
+    // we must not rely on CheckInfo.name), so we leave them empty.
+    return { name: "", description: "", status, logs: [] };
+}
+
+function results(overrides: Partial<Record<keyof LivekitCheckResults, CheckStatus>> = {}): LivekitCheckResults {
+    const statuses: Record<keyof LivekitCheckResults, CheckStatus> = {
+        websocket: CheckStatus.SUCCESS,
+        webRTC: CheckStatus.SUCCESS,
+        turn: CheckStatus.SUCCESS,
+        publishAudio: CheckStatus.SUCCESS,
+        publishVideo: CheckStatus.SUCCESS,
+        ...overrides,
+    };
+    return {
+        websocket: check(statuses.websocket),
+        webRTC: check(statuses.webRTC),
+        turn: check(statuses.turn),
+        publishAudio: check(statuses.publishAudio),
+        publishVideo: check(statuses.publishVideo),
+    };
+}
+
+describe("classifyLivekitChecks", () => {
+    it("returns Success when every check passes", () => {
+        const summary = classifyLivekitChecks(results());
+        expect(summary.status).toBe(LivekitConnectionStatus.Success);
+        expect(summary.failedChecks).toEqual([]);
+    });
+
+    it("returns Critical when the signaling websocket fails", () => {
+        const summary = classifyLivekitChecks(results({ websocket: CheckStatus.FAILED }));
+        expect(summary.status).toBe(LivekitConnectionStatus.Critical);
+        expect(summary.failedChecks).toContain("websocket");
+    });
+
+    it("prioritizes Critical over a degraded media path", () => {
+        const summary = classifyLivekitChecks(results({ websocket: CheckStatus.FAILED, turn: CheckStatus.FAILED }));
+        expect(summary.status).toBe(LivekitConnectionStatus.Critical);
+        expect(summary.failedChecks).toEqual(expect.arrayContaining(["websocket", "turn"]));
+    });
+
+    it.each(["webRTC", "turn", "publishAudio", "publishVideo"] as const)(
+        "returns Warning when only %s fails",
+        (failing) => {
+            const overrides: Partial<Record<keyof LivekitCheckResults, CheckStatus>> = {
+                [failing]: CheckStatus.FAILED,
+            };
+            const summary = classifyLivekitChecks(results(overrides));
+            expect(summary.status).toBe(LivekitConnectionStatus.Warning);
+            expect(summary.failedChecks).toEqual([failing]);
+        },
+    );
+
+    it("reports our own stable labels, never the minifiable CheckInfo.name", () => {
+        const summary = classifyLivekitChecks(results({ turn: CheckStatus.FAILED }));
+        // "turn", not livekit-client's class name "TURNCheck".
+        expect(summary.failedChecks).toEqual(["turn"]);
+    });
+
+    it("treats non-FAILED statuses (e.g. SKIPPED) as not failing", () => {
+        const summary = classifyLivekitChecks(results({ turn: CheckStatus.SKIPPED }));
+        expect(summary.status).toBe(LivekitConnectionStatus.Success);
+        expect(summary.failedChecks).toEqual([]);
+    });
+});


### PR DESCRIPTION
## What

Runs a LiveKit connection test right after a user joins a room and warns them up-front if their network or browser cannot use audio/video reliably — so connectivity problems are surfaced early instead of failing silently mid-call, reducing user frustration.

## How

- **Back**: when LiveKit is available, the server mints a short-lived test token for an ephemeral room and sends it to the client (new `LivekitCredentialsMessage`).
- **Front**: the client runs livekit-client's `ConnectionCheck` (websocket, WebRTC, TURN, publish audio/video) and classifies the result:
  - **Warning** (degraded media path) → transient toast ("audio/video quality might be reduced").
  - **Critical** (signaling websocket down → cannot communicate at all) → persistent popup with a *Reload* action.
- Failed checks are reported to Sentry so we can measure how often users hit connectivity issues in the field.

## Design notes

- The test only runs when LiveKit is actually configured (admin capability `api/livekit/credentials` or `LIVEKIT_*` env vars). WebRTC-only deployments are unaffected — no exception, no Sentry noise.
- Severity is decided from the check results directly, **not** from `CheckInfo.name` (that is the check's runtime class name and gets mangled by the production minifier).
- Checks run **sequentially** — livekit-client's `ConnectionCheck` shares state between checks and each opens its own connection, so it is not safe to run them concurrently.
- The connection test and its UI live in a dedicated handler consumed by `GameScene`; the transport layer (`RoomConnection`) only forwards the message on a stream.
- The severity classification is a pure function covered by a unit test.
- The ephemeral test token is short-lived (5 min).

## i18n

Adds `warning.livekitConnection.{critical,warning}` across all locales.

## Possible follow-up

- The Critical case uses a persistent, prominent popup (not a hard backdrop-blocking modal); a blocking modal could be used instead if we want to force acknowledgement.
