### PR TITLE
Fix duplicate user popup on same-tab reconnect

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -280,9 +280,6 @@ export class GameRoom implements BrothersFinder {
         }
         const position = ProtobufUtils.toPointInterface(positionMessage);
 
-        // Check if the same user (same uuid) is already connected in this room (another tab/device)
-        const sameUserAlreadyConnected = (this.getUsersByUuid(joinRoomMessage.userUuid)?.size ?? 0) >= 1;
-
         // Check if there's a stale connection from the same browser tab and kill it immediately
         // This prevents "ghost" users appearing when a user reconnects after a network disruption
         const tabId = joinRoomMessage.tabId;
@@ -299,6 +296,9 @@ export class GameRoom implements BrothersFinder {
                 existingUser.socket.end();
             }
         }
+
+        // Same-tab reconnections should not be reported as duplicate sessions.
+        const sameUserAlreadyConnected = (this.getUsersByUuid(joinRoomMessage.userUuid)?.size ?? 0) >= 1;
 
         this.nextUserId++;
         const user = await User.create(

--- a/back/tests/GameRoom.test.ts
+++ b/back/tests/GameRoom.test.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { describe, expect, it } from "vitest";
-import { JoinRoomMessage, PositionMessage_Direction } from "@workadventure/messages";
-import { ConnectCallback, DisconnectCallback, GameRoom } from "../src/Model/GameRoom";
+import { describe, expect, it, vi } from "vitest";
+import { JoinRoomMessage, PositionMessage_Direction, RoomJoinedMessage } from "@workadventure/messages";
+import { GameRoom } from "../src/Model/GameRoom";
+import type { ConnectCallback, DisconnectCallback } from "../src/Model/GameRoom";
 import { Point } from "../src/Model/Websocket/MessageUserPosition";
-import { Group } from "../src/Model/Group";
-import { User, UserSocket } from "../src/Model/User";
-import { EmoteCallback } from "../src/Model/Zone";
+import type { Group } from "../src/Model/Group";
+import type { User, UserSocket } from "../src/Model/User";
+import type { EmoteCallback } from "../src/Model/Zone";
 
 function createMockUser(userId: number): User {
     return {
@@ -13,13 +14,23 @@ function createMockUser(userId: number): User {
     } as unknown as User;
 }
 
-function createMockUserSocket(): UserSocket {
-    return {} as unknown as UserSocket;
+function createMockUserSocket() {
+    const write = vi.fn().mockReturnValue(true);
+    const end = vi.fn();
+
+    return {
+        socket: {
+            write,
+            end,
+        } as unknown as UserSocket,
+        write,
+        end,
+    };
 }
 
-function createJoinRoomMessage(uuid: string, x: number, y: number): JoinRoomMessage {
+function createJoinRoomMessage(uuid: string, x: number, y: number, tabId?: string): JoinRoomMessage {
     return JoinRoomMessage.fromPartial({
-        userUuid: "1",
+        userUuid: uuid,
         IPAddress: "10.0.0.2",
         name: "foo",
         roomId: "_/global/test.json",
@@ -29,7 +40,28 @@ function createJoinRoomMessage(uuid: string, x: number, y: number): JoinRoomMess
             direction: PositionMessage_Direction.DOWN,
             moving: false,
         },
+        tabId,
     } as const);
+}
+
+function flushPendingMessages(user: User): void {
+    user.write({
+        $case: "roomJoinedMessage",
+        roomJoinedMessage: RoomJoinedMessage.fromPartial({
+            currentUserId: user.id,
+        }),
+    });
+}
+
+function isServerMessageChunk(chunk: unknown): chunk is { message: { $case: string } } {
+    return typeof chunk === "object" && chunk !== null && "message" in chunk;
+}
+
+function getWrittenMessageCases(socket: ReturnType<typeof createMockUserSocket>): string[] {
+    return socket.write.mock.calls
+        .map((call): unknown => call[0])
+        .filter(isServerMessageChunk)
+        .map((chunk) => chunk.message.$case);
 }
 
 const emote: EmoteCallback = (emoteEventMessage, listener): void => {};
@@ -57,9 +89,11 @@ describe("GameRoom", () => {
             () => {}
         );
 
-        const user1 = await world.join(createMockUserSocket(), createJoinRoomMessage("1", 100, 100));
+        const user1Socket = createMockUserSocket();
+        const user1 = await world.join(user1Socket.socket, createJoinRoomMessage("1", 100, 100));
 
-        const user2 = await world.join(createMockUserSocket(), createJoinRoomMessage("2", 500, 100));
+        const user2Socket = createMockUserSocket();
+        const user2 = await world.join(user2Socket.socket, createJoinRoomMessage("2", 500, 100));
 
         world.updatePosition(user2, new Point(261, 100));
 
@@ -95,15 +129,18 @@ describe("GameRoom", () => {
             () => {}
         );
 
-        const user1 = await world.join(createMockUserSocket(), createJoinRoomMessage("1", 100, 100));
+        const user1Socket = createMockUserSocket();
+        const user1 = await world.join(user1Socket.socket, createJoinRoomMessage("1", 100, 100));
 
-        const user2 = await world.join(createMockUserSocket(), createJoinRoomMessage("2", 200, 100));
+        const user2Socket = createMockUserSocket();
+        const user2 = await world.join(user2Socket.socket, createJoinRoomMessage("2", 200, 100));
 
         expect(connectCalled).toBe(true);
         connectCalled = false;
 
         // baz joins at the outer limit of the group
-        const user3 = await world.join(createMockUserSocket(), createJoinRoomMessage("2", 311, 100));
+        const user3Socket = createMockUserSocket();
+        const user3 = await world.join(user3Socket.socket, createJoinRoomMessage("2", 311, 100));
 
         expect(connectCalled).toBe(false);
 
@@ -137,9 +174,11 @@ describe("GameRoom", () => {
             () => {}
         );
 
-        const user1 = await world.join(createMockUserSocket(), createJoinRoomMessage("1", 100, 100));
+        const user1Socket = createMockUserSocket();
+        const user1 = await world.join(user1Socket.socket, createJoinRoomMessage("1", 100, 100));
 
-        const user2 = await world.join(createMockUserSocket(), createJoinRoomMessage("2", 259, 100));
+        const user2Socket = createMockUserSocket();
+        const user2 = await world.join(user2Socket.socket, createJoinRoomMessage("2", 259, 100));
 
         expect(connectCalled).toBe(true);
         expect(disconnectCallNumber).toBe(0);
@@ -150,5 +189,96 @@ describe("GameRoom", () => {
 
         world.updatePosition(user2, new Point(262, 100));
         expect(disconnectCallNumber).toBe(2);
+    });
+
+    it("should not notify duplicate user when reconnecting from the same tab", async () => {
+        const world = await GameRoom.create(
+            "https://play.workadventu.re/_/global/localhost/test.json",
+            () => {},
+            () => {},
+            160,
+            160,
+            () => {},
+            () => {},
+            () => {},
+            emote,
+            () => {},
+            () => {},
+            () => {}
+        );
+
+        const firstSocket = createMockUserSocket();
+        await world.join(firstSocket.socket, createJoinRoomMessage("duplicate-user", 100, 100, "tab-1"));
+
+        const secondSocket = createMockUserSocket();
+        const reconnectedUser = await world.join(
+            secondSocket.socket,
+            createJoinRoomMessage("duplicate-user", 100, 100, "tab-1")
+        );
+
+        expect(firstSocket.end).toHaveBeenCalledTimes(1);
+
+        flushPendingMessages(reconnectedUser);
+
+        expect(getWrittenMessageCases(secondSocket)).not.toContain("duplicateUserConnectedMessage");
+    });
+
+    it("should notify duplicate user when connecting from another tab", async () => {
+        const world = await GameRoom.create(
+            "https://play.workadventu.re/_/global/localhost/test.json",
+            () => {},
+            () => {},
+            160,
+            160,
+            () => {},
+            () => {},
+            () => {},
+            emote,
+            () => {},
+            () => {},
+            () => {}
+        );
+
+        const firstSocket = createMockUserSocket();
+        await world.join(firstSocket.socket, createJoinRoomMessage("duplicate-user", 100, 100, "tab-1"));
+
+        const secondSocket = createMockUserSocket();
+        const secondUser = await world.join(
+            secondSocket.socket,
+            createJoinRoomMessage("duplicate-user", 100, 100, "tab-2")
+        );
+
+        expect(firstSocket.end).not.toHaveBeenCalled();
+
+        flushPendingMessages(secondUser);
+
+        expect(getWrittenMessageCases(secondSocket)).toContain("duplicateUserConnectedMessage");
+    });
+
+    it("should keep duplicate detection when tabId is missing", async () => {
+        const world = await GameRoom.create(
+            "https://play.workadventu.re/_/global/localhost/test.json",
+            () => {},
+            () => {},
+            160,
+            160,
+            () => {},
+            () => {},
+            () => {},
+            emote,
+            () => {},
+            () => {},
+            () => {}
+        );
+
+        const firstSocket = createMockUserSocket();
+        await world.join(firstSocket.socket, createJoinRoomMessage("duplicate-user", 100, 100));
+
+        const secondSocket = createMockUserSocket();
+        const secondUser = await world.join(secondSocket.socket, createJoinRoomMessage("duplicate-user", 100, 100));
+
+        flushPendingMessages(secondUser);
+
+        expect(getWrittenMessageCases(secondSocket)).toContain("duplicateUserConnectedMessage");
     });
 });


### PR DESCRIPTION
## Problem

The duplicate-user popup can still appear after a normal network reconnection in the same browser tab.

This happens because the backend detects an existing session for the same user before it removes the stale connection belonging to the same `tabId`.

## Solution

Use `tabId` as the source of truth to distinguish a real duplicate session from a same-tab reconnection.

When a new connection arrives with the same `userUuid` and the same `tabId`, the backend should first remove the stale connection, then evaluate whether another active session still exists before sending the duplicate-user message.

