### PR TITLE
Reading default TLS secret

### DIFF
--- a/contrib/helm/templates/icon-ingress.yaml
+++ b/contrib/helm/templates/icon-ingress.yaml
@@ -20,7 +20,7 @@ spec:
   tls:
     - hosts:
         - {{ (include "workadventure.iconDomainName" .) | quote }}
-      secretName: {{ .Values.icon.ingress.secretName | default (printf "%s-icon-cert" (include "workadventure.fullname" .)) }}
+      secretName: {{ .Values.icon.ingress.secretName | default .Values.ingress.secretName | default (printf "%s-icon-cert" (include "workadventure.fullname" .)) }}
   {{- end }}
   rules:
     - host: {{ (include "workadventure.iconDomainName" .) | quote }}

--- a/contrib/helm/templates/maps-ingress.yaml
+++ b/contrib/helm/templates/maps-ingress.yaml
@@ -21,7 +21,7 @@ spec:
   tls:
     - hosts:
         - {{ (include "workadventure.mapsDomainName" .) | quote }}
-      secretName: {{ .Values.maps.ingress.secretName | default (printf "%s-maps-cert" (include "workadventure.fullname" .)) }}
+      secretName: {{ .Values.maps.ingress.secretName | default .Values.ingress.secretName | default (printf "%s-maps-cert" (include "workadventure.fullname" .)) }}
   {{- end }}
   rules:
     - host: {{ (include "workadventure.mapsDomainName" .) | quote }}

--- a/contrib/helm/templates/mapstorage-ingress.yaml
+++ b/contrib/helm/templates/mapstorage-ingress.yaml
@@ -26,7 +26,7 @@ spec:
         {{- else }}
         - {{ (include "workadventure.mapStorageDomainName" .) | quote }}
         {{- end }}
-      secretName: {{ .Values.mapstorage.ingress.secretName | default (printf "%s-mapstorage-cert" (include "workadventure.fullname" .)) }}
+      secretName: {{ .Values.mapstorage.ingress.secretName | default .Values.ingress.secretName | default (printf "%s-mapstorage-cert" (include "workadventure.fullname" .)) }}
   {{- end }}
   rules:
   {{- if .Values.mapstorage.ingress.domainNames }}

--- a/contrib/helm/templates/play-ingress.yaml
+++ b/contrib/helm/templates/play-ingress.yaml
@@ -21,7 +21,7 @@ spec:
     - hosts:
         - {{ (include "workadventure.playDomainName" .) | quote }}
         - {{ (include "workadventure.pusherDomainName" .) | quote }}
-      secretName: {{ .Values.play.ingress.secretName | default (printf "%s-play-cert" (include "workadventure.fullname" .)) }}
+      secretName: {{ .Values.play.ingress.secretName | default .Values.ingress.secretName | default (printf "%s-play-cert" (include "workadventure.fullname" .)) }}
   {{- end }}
   rules:
     - host: {{ (include "workadventure.playDomainName" .) | quote }}

--- a/contrib/helm/templates/uploader-ingress.yaml
+++ b/contrib/helm/templates/uploader-ingress.yaml
@@ -20,7 +20,7 @@ spec:
   tls:
     - hosts:
         - {{ (include "workadventure.uploaderDomainName" .) | quote }}
-      secretName: {{ .Values.uploader.ingress.secretName | default (printf "%s-uploader-cert" (include "workadventure.fullname" .)) }}
+      secretName: {{ .Values.uploader.ingress.secretName | default .Values.ingress.secretName | default (printf "%s-uploader-cert" (include "workadventure.fullname" .)) }}
   {{- end }}
   rules:
     - host: {{ (include "workadventure.uploaderDomainName" .) | quote }}


### PR DESCRIPTION
In Helm chart, reading default TLS secret if per container TLS secret is not provided before falling back to default.