### PR TITLE
fix(i18n): improve Japanese translation for DO_NOT_DISTURB status label

### DIFF
--- a/play/src/i18n/ja-JP/actionbar.ts
+++ b/play/src/i18n/ja-JP/actionbar.ts
@@ -47,7 +47,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         ONLINE: "オンライン",
         AWAY: "不在",
         BACK_IN_A_MOMENT: "すぐ戻る",
-        DO_NOT_DISTURB: "邪魔しないで",
+        DO_NOT_DISTURB: "応答不可",
         BUSY: "忙しい",
         OFFLINE: "オフライン",
         SILENT: "サイレント",


### PR DESCRIPTION
## Summary

Improve the Japanese translation for the `DO_NOT_DISTURB` status label in `play/src/i18n/ja-JP/actionbar.ts`.

## Change

| Key | Before | After |
|-----|--------|-------|
| `status.DO_NOT_DISTURB` | 邪魔しないで | 応答不可 |

## Reason

"邪魔しないで" sounds rude and unnatural in Japanese.