### PR TITLE
Add metadata with room URL to BBB meetings

### DIFF
--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -851,7 +851,7 @@ export class SocketManager {
             .slice(0, maxPWLen);
 
         // This is idempotent, so we call it on each join in order to be sure that the meeting exists.
-        const createOptions = { attendeePW, moderatorPW, record: true };
+        const createOptions = { attendeePW, moderatorPW, record: true, "meta_worka-room-url": gameRoom.roomUrl };
         const createURL = api.administration.create(meetingName, meetingId, createOptions);
         await BigbluebuttonJs.http(createURL);
 


### PR DESCRIPTION
BBB meeting creation now includes the room URL as metadata, by adding the `meta_worka-room-url` property to the `createOptions` passed to the BigBlueButton API.
That metadata can be used by external applications to filter recordings by Workadventure room, using the `meta` parameter from `getRecordings` BBB API call ([API reference here](https://docs.bigbluebutton.org/development/api/#get-getrecordings)).