### PR TITLE
Change username rendering to use a seperate canvas and adapt scale

### DIFF
--- a/play/src/front/Phaser/Components/MegaphoneIcon.ts
+++ b/play/src/front/Phaser/Components/MegaphoneIcon.ts
@@ -27,8 +27,19 @@ export class MegaphoneIcon extends Phaser.GameObjects.Image {
         this.showAnimation(show, forceClose);
     }
 
-    public setX(value?: number): this {
-        this.defaultPosition.x = value || 0;
+    public setPosition(x: number, y: number): this {
+        this.defaultPosition = { x, y };
+        super.setPosition(x, y);
+        if (this.showAnimationTween) {
+            this.showAnimationTween?.stop();
+            this.showAnimationTween = undefined;
+            this.showAnimation(true, false);
+        }
+        return this;
+    }
+
+    public setX(value: number): this {
+        this.defaultPosition.x = value;
         super.setX(value);
         if (this.showAnimationTween) {
             this.showAnimationTween?.stop();

--- a/play/src/front/Phaser/Components/UsernameDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameDisplay.ts
@@ -1,0 +1,53 @@
+import type { AvailabilityStatus } from "@workadventure/messages";
+import { DEPTH_INGAME_TEXT_INDEX } from "../Game/DepthIndexes";
+import { MegaphoneIcon } from "./MegaphoneIcon";
+import { PlayerStatusDot } from "./PlayerStatusDot";
+
+export class UsernameDisplay extends Phaser.GameObjects.Container {
+    private readonly playerNameSprite: Phaser.GameObjects.Sprite;
+    private readonly statusDot: PlayerStatusDot;
+    private readonly megaphoneIcon: MegaphoneIcon;
+
+    constructor(scene: Phaser.Scene, x: number, y: number, playerNameTextureKey: string) {
+        super(scene, x, y);
+
+        this.playerNameSprite = new Phaser.GameObjects.Sprite(scene, 0, 0, playerNameTextureKey)
+            .setOrigin(0.5, 1)
+            .setDepth(DEPTH_INGAME_TEXT_INDEX);
+        this.statusDot = new PlayerStatusDot(scene, 0, -1);
+        this.megaphoneIcon = new MegaphoneIcon(scene, 0, -1);
+
+        this.megaphoneIcon.visible = false;
+
+        this.add([this.playerNameSprite, this.statusDot, this.megaphoneIcon]);
+        this.reflow();
+
+        this.scene.add.existing(this);
+    }
+
+    public setPlayerNameTexture(playerNameTextureKey: string): void {
+        this.playerNameSprite.setTexture(playerNameTextureKey);
+        this.reflow();
+    }
+
+    public setAvailabilityStatus(availabilityStatus: AvailabilityStatus, instant = false): void {
+        this.statusDot.setAvailabilityStatus(availabilityStatus, instant);
+    }
+
+    public getAvailabilityStatus(): AvailabilityStatus {
+        return this.statusDot.availabilityStatus;
+    }
+
+    public showMegaphone(show = true, forceClose = false): void {
+        this.megaphoneIcon.visible = show;
+        this.megaphoneIcon.show(show, forceClose);
+        this.reflow();
+    }
+
+    private reflow(): void {
+        const halfPlayerNameHeight = -this.playerNameSprite.displayHeight / 2;
+        const halfPlayerNameWidth = this.playerNameSprite.displayWidth / 2;
+        this.statusDot.setPosition(-halfPlayerNameWidth - 2, halfPlayerNameHeight);
+        this.megaphoneIcon.setPosition(halfPlayerNameWidth + 2, halfPlayerNameHeight);
+    }
+}

--- a/play/src/front/Phaser/Components/UsernameDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameDisplay.ts
@@ -1,17 +1,35 @@
-import type { AvailabilityStatus } from "@workadventure/messages";
+import { AvailabilityStatus } from "@workadventure/messages";
 import { DEPTH_INGAME_TEXT_INDEX } from "../Game/DepthIndexes";
 import { MegaphoneIcon } from "./MegaphoneIcon";
 import { PlayerStatusDot } from "./PlayerStatusDot";
 
+const DEFAULT_PLAYER_NAME_OUTLINE_COLOR = "#14304C";
+
 export class UsernameDisplay extends Phaser.GameObjects.Container {
+    private static nextPlayerNameTextureId = 0;
     private readonly playerNameSprite: Phaser.GameObjects.Sprite;
+    private readonly playerName: string;
+    private readonly playerNameFontSize: number;
+    private playerNameTextureKey: string;
+    private playerNameOutlineColor: number | undefined;
     private readonly statusDot: PlayerStatusDot;
     private readonly megaphoneIcon: MegaphoneIcon;
 
-    constructor(scene: Phaser.Scene, x: number, y: number, playerNameTextureKey: string) {
+    constructor(
+        scene: Phaser.Scene,
+        x: number,
+        y: number,
+        playerName: string,
+        playerNameFontSize: number,
+        outlineColor: number | undefined
+    ) {
         super(scene, x, y);
+        this.playerName = playerName;
+        this.playerNameFontSize = playerNameFontSize;
+        this.playerNameOutlineColor = outlineColor;
+        this.playerNameTextureKey = this.createPlayerNameTexture(outlineColor);
 
-        this.playerNameSprite = new Phaser.GameObjects.Sprite(scene, 0, 0, playerNameTextureKey)
+        this.playerNameSprite = new Phaser.GameObjects.Sprite(scene, 0, 0, this.playerNameTextureKey)
             .setOrigin(0.5, 1)
             .setDepth(DEPTH_INGAME_TEXT_INDEX);
         this.statusDot = new PlayerStatusDot(scene, 0, -1);
@@ -25,23 +43,40 @@ export class UsernameDisplay extends Phaser.GameObjects.Container {
         this.scene.add.existing(this);
     }
 
+    private showMegaphone(show = true, forceClose = false): void {
+        this.megaphoneIcon.visible = show;
+        this.megaphoneIcon.show(show, forceClose);
+        this.reflow();
+    }
+
     public setPlayerNameTexture(playerNameTextureKey: string): void {
         this.playerNameSprite.setTexture(playerNameTextureKey);
         this.reflow();
     }
 
-    public setAvailabilityStatus(availabilityStatus: AvailabilityStatus, instant = false): void {
+    public setPlayerNameOutlineColor(outlineColor: number | undefined): void {
+        if (this.playerNameOutlineColor === outlineColor) {
+            return;
+        }
+        this.playerNameOutlineColor = outlineColor;
+
+        const nextTextureKey = this.createPlayerNameTexture(outlineColor);
+        const previousTextureKey = this.playerNameTextureKey;
+        this.playerNameTextureKey = nextTextureKey;
+        this.setPlayerNameTexture(nextTextureKey);
+
+        if (previousTextureKey && this.scene.textures.exists(previousTextureKey)) {
+            this.scene.textures.remove(previousTextureKey);
+        }
+    }
+
+    public setAvailabilityStatus(availabilityStatus: AvailabilityStatus, instant = false, forceClose = false): void {
         this.statusDot.setAvailabilityStatus(availabilityStatus, instant);
+        this.showMegaphone(availabilityStatus === AvailabilityStatus.SPEAKER, forceClose);
     }
 
     public getAvailabilityStatus(): AvailabilityStatus {
         return this.statusDot.availabilityStatus;
-    }
-
-    public showMegaphone(show = true, forceClose = false): void {
-        this.megaphoneIcon.visible = show;
-        this.megaphoneIcon.show(show, forceClose);
-        this.reflow();
     }
 
     private reflow(): void {
@@ -49,5 +84,58 @@ export class UsernameDisplay extends Phaser.GameObjects.Container {
         const halfPlayerNameWidth = this.playerNameSprite.displayWidth / 2;
         this.statusDot.setPosition(-halfPlayerNameWidth - 2, halfPlayerNameHeight);
         this.megaphoneIcon.setPosition(halfPlayerNameWidth + 2, halfPlayerNameHeight);
+    }
+
+    private createPlayerNameTexture(outlineColor: number | undefined): string {
+        const textureKey = `player-name-${UsernameDisplay.nextPlayerNameTextureId++}`;
+        const dynamicOutlineColor =
+            outlineColor === undefined ? undefined : `#${outlineColor.toString(16).padStart(6, "0")}`;
+        const strokeThickness = 2;
+        const outlineThickness = 2;
+
+        const measurementCanvas = document.createElement("canvas");
+        const measurementContext = measurementCanvas.getContext("2d");
+        if (!measurementContext) {
+            throw new Error("Could not create canvas context for player name texture");
+        }
+        measurementContext.font = `${this.playerNameFontSize}px "Press Start 2P"`;
+        const measuredWidth = measurementContext.measureText(this.playerName).width;
+        const fullOutlineThickness = strokeThickness + outlineThickness * 2;
+        const textureWidth = Math.max(1, Math.ceil(measuredWidth + fullOutlineThickness * 2));
+        const textureHeight = Math.max(1, Math.ceil(this.playerNameFontSize + fullOutlineThickness * 2));
+
+        const texture = this.scene.textures.createCanvas(textureKey, textureWidth, textureHeight);
+        if (!texture) {
+            throw new Error("Could not create texture for player name");
+        }
+
+        const context = texture.getContext();
+        context.clearRect(0, 0, textureWidth, textureHeight);
+        context.font = `${this.playerNameFontSize}px "Press Start 2P"`;
+        context.textAlign = "center";
+        context.textBaseline = "middle";
+        context.lineJoin = "round";
+
+        if (dynamicOutlineColor) {
+            context.lineWidth = fullOutlineThickness;
+            context.strokeStyle = dynamicOutlineColor;
+            context.strokeText(this.playerName, textureWidth / 2, textureHeight / 2);
+        }
+
+        context.lineWidth = strokeThickness;
+        context.strokeStyle = DEFAULT_PLAYER_NAME_OUTLINE_COLOR;
+        context.fillStyle = "#ffffff";
+        context.strokeText(this.playerName, textureWidth / 2, textureHeight / 2);
+        context.fillText(this.playerName, textureWidth / 2, textureHeight / 2);
+        texture.refresh();
+
+        return textureKey;
+    }
+
+    public override destroy(fromScene?: boolean): void {
+        if (this.playerNameTextureKey && this.scene.textures.exists(this.playerNameTextureKey)) {
+            this.scene.textures.remove(this.playerNameTextureKey);
+        }
+        super.destroy(fromScene);
     }
 }

--- a/play/src/front/Phaser/Components/UsernameDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameDisplay.ts
@@ -1,4 +1,5 @@
 import { AvailabilityStatus } from "@workadventure/messages";
+import { StringUtils } from "../../Utils/StringUtils";
 import { DEPTH_INGAME_TEXT_INDEX } from "../Game/DepthIndexes";
 import { MegaphoneIcon } from "./MegaphoneIcon";
 import { PlayerStatusDot } from "./PlayerStatusDot";
@@ -15,17 +16,13 @@ export class UsernameDisplay extends Phaser.GameObjects.Container {
     private readonly statusDot: PlayerStatusDot;
     private readonly megaphoneIcon: MegaphoneIcon;
 
-    constructor(
-        scene: Phaser.Scene,
-        x: number,
-        y: number,
-        playerName: string,
-        playerNameFontSize: number,
-        outlineColor: number | undefined
-    ) {
+    constructor(scene: Phaser.Scene, x: number, y: number, playerName: string, outlineColor: number | undefined) {
         super(scene, x, y);
         this.playerName = playerName;
-        this.playerNameFontSize = playerNameFontSize;
+
+        // Todo: Replace the font family with a better one
+        // Use larger font size for non-Latin characters (Arabic, CJK, etc.) for better readability
+        this.playerNameFontSize = StringUtils.containsNonLatinCharacters(playerName) ? 11 : 8;
         this.playerNameOutlineColor = outlineColor;
         this.playerNameTextureKey = this.createPlayerNameTexture(outlineColor);
 

--- a/play/src/front/Phaser/Components/UsernameDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameDisplay.ts
@@ -1,6 +1,7 @@
 import { AvailabilityStatus } from "@workadventure/messages";
 import { StringUtils } from "../../Utils/StringUtils";
 import { DEPTH_INGAME_TEXT_INDEX } from "../Game/DepthIndexes";
+import { waScaleManager, WaScaleManagerEvent } from "../Services/WaScaleManager";
 import { MegaphoneIcon } from "./MegaphoneIcon";
 import { PlayerStatusDot } from "./PlayerStatusDot";
 
@@ -15,6 +16,9 @@ export class UsernameDisplay extends Phaser.GameObjects.Container {
     private playerNameOutlineColor: number | undefined;
     private readonly statusDot: PlayerStatusDot;
     private readonly megaphoneIcon: MegaphoneIcon;
+    private readonly onZoomChanged = (zoomModifier: number): void => {
+        this.setScale(this.getDisplayScale(zoomModifier));
+    };
 
     constructor(scene: Phaser.Scene, x: number, y: number, playerName: string, outlineColor: number | undefined) {
         super(scene, x, y);
@@ -38,42 +42,12 @@ export class UsernameDisplay extends Phaser.GameObjects.Container {
         this.reflow();
 
         this.scene.add.existing(this);
+        this.onZoomChanged(waScaleManager.zoomModifier);
+        this.scene.game.events.on(WaScaleManagerEvent.ZoomChanged, this.onZoomChanged);
     }
 
-    private showMegaphone(show = true, forceClose = false): void {
-        this.megaphoneIcon.visible = show;
-        this.megaphoneIcon.show(show, forceClose);
-        this.reflow();
-    }
-
-    public setPlayerNameTexture(playerNameTextureKey: string): void {
-        this.playerNameSprite.setTexture(playerNameTextureKey);
-        this.reflow();
-    }
-
-    public setPlayerNameOutlineColor(outlineColor: number | undefined): void {
-        if (this.playerNameOutlineColor === outlineColor) {
-            return;
-        }
-        this.playerNameOutlineColor = outlineColor;
-
-        const nextTextureKey = this.createPlayerNameTexture(outlineColor);
-        const previousTextureKey = this.playerNameTextureKey;
-        this.playerNameTextureKey = nextTextureKey;
-        this.setPlayerNameTexture(nextTextureKey);
-
-        if (previousTextureKey && this.scene.textures.exists(previousTextureKey)) {
-            this.scene.textures.remove(previousTextureKey);
-        }
-    }
-
-    public setAvailabilityStatus(availabilityStatus: AvailabilityStatus, instant = false, forceClose = false): void {
-        this.statusDot.setAvailabilityStatus(availabilityStatus, instant);
-        this.showMegaphone(availabilityStatus === AvailabilityStatus.SPEAKER, forceClose);
-    }
-
-    public getAvailabilityStatus(): AvailabilityStatus {
-        return this.statusDot.availabilityStatus;
+    private getDisplayScale(zoomModifier: number): number {
+        return Math.max(zoomModifier > 0 ? 0.8 / zoomModifier : 1, 1);
     }
 
     private reflow(): void {
@@ -129,7 +103,39 @@ export class UsernameDisplay extends Phaser.GameObjects.Container {
         return textureKey;
     }
 
+    private showMegaphone(show = true, forceClose = false): void {
+        this.megaphoneIcon.visible = show;
+        this.megaphoneIcon.show(show, forceClose);
+        this.reflow();
+    }
+
+    public setPlayerNameOutlineColor(outlineColor: number | undefined): void {
+        if (this.playerNameOutlineColor === outlineColor) {
+            return;
+        }
+        this.playerNameOutlineColor = outlineColor;
+
+        const nextTextureKey = this.createPlayerNameTexture(outlineColor);
+        const previousTextureKey = this.playerNameTextureKey;
+        this.playerNameTextureKey = nextTextureKey;
+        this.setPlayerNameTexture(nextTextureKey);
+
+        if (previousTextureKey && this.scene.textures.exists(previousTextureKey)) {
+            this.scene.textures.remove(previousTextureKey);
+        }
+    }
+
+    public setAvailabilityStatus(availabilityStatus: AvailabilityStatus, instant = false, forceClose = false): void {
+        this.statusDot.setAvailabilityStatus(availabilityStatus, instant);
+        this.showMegaphone(availabilityStatus === AvailabilityStatus.SPEAKER, forceClose);
+    }
+
+    public getAvailabilityStatus(): AvailabilityStatus {
+        return this.statusDot.availabilityStatus;
+    }
+
     public override destroy(fromScene?: boolean): void {
+        this.scene.game.events.off(WaScaleManagerEvent.ZoomChanged, this.onZoomChanged);
         if (this.playerNameTextureKey && this.scene.textures.exists(this.playerNameTextureKey)) {
             this.scene.textures.remove(this.playerNameTextureKey);
         }

--- a/play/src/front/Phaser/Components/UsernameDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameDisplay.ts
@@ -118,7 +118,7 @@ export class UsernameDisplay extends Phaser.GameObjects.Container {
         const nextTextureKey = this.createPlayerNameTexture(outlineColor);
         const previousTextureKey = this.playerNameTextureKey;
         this.playerNameTextureKey = nextTextureKey;
-        this.setPlayerNameTexture(nextTextureKey);
+        this.playerNameSprite.setTexture(nextTextureKey);
 
         if (previousTextureKey && this.scene.textures.exists(previousTextureKey)) {
             this.scene.textures.remove(previousTextureKey);

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -16,7 +16,6 @@ import { CharacterTextureError } from "../../Exception/CharacterTextureError";
 import { getPlayerAnimations, PlayerAnimationTypes } from "../Player/Animation";
 import { ProtobufClientUtils } from "../../Network/ProtobufClientUtils";
 import { SpeakerIcon } from "../Components/SpeakerIcon";
-import { waScaleManager } from "../Services/WaScaleManager";
 
 import { UsernameDisplay } from "../Components/UsernameDisplay";
 import { lazyLoadPlayerCharacterTextures } from "./PlayerTexturesLoadingManager";
@@ -164,7 +163,6 @@ export abstract class Character extends Container implements OutlineableInterfac
 
             const playerNameOutlineColor = get(this.outlineColorStore);
             this.usernameDisplay = new UsernameDisplay(scene, 0, playerNameY, this.playerName, playerNameOutlineColor);
-            this.usernameDisplay.setScale(this.getSpriteScale(waScaleManager.zoomModifier));
             this.usernameDisplay.setAvailabilityStatus(this.availabilityStatus, true, true);
             this.add(this.usernameDisplay);
 
@@ -228,10 +226,6 @@ export abstract class Character extends Container implements OutlineableInterfac
                     resolve(defaultWoka);
                 });
         });
-    }
-
-    private getSpriteScale(zoomModifier: number): number {
-        return Math.max(zoomModifier > 0 ? 0.8 / zoomModifier : 1, 1);
     }
 
     public setClickable(clickable = true): void {
@@ -313,14 +307,6 @@ export abstract class Character extends Container implements OutlineableInterfac
             this.availabilityStatus = availabilityStatus;
         }
         this.usernameDisplay?.setAvailabilityStatus(availabilityStatus, instant, false);
-    }
-
-    public syncPlayerNameZoom(zoomModifier: number): void {
-        if (!this.usernameDisplay) {
-            return;
-        }
-
-        this.usernameDisplay.setScale(this.getSpriteScale(zoomModifier));
     }
 
     public getAvailabilityStatus() {

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -30,7 +30,6 @@ import RenderTexture = Phaser.GameObjects.RenderTexture;
 
 const playerNameY = -16;
 const interactiveRadius = 25;
-const DEFAULT_PLAYER_NAME_OUTLINE_COLOR = "#14304C";
 
 export const CHARACTER_BODY_WIDTH = 16;
 export const CHARACTER_BODY_HEIGHT = 16;
@@ -40,12 +39,8 @@ export const CHARACTER_BODY_OFFSET_Y = 8;
 export const PLAYTEXT_NEW_MEDIA_DEVICE_PREFIX = "playtext-mediadevice-";
 
 export abstract class Character extends Container implements OutlineableInterface {
-    private static nextPlayerNameTextureId = 0;
     private bubble: RenderTexture | null | DOMElement = null;
     private usernameDisplay: UsernameDisplay | undefined;
-    private playerNameTextureKey: string | undefined;
-    private playerNameFontSize: number | undefined;
-    private playerNameOutlineColor: number | undefined;
     private readonly talkIcon: TalkIcon;
     protected readonly speakerIcon: SpeakerIcon;
     private availabilityStatus: AvailabilityStatusType = AvailabilityStatus.ONLINE;
@@ -169,17 +164,23 @@ export abstract class Character extends Container implements OutlineableInterfac
 
             // Todo: Replace the font family with a better one
             // Use larger font size for non-Latin characters (Arabic, CJK, etc.) for better readability
-            this.playerNameFontSize = StringUtils.containsNonLatinCharacters(name) ? 11 : 8;
-            this.playerNameOutlineColor = get(this.outlineColorStore);
-            this.playerNameTextureKey = this.createPlayerNameTexture(this.playerNameOutlineColor);
-            this.usernameDisplay = new UsernameDisplay(scene, 0, playerNameY, this.playerNameTextureKey);
+            const playerNameFontSize = StringUtils.containsNonLatinCharacters(name) ? 11 : 8;
+            const playerNameOutlineColor = get(this.outlineColorStore);
+            this.usernameDisplay = new UsernameDisplay(
+                scene,
+                0,
+                playerNameY,
+                this.playerName,
+                playerNameFontSize,
+                playerNameOutlineColor
+            );
             this.usernameDisplay.setScale(this.getSpriteScale(waScaleManager.zoomModifier));
-            this.usernameDisplay.setAvailabilityStatus(this.availabilityStatus, true);
-            this.usernameDisplay.showMegaphone(this.availabilityStatus === AvailabilityStatus.SPEAKER, true);
+            this.usernameDisplay.setAvailabilityStatus(this.availabilityStatus, true, true);
             this.add(this.usernameDisplay);
 
             this.outlineColorStoreUnsubscribe = this.outlineColorStore.subscribe((color) => {
-                this.updatePlayerNameTexture(color);
+                this.usernameDisplay?.setPlayerNameOutlineColor(color);
+                this.scene.markDirty();
             });
             this.scene.markDirty();
         }, 0);
@@ -321,8 +322,7 @@ export abstract class Character extends Container implements OutlineableInterfac
         if (availabilityStatus !== AvailabilityStatus.UNCHANGED) {
             this.availabilityStatus = availabilityStatus;
         }
-        this.usernameDisplay?.setAvailabilityStatus(availabilityStatus, instant);
-        this.usernameDisplay?.showMegaphone(this.availabilityStatus === AvailabilityStatus.SPEAKER, false);
+        this.usernameDisplay?.setAvailabilityStatus(availabilityStatus, instant, false);
     }
 
     public syncPlayerNameZoom(zoomModifier: number): void {
@@ -449,9 +449,6 @@ export abstract class Character extends Container implements OutlineableInterfac
                 this.scene.sys.updateList.remove(sprite);
             }
         }
-        if (this.playerNameTextureKey && this.scene.textures.exists(this.playerNameTextureKey)) {
-            this.scene.textures.remove(this.playerNameTextureKey);
-        }
         this.texturePromise?.cancel();
         this.list.forEach((objectContaining) => objectContaining.destroy());
         this.outlineColorStoreUnsubscribe?.();
@@ -559,72 +556,6 @@ export abstract class Character extends Container implements OutlineableInterfac
                 this.destroyEmote();
             },
         });
-    }
-
-    private createPlayerNameTexture(outlineColor: number | undefined): string {
-        const textureKey = `player-name-${Character.nextPlayerNameTextureId++}`;
-        const fontSize = this.playerNameFontSize ?? 8;
-        const dynamicOutlineColor =
-            outlineColor === undefined ? undefined : `#${outlineColor.toString(16).padStart(6, "0")}`;
-        const strokeThickness = 2;
-        const outlineThickness = 2;
-
-        const measurementCanvas = document.createElement("canvas");
-        const measurementContext = measurementCanvas.getContext("2d");
-        if (!measurementContext) {
-            throw new Error("Could not create canvas context for player name texture");
-        }
-        measurementContext.font = `${fontSize}px "Press Start 2P"`;
-        const measuredWidth = measurementContext.measureText(this.playerName).width;
-        const fullOutlineThickness = strokeThickness + outlineThickness * 2;
-        const textureWidth = Math.max(1, Math.ceil(measuredWidth + fullOutlineThickness * 2));
-        const textureHeight = Math.max(1, Math.ceil(fontSize + fullOutlineThickness * 2));
-
-        const texture = this.scene.textures.createCanvas(textureKey, textureWidth, textureHeight);
-        if (!texture) {
-            throw new Error("Could not create texture for player name");
-        }
-
-        const context = texture.getContext();
-        context.clearRect(0, 0, textureWidth, textureHeight);
-        context.font = `${fontSize}px "Press Start 2P"`;
-        context.textAlign = "center";
-        context.textBaseline = "middle";
-        context.lineJoin = "round";
-
-        if (dynamicOutlineColor) {
-            context.lineWidth = fullOutlineThickness;
-            context.strokeStyle = dynamicOutlineColor;
-            context.strokeText(this.playerName, textureWidth / 2, textureHeight / 2);
-        }
-
-        context.lineWidth = strokeThickness;
-        context.strokeStyle = DEFAULT_PLAYER_NAME_OUTLINE_COLOR;
-        context.fillStyle = "#ffffff";
-        context.strokeText(this.playerName, textureWidth / 2, textureHeight / 2);
-        context.fillText(this.playerName, textureWidth / 2, textureHeight / 2);
-        texture.refresh();
-
-        return textureKey;
-    }
-
-    private updatePlayerNameTexture(color: number | undefined) {
-        if (!this.usernameDisplay || this.playerNameOutlineColor === color) {
-            return;
-        }
-        this.playerNameOutlineColor = color;
-
-        const nextTextureKey = this.createPlayerNameTexture(color);
-        const previousTextureKey = this.playerNameTextureKey;
-        this.playerNameTextureKey = nextTextureKey;
-        this.usernameDisplay.setPlayerNameTexture(nextTextureKey);
-
-        if (previousTextureKey && this.scene.textures.exists(previousTextureKey)) {
-            this.scene.textures.remove(previousTextureKey);
-        }
-
-        this.usernameDisplay.setScale(this.getSpriteScale(waScaleManager.zoomModifier));
-        this.scene.markDirty();
     }
 
     private cancelPreviousEmote() {

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -5,21 +5,20 @@ import type { AvailabilityStatus as AvailabilityStatusType } from "@workadventur
 import { SayMessageType, AvailabilityStatus, PositionMessage_Direction } from "@workadventure/messages";
 import { defaultWoka, Deferred } from "@workadventure/shared-utils";
 import { currentPlayerWokaStore } from "../../Stores/CurrentPlayerWokaStore";
-import { PlayerStatusDot } from "../Components/PlayerStatusDot";
 import { TalkIcon } from "../Components/TalkIcon";
 import type { OutlineableInterface } from "../Game/OutlineableInterface";
 import { createColorStore } from "../../Stores/OutlineColorStore";
 import type { PictureStore } from "../../Stores/PictureStore";
 import { TexturesHelper } from "../Helpers/TexturesHelper";
-import { DEPTH_INGAME_TEXT_INDEX } from "../Game/DepthIndexes";
 import type { GameScene } from "../Game/GameScene";
 import { Companion } from "../Companion/Companion";
 import { CharacterTextureError } from "../../Exception/CharacterTextureError";
 import { getPlayerAnimations, PlayerAnimationTypes } from "../Player/Animation";
 import { ProtobufClientUtils } from "../../Network/ProtobufClientUtils";
 import { SpeakerIcon } from "../Components/SpeakerIcon";
-import { MegaphoneIcon } from "../Components/MegaphoneIcon";
+import { waScaleManager } from "../Services/WaScaleManager";
 import { StringUtils } from "../../Utils/StringUtils";
+import { UsernameDisplay } from "../Components/UsernameDisplay";
 import { lazyLoadPlayerCharacterTextures } from "./PlayerTexturesLoadingManager";
 import { SpeechBubble } from "./SpeechBubble";
 import { SpeechDomElement } from "./SpeechDomElement";
@@ -29,7 +28,7 @@ import Sprite = Phaser.GameObjects.Sprite;
 import DOMElement = Phaser.GameObjects.DOMElement;
 import RenderTexture = Phaser.GameObjects.RenderTexture;
 
-const playerNameY = -25;
+const playerNameY = -16;
 const interactiveRadius = 25;
 const DEFAULT_PLAYER_NAME_OUTLINE_COLOR = "#14304C";
 
@@ -43,14 +42,13 @@ export const PLAYTEXT_NEW_MEDIA_DEVICE_PREFIX = "playtext-mediadevice-";
 export abstract class Character extends Container implements OutlineableInterface {
     private static nextPlayerNameTextureId = 0;
     private bubble: RenderTexture | null | DOMElement = null;
-    private playerNameSprite: Sprite | undefined;
+    private usernameDisplay: UsernameDisplay | undefined;
     private playerNameTextureKey: string | undefined;
     private playerNameFontSize: number | undefined;
     private playerNameOutlineColor: number | undefined;
     private readonly talkIcon: TalkIcon;
-    protected readonly statusDot: PlayerStatusDot;
     protected readonly speakerIcon: SpeakerIcon;
-    protected readonly megaphoneIcon: MegaphoneIcon;
+    private availabilityStatus: AvailabilityStatusType = AvailabilityStatus.ONLINE;
     public readonly playerName: string;
     public sprites: Map<string, Sprite>;
     protected _lastDirection: PositionMessage_Direction = PositionMessage_Direction.DOWN;
@@ -174,15 +172,11 @@ export abstract class Character extends Container implements OutlineableInterfac
             this.playerNameFontSize = StringUtils.containsNonLatinCharacters(name) ? 11 : 8;
             this.playerNameOutlineColor = get(this.outlineColorStore);
             this.playerNameTextureKey = this.createPlayerNameTexture(this.playerNameOutlineColor);
-            this.playerNameSprite = new Sprite(scene, 0, playerNameY, this.playerNameTextureKey);
-            this.playerNameSprite.setOrigin(0.5).setDepth(DEPTH_INGAME_TEXT_INDEX);
-            this.add([this.playerNameSprite]);
-
-            // Reposition status dot and megaphone icon
-            this.statusDot.x = (this.playerNameSprite.getLeftCenter().x ?? 0) - 2;
-            this.megaphoneIcon.setX((this.playerNameSprite.getRightCenter().x ?? 0) + 2);
-            this.statusDot.visible = true;
-            this.megaphoneIcon.visible = true;
+            this.usernameDisplay = new UsernameDisplay(scene, 0, playerNameY, this.playerNameTextureKey);
+            this.usernameDisplay.setScale(this.getSpriteScale(waScaleManager.zoomModifier));
+            this.usernameDisplay.setAvailabilityStatus(this.availabilityStatus, true);
+            this.usernameDisplay.showMegaphone(this.availabilityStatus === AvailabilityStatus.SPEAKER, true);
+            this.add(this.usernameDisplay);
 
             this.outlineColorStoreUnsubscribe = this.outlineColorStore.subscribe((color) => {
                 this.updatePlayerNameTexture(color);
@@ -190,13 +184,9 @@ export abstract class Character extends Container implements OutlineableInterfac
             this.scene.markDirty();
         }, 0);
 
-        this.statusDot = new PlayerStatusDot(scene, 0, playerNameY - 1);
-        this.megaphoneIcon = new MegaphoneIcon(scene, 0, playerNameY - 1);
-        this.statusDot.visible = false;
-        this.megaphoneIcon.visible = false;
         this.talkIcon = new TalkIcon(scene, 0, -45);
         this.speakerIcon = new SpeakerIcon(scene, 0, -45);
-        this.add([this.talkIcon, this.speakerIcon, this.statusDot, this.megaphoneIcon]);
+        this.add([this.talkIcon, this.speakerIcon]);
 
         if (isClickable) {
             this.setInteractive({
@@ -247,6 +237,10 @@ export abstract class Character extends Container implements OutlineableInterfac
                     resolve(defaultWoka);
                 });
         });
+    }
+
+    private getSpriteScale(zoomModifier: number): number {
+        return Math.max(zoomModifier > 0 ? 0.8 / zoomModifier : 1, 1);
     }
 
     public setClickable(clickable = true): void {
@@ -324,16 +318,23 @@ export abstract class Character extends Container implements OutlineableInterfac
     }
 
     public setAvailabilityStatus(availabilityStatus: AvailabilityStatusType, instant = false): void {
-        this.statusDot.setAvailabilityStatus(availabilityStatus, instant);
-        if (this.getAvailabilityStatus() === AvailabilityStatus.SPEAKER) {
-            this.megaphoneIcon.show(true, false);
-        } else {
-            this.megaphoneIcon.show(false, false);
+        if (availabilityStatus !== AvailabilityStatus.UNCHANGED) {
+            this.availabilityStatus = availabilityStatus;
         }
+        this.usernameDisplay?.setAvailabilityStatus(availabilityStatus, instant);
+        this.usernameDisplay?.showMegaphone(this.availabilityStatus === AvailabilityStatus.SPEAKER, false);
+    }
+
+    public syncPlayerNameZoom(zoomModifier: number): void {
+        if (!this.usernameDisplay) {
+            return;
+        }
+
+        this.usernameDisplay.setScale(this.getSpriteScale(zoomModifier));
     }
 
     public getAvailabilityStatus() {
-        return this.statusDot.availabilityStatus;
+        return this.usernameDisplay?.getAvailabilityStatus() ?? this.availabilityStatus;
     }
 
     public addCompanion(texturePromise: CancelablePromise<string>): void {
@@ -580,6 +581,10 @@ export abstract class Character extends Container implements OutlineableInterfac
         const textureHeight = Math.max(1, Math.ceil(fontSize + fullOutlineThickness * 2));
 
         const texture = this.scene.textures.createCanvas(textureKey, textureWidth, textureHeight);
+        if (!texture) {
+            throw new Error("Could not create texture for player name");
+        }
+
         const context = texture.getContext();
         context.clearRect(0, 0, textureWidth, textureHeight);
         context.font = `${fontSize}px "Press Start 2P"`;
@@ -604,7 +609,7 @@ export abstract class Character extends Container implements OutlineableInterfac
     }
 
     private updatePlayerNameTexture(color: number | undefined) {
-        if (!this.playerNameSprite || this.playerNameOutlineColor === color) {
+        if (!this.usernameDisplay || this.playerNameOutlineColor === color) {
             return;
         }
         this.playerNameOutlineColor = color;
@@ -612,14 +617,13 @@ export abstract class Character extends Container implements OutlineableInterfac
         const nextTextureKey = this.createPlayerNameTexture(color);
         const previousTextureKey = this.playerNameTextureKey;
         this.playerNameTextureKey = nextTextureKey;
-        this.playerNameSprite.setTexture(nextTextureKey);
+        this.usernameDisplay.setPlayerNameTexture(nextTextureKey);
 
         if (previousTextureKey && this.scene.textures.exists(previousTextureKey)) {
             this.scene.textures.remove(previousTextureKey);
         }
 
-        this.statusDot.x = (this.playerNameSprite.getLeftCenter().x ?? 0) - 2;
-        this.megaphoneIcon.setX((this.playerNameSprite.getRightCenter().x ?? 0) + 2);
+        this.usernameDisplay.setScale(this.getSpriteScale(waScaleManager.zoomModifier));
         this.scene.markDirty();
     }
 

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -17,7 +17,7 @@ import { getPlayerAnimations, PlayerAnimationTypes } from "../Player/Animation";
 import { ProtobufClientUtils } from "../../Network/ProtobufClientUtils";
 import { SpeakerIcon } from "../Components/SpeakerIcon";
 import { waScaleManager } from "../Services/WaScaleManager";
-import { StringUtils } from "../../Utils/StringUtils";
+
 import { UsernameDisplay } from "../Components/UsernameDisplay";
 import { lazyLoadPlayerCharacterTextures } from "./PlayerTexturesLoadingManager";
 import { SpeechBubble } from "./SpeechBubble";
@@ -162,18 +162,8 @@ export abstract class Character extends Container implements OutlineableInterfac
                 return;
             }
 
-            // Todo: Replace the font family with a better one
-            // Use larger font size for non-Latin characters (Arabic, CJK, etc.) for better readability
-            const playerNameFontSize = StringUtils.containsNonLatinCharacters(name) ? 11 : 8;
             const playerNameOutlineColor = get(this.outlineColorStore);
-            this.usernameDisplay = new UsernameDisplay(
-                scene,
-                0,
-                playerNameY,
-                this.playerName,
-                playerNameFontSize,
-                playerNameOutlineColor
-            );
+            this.usernameDisplay = new UsernameDisplay(scene, 0, playerNameY, this.playerName, playerNameOutlineColor);
             this.usernameDisplay.setScale(this.getSpriteScale(waScaleManager.zoomModifier));
             this.usernameDisplay.setAvailabilityStatus(this.availabilityStatus, true, true);
             this.add(this.usernameDisplay);

--- a/play/src/front/Phaser/Entity/Character.ts
+++ b/play/src/front/Phaser/Entity/Character.ts
@@ -1,4 +1,3 @@
-import type OutlinePipelinePlugin from "phaser3-rex-plugins/plugins/outlinepipeline-plugin.js";
 import type { Unsubscriber, Readable } from "svelte/store";
 import { get, readable } from "svelte/store";
 import type CancelablePromise from "cancelable-promise";
@@ -25,7 +24,6 @@ import { lazyLoadPlayerCharacterTextures } from "./PlayerTexturesLoadingManager"
 import { SpeechBubble } from "./SpeechBubble";
 import { SpeechDomElement } from "./SpeechDomElement";
 import { ThinkingCloud } from "./ThinkingCloud";
-import Text = Phaser.GameObjects.Text;
 import Container = Phaser.GameObjects.Container;
 import Sprite = Phaser.GameObjects.Sprite;
 import DOMElement = Phaser.GameObjects.DOMElement;
@@ -33,6 +31,7 @@ import RenderTexture = Phaser.GameObjects.RenderTexture;
 
 const playerNameY = -25;
 const interactiveRadius = 25;
+const DEFAULT_PLAYER_NAME_OUTLINE_COLOR = "#14304C";
 
 export const CHARACTER_BODY_WIDTH = 16;
 export const CHARACTER_BODY_HEIGHT = 16;
@@ -42,8 +41,12 @@ export const CHARACTER_BODY_OFFSET_Y = 8;
 export const PLAYTEXT_NEW_MEDIA_DEVICE_PREFIX = "playtext-mediadevice-";
 
 export abstract class Character extends Container implements OutlineableInterface {
+    private static nextPlayerNameTextureId = 0;
     private bubble: RenderTexture | null | DOMElement = null;
-    private playerNameText: Text | undefined;
+    private playerNameSprite: Sprite | undefined;
+    private playerNameTextureKey: string | undefined;
+    private playerNameFontSize: number | undefined;
+    private playerNameOutlineColor: number | undefined;
     private readonly talkIcon: TalkIcon;
     protected readonly statusDot: PlayerStatusDot;
     protected readonly speakerIcon: SpeakerIcon;
@@ -168,35 +171,23 @@ export abstract class Character extends Container implements OutlineableInterfac
 
             // Todo: Replace the font family with a better one
             // Use larger font size for non-Latin characters (Arabic, CJK, etc.) for better readability
-            const fontSize = StringUtils.containsNonLatinCharacters(name) ? "11px" : "8px";
-            this.playerNameText = new Text(scene, 0, playerNameY, name, {
-                fontFamily: '"Press Start 2P"',
-                fontSize,
-                strokeThickness: 2,
-                stroke: "#14304C",
-                metrics: {
-                    ascent: 20,
-                    descent: 10,
-                    fontSize: 35,
-                },
-            });
-
-            this.playerNameText.setOrigin(0.5).setDepth(DEPTH_INGAME_TEXT_INDEX);
-            this.add([this.playerNameText]);
+            this.playerNameFontSize = StringUtils.containsNonLatinCharacters(name) ? 11 : 8;
+            this.playerNameOutlineColor = get(this.outlineColorStore);
+            this.playerNameTextureKey = this.createPlayerNameTexture(this.playerNameOutlineColor);
+            this.playerNameSprite = new Sprite(scene, 0, playerNameY, this.playerNameTextureKey);
+            this.playerNameSprite.setOrigin(0.5).setDepth(DEPTH_INGAME_TEXT_INDEX);
+            this.add([this.playerNameSprite]);
 
             // Reposition status dot and megaphone icon
-            this.statusDot.x = (this.playerNameText.getLeftCenter().x ?? 0) - 6;
-            this.megaphoneIcon.setX((this.playerNameText.getRightCenter().x ?? 0) + 8);
+            this.statusDot.x = (this.playerNameSprite.getLeftCenter().x ?? 0) - 2;
+            this.megaphoneIcon.setX((this.playerNameSprite.getRightCenter().x ?? 0) + 2);
             this.statusDot.visible = true;
             this.megaphoneIcon.visible = true;
 
-            scene.getOutlineManager().add(this.playerNameText, () => {
-                return this.getCurrentOutline();
-            });
-
             this.outlineColorStoreUnsubscribe = this.outlineColorStore.subscribe((color) => {
-                this.setOutline(color);
+                this.updatePlayerNameTexture(color);
             });
+            this.scene.markDirty();
         }, 0);
 
         this.statusDot = new PlayerStatusDot(scene, 0, playerNameY - 1);
@@ -378,10 +369,6 @@ export abstract class Character extends Container implements OutlineableInterfac
         }
     }
 
-    private getOutlinePlugin(): OutlinePipelinePlugin | undefined {
-        return this.scene.plugins.get("rexOutlinePipeline") as unknown as OutlinePipelinePlugin | undefined;
-    }
-
     protected playAnimation(direction: PositionMessage_Direction, moving: boolean): void {
         if (this.invisible) return;
         for (const [texture, sprite] of this.sprites.entries()) {
@@ -460,6 +447,9 @@ export abstract class Character extends Container implements OutlineableInterfac
             if (this.scene) {
                 this.scene.sys.updateList.remove(sprite);
             }
+        }
+        if (this.playerNameTextureKey && this.scene.textures.exists(this.playerNameTextureKey)) {
+            this.scene.textures.remove(this.playerNameTextureKey);
         }
         this.texturePromise?.cancel();
         this.list.forEach((objectContaining) => objectContaining.destroy());
@@ -570,22 +560,67 @@ export abstract class Character extends Container implements OutlineableInterfac
         });
     }
 
-    private setOutline(color: number | undefined) {
-        if (!this.playerNameText) {
-            throw new Error("Player name text is not defined when setOuline is called");
+    private createPlayerNameTexture(outlineColor: number | undefined): string {
+        const textureKey = `player-name-${Character.nextPlayerNameTextureId++}`;
+        const fontSize = this.playerNameFontSize ?? 8;
+        const dynamicOutlineColor =
+            outlineColor === undefined ? undefined : `#${outlineColor.toString(16).padStart(6, "0")}`;
+        const strokeThickness = 2;
+        const outlineThickness = 2;
+
+        const measurementCanvas = document.createElement("canvas");
+        const measurementContext = measurementCanvas.getContext("2d");
+        if (!measurementContext) {
+            throw new Error("Could not create canvas context for player name texture");
         }
-        if (color === undefined) {
-            this.getOutlinePlugin()?.remove(this.playerNameText);
-        } else {
-            this.getOutlinePlugin()?.remove(this.playerNameText);
-            this.getOutlinePlugin()?.add(this.playerNameText, {
-                thickness: 2,
-                outlineColor: color,
-            });
+        measurementContext.font = `${fontSize}px "Press Start 2P"`;
+        const measuredWidth = measurementContext.measureText(this.playerName).width;
+        const fullOutlineThickness = strokeThickness + outlineThickness * 2;
+        const textureWidth = Math.max(1, Math.ceil(measuredWidth + fullOutlineThickness * 2));
+        const textureHeight = Math.max(1, Math.ceil(fontSize + fullOutlineThickness * 2));
+
+        const texture = this.scene.textures.createCanvas(textureKey, textureWidth, textureHeight);
+        const context = texture.getContext();
+        context.clearRect(0, 0, textureWidth, textureHeight);
+        context.font = `${fontSize}px "Press Start 2P"`;
+        context.textAlign = "center";
+        context.textBaseline = "middle";
+        context.lineJoin = "round";
+
+        if (dynamicOutlineColor) {
+            context.lineWidth = fullOutlineThickness;
+            context.strokeStyle = dynamicOutlineColor;
+            context.strokeText(this.playerName, textureWidth / 2, textureHeight / 2);
         }
 
-        //Using outline quickfix
-        this.scene.refreshSceneForOutline();
+        context.lineWidth = strokeThickness;
+        context.strokeStyle = DEFAULT_PLAYER_NAME_OUTLINE_COLOR;
+        context.fillStyle = "#ffffff";
+        context.strokeText(this.playerName, textureWidth / 2, textureHeight / 2);
+        context.fillText(this.playerName, textureWidth / 2, textureHeight / 2);
+        texture.refresh();
+
+        return textureKey;
+    }
+
+    private updatePlayerNameTexture(color: number | undefined) {
+        if (!this.playerNameSprite || this.playerNameOutlineColor === color) {
+            return;
+        }
+        this.playerNameOutlineColor = color;
+
+        const nextTextureKey = this.createPlayerNameTexture(color);
+        const previousTextureKey = this.playerNameTextureKey;
+        this.playerNameTextureKey = nextTextureKey;
+        this.playerNameSprite.setTexture(nextTextureKey);
+
+        if (previousTextureKey && this.scene.textures.exists(previousTextureKey)) {
+            this.scene.textures.remove(previousTextureKey);
+        }
+
+        this.statusDot.x = (this.playerNameSprite.getLeftCenter().x ?? 0) - 2;
+        this.megaphoneIcon.setX((this.playerNameSprite.getRightCenter().x ?? 0) + 2);
+        this.scene.markDirty();
     }
 
     private cancelPreviousEmote() {
@@ -663,10 +698,6 @@ export abstract class Character extends Container implements OutlineableInterfac
 
     public characterFarAwayOutline(): void {
         this.outlineColorStore.characterFarAway();
-    }
-
-    private getCurrentOutline(): { thickness: number; color?: number } {
-        return { thickness: 2, color: get(this.outlineColorStore) };
     }
 
     /**

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -830,7 +830,6 @@ export class GameScene extends DirtyScene {
         this.activatablesManager = new ActivatablesManager(this.CurrentPlayer);
 
         biggestAvailableAreaStore.recompute();
-        this.cameraManager.on(CameraManagerEvent.CameraUpdate, this.syncPlayerNameZoomsOnCameraUpdate);
         this.cameraManager.startFollowPlayer(this.CurrentPlayer);
         this.syncPlayerNameZooms();
         if (ENABLE_MAP_EDITOR) {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -367,6 +367,9 @@ export class GameScene extends DirtyScene {
     private serverViewportDebugGraphics: Phaser.GameObjects.Graphics | undefined;
     private playersDebugLogAlreadyDisplayed = false;
     private hideTimeout: ReturnType<typeof setTimeout> | undefined;
+    private readonly syncPlayerNameZoomsOnCameraUpdate = (): void => {
+        this.syncPlayerNameZooms();
+    };
     // The promise that will resolve to the current player textures. This will be available only after connection is established.
     private currentPlayerTexturesResolve!: (value: string[]) => void;
     private currentPlayerTexturesReject!: (reason: unknown) => void;
@@ -827,7 +830,9 @@ export class GameScene extends DirtyScene {
         this.activatablesManager = new ActivatablesManager(this.CurrentPlayer);
 
         biggestAvailableAreaStore.recompute();
+        this.cameraManager.on(CameraManagerEvent.CameraUpdate, this.syncPlayerNameZoomsOnCameraUpdate);
         this.cameraManager.startFollowPlayer(this.CurrentPlayer);
+        this.syncPlayerNameZooms();
         if (ENABLE_MAP_EDITOR) {
             this.mapEditorModeManager = new MapEditorModeManager(this);
         }
@@ -1177,6 +1182,7 @@ export class GameScene extends DirtyScene {
         this.isLiveStreamingUnsubscriber?.();
         this.pinchManager?.destroy();
         this.emoteManager?.destroy();
+        this.cameraManager?.off(CameraManagerEvent.CameraUpdate, this.syncPlayerNameZoomsOnCameraUpdate);
         this.cameraManager?.destroy();
         this.mapEditorModeManager?.destroy();
         this.gameMapPropertiesListener?.destroy();
@@ -1504,6 +1510,7 @@ export class GameScene extends DirtyScene {
     public onResize(): void {
         super.onResize();
         this.reposition(true);
+        this.syncPlayerNameZooms();
 
         this.throttledSendViewportToServer_();
     }
@@ -1634,6 +1641,14 @@ export class GameScene extends DirtyScene {
 
     public getCameraManager(): CameraManager {
         return this.cameraManager;
+    }
+
+    private syncPlayerNameZooms(): void {
+        const zoomModifier = waScaleManager.zoomModifier;
+        this.CurrentPlayer?.syncPlayerNameZoom(zoomModifier);
+        for (const player of this.MapPlayersByKey.values()) {
+            player.syncPlayerNameZoom(zoomModifier);
+        }
     }
 
     public getRemotePlayersRepository(): RemotePlayersRepository {
@@ -3906,6 +3921,7 @@ ${escapedMessage}
             player.setAvailabilityStatus(addPlayerData.availabilityStatus, true);
         }
         this.MapPlayersByKey.set(player.userId, player);
+        player.syncPlayerNameZoom(waScaleManager.zoomModifier);
         player.updatePosition(addPlayerData.position);
 
         player.on(Phaser.Input.Events.POINTER_OVER, () => {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1181,7 +1181,6 @@ export class GameScene extends DirtyScene {
         this.isLiveStreamingUnsubscriber?.();
         this.pinchManager?.destroy();
         this.emoteManager?.destroy();
-        this.cameraManager?.off(CameraManagerEvent.CameraUpdate, this.syncPlayerNameZoomsOnCameraUpdate);
         this.cameraManager?.destroy();
         this.mapEditorModeManager?.destroy();
         this.gameMapPropertiesListener?.destroy();

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -367,9 +367,6 @@ export class GameScene extends DirtyScene {
     private serverViewportDebugGraphics: Phaser.GameObjects.Graphics | undefined;
     private playersDebugLogAlreadyDisplayed = false;
     private hideTimeout: ReturnType<typeof setTimeout> | undefined;
-    private readonly syncPlayerNameZoomsOnCameraUpdate = (): void => {
-        this.syncPlayerNameZooms();
-    };
     // The promise that will resolve to the current player textures. This will be available only after connection is established.
     private currentPlayerTexturesResolve!: (value: string[]) => void;
     private currentPlayerTexturesReject!: (reason: unknown) => void;
@@ -831,7 +828,6 @@ export class GameScene extends DirtyScene {
 
         biggestAvailableAreaStore.recompute();
         this.cameraManager.startFollowPlayer(this.CurrentPlayer);
-        this.syncPlayerNameZooms();
         if (ENABLE_MAP_EDITOR) {
             this.mapEditorModeManager = new MapEditorModeManager(this);
         }
@@ -1508,7 +1504,6 @@ export class GameScene extends DirtyScene {
     public onResize(): void {
         super.onResize();
         this.reposition(true);
-        this.syncPlayerNameZooms();
 
         this.throttledSendViewportToServer_();
     }
@@ -1639,14 +1634,6 @@ export class GameScene extends DirtyScene {
 
     public getCameraManager(): CameraManager {
         return this.cameraManager;
-    }
-
-    private syncPlayerNameZooms(): void {
-        const zoomModifier = waScaleManager.zoomModifier;
-        this.CurrentPlayer?.syncPlayerNameZoom(zoomModifier);
-        for (const player of this.MapPlayersByKey.values()) {
-            player.syncPlayerNameZoom(zoomModifier);
-        }
     }
 
     public getRemotePlayersRepository(): RemotePlayersRepository {
@@ -3919,7 +3906,6 @@ ${escapedMessage}
             player.setAvailabilityStatus(addPlayerData.availabilityStatus, true);
         }
         this.MapPlayersByKey.set(player.userId, player);
-        player.syncPlayerNameZoom(waScaleManager.zoomModifier);
         player.updatePosition(addPlayerData.position);
 
         player.on(Phaser.Input.Events.POINTER_OVER, () => {

--- a/play/src/front/Phaser/Services/WaScaleManager.ts
+++ b/play/src/front/Phaser/Services/WaScaleManager.ts
@@ -6,6 +6,7 @@ import ScaleManager = Phaser.Scale.ScaleManager;
 
 export enum WaScaleManagerEvent {
     RefreshFocusOnTarget = "wa-scale-manager:refresh-focus-on-target",
+    ZoomChanged = "wa-scale-manager:zoom-changed",
 }
 
 export type WaScaleManagerFocusTarget = { x: number; y: number; width?: number; height?: number };
@@ -16,6 +17,7 @@ export class WaScaleManager {
     private game!: Game;
     private actualZoom = 1;
     private _saveZoom = 1;
+    private lastEmittedZoomModifier: number | undefined;
 
     private focusTarget?: WaScaleManagerFocusTarget;
 
@@ -23,9 +25,20 @@ export class WaScaleManager {
         this.hdpiManager = new HdpiManager(minGamePixelsNumber, absoluteMinPixelNumber);
     }
 
+    private emitZoomChangedIfNeeded(): void {
+        const zoomModifier = this.hdpiManager.zoomModifier;
+        if (this.lastEmittedZoomModifier === zoomModifier) {
+            return;
+        }
+
+        this.lastEmittedZoomModifier = zoomModifier;
+        this.game.events.emit(WaScaleManagerEvent.ZoomChanged, zoomModifier);
+    }
+
     public setGame(game: Game): void {
         this.scaleManager = game.scale;
         this.game = game;
+        this.lastEmittedZoomModifier = this.hdpiManager.zoomModifier;
     }
 
     public applyNewSize(camera?: Phaser.Cameras.Scene2D.Camera) {
@@ -71,6 +84,7 @@ export class WaScaleManager {
             }
         }
 
+        this.emitZoomChangedIfNeeded();
         this.game.markDirty();
     }
 


### PR DESCRIPTION
The user name will now be displayed bigger when you zoom out (we try to keep it readable even when you zoom out a lot)

Furthermore, the username rendering is now sent to a sprite, which fixes a performance issue when a lot of names were displayed with outline.

Closes #5893