### PR TITLE
Rewording the "sound blocked" popup

### DIFF
--- a/play/src/front/Components/Toasts/BrowserNoSoundInfoToast.svelte
+++ b/play/src/front/Components/Toasts/BrowserNoSoundInfoToast.svelte
@@ -62,7 +62,7 @@
 <ToastContainer extraClasses="w-full min-w-72 max-w-sm sm:min-w-80 sm:max-w-md" theme="secondary" {toastUuid}>
     <div class="flex flex-col gap-2">
         <p class="m-0 text-sm leading-snug text-white text-center">
-            {$LL.chat.status.do_not_disturb()}. {$LL.chat.status.click_to_become_available()}
+            {$LL.statusModal.soundBlockedBackInAMoment()}
         </p>
     </div>
     <svelte:fragment slot="buttons">
@@ -72,7 +72,7 @@
             data-testid="do-not-disturb-activate"
             on:click|stopPropagation|preventDefault={closeToast}
         >
-            {$LL.chat.status.online()}
+            {$LL.statusModal.turnSoundOn()}
         </button>
     </svelte:fragment>
 </ToastContainer>

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -116,7 +116,7 @@ import {
     speakerSelectedStore,
 } from "../../Stores/MediaStore";
 import NoMicrophoneSoundToast from "../../Components/Toasts/NoMicrophoneSoundToast.svelte";
-import DoNotDisturbInfoToast from "../../Components/Toasts/DoNotDisturbInfoToast.svelte";
+import BrowserNoSoundInfoToast from "../../Components/Toasts/BrowserNoSoundInfoToast.svelte";
 import { LL, locale } from "../../../i18n/i18n-svelte";
 import { toastStore } from "../../Stores/ToastStore";
 import { GameSceneUserInputHandler } from "../UserInput/GameSceneUserInputHandler";
@@ -160,7 +160,7 @@ import { closeCoWebsite, getCoWebSite, openCoWebSite, openCoWebSiteWithoutSource
 import { navChat } from "../../Chat/Stores/ChatStore";
 import { ProximityChatRoom } from "../../Chat/Connection/Proximity/ProximityChatRoom";
 import { ProximitySpaceManager } from "../../WebRtc/ProximitySpaceManager";
-import { audioContextManager } from "../../WebRtc/AudioContextManager";
+import { AUDIO_CONTEXT_TOAST_UUID, audioContextManager } from "../../WebRtc/AudioContextManager";
 import { notificationManager } from "../../Notification/NotificationManager";
 import { noMicrophoneSoundWarningVisibleStore } from "../../Stores/NoMicrophoneSoundWarningVisibleStore";
 import type { SpaceRegistryInterface } from "../../Space/SpaceRegistry/SpaceRegistryInterface";
@@ -2330,7 +2330,7 @@ export class GameScene extends DirtyScene {
                     if (!hasNotification && !isPWAInstalled) {
                         console.warn("Audio context is suspended. Please allow the page to play audio.");
                         // Show a toast to the user to allow the page to play audio.
-                        toastStore.addToast(DoNotDisturbInfoToast, {}, "do-not-disturb-info-toast");
+                        toastStore.addToast(BrowserNoSoundInfoToast, {}, AUDIO_CONTEXT_TOAST_UUID);
                         let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
                         let isNotSuspendedAudioContextStoreSubscription: Unsubscriber | undefined = undefined;
                         // Verify that the audio context is not suspended before the timeout expires

--- a/play/src/front/WebRtc/AudioContextManager.ts
+++ b/play/src/front/WebRtc/AudioContextManager.ts
@@ -2,7 +2,7 @@ import { isNotSuspendedAudioContextStore } from "../Stores/AudioContextStore";
 import { requestedStatusStore } from "../Stores/MediaStore";
 import { toastStore } from "../Stores/ToastStore";
 
-export const AUDIO_CONTEXT_TOAST_UUID = "do-not-disturb-info-toast";
+export const AUDIO_CONTEXT_TOAST_UUID = "browser-no-sound-info-toast";
 /**
  * Singleton manager for AudioContext instances.
  * This manager ensures that we create only one AudioContext per sample rate,

--- a/play/src/i18n/ar-SA/chat.ts
+++ b/play/src/i18n/ar-SA/chat.ts
@@ -84,7 +84,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "غير متاح",
         back_in_a_moment: "سأعود بعد قليل",
         do_not_disturb: "لا تزعج",
-        click_to_become_available: "انقر لتصبح متاحًا مرة أخرى وتحادث الآخرين.",
         busy: "مشغول",
         meeting: "في اجتماع",
         megaphone: "يستخدم مكبر الصوت",

--- a/play/src/i18n/ar-SA/statusModal.ts
+++ b/play/src/i18n/ar-SA/statusModal.ts
@@ -8,6 +8,8 @@ const statusModal: DeepPartial<Translation["statusModal"]> = {
     goBackToOnlineStatusLabel: "هل تريد العودة إلى الوضع المتصل؟", // Do you want to go back online?
     allowNotification: "هل تريد السماح بالإشعارات؟", // Do you want to allow notifications?
     allowNotificationExplanation: "احصل على إشعار سطح المكتب عندما يريد شخص ما التحدث إليك.",
+    soundBlockedBackInAMoment: "متصفحك يمنع الصوت حاليا، لذلك أنت في وضع سأعود بعد قليل.",
+    turnSoundOn: "تشغيل الصوت",
 };
 
 export default statusModal;

--- a/play/src/i18n/ca-ES/chat.ts
+++ b/play/src/i18n/ca-ES/chat.ts
@@ -84,7 +84,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         away: "Absent",
         back_in_a_moment: "Torna en un moment",
         do_not_disturb: "No molestar",
-        click_to_become_available: "Feu clic per tornar a estar disponible i xatejar amb els altres.",
         busy: "Ocupat",
         unavailable: "No disponible",
         meeting: "En reunió",

--- a/play/src/i18n/ca-ES/statusModal.ts
+++ b/play/src/i18n/ca-ES/statusModal.ts
@@ -8,6 +8,9 @@ const statusModal: DeepPartial<Translation["statusModal"]> = {
     goBackToOnlineStatusLabel: "Vols tornar a estar en línia?",
     allowNotification: "Permetre notificacions?",
     allowNotificationExplanation: "Rep una notificació d'escriptori quan algú vulgui parlar amb tu.",
+    soundBlockedBackInAMoment:
+        "El teu navegador està bloquejant el so ara mateix, per això ets en mode Torna en un moment.",
+    turnSoundOn: "Activar el so",
 };
 
 export default statusModal;

--- a/play/src/i18n/de-DE/chat.ts
+++ b/play/src/i18n/de-DE/chat.ts
@@ -85,7 +85,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         away: "Abwesend",
         back_in_a_moment: "Komme gleich zurück",
         do_not_disturb: "Nicht stören",
-        click_to_become_available: "Klicken Sie, um wieder verfügbar zu werden und mit anderen zu chatten.",
         busy: "Beschäftigt",
         unavailable: "Nicht verfügbar",
         meeting: "In Besprechung",

--- a/play/src/i18n/de-DE/statusModal.ts
+++ b/play/src/i18n/de-DE/statusModal.ts
@@ -8,6 +8,9 @@ const statusModal: DeepPartial<Translation["statusModal"]> = {
     confirm: "Bestätigen",
     goBackToOnlineStatusLabel: "Möchtest du wieder online gehen?",
     allowNotification: "Möchtest du Benachrichtigungen erlauben?",
+    soundBlockedBackInAMoment:
+        'Ihr Browser blockiert den Ton im Moment, deshalb sind Sie im Modus "Komme gleich zurück".',
+    turnSoundOn: "Ton aktivieren",
 };
 
 export default statusModal;

--- a/play/src/i18n/dsb-DE/chat.ts
+++ b/play/src/i18n/dsb-DE/chat.ts
@@ -85,7 +85,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         away: "njepśibytny",
         back_in_a_moment: "Wrośo se za moment",
         do_not_disturb: "Njewócynjeś",
-        click_to_become_available: "Klikniś, aby zasej k dispoziciji był a z drugimi gadaś.",
         busy: "Zajźony",
         unavailable: "njestoj k dipoziciji",
         meeting: "W zasedańu",

--- a/play/src/i18n/dsb-DE/statusModal.ts
+++ b/play/src/i18n/dsb-DE/statusModal.ts
@@ -8,6 +8,8 @@ const statusModal: DeepPartial<Translation["statusModal"]> = {
     goBackToOnlineStatusLabel: "Cośo se wróśiś online?",
     allowNotification: "Powěźeśe dowóliś?",
     allowNotificationExplanation: "Dostańśo powěźeńku na desktopje, gaž něchten z wami powědaś co.",
+    soundBlockedBackInAMoment: 'Waš wobglědowak tuchylu zuk blokěrujo, togodla sćo we modusu "Wrośo se za moment".',
+    turnSoundOn: "Zuk zmóžniś",
 };
 
 export default statusModal;

--- a/play/src/i18n/en-US/chat.ts
+++ b/play/src/i18n/en-US/chat.ts
@@ -84,7 +84,6 @@ const chat: BaseTranslation = {
         unavailable: "Unavailable",
         back_in_a_moment: "Back in a moment",
         do_not_disturb: "Do not disturb",
-        click_to_become_available: "Click to become available again and chat with others.",
         busy: "Busy",
         meeting: "In a meeting",
         megaphone: "Using the megaphone",

--- a/play/src/i18n/en-US/statusModal.ts
+++ b/play/src/i18n/en-US/statusModal.ts
@@ -7,6 +7,8 @@ const statusModal: BaseTranslation = {
     goBackToOnlineStatusLabel: "Do you want to go back online?",
     allowNotification: "Allow notifications?",
     allowNotificationExplanation: "Get a desktop notification when someone wants to talk to you.",
+    soundBlockedBackInAMoment: "Your browser is blocking sound for now, so you're in Back in a moment mode.",
+    turnSoundOn: "Turn sound on",
 };
 
 export default statusModal;

--- a/play/src/i18n/es-ES/chat.ts
+++ b/play/src/i18n/es-ES/chat.ts
@@ -84,7 +84,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         away: "Ausente",
         back_in_a_moment: "Vuelve en un momento",
         do_not_disturb: "No molestar",
-        click_to_become_available: "Haz clic para volver a estar disponible y chatear con otros.",
         busy: "Ocupado",
         unavailable: "No disponible",
         meeting: "En reunión",

--- a/play/src/i18n/es-ES/statusModal.ts
+++ b/play/src/i18n/es-ES/statusModal.ts
@@ -8,6 +8,9 @@ const statusModal: DeepPartial<Translation["statusModal"]> = {
     goBackToOnlineStatusLabel: "¿Quieres volver a estar en línea?",
     allowNotification: "¿Permitir notificaciones?",
     allowNotificationExplanation: "Recibe una notificación de escritorio cuando alguien quiera hablar contigo.",
+    soundBlockedBackInAMoment:
+        "Tu navegador está bloqueando el sonido por ahora, por eso estás en modo Vuelve en un momento.",
+    turnSoundOn: "Activar sonido",
 };
 
 export default statusModal;

--- a/play/src/i18n/fr-FR/chat.ts
+++ b/play/src/i18n/fr-FR/chat.ts
@@ -84,7 +84,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         away: "Absent",
         back_in_a_moment: "Revient dans un moment",
         do_not_disturb: "Ne pas déranger",
-        click_to_become_available: "Cliquez pour redevenir disponible et discuter avec les autres.",
         busy: "Occupé",
         unavailable: "Non disponible",
         meeting: "En réunion",

--- a/play/src/i18n/fr-FR/statusModal.ts
+++ b/play/src/i18n/fr-FR/statusModal.ts
@@ -8,6 +8,9 @@ const statusModal: DeepPartial<Translation["statusModal"]> = {
     goBackToOnlineStatusLabel: "Veux-tu revenir en ligne ?",
     allowNotification: "Autoriser les notifications ?",
     allowNotificationExplanation: "Recevoir une notification de bureau lorsque quelqu'un souhaite me parler.",
+    soundBlockedBackInAMoment:
+        'Votre navigateur bloque le son pour le moment, vous êtes donc en mode "Revient dans un moment".',
+    turnSoundOn: "Activer le son",
 };
 
 export default statusModal;

--- a/play/src/i18n/hsb-DE/chat.ts
+++ b/play/src/i18n/hsb-DE/chat.ts
@@ -85,7 +85,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         away: "njepřitomny",
         back_in_a_moment: "Wróćo so za moment",
         do_not_disturb: "Njewobroćeć",
-        click_to_become_available: "Klikńće, zo byšće zaso k dispoziciji był a z druhimi rěčeć.",
         busy: "Zajaty",
         unavailable: "njesteji k dispoziciji",
         meeting: "W zasedanju",

--- a/play/src/i18n/hsb-DE/statusModal.ts
+++ b/play/src/i18n/hsb-DE/statusModal.ts
@@ -8,6 +8,8 @@ const statusModal: DeepPartial<Translation["statusModal"]> = {
     goBackToOnlineStatusLabel: "Chceće so wróćić online?",
     allowNotification: "Zdźělenki dowolić?",
     allowNotificationExplanation: "Dóstaće desktopowe zdźělenku, hdyž chce něchtó z wami rěčeć.",
+    soundBlockedBackInAMoment: 'Waš wobhladowak tuchwilu zwuk blokuje, tohodla sće w modusu "Wróćo so za moment".',
+    turnSoundOn: "Zwuk zmóžnić",
 };
 
 export default statusModal;

--- a/play/src/i18n/it-IT/chat.ts
+++ b/play/src/i18n/it-IT/chat.ts
@@ -85,7 +85,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         away: "Assente",
         back_in_a_moment: "Torno subito",
         do_not_disturb: "Non disturbare",
-        click_to_become_available: "Fai clic per tornare disponibile e chattare con gli altri.",
         busy: "Occupato",
         unavailable: "Non disponibile",
         meeting: "In riunione",

--- a/play/src/i18n/it-IT/statusModal.ts
+++ b/play/src/i18n/it-IT/statusModal.ts
@@ -8,6 +8,9 @@ const statusModal: DeepPartial<Translation["statusModal"]> = {
     confirm: "Conferma",
     goBackToOnlineStatusLabel: "Vuoi tornare online?",
     allowNotification: "Vuoi consentire le notifiche?",
+    soundBlockedBackInAMoment:
+        "Il tuo browser sta bloccando l'audio per il momento, quindi sei in modalita Torno subito.",
+    turnSoundOn: "Attiva l'audio",
 };
 
 export default statusModal;

--- a/play/src/i18n/ja-JP/chat.ts
+++ b/play/src/i18n/ja-JP/chat.ts
@@ -85,7 +85,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         away: "離席中",
         back_in_a_moment: "すぐ戻ります",
         do_not_disturb: "邪魔しないでください",
-        click_to_become_available: "クリックして再び利用可能になり、他の人とチャットできます。",
         busy: "取り込み中",
         unavailable: "利用不可",
         meeting: "ミーティング中",

--- a/play/src/i18n/ja-JP/statusModal.ts
+++ b/play/src/i18n/ja-JP/statusModal.ts
@@ -8,6 +8,8 @@ const statusModal: DeepPartial<Translation["statusModal"]> = {
     confirm: "確認する",
     goBackToOnlineStatusLabel: "オンラインに戻りますか？",
     allowNotification: "通知を許可しますか？",
+    soundBlockedBackInAMoment: "現在ブラウザで音声がブロックされているため、「すぐ戻ります」モードになっています。",
+    turnSoundOn: "音声を有効にする",
 };
 
 export default statusModal;

--- a/play/src/i18n/ko-KR/chat.ts
+++ b/play/src/i18n/ko-KR/chat.ts
@@ -85,7 +85,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "사용 불가",
         back_in_a_moment: "곧 돌아옴",
         do_not_disturb: "방해 금지",
-        click_to_become_available: "클릭하면 다시 사용 가능 상태가 되어 다른 사람과 대화할 수 있습니다.",
         busy: "바쁨",
         meeting: "회의 중",
         megaphone: "확성기 사용 중",

--- a/play/src/i18n/ko-KR/statusModal.ts
+++ b/play/src/i18n/ko-KR/statusModal.ts
@@ -8,6 +8,8 @@ const statusModal: DeepPartial<Translation["statusModal"]> = {
     goBackToOnlineStatusLabel: "온라인 상태로 돌아가시겠습니까?",
     allowNotification: "알림을 허용하시겠습니까?",
     allowNotificationExplanation: "누군가 대화를 원할 때 데스크톱 알림을 받습니다.",
+    soundBlockedBackInAMoment: "현재 브라우저가 소리를 차단하고 있어 곧 돌아옴 모드로 설정되어 있습니다.",
+    turnSoundOn: "소리 켜기",
 };
 
 export default statusModal;

--- a/play/src/i18n/nl-NL/chat.ts
+++ b/play/src/i18n/nl-NL/chat.ts
@@ -85,7 +85,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         away: "Afwezig",
         back_in_a_moment: "Zo terug",
         do_not_disturb: "Niet storen",
-        click_to_become_available: "Klik om weer beschikbaar te worden en met anderen te chatten.",
         busy: "Bezet",
         unavailable: "Niet beschikbaar",
         meeting: "In vergadering",

--- a/play/src/i18n/nl-NL/statusModal.ts
+++ b/play/src/i18n/nl-NL/statusModal.ts
@@ -8,6 +8,8 @@ const statusModal: DeepPartial<Translation["statusModal"]> = {
     confirm: "Bevestigen",
     goBackToOnlineStatusLabel: "Wil je weer online gaan?",
     allowNotification: "Wil je meldingen toestaan?",
+    soundBlockedBackInAMoment: "Je browser blokkeert het geluid op dit moment, daarom sta je in de modus Zo terug.",
+    turnSoundOn: "Geluid inschakelen",
 };
 
 export default statusModal;

--- a/play/src/i18n/pt-BR/chat.ts
+++ b/play/src/i18n/pt-BR/chat.ts
@@ -85,7 +85,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "Indisponível",
         back_in_a_moment: "Volto em instantes",
         do_not_disturb: "Não perturbe",
-        click_to_become_available: "Clique para ficar disponível novamente e conversar com outras pessoas.",
         busy: "Ocupado",
         meeting: "Em uma reunião",
         megaphone: "Usando o megafone",

--- a/play/src/i18n/pt-BR/statusModal.ts
+++ b/play/src/i18n/pt-BR/statusModal.ts
@@ -7,6 +7,9 @@ const statusModal: BaseTranslation = {
     goBackToOnlineStatusLabel: "Você quer voltar a ficar online?",
     allowNotification: "Permitir notificações?",
     allowNotificationExplanation: "Receba uma notificação na área de trabalho quando alguém quiser falar com você.",
+    soundBlockedBackInAMoment:
+        "Seu navegador está bloqueando o som por enquanto, então você está no modo Volto em instantes.",
+    turnSoundOn: "Ativar som",
 };
 
 export default statusModal;

--- a/play/src/i18n/zh-CN/chat.ts
+++ b/play/src/i18n/zh-CN/chat.ts
@@ -82,7 +82,6 @@ const chat: DeepPartial<Translation["chat"]> = {
         away: "离开",
         back_in_a_moment: "稍后回来",
         do_not_disturb: "请勿打扰",
-        click_to_become_available: "点击即可重新上线并与他人聊天。",
         busy: "忙碌",
         unavailable: "不可用",
         meeting: "会议中",

--- a/play/src/i18n/zh-CN/statusModal.ts
+++ b/play/src/i18n/zh-CN/statusModal.ts
@@ -8,6 +8,8 @@ const statusModal: DeepPartial<Translation["statusModal"]> = {
     goBackToOnlineStatusLabel: "您想重新上线吗？",
     allowNotification: "允许通知？",
     allowNotificationExplanation: "当有人想与您交谈时，接收桌面通知。",
+    soundBlockedBackInAMoment: "您的浏览器当前正在阻止声音播放，因此您处于“稍后回来”模式。",
+    turnSoundOn: "开启声音",
 };
 
 export default statusModal;


### PR DESCRIPTION
The "there is no sound available" popup because there has been no user interaction and you are now in "back in a moment" mode has been reworded.