### PR TITLE
fix: align camera publishing with permission and stabilize local stream

### DIFF
--- a/play/src/front/Components/Video/MediaBox.svelte
+++ b/play/src/front/Components/Video/MediaBox.svelte
@@ -27,7 +27,10 @@
 
 <!-- Bug with transition : transition:fly={{ y: 50, duration: 150 }} -->
 
-<div class="video-media-box pointer-events-auto media-container justify-center relative h-full w-full">
+<div
+    class="video-media-box pointer-events-auto media-container justify-center relative h-full w-full"
+    data-testid={`camera-box-${videoBox.spaceUser.name}`}
+>
     <!-- in:fly={{ y: 50, duration: 150 }} -->
     <VideoMediaBox {videoBox} {fullScreen} />
 </div>

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -112,7 +112,7 @@ import { chatZoneLiveStore } from "../Stores/ChatStore";
 import { errorScreenStore } from "../Stores/ErrorScreenStore";
 import { duplicateUserConnectedStore, shouldShowDuplicateUserPopup } from "../Stores/DuplicateUserConnectedStore";
 import { followRoleStore, followUsersStore } from "../Stores/FollowStore";
-import { isSpeakerStore, requestedMicrophoneState, requestedCameraState } from "../Stores/MediaStore";
+import { isSpeakerStore, requestedMicrophoneState, synchronizedCameraStateStore } from "../Stores/MediaStore";
 import { currentLiveStreamingSpaceStore } from "../Stores/MegaphoneStore";
 import {
     inviteUserActivated,
@@ -305,7 +305,7 @@ export class RoomConnection implements RoomConnection {
         params.set("version", apiVersionHash);
         params.set("chatID", localUserStore.getChatId() ?? "");
         params.set("roomName", gameManager.currentStartedRoom.roomName ?? "");
-        params.set("cameraState", get(requestedCameraState) ? "true" : "false");
+        params.set("cameraState", get(synchronizedCameraStateStore) ? "true" : "false");
         params.set("microphoneState", get(requestedMicrophoneState) ? "true" : "false");
         // TODO: check if the screenSharingState variable is used
         params.set("screenSharingState", get(requestedScreenSharingState) ? "true" : "false");

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -109,7 +109,7 @@ import { chatZoneLiveStore } from "../Stores/ChatStore";
 import { errorScreenStore } from "../Stores/ErrorScreenStore";
 import { duplicateUserConnectedStore, shouldShowDuplicateUserPopup } from "../Stores/DuplicateUserConnectedStore";
 import { followRoleStore, followUsersStore } from "../Stores/FollowStore";
-import { isSpeakerStore, requestedMicrophoneState, requestedCameraState } from "../Stores/MediaStore";
+import { isSpeakerStore, requestedMicrophoneState, synchronizedCameraStateStore } from "../Stores/MediaStore";
 import { currentLiveStreamingSpaceStore } from "../Stores/MegaphoneStore";
 import {
     inviteUserActivated,
@@ -321,7 +321,7 @@ export class RoomConnection implements RoomConnection {
         params.set("version", apiVersionHash);
         params.set("chatID", localUserStore.getChatId() ?? "");
         params.set("roomName", gameManager.currentStartedRoom.roomName ?? "");
-        params.set("cameraState", get(requestedCameraState) ? "true" : "false");
+        params.set("cameraState", get(synchronizedCameraStateStore) ? "true" : "false");
         params.set("microphoneState", get(requestedMicrophoneState) ? "true" : "false");
         // TODO: check if the screenSharingState variable is used
         params.set("screenSharingState", get(requestedScreenSharingState) ? "true" : "false");

--- a/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
+++ b/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
@@ -9,7 +9,7 @@ import type { Readable, Unsubscriber } from "svelte/store";
 import { get } from "svelte/store";
 import type { SpaceInterface } from "../SpaceInterface";
 import type { LocalStreamStoreValue } from "../../Stores/MediaStore";
-import { requestedCameraState, requestedMicrophoneState } from "../../Stores/MediaStore";
+import { requestedMicrophoneState, synchronizedCameraStateStore } from "../../Stores/MediaStore";
 import { recordingStore } from "../../Stores/RecordingStore";
 import { screenSharingLocalStreamStore } from "../../Stores/ScreenSharingStore";
 import { nbSoundPlayedInBubbleStore } from "../../Stores/ApparentMediaContraintStore";
@@ -154,7 +154,7 @@ export class SpacePeerManager {
         private space: SpaceInterface,
         blockedUsersStore: Readable<Set<string>>,
         private microphoneStateStore: Readable<boolean> = requestedMicrophoneState,
-        private cameraStateStore: Readable<boolean> = requestedCameraState,
+        private cameraStateStore: Readable<boolean> = synchronizedCameraStateStore,
         _screenSharingLocalStreamStore: Readable<LocalStreamStoreValue> = screenSharingLocalStreamStore,
         _bindMuteEventsToSpace: (space: SpaceInterface) => void = bindMuteEventsToSpace,
         private _notificationPlayingStore = notificationPlayingStore,

--- a/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
+++ b/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
@@ -9,7 +9,7 @@ import { get } from "svelte/store";
 import { localUserStore } from "../../Connection/LocalUserStore";
 import type { SpaceInterface } from "../SpaceInterface";
 import type { LocalStreamStoreValue } from "../../Stores/MediaStore";
-import { requestedCameraState, requestedMicrophoneState } from "../../Stores/MediaStore";
+import { requestedMicrophoneState, synchronizedCameraStateStore } from "../../Stores/MediaStore";
 import { recordingStore } from "../../Stores/RecordingStore";
 import { screenSharingLocalStreamStore } from "../../Stores/ScreenSharingStore";
 import { nbSoundPlayedInBubbleStore } from "../../Stores/ApparentMediaContraintStore";
@@ -142,7 +142,7 @@ export class SpacePeerManager {
         private space: SpaceInterface,
         blockedUsersStore: Readable<Set<string>>,
         private microphoneStateStore: Readable<boolean> = requestedMicrophoneState,
-        private cameraStateStore: Readable<boolean> = requestedCameraState,
+        private cameraStateStore: Readable<boolean> = synchronizedCameraStateStore,
         private screenSharingStateStore: Readable<LocalStreamStoreValue> = screenSharingLocalStreamStore,
         _bindMuteEventsToSpace: (space: SpaceInterface) => void = bindMuteEventsToSpace,
         private _localUserStore = localUserStore,

--- a/play/src/front/Stores/MediaPublishingUtils.test.ts
+++ b/play/src/front/Stores/MediaPublishingUtils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { getSynchronizedCameraState } from "./MediaPublishingUtils";
+
+describe("MediaPublishingUtils", () => {
+    describe("getSynchronizedCameraState", () => {
+        it("should return false when camera is not requested", () => {
+            expect(getSynchronizedCameraState(false, "granted")).toBe(false);
+            expect(getSynchronizedCameraState(false, "denied")).toBe(false);
+            expect(getSynchronizedCameraState(false, "prompt")).toBe(false);
+            expect(getSynchronizedCameraState(false, null)).toBe(false);
+        });
+
+        it("should return true when camera is requested and permission is granted", () => {
+            expect(getSynchronizedCameraState(true, "granted")).toBe(true);
+        });
+
+        it("should return false when camera is requested and permission is denied or still prompt", () => {
+            expect(getSynchronizedCameraState(true, "denied")).toBe(false);
+            expect(getSynchronizedCameraState(true, "prompt")).toBe(false);
+        });
+
+        it("should fall back to the requested state when permission is unknown", () => {
+            expect(getSynchronizedCameraState(true, null)).toBe(true);
+        });
+    });
+});

--- a/play/src/front/Stores/MediaPublishingUtils.ts
+++ b/play/src/front/Stores/MediaPublishingUtils.ts
@@ -1,0 +1,28 @@
+import type { BrowserMediaPermissionState } from "./MediaStatusStore";
+import type { LocalStreamStoreValue } from "./MediaStore";
+
+export function getSynchronizedCameraState(
+    requestedCameraState: boolean,
+    cameraPermissionState: BrowserMediaPermissionState
+): boolean {
+    return requestedCameraState && cameraPermissionState === "granted";
+}
+
+export function getLocalStreamForPublishing(
+    localStreamStoreValue: LocalStreamStoreValue,
+    shouldMaskVideoForPublishing: boolean
+): LocalStreamStoreValue {
+    if (
+        !shouldMaskVideoForPublishing ||
+        localStreamStoreValue.type !== "success" ||
+        !localStreamStoreValue.stream ||
+        localStreamStoreValue.stream.getVideoTracks().length === 0
+    ) {
+        return localStreamStoreValue;
+    }
+
+    return {
+        type: "success",
+        stream: new MediaStream(localStreamStoreValue.stream.getAudioTracks()),
+    };
+}

--- a/play/src/front/Stores/MediaPublishingUtils.ts
+++ b/play/src/front/Stores/MediaPublishingUtils.ts
@@ -5,7 +5,15 @@ export function getSynchronizedCameraState(
     requestedCameraState: boolean,
     cameraPermissionState: BrowserMediaPermissionState
 ): boolean {
-    return requestedCameraState && cameraPermissionState === "granted";
+    if (!requestedCameraState) {
+        return false;
+    }
+
+    if (cameraPermissionState === null) {
+        return true;
+    }
+
+    return cameraPermissionState === "granted";
 }
 
 export function getLocalStreamForPublishing(

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -29,6 +29,8 @@ import { hideHelpCameraSettings } from "./HelpSettingsStore";
 import { isLiveStreamingStore } from "./IsStreamingStore";
 
 import { backgroundConfigStore, backgroundProcessingEnabledStore } from "./BackgroundTransformStore";
+import { cameraPermissionStateStore } from "./MediaStatusStore";
+import { getLocalStreamForPublishing, getSynchronizedCameraState } from "./MediaPublishingUtils";
 
 export const inBackgroundSettingsStore = writable<boolean>(false);
 
@@ -100,6 +102,12 @@ function createEnableCameraSceneVisibilityStore() {
 export const requestedCameraState = createRequestedCameraState();
 export const requestedMicrophoneState = createRequestedMicrophoneState();
 export const enableCameraSceneVisibilityStore = createEnableCameraSceneVisibilityStore();
+
+export const synchronizedCameraStateStore = derived(
+    [requestedCameraState, cameraPermissionStateStore],
+    ([$requestedCameraState, $cameraPermissionStateStore]) =>
+        getSynchronizedCameraState($requestedCameraState, $cameraPermissionStateStore)
+);
 
 /**
  * A store that is true when the megaphone screen is displayed.
@@ -953,30 +961,26 @@ export const localStreamStore = derived<
  * so that LiveKit/WebRTC do not publish camera; preview in BackgroundSettingsPanel still uses localStreamStore.
  */
 export const localStreamStoreForPublishing = derived<
-    [typeof localStreamStore, typeof availabilityStatusStore, typeof inBackgroundSettingsStore],
+    [
+        typeof localStreamStore,
+        typeof availabilityStatusStore,
+        typeof inBackgroundSettingsStore,
+        typeof synchronizedCameraStateStore
+    ],
     LocalStreamStoreValue
 >(
-    [localStreamStore, availabilityStatusStore, inBackgroundSettingsStore],
-    ([$localStreamStore, $availabilityStatusStore, $inBackgroundSettingsStore], set) => {
+    [localStreamStore, availabilityStatusStore, inBackgroundSettingsStore, synchronizedCameraStateStore],
+    ([$localStreamStore, $availabilityStatusStore, $inBackgroundSettingsStore, $synchronizedCameraStateStore], set) => {
         const isUnavailableStatus =
             $availabilityStatusStore === AvailabilityStatus.DENY_PROXIMITY_MEETING ||
             $availabilityStatusStore === AvailabilityStatus.SILENT ||
             $availabilityStatusStore === AvailabilityStatus.DO_NOT_DISTURB ||
             $availabilityStatusStore === AvailabilityStatus.BACK_IN_A_MOMENT ||
             $availabilityStatusStore === AvailabilityStatus.BUSY;
-        const shouldMaskVideoForPublishing = isUnavailableStatus && $inBackgroundSettingsStore;
+        const shouldMaskVideoForPublishing =
+            !$synchronizedCameraStateStore || (isUnavailableStatus && $inBackgroundSettingsStore);
 
-        if (
-            shouldMaskVideoForPublishing &&
-            $localStreamStore.type === "success" &&
-            $localStreamStore.stream &&
-            $localStreamStore.stream.getVideoTracks().length > 0
-        ) {
-            const audioOnlyStream = new MediaStream($localStreamStore.stream.getAudioTracks());
-            set({ type: "success", stream: audioOnlyStream });
-            return;
-        }
-        set($localStreamStore);
+        set(getLocalStreamForPublishing($localStreamStore, shouldMaskVideoForPublishing));
     }
 );
 

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -957,8 +957,9 @@ export const localStreamStore = derived<
 );
 
 /**
- * When (unavailable status + in background settings), we expose the local stream without video tracks
- * so that LiveKit/WebRTC do not publish camera; preview in BackgroundSettingsPanel still uses localStreamStore.
+ * We expose the local stream without video tracks when the camera is not effectively publishable
+ * or when background settings must hide video while unavailable, so that LiveKit/WebRTC do not
+ * publish camera; preview in BackgroundSettingsPanel still uses localStreamStore.
  */
 export const localStreamStoreForPublishing = derived<
     [

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -29,6 +29,8 @@ import { hideHelpCameraSettings } from "./HelpSettingsStore";
 import { isLiveStreamingStore } from "./IsStreamingStore";
 
 import { backgroundConfigStore, backgroundProcessingEnabledStore } from "./BackgroundTransformStore";
+import { cameraPermissionStateStore } from "./MediaStatusStore";
+import { getLocalStreamForPublishing, getSynchronizedCameraState } from "./MediaPublishingUtils";
 
 export const inBackgroundSettingsStore = writable<boolean>(false);
 
@@ -100,6 +102,12 @@ function createEnableCameraSceneVisibilityStore() {
 export const requestedCameraState = createRequestedCameraState();
 export const requestedMicrophoneState = createRequestedMicrophoneState();
 export const enableCameraSceneVisibilityStore = createEnableCameraSceneVisibilityStore();
+
+export const synchronizedCameraStateStore = derived(
+    [requestedCameraState, cameraPermissionStateStore],
+    ([$requestedCameraState, $cameraPermissionStateStore]) =>
+        getSynchronizedCameraState($requestedCameraState, $cameraPermissionStateStore)
+);
 
 /**
  * A store that is true when the megaphone screen is displayed.
@@ -947,30 +955,26 @@ export const localStreamStore = derived<
  * so that LiveKit/WebRTC do not publish camera; preview in BackgroundSettingsPanel still uses localStreamStore.
  */
 export const localStreamStoreForPublishing = derived<
-    [typeof localStreamStore, typeof availabilityStatusStore, typeof inBackgroundSettingsStore],
+    [
+        typeof localStreamStore,
+        typeof availabilityStatusStore,
+        typeof inBackgroundSettingsStore,
+        typeof synchronizedCameraStateStore
+    ],
     LocalStreamStoreValue
 >(
-    [localStreamStore, availabilityStatusStore, inBackgroundSettingsStore],
-    ([$localStreamStore, $availabilityStatusStore, $inBackgroundSettingsStore], set) => {
+    [localStreamStore, availabilityStatusStore, inBackgroundSettingsStore, synchronizedCameraStateStore],
+    ([$localStreamStore, $availabilityStatusStore, $inBackgroundSettingsStore, $synchronizedCameraStateStore], set) => {
         const isUnavailableStatus =
             $availabilityStatusStore === AvailabilityStatus.DENY_PROXIMITY_MEETING ||
             $availabilityStatusStore === AvailabilityStatus.SILENT ||
             $availabilityStatusStore === AvailabilityStatus.DO_NOT_DISTURB ||
             $availabilityStatusStore === AvailabilityStatus.BACK_IN_A_MOMENT ||
             $availabilityStatusStore === AvailabilityStatus.BUSY;
-        const shouldMaskVideoForPublishing = isUnavailableStatus && $inBackgroundSettingsStore;
+        const shouldMaskVideoForPublishing =
+            !$synchronizedCameraStateStore || (isUnavailableStatus && $inBackgroundSettingsStore);
 
-        if (
-            shouldMaskVideoForPublishing &&
-            $localStreamStore.type === "success" &&
-            $localStreamStore.stream &&
-            $localStreamStore.stream.getVideoTracks().length > 0
-        ) {
-            const audioOnlyStream = new MediaStream($localStreamStore.stream.getAudioTracks());
-            set({ type: "success", stream: audioOnlyStream });
-            return;
-        }
-        set($localStreamStore);
+        set(getLocalStreamForPublishing($localStreamStore, shouldMaskVideoForPublishing));
     }
 );
 

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -21,10 +21,10 @@ import {
     localStreamStore,
     localVoiceIndicatorStore,
     localVolumeStore,
-    mediaStreamConstraintsStore,
     requestedCameraState,
     requestedMicrophoneState,
     silentStore,
+    synchronizedCameraStateStore,
 } from "./MediaStore";
 import { screenShareStreamElementsStore, videoStreamElementsStore } from "./PeerStore";
 import { windowSize } from "./CoWebsiteStore";
@@ -68,10 +68,7 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL], set) 
             },
         },
         volumeStore: localVolumeStore,
-        hasVideo: derived(
-            mediaStreamConstraintsStore,
-            ($mediaStreamConstraintsStore) => $mediaStreamConstraintsStore.video !== false
-        ),
+        hasVideo: synchronizedCameraStateStore,
         // hasAudio = true because the webcam has a microphone attached and could potentially play sound
         hasAudio: writable(true),
         isMuted: derived(requestedMicrophoneState, (micState) => !micState),

--- a/play/src/front/WebRtc/SimplePeer.ts
+++ b/play/src/front/WebRtc/SimplePeer.ts
@@ -10,6 +10,7 @@ import { analyticsClient } from "../Administration/AnalyticsClient";
 import type { SimplePeerConnectionInterface, StreamableSubjects } from "../Space/SpacePeerManager/SpacePeerManager";
 import type { SpaceInterface, SpaceUserExtended } from "../Space/SpaceInterface";
 import { localStreamStoreForPublishing, type LocalStreamStoreValue } from "../Stores/MediaStore";
+import { createStableStreamStore } from "../Stores/StableStreamStore";
 import { RetryWithBackoff } from "../Utils/RetryWithBackoff";
 import { warningMessageStore } from "../Stores/ErrorStore";
 import LL from "../../i18n/i18n-svelte";
@@ -64,7 +65,7 @@ export class SimplePeer implements SimplePeerConnectionInterface {
         private _screenSharingLocalStreamStore: Readable<LocalStreamStoreValue | undefined>,
         private _analyticsClient = analyticsClient,
         private _customWebRTCLogger = customWebRTCLogger,
-        private _localStreamStore = localStreamStoreForPublishing
+        private _localStreamStore = createStableStreamStore(localStreamStoreForPublishing)
     ) {
         // Initialize retry manager with 30 attempts, backoff up to 15 seconds
         this.retryManager = new RetryWithBackoff({

--- a/play/src/front/WebRtc/SimplePeer.ts
+++ b/play/src/front/WebRtc/SimplePeer.ts
@@ -11,6 +11,7 @@ import { analyticsClient } from "../Administration/AnalyticsClient";
 import type { SimplePeerConnectionInterface, StreamableSubjects } from "../Space/SpacePeerManager/SpacePeerManager";
 import type { SpaceInterface, SpaceUserExtended } from "../Space/SpaceInterface";
 import { localStreamStoreForPublishing } from "../Stores/MediaStore";
+import { createStableStreamStore } from "../Stores/StableStreamStore";
 import { RetryWithBackoff } from "../Utils/RetryWithBackoff";
 import { warningMessageStore } from "../Stores/ErrorStore";
 import LL from "../../i18n/i18n-svelte";
@@ -65,7 +66,7 @@ export class SimplePeer implements SimplePeerConnectionInterface {
         private _screenSharingLocalStreamStore = screenSharingLocalStreamStore,
         private _analyticsClient = analyticsClient,
         private _customWebRTCLogger = customWebRTCLogger,
-        private _localStreamStore = localStreamStoreForPublishing
+        private _localStreamStore = createStableStreamStore(localStreamStoreForPublishing)
     ) {
         // Initialize retry manager with 30 attempts, backoff up to 15 seconds
         this.retryManager = new RetryWithBackoff({

--- a/tests/tests/camera_permission_prompt.spec.ts
+++ b/tests/tests/camera_permission_prompt.spec.ts
@@ -1,0 +1,72 @@
+import { expect, type Page, test } from "@playwright/test";
+import { getPage } from "./utils/auth";
+import Map from "./utils/map";
+import Menu from "./utils/menu";
+import { publicTestMapUrl } from "./utils/urls";
+
+test.use({
+    launchOptions: {
+        args: ["--use-fake-device-for-media-stream"],
+    },
+});
+
+async function expectCameraPermissionState(page: Page, state: PermissionState) {
+    await expect
+        .poll(
+            () =>
+                page.evaluate(async () => {
+                    if (!navigator.permissions?.query) {
+                        return null;
+                    }
+
+                    const permissionStatus = await navigator.permissions.query({
+                        name: "camera",
+                    } as PermissionDescriptor);
+
+                    return permissionStatus.state;
+                }),
+            { timeout: 15_000 },
+        )
+        .toBe(state);
+}
+
+test.describe("Camera permission prompt placeholder @nowebkit @nomobile", () => {
+    test("should render the local camera-off placeholder while camera permission is still prompt", async ({
+        browser,
+    }) => {
+        await using alice = await getPage(browser, "Alice", publicTestMapUrl("tests/E2E/empty.json", "meeting"), {
+            clearPermissions: true,
+        });
+        await using bob = await getPage(browser, "Bob", publicTestMapUrl("tests/E2E/empty.json", "meeting"), {
+            permissions: ["camera", "microphone", "notifications"],
+        });
+
+        await Menu.turnOffCamera(alice);
+        await expectCameraPermissionState(alice, "prompt");
+
+        await Map.teleportToPosition(alice, 160, 160);
+        await Map.teleportToPosition(bob, 160, 160);
+
+        await alice.getByTestId("camera-button").click();
+        await expectCameraPermissionState(alice, "prompt");
+
+        const aliceLocalCameraBox = alice.getByTestId("camera-box-You");
+        const aliceRemoteBobCameraBox = alice.getByTestId("camera-box-Bob");
+        const bobRemoteAliceCameraBox = bob.getByTestId("camera-box-Alice");
+
+        await expect(aliceLocalCameraBox).toBeVisible({
+            timeout: 30_000,
+        });
+        await expect(aliceRemoteBobCameraBox).toBeVisible({
+            timeout: 30_000,
+        });
+        await expect(bobRemoteAliceCameraBox).toBeVisible({
+            timeout: 30_000,
+        });
+
+        await expect(aliceLocalCameraBox.locator("video")).toHaveCount(0);
+        await expect(aliceLocalCameraBox.locator("img.noselect")).toBeVisible();
+        await expect(bobRemoteAliceCameraBox.locator("video")).toHaveCount(0);
+        await expect(bobRemoteAliceCameraBox.locator("img.noselect")).toBeVisible();
+    });
+});

--- a/tests/tests/utils/auth.ts
+++ b/tests/tests/utils/auth.ts
@@ -8,6 +8,12 @@ import { dismissPwaInstallScreenIfShown } from "./pwaInstall";
 import { dismissDuplicateUserConnectedModalIfShown } from "./duplicateUserModal";
 import { dismissDoNotDisturbInfoToast } from "./doNotDisturbInfoToast";
 
+type GetPageOptions = {
+    pageCreatedHook?: (page: Page) => void;
+    permissions?: string[];
+    clearPermissions?: boolean;
+};
+
 function selectWoka(name: string): number {
     let res = 0;
     for (let i = 0; i < name.length; i++) {
@@ -44,11 +50,18 @@ async function createUser(
         | "User1",
     browser: Browser,
     url: string,
+    options: Pick<GetPageOptions, "permissions" | "clearPermissions"> = {},
 ): Promise<void> {
     if (isJsonCreate(name)) {
         return;
     }
     const context: BrowserContext = await browser.newContext();
+    if (options.clearPermissions || options.permissions !== undefined) {
+        await context.clearPermissions();
+        if (options.permissions && options.permissions.length > 0 && browser.browserType().name() !== "firefox") {
+            await context.grantPermissions(options.permissions, { origin: play_url });
+        }
+    }
     const page: Page = await context.newPage();
     const targetUrl = new URL(url, play_url).toString();
 
@@ -77,10 +90,10 @@ async function createUser(
     await dismissDoNotDisturbInfoToast(page);
     await skipOnboardingWhenShown(page);
 
-    if (browser.browserType().name() !== "webkit") {
+    if (options.permissions === undefined && !options.clearPermissions && browser.browserType().name() !== "webkit") {
         await Menu.expectButtonState(page, "microphone-button", "normal");
         await Menu.expectButtonState(page, "camera-button", "normal");
-    } else {
+    } else if (options.permissions === undefined && !options.clearPermissions) {
         await Menu.expectButtonState(page, "microphone-button", "forbidden");
         await Menu.expectButtonState(page, "camera-button", "forbidden");
     }
@@ -125,12 +138,16 @@ export async function getPage(
         | "UserMatrix2"
         | "User1",
     url: string,
-    options: {
-        pageCreatedHook?: (page: Page) => void;
-    } = {},
+    options: GetPageOptions = {},
 ): Promise<Page> {
-    await createUser(name, browser, url);
+    await createUser(name, browser, url, options);
     const newBrowser: BrowserContext = await browser.newContext({ storageState: "./.auth/" + name + ".json" });
+    if (options.clearPermissions || options.permissions !== undefined) {
+        await newBrowser.clearPermissions();
+        if (options.permissions && options.permissions.length > 0 && browser.browserType().name() !== "firefox") {
+            await newBrowser.grantPermissions(options.permissions, { origin: play_url });
+        }
+    }
     const page: Page = await newBrowser.newPage();
     if (options.pageCreatedHook) {
         options.pageCreatedHook(page);


### PR DESCRIPTION
## Problem
Camera “on” for the user could disagree with what we publish or report: we used the requested camera flag without tying it to browser permission, and peers could see unnecessary stream churn when the derived publishing stream changed shape.
## Solution
Introduce a derived `synchronizedCameraStateStore` that is true only when the camera is requested **and** permission is `granted`. Use it for connection query params, space peer camera state, and masking video in `localStreamStoreForPublishing` when the camera is not effectively on. Extract stream-masking logic into `MediaPublishingUtils` for clarity. Wrap `localStreamStoreForPublishing` with `createStableStreamStore` in `SimplePeer` to reduce unstable stream references for WebRTC.
