### PR TITLE
Retry LiveKit audio playback after user activation

### DIFF
--- a/play/src/front/Components/Toasts/BrowserNoSoundInfoToast.svelte
+++ b/play/src/front/Components/Toasts/BrowserNoSoundInfoToast.svelte
@@ -36,8 +36,8 @@
     }
 
     onMount(() => {
-        // We need to check if the context still suspended or not.
-        // Unfortunelly, the onstatechange event is not triggered when the context is running.
+        // We need to check if the context is still suspended or not.
+        // Unfortunately, the onstatechange event is not triggered when the context is running.
         intervalId = setInterval(() => {
             if (!audioContextManager.verifyContextIsNotSuspended()) {
                 return;

--- a/play/src/front/Components/Video/PictureInPicture/AudioStream.svelte
+++ b/play/src/front/Components/Video/PictureInPicture/AudioStream.svelte
@@ -5,6 +5,7 @@
     import Debug from "debug";
     import * as Sentry from "@sentry/svelte";
     import type { Readable } from "svelte/store";
+    import { userActivationManager } from "../../../Stores/UserActivationStore";
 
     export let streamStore: Readable<MediaStream | undefined>;
     export let outputDeviceId: string | undefined = undefined;
@@ -26,6 +27,56 @@
     }
 
     let lastRequestedDeviceId: string | undefined;
+    let pendingPlaybackPromise: Promise<void> | undefined;
+
+    async function playAudio() {
+        if (destroyed || !audioElement || !stream) {
+            return;
+        }
+
+        try {
+            await audioElement.play();
+        } catch (error) {
+            if (destroyed) {
+                return;
+            }
+
+            if (!(error instanceof DOMException) || error.name !== "NotAllowedError") {
+                console.error("Error playing audio stream: ", error);
+                Sentry.captureException(error);
+                return;
+            }
+
+            await userActivationManager.waitForUserActivation();
+
+            if (destroyed || !audioElement || !stream) {
+                return;
+            }
+
+            try {
+                await audioElement.play();
+            } catch (retryError) {
+                if (destroyed) {
+                    return;
+                }
+
+                console.error("Error replaying audio stream after user activation: ", retryError);
+                Sentry.captureException(retryError);
+            }
+        }
+    }
+
+    function ensurePlayback() {
+        if (pendingPlaybackPromise) {
+            return pendingPlaybackPromise;
+        }
+
+        pendingPlaybackPromise = playAudio().finally(() => {
+            pendingPlaybackPromise = undefined;
+        });
+
+        return pendingPlaybackPromise;
+    }
 
     async function safeSetSinkId(deviceId: string, el: HTMLAudioElement) {
         if (destroyed) {
@@ -81,9 +132,17 @@
 
     $: stream = $streamStore ? $streamStore : undefined;
 
-    $: if (audioElement && stream) {
-        if (audioElement.srcObject !== stream) {
-            audioElement.srcObject = stream;
+    $: if (audioElement) {
+        const nextStream = stream ?? null;
+        if (audioElement.srcObject !== nextStream) {
+            audioElement.srcObject = nextStream;
+        }
+
+        if (stream) {
+            ensurePlayback().catch((e) => {
+                console.error("Error playing audio stream: ", e);
+                Sentry.captureException(e);
+            });
         }
     }
 
@@ -98,6 +157,8 @@
                 audioElement.srcObject = stream ?? null;
                 audioElement.volume = $volume;
             }
+
+            await ensurePlayback();
         })().catch((e) => {
             console.error(e);
             Sentry.captureException(e);

--- a/play/src/front/Stores/UserActivationStore.test.ts
+++ b/play/src/front/Stores/UserActivationStore.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UserActivationManager } from "./UserActivationStore";
+
+describe("UserActivationManager", () => {
+    const originalUserActivationDescriptor = Object.getOwnPropertyDescriptor(navigator, "userActivation");
+
+    beforeEach(() => {
+        if (originalUserActivationDescriptor) {
+            Object.defineProperty(navigator, "userActivation", originalUserActivationDescriptor);
+        } else {
+            // navigator.userActivation is not defined in jsdom by default
+            Reflect.deleteProperty(navigator, "userActivation");
+        }
+    });
+
+    afterEach(() => {
+        if (originalUserActivationDescriptor) {
+            Object.defineProperty(navigator, "userActivation", originalUserActivationDescriptor);
+        } else {
+            Reflect.deleteProperty(navigator, "userActivation");
+        }
+    });
+
+    it("resolves immediately when the activation API is unavailable", async () => {
+        const manager = new UserActivationManager();
+        const onActivated = vi.fn();
+
+        await manager.waitForUserActivation().then(onActivated);
+
+        expect(onActivated).toHaveBeenCalledOnce();
+    });
+
+    it("resolves immediately when the browser already reports activation", async () => {
+        Object.defineProperty(navigator, "userActivation", {
+            configurable: true,
+            value: {
+                hasBeenActive: true,
+            },
+        });
+
+        const manager = new UserActivationManager();
+        const onActivated = vi.fn();
+
+        await manager.waitForUserActivation().then(onActivated);
+
+        expect(onActivated).toHaveBeenCalledOnce();
+    });
+
+    it("polls until the browser reports activation", async () => {
+        vi.useFakeTimers();
+
+        try {
+            const userActivation = {
+                hasBeenActive: false,
+            };
+
+            Object.defineProperty(navigator, "userActivation", {
+                configurable: true,
+                value: userActivation,
+            });
+
+            const manager = new UserActivationManager();
+            const onActivated = vi.fn();
+
+            const activationPromise = manager.waitForUserActivation().then(onActivated);
+
+            await vi.advanceTimersByTimeAsync(500);
+            expect(onActivated).not.toHaveBeenCalled();
+
+            userActivation.hasBeenActive = true;
+            await vi.advanceTimersByTimeAsync(500);
+            await activationPromise;
+
+            expect(onActivated).toHaveBeenCalledOnce();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/play/src/front/Stores/UserActivationStore.ts
+++ b/play/src/front/Stores/UserActivationStore.ts
@@ -1,11 +1,47 @@
 import { Deferred } from "@workadventure/shared-utils";
-import * as Sentry from "@sentry/svelte";
 
-class UserActivationManager {
+export class UserActivationManager {
     private activationDeferred = new Deferred<void>();
+    private activated = false;
+    private activationCheckIntervalId: ReturnType<typeof setInterval> | undefined;
 
     private supportsActivation() {
+        if (typeof navigator === "undefined") {
+            return false;
+        }
+
         return "userActivation" in navigator;
+    }
+
+    private hasBeenActivated() {
+        return this.activated || (this.supportsActivation() && navigator.userActivation.hasBeenActive);
+    }
+
+    private startPollingActivation() {
+        if (this.activationCheckIntervalId !== undefined || !this.supportsActivation()) {
+            return;
+        }
+
+        this.activationCheckIntervalId = setInterval(() => {
+            if (!navigator.userActivation.hasBeenActive) {
+                return;
+            }
+
+            this.resolveActivation();
+        }, 500);
+    }
+
+    private resolveActivation() {
+        if (this.activated) {
+            return;
+        }
+
+        this.activated = true;
+        if (this.activationCheckIntervalId !== undefined) {
+            clearInterval(this.activationCheckIntervalId);
+            this.activationCheckIntervalId = undefined;
+        }
+        this.activationDeferred.resolve();
     }
 
     /**
@@ -18,10 +54,13 @@ class UserActivationManager {
         if (!this.supportsActivation()) {
             return;
         }
-        if (navigator.userActivation.hasBeenActive) {
+
+        if (this.hasBeenActivated()) {
+            this.resolveActivation();
             return;
         }
 
+        this.startPollingActivation();
         return this.activationDeferred.promise;
     }
 
@@ -30,12 +69,11 @@ class UserActivationManager {
      * to notify that the user has activated the page.
      */
     public notifyUserActivation() {
-        if (this.supportsActivation() && !navigator.userActivation.hasBeenActive) {
-            console.error("notifyUserActivation called but userActivation.hasBeenActive is false");
-            Sentry.captureMessage("notifyUserActivation called but userActivation.hasBeenActive is false");
+        if (this.activated) {
+            return;
         }
 
-        this.activationDeferred.resolve();
+        this.resolveActivation();
     }
 }
 


### PR DESCRIPTION
## What changed
- retry LiveKit audio playback when the browser initially blocks autoplay in listener zones
- centralize user-activation waiting in `UserActivationManager` using the same polling approach as the no-sound toast

## Why
When a user enters a listener zone before any browser activation, LiveKit audio elements can attach successfully but remain silent because the initial `play()` is blocked by autoplay policy. Previously, clicking later did not retry playback, so users had to leave and re-enter the zone.

## Impact
- listeners can recover audio after their first user interaction without leaving the zone
- activation detection logic is shared instead of duplicated in separate UI flows
- the behavior is covered by targeted tests around activation polling

Closes #5962