### PR TITLE
Switching Livekit to "selective subscription"

### DIFF
--- a/play/src/front/Components/Video/CenteredVideo.svelte
+++ b/play/src/front/Components/Video/CenteredVideo.svelte
@@ -174,7 +174,7 @@
                     />
                 {:else if media?.type === "livekit"}
                     <LivekitVideo
-                        remoteVideoTrack={media.remoteVideoTrack}
+                        {media}
                         {onLoadVideoElement}
                         style={"width: " +
                             Math.ceil(videoWidth) +

--- a/play/src/front/Components/Video/PictureInPicture/PictureInPictureWindow.ts
+++ b/play/src/front/Components/Video/PictureInPicture/PictureInPictureWindow.ts
@@ -1,13 +1,40 @@
+export interface DocumentPictureInPictureEvent extends Event {
+    readonly window: Window;
+}
+
+interface DocumentPictureInPicture extends EventTarget {
+    readonly window?: Window;
+    requestWindow: (options: {
+        preferInitialWindowPlacement: boolean;
+        height: string;
+        width: string;
+    }) => Promise<Window>;
+    addEventListener(
+        type: string,
+        callback: EventListenerOrEventListenerObject | null,
+        options?: boolean | AddEventListenerOptions
+    ): void;
+    addEventListener(
+        type: "enter",
+        listener: (event: DocumentPictureInPictureEvent) => void,
+        options?: boolean | AddEventListenerOptions
+    ): void;
+    removeEventListener(
+        type: string,
+        callback: EventListenerOrEventListenerObject | null,
+        options?: boolean | EventListenerOptions
+    ): void;
+    removeEventListener(
+        type: "enter",
+        listener: (event: DocumentPictureInPictureEvent) => void,
+        options?: boolean | EventListenerOptions
+    ): void;
+}
+
 // create interface for window with documentPictureInPicture
 declare global {
     interface Window {
-        documentPictureInPicture: {
-            requestWindow: (options: {
-                preferInitialWindowPlacement: boolean;
-                height: string;
-                width: string;
-            }) => Promise<Window>;
-        };
+        documentPictureInPicture: DocumentPictureInPicture;
     }
 }
 

--- a/play/src/front/Components/Video/VideoBoxOptimizer.svelte
+++ b/play/src/front/Components/Video/VideoBoxOptimizer.svelte
@@ -5,6 +5,7 @@
     import { oneLineStreamableCollectionStore } from "../../Stores/OneLineStreamableCollectionStore";
     import type { ObservableElement } from "../../Interfaces/ObservableElement";
     import type { TokenRemovalHandle } from "../../Utils/TokenBucket";
+    import type { DocumentPictureInPictureEvent } from "./PictureInPicture/PictureInPictureWindow";
     import { videoBoxVisibilityTokenBucket } from "./VideoBoxVisibilityTokenBucket";
 
     export let videoBox: VideoBox;
@@ -22,6 +23,31 @@
     $: isFirst = $orderStore === 0;
 
     $: isLast = $orderStore === $oneLineStreamableCollectionStore.length - 1;
+
+    let currentDocumentPictureInPictureWindow: Window | undefined;
+    let intersectionObserverRefreshTimeout: number | undefined;
+
+    function refreshIntersectionObserver() {
+        if (!videoBoxElement || !intersectionObserver) {
+            return;
+        }
+
+        intersectionObserver.unobserve(videoBoxElement);
+        intersectionObserver.observe(videoBoxElement);
+    }
+
+    function scheduleIntersectionObserverRefresh() {
+        if (intersectionObserverRefreshTimeout !== undefined) {
+            clearTimeout(intersectionObserverRefreshTimeout);
+        }
+
+        // PiP enter/pagehide can fire before the DOM node has been moved to its new document.
+        // Use setTimeout instead of requestAnimationFrame because the main document can be hidden when PiP closes.
+        intersectionObserverRefreshTimeout = window.setTimeout(() => {
+            intersectionObserverRefreshTimeout = undefined;
+            refreshIntersectionObserver();
+        }, 100);
+    }
 
     onMount(() => {
         if (!videoBoxElement) {
@@ -53,7 +79,37 @@
             }
         };
 
+        const handleDocumentPictureInPictureLeave = () => {
+            // The refresh will trigger only when the page becomes visible again.
+            // In case we close the PiP window without switching to the main page, this will not happen right away.
+            // In the meantime, we can assume the video is hidden.
+            isVisible = false;
+            scheduleIntersectionObserverRefresh();
+        };
+
+        const handleDocumentPictureInPictureEnter = (event: DocumentPictureInPictureEvent) => {
+            currentDocumentPictureInPictureWindow?.removeEventListener("pagehide", handleDocumentPictureInPictureLeave);
+            currentDocumentPictureInPictureWindow = event.window;
+            currentDocumentPictureInPictureWindow.addEventListener("pagehide", handleDocumentPictureInPictureLeave, {
+                once: true,
+            });
+            scheduleIntersectionObserverRefresh();
+        };
+
+        const documentPictureInPicture =
+            "documentPictureInPicture" in window ? window.documentPictureInPicture : undefined;
+
+        // When entering / leaving PiP, we noticed the intersection observer is not correctly updated.
+        // Here, we are adding some custom PiP tracking to force refreshing the intersection observer each time PiP
+        // is triggered.
+        documentPictureInPicture?.addEventListener("enter", handleDocumentPictureInPictureEnter);
+
         return () => {
+            documentPictureInPicture?.removeEventListener("enter", handleDocumentPictureInPictureEnter);
+            currentDocumentPictureInPictureWindow?.removeEventListener("pagehide", handleDocumentPictureInPictureLeave);
+            if (intersectionObserverRefreshTimeout !== undefined) {
+                clearTimeout(intersectionObserverRefreshTimeout);
+            }
             if (videoBoxElement) {
                 intersectionObserver?.unobserve(videoBoxElement);
             }

--- a/play/src/front/Components/Video/VideoTags/LivekitVideo.svelte
+++ b/play/src/front/Components/Video/VideoTags/LivekitVideo.svelte
@@ -1,9 +1,8 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-    import type { Readable } from "svelte/store";
-    import type { RemoteVideoTrack } from "livekit-client";
-    import { createEventDispatcher } from "svelte";
+    import { createEventDispatcher, onDestroy } from "svelte";
+    import type { LivekitStreamable } from "../../../Space/Streamable";
     import InnerLivekitVideo from "./InnerLivekitVideo.svelte";
 
     const dispatch = createEventDispatcher<{
@@ -16,8 +15,24 @@
     export let videoWidth: number;
     export let videoHeight: number;
     export let onLoadVideoElement: (event: Event) => void;
+    export let media: LivekitStreamable;
 
-    export let remoteVideoTrack: Readable<RemoteVideoTrack | undefined>;
+    let remoteVideoTrack: LivekitStreamable["remoteVideoTrack"];
+    let activeMedia: LivekitStreamable | undefined;
+
+    $: remoteVideoTrack = media.remoteVideoTrack;
+
+    $: {
+        if (activeMedia !== media) {
+            activeMedia?.setVideoSubscribed(false);
+            activeMedia = media;
+            media.setVideoSubscribed(true);
+        }
+    }
+
+    onDestroy(() => {
+        activeMedia?.setVideoSubscribed(false);
+    });
 </script>
 
 {#if $remoteVideoTrack}

--- a/play/src/front/Components/Video/VideoTags/LivekitVideo.svelte
+++ b/play/src/front/Components/Video/VideoTags/LivekitVideo.svelte
@@ -19,19 +19,20 @@
 
     let remoteVideoTrack: LivekitStreamable["remoteVideoTrack"];
     let activeMedia: LivekitStreamable | undefined;
+    let releaseVideoSubscription: (() => void) | undefined;
 
     $: remoteVideoTrack = media.remoteVideoTrack;
 
     $: {
         if (activeMedia !== media) {
-            activeMedia?.setVideoSubscribed(false);
+            releaseVideoSubscription?.();
             activeMedia = media;
-            media.setVideoSubscribed(true);
+            releaseVideoSubscription = media.acquireVideoSubscription();
         }
     }
 
     onDestroy(() => {
-        activeMedia?.setVideoSubscribed(false);
+        releaseVideoSubscription?.();
     });
 </script>
 

--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { FilterType } from "@workadventure/messages";
 import { MapStore } from "@workadventure/store-utils";
-import type { LocalParticipant, Participant, TrackPublishOptions } from "livekit-client";
+import type { LocalParticipant, Participant, RemoteParticipant, TrackPublishOptions } from "livekit-client";
 import {
     BackupCodecPolicy,
     LocalAudioTrack,
@@ -49,7 +49,7 @@ export class LiveKitRoom implements LiveKitRoomInterface {
     private room: Room | undefined;
     private participants: MapStore<string, LiveKitParticipant> = new MapStore<string, LiveKitParticipant>();
     // Stores LiveKit participants that connected before their corresponding spaceUser was available
-    private pendingParticipants: Map<string, Participant> = new Map();
+    private pendingParticipants: Map<string, RemoteParticipant> = new Map();
     private localParticipant: LocalParticipant | undefined;
     private localScreenSharingVideoTrack: LocalVideoTrack | undefined;
     private localScreenSharingAudioTrack: LocalAudioTrack | undefined;
@@ -132,7 +132,7 @@ export class LiveKitRoom implements LiveKitRoomInterface {
 
         this.handleRoomEvents();
         await room.connect(this.serverUrl, this.token, {
-            autoSubscribe: true,
+            autoSubscribe: false,
         });
         if (this.abortSignal.aborted) {
             await room.disconnect();
@@ -538,7 +538,6 @@ export class LiveKitRoom implements LiveKitRoomInterface {
         this.room.on(RoomEvent.ParticipantConnected, this.boundHandleParticipantConnected);
         this.room.on(RoomEvent.ParticipantDisconnected, this.boundHandleParticipantDisconnected);
         this.room.on(RoomEvent.ActiveSpeakersChanged, this.boundHandleActiveSpeakersChanged);
-        this.room.on(RoomEvent.ParticipantActive, this.boundHandleParticipantConnected);
         this.room.on(RoomEvent.Disconnected, this.boundHandleDisconnected);
     }
 
@@ -631,7 +630,7 @@ export class LiveKitRoom implements LiveKitRoomInterface {
         });
     }
 
-    private handleParticipantConnected(participant: Participant) {
+    private handleParticipantConnected(participant: RemoteParticipant) {
         if (this.abortSignal.aborted) {
             return;
         }
@@ -662,7 +661,7 @@ export class LiveKitRoom implements LiveKitRoomInterface {
      * Creates a LiveKitParticipant and adds it to the participants map
      */
     private createLiveKitParticipant(
-        participant: Participant,
+        participant: RemoteParticipant,
         spaceUser: ReturnType<SpaceInterface["getSpaceUserBySpaceUserId"]>
     ) {
         if (!spaceUser) {
@@ -805,7 +804,6 @@ export class LiveKitRoom implements LiveKitRoomInterface {
             this.room?.off(RoomEvent.ParticipantConnected, this.boundHandleParticipantConnected);
             this.room?.off(RoomEvent.ParticipantDisconnected, this.boundHandleParticipantDisconnected);
             this.room?.off(RoomEvent.ActiveSpeakersChanged, this.boundHandleActiveSpeakersChanged);
-            this.room?.off(RoomEvent.ParticipantActive, this.boundHandleParticipantConnected);
             this.room?.off(RoomEvent.Disconnected, this.boundHandleDisconnected);
             this.leaveRoom();
         } finally {

--- a/play/src/front/Livekit/LivekitParticipant.test.ts
+++ b/play/src/front/Livekit/LivekitParticipant.test.ts
@@ -18,10 +18,12 @@ describe("LiveKitParticipant", () => {
     });
 
     afterEach(() => {
+        vi.useRealTimers();
         vi.restoreAllMocks();
     });
 
     it("should keep the camera publication subscribed until the last lease is released", () => {
+        vi.useFakeTimers();
         const publication = createCameraPublication();
         const participant = createParticipant({ publications: [publication] });
         const media = participant.getStreamable().media as LivekitStreamable;
@@ -39,11 +41,16 @@ describe("LiveKitParticipant", () => {
         expect(publication.setSubscribed).toHaveBeenCalledTimes(1);
 
         releaseSecond();
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(1);
+
+        vi.advanceTimersByTime(75);
+
         expect(publication.setSubscribed).toHaveBeenCalledTimes(2);
         expect(publication.setSubscribed).toHaveBeenLastCalledWith(false);
     });
 
     it("should ignore duplicate lease releases", () => {
+        vi.useFakeTimers();
         const publication = createCameraPublication();
         const participant = createParticipant({ publications: [publication] });
         const media = participant.getStreamable().media as LivekitStreamable;
@@ -54,12 +61,17 @@ describe("LiveKitParticipant", () => {
         release();
         release();
 
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(1);
+
+        vi.advanceTimersByTime(75);
+
         expect(publication.setSubscribed).toHaveBeenCalledTimes(2);
         expect(publication.setSubscribed).toHaveBeenNthCalledWith(1, true);
         expect(publication.setSubscribed).toHaveBeenNthCalledWith(2, false);
     });
 
     it("should subscribe a newly published camera track when a lease is already active", () => {
+        vi.useFakeTimers();
         const participant = createParticipant({ publications: [] });
         const media = participant.getStreamable().media as LivekitStreamable;
         const publication = createCameraPublication();
@@ -72,6 +84,37 @@ describe("LiveKitParticipant", () => {
         expect(publication.setSubscribed).toHaveBeenCalledWith(true);
 
         release();
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(1);
+
+        vi.advanceTimersByTime(75);
+
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(2);
+        expect(publication.setSubscribed).toHaveBeenLastCalledWith(false);
+    });
+
+    it("should cancel a pending unsubscribe when the same video is reacquired quickly", () => {
+        vi.useFakeTimers();
+        const publication = createCameraPublication();
+        const participant = createParticipant({ publications: [publication] });
+        const media = participant.getStreamable().media as LivekitStreamable;
+
+        publication.setSubscribed.mockClear();
+
+        const releaseFirst = media.acquireVideoSubscription();
+        releaseFirst();
+
+        vi.advanceTimersByTime(50);
+        const releaseSecond = media.acquireVideoSubscription();
+
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(1);
+        expect(publication.setSubscribed).toHaveBeenLastCalledWith(true);
+
+        vi.advanceTimersByTime(100);
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(1);
+
+        releaseSecond();
+        vi.advanceTimersByTime(75);
+
         expect(publication.setSubscribed).toHaveBeenCalledTimes(2);
         expect(publication.setSubscribed).toHaveBeenLastCalledWith(false);
     });

--- a/play/src/front/Livekit/LivekitParticipant.test.ts
+++ b/play/src/front/Livekit/LivekitParticipant.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { Subject } from "rxjs";
+import { writable } from "svelte/store";
+import { ConnectionQuality, Track, type RemoteParticipant, type RemoteTrackPublication } from "livekit-client";
+import type { SpaceUserExtended } from "../Space/SpaceInterface";
+import type { StreamableSubjects } from "../Space/SpacePeerManager/SpacePeerManager";
+import type { LivekitStreamable, Streamable } from "../Space/Streamable";
+import { LiveKitParticipant } from "./LivekitParticipant";
+
+type MockRemoteTrackPublication = RemoteTrackPublication & {
+    setSubscribed: ReturnType<typeof vi.fn<(subscribed: boolean) => void>>;
+    setVideoQuality: ReturnType<typeof vi.fn>;
+};
+
+describe("LiveKitParticipant", () => {
+    beforeEach(() => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("should keep the camera publication subscribed until the last lease is released", () => {
+        const publication = createCameraPublication();
+        const participant = createParticipant({ publications: [publication] });
+        const media = participant.getStreamable().media as LivekitStreamable;
+
+        publication.setSubscribed.mockClear();
+
+        const releaseFirst = media.acquireVideoSubscription();
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(1);
+        expect(publication.setSubscribed).toHaveBeenLastCalledWith(true);
+
+        const releaseSecond = media.acquireVideoSubscription();
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(1);
+
+        releaseFirst();
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(1);
+
+        releaseSecond();
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(2);
+        expect(publication.setSubscribed).toHaveBeenLastCalledWith(false);
+    });
+
+    it("should ignore duplicate lease releases", () => {
+        const publication = createCameraPublication();
+        const participant = createParticipant({ publications: [publication] });
+        const media = participant.getStreamable().media as LivekitStreamable;
+
+        publication.setSubscribed.mockClear();
+
+        const release = media.acquireVideoSubscription();
+        release();
+        release();
+
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(2);
+        expect(publication.setSubscribed).toHaveBeenNthCalledWith(1, true);
+        expect(publication.setSubscribed).toHaveBeenNthCalledWith(2, false);
+    });
+
+    it("should subscribe a newly published camera track when a lease is already active", () => {
+        const participant = createParticipant({ publications: [] });
+        const media = participant.getStreamable().media as LivekitStreamable;
+        const publication = createCameraPublication();
+
+        const release = media.acquireVideoSubscription();
+
+        participant["handleTrackPublished"](publication);
+
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(1);
+        expect(publication.setSubscribed).toHaveBeenCalledWith(true);
+
+        release();
+        expect(publication.setSubscribed).toHaveBeenCalledTimes(2);
+        expect(publication.setSubscribed).toHaveBeenLastCalledWith(false);
+    });
+});
+
+function createParticipant({ publications }: { publications: RemoteTrackPublication[] }): LiveKitParticipant {
+    const streamableSubjects: StreamableSubjects = {
+        videoPeerAdded: new Subject<Streamable>(),
+        videoPeerRemoved: new Subject<Streamable>(),
+        screenSharingPeerAdded: new Subject<Streamable>(),
+        screenSharingPeerRemoved: new Subject<Streamable>(),
+    };
+
+    const participant = {
+        identity: "user-1",
+        sid: "sid-1",
+        isSpeaking: false,
+        connectionQuality: ConnectionQuality.Excellent,
+        name: "Alice",
+        on: vi.fn(),
+        off: vi.fn(),
+        getTrackPublications: () => publications,
+    } as unknown as RemoteParticipant;
+
+    const spaceUser = {
+        spaceUserId: "user-1",
+        reactiveUser: {
+            cameraState: writable(true),
+            microphoneState: writable(true),
+        },
+    } as unknown as SpaceUserExtended;
+
+    return new LiveKitParticipant(
+        participant,
+        spaceUser,
+        streamableSubjects,
+        writable(new Set<string>()),
+        new AbortController().signal
+    );
+}
+
+function createCameraPublication(): MockRemoteTrackPublication {
+    return {
+        isLocal: false,
+        isMuted: false,
+        source: Track.Source.Camera,
+        track: undefined,
+        setSubscribed: vi.fn(),
+        setVideoQuality: vi.fn(),
+    } as unknown as MockRemoteTrackPublication;
+}

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -21,6 +21,10 @@ import { screenShareQualityStore } from "../Stores/ScreenSharingStore";
 import { createLivekitWebRtcStats } from "../WebRtc/WebRtcStatsFactory";
 import type { LivekitStreamable, Streamable } from "../Space/Streamable";
 
+// Maximize/minimize can briefly mount 2 video components for the same participant.
+// Delaying the final unsubscribe avoids sending a false->true bounce to LiveKit during that handoff.
+const VIDEO_UNSUBSCRIBE_DELAY_MS = 75;
+
 export class LiveKitParticipant {
     private _isSpeakingStore: Writable<boolean>;
     private _connectionQualityStore: Writable<ConnectionQuality>;
@@ -50,6 +54,10 @@ export class LiveKitParticipant {
     private _muteAudioStore: Writable<boolean> = writable<boolean>(false);
     private _cameraVideoSubscriptions = new Set<symbol>();
     private _screenShareVideoSubscriptions = new Set<symbol>();
+    private _cameraVideoSubscribed = false;
+    private _screenShareVideoSubscribed = false;
+    private _cameraUnsubscribeTimeout: ReturnType<typeof setTimeout> | undefined;
+    private _screenShareUnsubscribeTimeout: ReturnType<typeof setTimeout> | undefined;
 
     private _cameraPublication: RemoteTrackPublication | undefined;
     private _microphonePublication: RemoteTrackPublication | undefined;
@@ -121,7 +129,10 @@ export class LiveKitParticipant {
 
         subscriptions.add(token);
         if (subscriptions.size === 1) {
-            this.syncVideoSubscriptionState(type);
+            // A new viewer arrived before the delayed unsubscribe fired. Keep the current server-side
+            // subscription alive so layout churn does not trigger unnecessary LiveKit updates.
+            this.clearPendingVideoUnsubscribe(type);
+            this.setVideoSubscribed(type, true);
         }
 
         return () => {
@@ -132,18 +143,79 @@ export class LiveKitParticipant {
             released = true;
             subscriptions.delete(token);
             if (subscriptions.size === 0) {
-                this.syncVideoSubscriptionState(type);
+                this.scheduleVideoUnsubscribe(type);
             }
         };
     }
 
-    private syncVideoSubscriptionState(type: "camera" | "screenShare") {
-        if (type === "camera") {
-            this._cameraPublication?.setSubscribed(this._cameraVideoSubscriptions.size > 0);
+    private clearPendingVideoUnsubscribe(type: "camera" | "screenShare") {
+        const timeout = type === "camera" ? this._cameraUnsubscribeTimeout : this._screenShareUnsubscribeTimeout;
+        if (timeout === undefined) {
             return;
         }
 
-        this._screenSharePublication?.setSubscribed(this._screenShareVideoSubscriptions.size > 0);
+        clearTimeout(timeout);
+
+        if (type === "camera") {
+            this._cameraUnsubscribeTimeout = undefined;
+        } else {
+            this._screenShareUnsubscribeTimeout = undefined;
+        }
+    }
+
+    private scheduleVideoUnsubscribe(type: "camera" | "screenShare") {
+        this.clearPendingVideoUnsubscribe(type);
+
+        const timeout = setTimeout(() => {
+            if (type === "camera") {
+                this._cameraUnsubscribeTimeout = undefined;
+                if (this._cameraVideoSubscriptions.size === 0) {
+                    // Only unsubscribe if nobody reacquired the video during the short grace period.
+                    this.setVideoSubscribed("camera", false);
+                }
+                return;
+            }
+
+            this._screenShareUnsubscribeTimeout = undefined;
+            if (this._screenShareVideoSubscriptions.size === 0) {
+                // Only unsubscribe if nobody reacquired the screen share during the short grace period.
+                this.setVideoSubscribed("screenShare", false);
+            }
+        }, VIDEO_UNSUBSCRIBE_DELAY_MS);
+
+        if (type === "camera") {
+            this._cameraUnsubscribeTimeout = timeout;
+        } else {
+            this._screenShareUnsubscribeTimeout = timeout;
+        }
+    }
+
+    private setVideoSubscribed(type: "camera" | "screenShare", subscribed: boolean) {
+        if (type === "camera") {
+            if (this._cameraVideoSubscribed === subscribed) {
+                return;
+            }
+
+            this._cameraVideoSubscribed = subscribed;
+            this._cameraPublication?.setSubscribed(subscribed);
+            return;
+        }
+
+        if (this._screenShareVideoSubscribed === subscribed) {
+            return;
+        }
+
+        this._screenShareVideoSubscribed = subscribed;
+        this._screenSharePublication?.setSubscribed(subscribed);
+    }
+
+    private syncVideoSubscriptionState(type: "camera" | "screenShare") {
+        if (type === "camera") {
+            this._cameraPublication?.setSubscribed(this._cameraVideoSubscribed);
+            return;
+        }
+
+        this._screenSharePublication?.setSubscribed(this._screenShareVideoSubscribed);
     }
 
     private handleTrackPublished(publication: RemoteTrackPublication) {
@@ -474,8 +546,12 @@ export class LiveKitParticipant {
             this._actualScreenShare = undefined;
         }
 
+        this.clearPendingVideoUnsubscribe("camera");
+        this.clearPendingVideoUnsubscribe("screenShare");
         this._cameraVideoSubscriptions.clear();
         this._screenShareVideoSubscriptions.clear();
+        this._cameraVideoSubscribed = false;
+        this._screenShareVideoSubscribed = false;
         this._cameraPublication?.setSubscribed(false);
         this._microphonePublication?.setSubscribed(false);
         this._screenSharePublication?.setSubscribed(false);

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -48,6 +48,8 @@ export class LiveKitParticipant {
     );
     private _isActiveSpeaker = writable<boolean>(false);
     private _muteAudioStore: Writable<boolean> = writable<boolean>(false);
+    private _cameraVideoSubscriptions = new Set<symbol>();
+    private _screenShareVideoSubscriptions = new Set<symbol>();
 
     private _cameraPublication: RemoteTrackPublication | undefined;
     private _microphonePublication: RemoteTrackPublication | undefined;
@@ -112,6 +114,38 @@ export class LiveKitParticipant {
         this.updateLivekitVideoStreamStore();
     }
 
+    private acquireVideoSubscription(type: "camera" | "screenShare"): () => void {
+        const subscriptions = type === "camera" ? this._cameraVideoSubscriptions : this._screenShareVideoSubscriptions;
+        const token = Symbol(type);
+        let released = false;
+
+        subscriptions.add(token);
+        if (subscriptions.size === 1) {
+            this.syncVideoSubscriptionState(type);
+        }
+
+        return () => {
+            if (released) {
+                return;
+            }
+
+            released = true;
+            subscriptions.delete(token);
+            if (subscriptions.size === 0) {
+                this.syncVideoSubscriptionState(type);
+            }
+        };
+    }
+
+    private syncVideoSubscriptionState(type: "camera" | "screenShare") {
+        if (type === "camera") {
+            this._cameraPublication?.setSubscribed(this._cameraVideoSubscriptions.size > 0);
+            return;
+        }
+
+        this._screenSharePublication?.setSubscribed(this._screenShareVideoSubscriptions.size > 0);
+    }
+
     private handleTrackPublished(publication: RemoteTrackPublication) {
         if (this.abortSignal.aborted) {
             return;
@@ -129,6 +163,7 @@ export class LiveKitParticipant {
             }
             this._cameraPublication = publication;
             this._hasVideo.set(!publication.isMuted);
+            this.syncVideoSubscriptionState("camera");
         } else if (publication.source === Track.Source.ScreenShare) {
             if (this._screenSharePublication && this._screenSharePublication !== publication) {
                 console.warn(
@@ -141,6 +176,7 @@ export class LiveKitParticipant {
             }
             this._screenSharePublication = publication;
             this._hasScreenShareVideo.set(!publication.isMuted);
+            this.syncVideoSubscriptionState("screenShare");
             this.refreshLivekitScreenShareStreamStore();
         } else if (publication.source === Track.Source.ScreenShareAudio) {
             if (this._screenShareAudioPublication && this._screenShareAudioPublication !== publication) {
@@ -352,7 +388,7 @@ export class LiveKitParticipant {
                 isBlocked: derived(this._blockedUsersStore, ($blockedUsersStore) =>
                     $blockedUsersStore.has(this._spaceUser.spaceUserId)
                 ),
-                setVideoSubscribed: (subscribed: boolean) => this._cameraPublication?.setSubscribed(subscribed),
+                acquireVideoSubscription: () => this.acquireVideoSubscription("camera"),
             } as LivekitStreamable,
             volumeStore: writable(undefined),
             volume: writable(this.defaultVolume),
@@ -386,7 +422,7 @@ export class LiveKitParticipant {
                 isBlocked: derived(this._blockedUsersStore, ($blockedUsersStore) =>
                     $blockedUsersStore.has(this._spaceUser.spaceUserId)
                 ),
-                setVideoSubscribed: (subscribed: boolean) => this._screenSharePublication?.setSubscribed(subscribed),
+                acquireVideoSubscription: () => this.acquireVideoSubscription("screenShare"),
             } as LivekitStreamable,
             volumeStore: writable(undefined),
             volume: writable(this.defaultVolume),
@@ -438,6 +474,8 @@ export class LiveKitParticipant {
             this._actualScreenShare = undefined;
         }
 
+        this._cameraVideoSubscriptions.clear();
+        this._screenShareVideoSubscriptions.clear();
         this._cameraPublication?.setSubscribed(false);
         this._microphonePublication?.setSubscribed(false);
         this._screenSharePublication?.setSubscribed(false);

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -1,11 +1,12 @@
 import type {
-    Participant,
+    RemoteParticipant,
     RemoteTrack,
     RemoteTrackPublication,
     TrackPublication,
     ConnectionQuality,
     RemoteVideoTrack,
 } from "livekit-client";
+import * as Sentry from "@sentry/svelte";
 import { Track, ParticipantEvent, VideoQuality } from "livekit-client";
 import type { Readable, Writable } from "svelte/store";
 import { derived, get, writable } from "svelte/store";
@@ -23,14 +24,10 @@ import type { LivekitStreamable, Streamable } from "../Space/Streamable";
 export class LiveKitParticipant {
     private _isSpeakingStore: Writable<boolean>;
     private _connectionQualityStore: Writable<ConnectionQuality>;
-    private _videoStreamStore: Writable<MediaStream | undefined> = writable<MediaStream | undefined>(undefined);
     private _audioStreamStore: Writable<MediaStream | undefined> = writable<MediaStream | undefined>(undefined);
     private _actualVideo: Streamable | undefined;
     private _actualScreenShare: Streamable | undefined;
 
-    private _videoScreenShareStreamStore: Writable<MediaStream | undefined> = writable<MediaStream | undefined>(
-        undefined
-    );
     private _audioScreenShareStreamStore: Writable<MediaStream | undefined> = writable<MediaStream | undefined>(
         undefined
     );
@@ -39,6 +36,9 @@ export class LiveKitParticipant {
     private _hasAudio = writable<boolean>(true);
     private _hasVideo = writable<boolean>(false);
     private _isMuted = writable<boolean>(true);
+    private _hasScreenShareVideo = writable<boolean>(false);
+    private _hasScreenShareAudio = writable<boolean>(false);
+    private _isScreenShareAudioMuted = writable<boolean>(true);
     private _spaceUser: SpaceUserExtended;
     private _videoRemoteTrack: Writable<RemoteVideoTrack | undefined> = writable<RemoteVideoTrack | undefined>(
         undefined
@@ -49,7 +49,14 @@ export class LiveKitParticipant {
     private _isActiveSpeaker = writable<boolean>(false);
     private _muteAudioStore: Writable<boolean> = writable<boolean>(false);
 
+    private _cameraPublication: RemoteTrackPublication | undefined;
+    private _microphonePublication: RemoteTrackPublication | undefined;
+    private _screenSharePublication: RemoteTrackPublication | undefined;
+    private _screenShareAudioPublication: RemoteTrackPublication | undefined;
+
+    private boundHandleTrackPublished: (publication: RemoteTrackPublication) => void;
     private boundHandleTrackSubscribed: (track: RemoteTrack, publication: RemoteTrackPublication) => void;
+    private boundHandleTrackUnpublished: (publication: RemoteTrackPublication) => void;
     private boundHandleTrackUnsubscribed: (track: RemoteTrack, publication: RemoteTrackPublication) => void;
     private boundHandleTrackMuted: (publication: TrackPublication) => void;
     private boundHandleTrackUnmuted: (publication: TrackPublication) => void;
@@ -57,7 +64,7 @@ export class LiveKitParticipant {
     private boundHandleIsSpeakingChanged: (isSpeaking: boolean) => void;
 
     constructor(
-        public participant: Participant,
+        public participant: RemoteParticipant,
         private spaceUser: SpaceUserExtended,
         private _streamableSubjects: StreamableSubjects,
         private _blockedUsersStore: Readable<Set<string>>,
@@ -65,17 +72,18 @@ export class LiveKitParticipant {
         private defaultVolume: number = get(volumeProximityDiscussionStore)
     ) {
         incrementLivekitConnectionsCount();
+        this.boundHandleTrackPublished = this.handleTrackPublished.bind(this);
         this.boundHandleTrackSubscribed = this.handleTrackSubscribed.bind(this);
+        this.boundHandleTrackUnpublished = this.handleTrackUnpublished.bind(this);
         this.boundHandleTrackUnsubscribed = this.handleTrackUnsubscribed.bind(this);
         this.boundHandleTrackMuted = this.handleTrackMuted.bind(this);
         this.boundHandleTrackUnmuted = this.handleTrackUnmuted.bind(this);
         this.boundHandleConnectionQualityChanged = this.handleConnectionQualityChanged.bind(this);
         this.boundHandleIsSpeakingChanged = this.handleIsSpeakingChanged.bind(this);
 
-        this._isMuted.set(!this.participant.isMicrophoneEnabled);
-        this._hasVideo.set(this.participant.isCameraEnabled);
-
+        this.participant.on(ParticipantEvent.TrackPublished, this.boundHandleTrackPublished);
         this.participant.on(ParticipantEvent.TrackSubscribed, this.boundHandleTrackSubscribed);
+        this.participant.on(ParticipantEvent.TrackUnpublished, this.boundHandleTrackUnpublished);
         this.participant.on(ParticipantEvent.TrackUnsubscribed, this.boundHandleTrackUnsubscribed);
         this.participant.on(ParticipantEvent.TrackMuted, this.boundHandleTrackMuted);
         this.participant.on(ParticipantEvent.TrackUnmuted, this.boundHandleTrackUnmuted);
@@ -86,13 +94,83 @@ export class LiveKitParticipant {
         this._isSpeakingStore = writable(this.participant.isSpeaking);
         this._connectionQualityStore = writable(this.participant.connectionQuality);
         this._nameStore = writable(this.participant.name);
-        this.updateLivekitVideoStreamStore();
 
         for (const publication of this.participant.getTrackPublications()) {
-            const track = publication.track;
-            if (track && !publication.isLocal) {
-                this.handleTrackSubscribed(track as RemoteTrack, publication as RemoteTrackPublication);
+            if (publication.isLocal) {
+                continue;
             }
+
+            const remotePublication = publication as RemoteTrackPublication;
+            this.handleTrackPublished(remotePublication);
+
+            const track = remotePublication.track;
+            if (track) {
+                this.handleTrackSubscribed(track, remotePublication);
+            }
+        }
+
+        this.updateLivekitVideoStreamStore();
+    }
+
+    private handleTrackPublished(publication: RemoteTrackPublication) {
+        if (this.abortSignal.aborted) {
+            return;
+        }
+
+        if (publication.source === Track.Source.Camera) {
+            if (this._cameraPublication && this._cameraPublication !== publication) {
+                console.warn(
+                    "Camera track received on a publication that is not the one we expected. This should not happen."
+                );
+                Sentry.captureMessage(
+                    "Camera track received on a publication that is not the one we expected. This should not happen."
+                );
+                this._cameraPublication.setSubscribed(false);
+            }
+            this._cameraPublication = publication;
+            this._hasVideo.set(!publication.isMuted);
+        } else if (publication.source === Track.Source.ScreenShare) {
+            if (this._screenSharePublication && this._screenSharePublication !== publication) {
+                console.warn(
+                    "Screen share track received on a publication that is not the one we expected. This should not happen."
+                );
+                Sentry.captureMessage(
+                    "Screen share track received on a publication that is not the one we expected. This should not happen."
+                );
+                this._screenSharePublication.setSubscribed(false);
+            }
+            this._screenSharePublication = publication;
+            this._hasScreenShareVideo.set(!publication.isMuted);
+            this.refreshLivekitScreenShareStreamStore();
+        } else if (publication.source === Track.Source.ScreenShareAudio) {
+            if (this._screenShareAudioPublication && this._screenShareAudioPublication !== publication) {
+                console.warn(
+                    "Screen share audio track received on a publication that is not the one we expected. This should not happen."
+                );
+                Sentry.captureMessage(
+                    "Screen share audio track received on a publication that is not the one we expected. This should not happen."
+                );
+                this._screenShareAudioPublication.setSubscribed(false);
+            }
+            publication.setSubscribed(true);
+            this._screenShareAudioPublication = publication;
+            this._hasScreenShareAudio.set(true);
+            this._isScreenShareAudioMuted.set(publication.isMuted);
+            this.refreshLivekitScreenShareStreamStore();
+        } else if (publication.source === Track.Source.Microphone) {
+            if (this._microphonePublication && this._microphonePublication !== publication) {
+                console.warn(
+                    "Microphone track received on a publication that is not the one we expected. This should not happen."
+                );
+                Sentry.captureMessage(
+                    "Microphone track received on a publication that is not the one we expected. This should not happen."
+                );
+                this._microphonePublication.setSubscribed(false);
+            }
+            publication.setSubscribed(true);
+            this._microphonePublication = publication;
+            this._hasAudio.set(true);
+            this._isMuted.set(publication.isMuted);
         }
     }
 
@@ -101,12 +179,7 @@ export class LiveKitParticipant {
             return;
         }
         if (publication.source === Track.Source.Camera) {
-            this._videoStreamStore.set(track.mediaStream);
-            this._hasVideo.set(!track.isMuted);
-
             this._videoRemoteTrack.set(track as RemoteVideoTrack);
-
-            this.updateLivekitVideoStreamStore();
 
             // Apply video quality based on bandwidth setting
             const videoQualitySetting = get(videoQualityStore);
@@ -115,11 +188,7 @@ export class LiveKitParticipant {
                 publication.setVideoQuality(VideoQuality.MEDIUM);
             }
         } else if (publication.source === Track.Source.ScreenShare) {
-            this._videoScreenShareStreamStore.set(track.mediaStream);
-
             this._screenShareRemoteTrack.set(track as RemoteVideoTrack);
-
-            this.updateLivekitScreenShareStreamStore();
 
             // Apply video quality based on screen share bandwidth setting
             const screenShareQualitySetting = get(screenShareQualityStore);
@@ -129,34 +198,57 @@ export class LiveKitParticipant {
             }
         } else if (publication.source === Track.Source.ScreenShareAudio) {
             this._audioScreenShareStreamStore.set(track.mediaStream);
-            this.updateLivekitScreenShareStreamStore();
         } else if (publication.source === Track.Source.Microphone) {
             this._audioStreamStore.set(track.mediaStream);
         }
     }
 
+    private handleTrackUnpublished(publication: RemoteTrackPublication) {
+        if (publication.source === Track.Source.Camera) {
+            publication.setSubscribed(false);
+            if (this._cameraPublication === publication) {
+                this._cameraPublication = undefined;
+            }
+            this._videoRemoteTrack.set(undefined);
+            this._hasVideo.set(false);
+        } else if (publication.source === Track.Source.ScreenShare) {
+            publication.setSubscribed(false);
+            if (this._screenSharePublication === publication) {
+                this._screenSharePublication = undefined;
+            }
+            this._screenShareRemoteTrack.set(undefined);
+            this._hasScreenShareVideo.set(false);
+            this.refreshLivekitScreenShareStreamStore();
+        } else if (publication.source === Track.Source.ScreenShareAudio) {
+            publication.setSubscribed(false);
+            if (this._screenShareAudioPublication === publication) {
+                this._screenShareAudioPublication = undefined;
+            }
+            this._audioScreenShareStreamStore.set(undefined);
+            this._hasScreenShareAudio.set(false);
+            this._isScreenShareAudioMuted.set(true);
+            this.refreshLivekitScreenShareStreamStore();
+        } else if (publication.source === Track.Source.Microphone) {
+            publication.setSubscribed(false);
+            if (this._microphonePublication === publication) {
+                this._microphonePublication = undefined;
+            }
+            this._audioStreamStore.set(undefined);
+            this._isMuted.set(true);
+        }
+    }
+
     private handleTrackUnsubscribed(track: RemoteTrack, publication: RemoteTrackPublication) {
         if (publication.source === Track.Source.Camera) {
-            // this.space.livekitVideoStreamStore.delete(this._spaceUser.spaceUserId);
             if (get(this._videoRemoteTrack) === track) {
                 this._videoRemoteTrack.set(undefined);
             }
-
-            if (this._actualVideo) {
-                this._streamableSubjects.videoPeerRemoved.next(this._actualVideo);
-            }
         } else if (publication.source === Track.Source.ScreenShare) {
-            // this.space.livekitScreenShareStreamStore.delete(this._spaceUser.spaceUserId);
             if (get(this._screenShareRemoteTrack) === track) {
                 this._screenShareRemoteTrack.set(undefined);
             }
-
-            if (this._actualScreenShare) {
-                this._streamableSubjects.screenSharingPeerRemoved.next(this._actualScreenShare);
-            }
         } else if (publication.source === Track.Source.ScreenShareAudio) {
             this._audioScreenShareStreamStore.set(undefined);
-            this.updateLivekitScreenShareStreamStore();
         } else if (publication.source === Track.Source.Microphone) {
             this._audioStreamStore.set(undefined);
         }
@@ -167,6 +259,11 @@ export class LiveKitParticipant {
             this._isMuted.set(true);
         } else if (publication.source === Track.Source.Camera) {
             this._hasVideo.set(false);
+        } else if (publication.source === Track.Source.ScreenShare) {
+            this._hasScreenShareVideo.set(false);
+            this.refreshLivekitScreenShareStreamStore();
+        } else if (publication.source === Track.Source.ScreenShareAudio) {
+            this._isScreenShareAudioMuted.set(true);
         }
     }
 
@@ -175,6 +272,11 @@ export class LiveKitParticipant {
             this._isMuted.set(false);
         } else if (publication.source === Track.Source.Camera) {
             this._hasVideo.set(true);
+        } else if (publication.source === Track.Source.ScreenShare) {
+            this._hasScreenShareVideo.set(true);
+            this.refreshLivekitScreenShareStreamStore();
+        } else if (publication.source === Track.Source.ScreenShareAudio) {
+            this._isScreenShareAudioMuted.set(false);
         }
     }
 
@@ -199,25 +301,40 @@ export class LiveKitParticipant {
         this._streamableSubjects.videoPeerAdded.next(this._actualVideo);
     }
 
-    private updateLivekitScreenShareStreamStore() {
-        //Old stream
-        const actualScreenShare = this._actualScreenShare;
+    private refreshLivekitScreenShareStreamStore() {
+        const shouldHaveScreenShareStream = get(this._hasScreenShareVideo) || get(this._hasScreenShareAudio);
 
-        if (actualScreenShare) {
-            this._streamableSubjects.screenSharingPeerRemoved.next(actualScreenShare);
+        if (!shouldHaveScreenShareStream) {
+            if (this._actualScreenShare) {
+                const actualScreenShare = this._actualScreenShare;
+                this._actualScreenShare = undefined;
+                this._streamableSubjects.screenSharingPeerRemoved.next(actualScreenShare);
+            }
+            return;
         }
 
-        // New Stream
-        this._actualScreenShare = this.getScreenShareStream();
-        this._streamableSubjects.screenSharingPeerAdded.next(this._actualScreenShare);
+        if (!this._actualScreenShare) {
+            this._actualScreenShare = this.getScreenShareStream();
+            this._streamableSubjects.screenSharingPeerAdded.next(this._actualScreenShare);
+        }
     }
 
     private getVideoStream(): Streamable {
         return {
             uniqueId: this.participant.identity,
             hasAudio: this._hasAudio,
-            hasVideo: this._spaceUser.reactiveUser.cameraState,
-            isMuted: derived(this._spaceUser.reactiveUser.microphoneState, ($microphoneState) => !$microphoneState),
+            hasVideo: derived(
+                [this._spaceUser.reactiveUser.cameraState, this._hasVideo],
+                ([$spaceCameraState, $livekitHasVideo]) => {
+                    return $spaceCameraState && $livekitHasVideo;
+                }
+            ),
+            isMuted: derived(
+                [this._spaceUser.reactiveUser.microphoneState, this._isMuted],
+                ([$spaceMicrophoneState, $livekitIsMuted]) => {
+                    return !$spaceMicrophoneState || $livekitIsMuted;
+                }
+            ),
             statusStore: writable("connected"),
             spaceUserId: this._spaceUser.spaceUserId,
             name: this._nameStore,
@@ -230,12 +347,12 @@ export class LiveKitParticipant {
             media: {
                 type: "livekit",
                 remoteVideoTrack: this._videoRemoteTrack,
-                //remoteAudioTrack: this._audioRemoteTrack,
                 // Important note: the stream store only contains the audio track:
                 streamStore: this._audioStreamStore,
                 isBlocked: derived(this._blockedUsersStore, ($blockedUsersStore) =>
                     $blockedUsersStore.has(this._spaceUser.spaceUserId)
                 ),
+                setVideoSubscribed: (subscribed: boolean) => this._cameraPublication?.setSubscribed(subscribed),
             } as LivekitStreamable,
             volumeStore: writable(undefined),
             volume: writable(this.defaultVolume),
@@ -247,19 +364,11 @@ export class LiveKitParticipant {
     }
 
     private getScreenShareStream(): Streamable {
-        const hasAudio = derived(this._audioScreenShareStreamStore, ($audioStream) => {
-            return $audioStream !== undefined && $audioStream.getAudioTracks().length > 0;
-        });
-
-        const isMuted = derived(this._audioScreenShareStreamStore, ($audioStream) => {
-            return $audioStream === undefined || $audioStream.getAudioTracks().length === 0;
-        });
-
         return {
             uniqueId: this.participant.sid,
-            hasAudio: hasAudio,
-            hasVideo: writable(true),
-            isMuted: isMuted,
+            hasAudio: this._hasScreenShareAudio,
+            hasVideo: this._hasScreenShareVideo,
+            isMuted: this._isScreenShareAudioMuted,
             statusStore: writable("connected"),
             spaceUserId: this._spaceUser.spaceUserId,
             name: this._nameStore,
@@ -277,6 +386,7 @@ export class LiveKitParticipant {
                 isBlocked: derived(this._blockedUsersStore, ($blockedUsersStore) =>
                     $blockedUsersStore.has(this._spaceUser.spaceUserId)
                 ),
+                setVideoSubscribed: (subscribed: boolean) => this._screenSharePublication?.setSubscribed(subscribed),
             } as LivekitStreamable,
             volumeStore: writable(undefined),
             volume: writable(this.defaultVolume),
@@ -318,7 +428,24 @@ export class LiveKitParticipant {
     public destroy() {
         decrementLivekitConnectionsCount();
 
+        if (this._actualVideo) {
+            this._streamableSubjects.videoPeerRemoved.next(this._actualVideo);
+            this._actualVideo = undefined;
+        }
+
+        if (this._actualScreenShare) {
+            this._streamableSubjects.screenSharingPeerRemoved.next(this._actualScreenShare);
+            this._actualScreenShare = undefined;
+        }
+
+        this._cameraPublication?.setSubscribed(false);
+        this._microphonePublication?.setSubscribed(false);
+        this._screenSharePublication?.setSubscribed(false);
+        this._screenShareAudioPublication?.setSubscribed(false);
+
+        this.participant.off(ParticipantEvent.TrackPublished, this.boundHandleTrackPublished);
         this.participant.off(ParticipantEvent.TrackSubscribed, this.boundHandleTrackSubscribed);
+        this.participant.off(ParticipantEvent.TrackUnpublished, this.boundHandleTrackUnpublished);
         this.participant.off(ParticipantEvent.TrackUnsubscribed, this.boundHandleTrackUnsubscribed);
         this.participant.off(ParticipantEvent.TrackMuted, this.boundHandleTrackMuted);
         this.participant.off(ParticipantEvent.TrackUnmuted, this.boundHandleTrackUnmuted);

--- a/play/src/front/Space/Streamable.ts
+++ b/play/src/front/Space/Streamable.ts
@@ -10,7 +10,7 @@ export interface LivekitStreamable {
     remoteVideoTrack: Readable<RemoteVideoTrack | undefined>;
     readonly streamStore: Readable<MediaStream | undefined>;
     readonly isBlocked: Readable<boolean>;
-    setVideoSubscribed: (subscribed: boolean) => void;
+    acquireVideoSubscription: () => () => void;
 }
 
 export interface WebRtcStreamable {

--- a/play/src/front/Space/Streamable.ts
+++ b/play/src/front/Space/Streamable.ts
@@ -10,6 +10,7 @@ export interface LivekitStreamable {
     remoteVideoTrack: Readable<RemoteVideoTrack | undefined>;
     readonly streamStore: Readable<MediaStream | undefined>;
     readonly isBlocked: Readable<boolean>;
+    setVideoSubscribed: (subscribed: boolean) => void;
 }
 
 export interface WebRtcStreamable {

--- a/tests/tests/scripting_audio_stream.spec.ts
+++ b/tests/tests/scripting_audio_stream.spec.ts
@@ -6,6 +6,11 @@ import { publicTestMapUrl } from "./utils/urls";
 import { getPage } from "./utils/auth";
 import { isMobile } from "./utils/isMobile";
 import Menu from "./utils/menu";
+import {
+    expectLivekitConnectionsCountToBe,
+    expectWebRtcConnectionsCountToBe,
+    getLivekitConnectionsCount,
+} from "./utils/webRtc";
 
 async function playAudioStream(page: Page, frequency: number) {
     // Test play sound scripting
@@ -166,6 +171,7 @@ test.describe("Scripting audio streams @nomobile @nofirefox @nowebkit", () => {
 
         // Let's restart the audio buffer
         await playAudioStream(page, 330);
+        await expect.poll(() => getLivekitConnectionsCount(alice2), { timeout: 35_000 }).toBeGreaterThan(0);
         await hasAudioStream(alice2);
 
         // Now, let's disconnect eve to force the switch back to WebRTC
@@ -173,7 +179,11 @@ test.describe("Scripting audio streams @nomobile @nofirefox @nowebkit", () => {
         await eve.context().close();
 
         // Let's wait for eve to be disconnected
-        await expect(alice2.getByText("eve")).toBeHidden();
+        await expect(alice2.getByText("Eve", { exact: true })).toBeHidden();
+
+        // Wait for the delayed LiveKit -> WebRTC fallback before asserting audio again.
+        await expectLivekitConnectionsCountToBe(alice2, 0, 35_000);
+        await expectWebRtcConnectionsCountToBe(alice2, 2, 35_000);
 
         // After disconnect, alice2 should still receive the sound through WebRTC
         await hasAudioStream(alice2);

--- a/tests/tests/utils/auth.ts
+++ b/tests/tests/utils/auth.ts
@@ -148,6 +148,13 @@ export async function getPage(
 
 async function skipOnboardingWhenShown(page: Page) {
     await page.addLocatorHandler(page.getByTestId("onboarding-button-welcome-skip"), async () => {
-        await page.getByTestId("onboarding-button-welcome-skip").click();
+        try {
+            await page.getByTestId("onboarding-button-welcome-skip").click();
+        } catch (e) {
+            if (e instanceof Error && e.message.includes("Target page, context or browser has been closed")) {
+                return;
+            }
+            throw e;
+        }
     });
 }


### PR DESCRIPTION
We are now deciding from WorkAdventure what should be displayed or not displayed by each client.

This will hopefully solve a bug that was causing false positives in Livekit streams broadcasting. When a user was joining a space, he vas first considered as a good candidate to stream its data (even if the user was a listener) Only after all other clients would send a message to say they were not looking at him would the user stream upload stop.

With selective subscription, we are only sending the video stream if at least one user displays this stream.