### PR TITLE
[codex] isolate E2E specs on per-file maps

### DIFF
--- a/tests/tests/chat/matrixChat.spec.ts
+++ b/tests/tests/chat/matrixChat.spec.ts
@@ -1,11 +1,13 @@
 import { expect, test } from "@playwright/test";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import Map from "../utils/map";
 import { oidcLogout, oidcMatrixUserLogin } from "../utils/oidc";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
 import Menu from "../utils/menu";
 import ChatUtils from "./chatUtils";
+
+const mapUrl = Map.url("matrixChat");
 
 test.setTimeout(120000);
 
@@ -16,7 +18,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
         async ({ request, browserName }) => {
             // WebKit has issue with camera
             test.skip(browserName === "webkit", "WebKit has issues with camera/microphone");
-            await resetWamMaps(request);
+            await uploadEmptyMap(request, "matrixChat");
             await ChatUtils.resetMatrixDatabase();
         },
     );
@@ -26,7 +28,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Open matrix Chat", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
 
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
@@ -35,7 +37,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
         await page.context().close();
     });
     test("Create a public chat room", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -49,7 +51,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
         await page.context().close();
     });
     test("Send messages in public chat room", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -67,7 +69,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
         await page.context().close();
     });
     test("Send application messages in public chat room", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -86,7 +88,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
         await page.context().close();
     });
     test("Send application messages and youtube link in public chat room", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -148,7 +150,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
             "Skip Klaxoon test on forked PR because the secret env variable is not set",
         );
 
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -211,7 +213,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
         await page.context().close();
     });
     test("Reply to message", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -233,7 +235,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("React to message and remove reaction to message", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -256,7 +258,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Remove message", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -276,7 +278,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Edit message", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -300,7 +302,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Cancel edit message", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -324,7 +326,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     // test("Create a private chat room", async ({ browser }) => {
-    //   const page = await getPage(browser, 'Alice', Map.url("empty"));
+    //   const page = await getPage(browser, 'Alice', mapUrl);
     //   await oidcMatrixUserLogin(page);
     //   await ChatUtils.openChat(page);
     //   await ChatUtils.openCreateRoomDialog(page);
@@ -339,7 +341,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
 
     // test("Create a private encrypted chat room (new user)", async ({
     //   browser }) => {
-    //   const page = await getPage(browser, 'Alice', Map.url("empty"));
+    //   const page = await getPage(browser, 'Alice', mapUrl);
     //   await oidcMatrixUserLogin(page);
     //   await ChatUtils.openChat(page);
     //   await ChatUtils.openCreateRoomDialog(page);
@@ -357,7 +359,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
 
     // test("Send message in private chat room (new user)", async ({
     //   browser }) => {
-    //   const page = await getPage(browser, 'Alice', Map.url("empty"));
+    //   const page = await getPage(browser, 'Alice', mapUrl);
     //   await oidcMatrixUserLogin(page);
     //   await ChatUtils.openChat(page);
     //   await ChatUtils.openCreateRoomDialog(page);
@@ -378,7 +380,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     // });
 
     test("Retrieve encrypted message", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -422,7 +424,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Retrieve encrypted message after cancelling passphrase request", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -472,7 +474,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Key creation should stop after the SSO process is canceled", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -495,7 +497,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Create a public folder", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateFolderDialog(page);
@@ -512,7 +514,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Create a private folder", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateFolderDialog(page);
@@ -529,7 +531,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Create a nested folder", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
 
@@ -561,7 +563,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Create a room in a folder", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
 
@@ -590,7 +592,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Create a restricted room", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
 
@@ -616,7 +618,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Verify a session with emoji", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await Menu.openMenuIfMobile(page);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
@@ -633,7 +635,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
 
         await Map.teleportToPosition(page, 0, 0);
 
-        await using otherPage = await getPage(browser, "Bob", Map.url("empty"));
+        await using otherPage = await getPage(browser, "Bob", mapUrl);
         await Menu.openMenuIfMobile(otherPage);
         await oidcMatrixUserLogin(otherPage);
         await ChatUtils.openChat(otherPage);
@@ -654,7 +656,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
     });
 
     test("Verify a session with emoji , one device click on mismatch button", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await Menu.openMenuIfMobile(page);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
@@ -671,7 +673,7 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
 
         await Map.teleportToPosition(page, 0, 0);
 
-        const otherPage = await getPage(browser, "Bob", Map.url("empty"));
+        const otherPage = await getPage(browser, "Bob", mapUrl);
         await Menu.openMenuIfMobile(otherPage);
         await oidcMatrixUserLogin(otherPage);
         await ChatUtils.openChat(otherPage);

--- a/tests/tests/chat/matrixChatArea.spec.ts
+++ b/tests/tests/chat/matrixChatArea.spec.ts
@@ -6,7 +6,7 @@ import AreaEditor from "../utils/map-editor/areaEditor";
 import Map from "../utils/map";
 import { hideNoCamera } from "../utils/hideNoCamera";
 import { oidcMatrixUserLogin, oidcMemberTagLogin } from "../utils/oidc";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
 import chatUtils from "./chatUtils";
@@ -17,6 +17,8 @@ async function hideNoCameraIfWebkit(page: Page, browserName: string) {
     }
 }
 
+const mapUrl = Map.url("matrixChatArea");
+
 test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
     test.beforeEach(
         "Ignore tests on mobilechromium because map editor not available for mobile devices",
@@ -24,7 +26,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
             // Map Editor not available on mobile / WebKit has issue with camera
             test.skip(isMobile(page) || project.name === "webkit", "Skip on mobile or WebKit");
             await chatUtils.resetMatrixDatabase();
-            await resetWamMaps(request);
+            await uploadEmptyMap(request, "matrixChatArea");
         },
     );
 
@@ -37,7 +39,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
         browser,
     }) => {
         //await page.evaluate(() => localStorage.setItem('debug', '*'));
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
 
         // Because webkit in playwright does not support Camera/Microphone Permission by settings
@@ -61,7 +63,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
     });
 
     test("it should automatically close the chat when the user leaves the area", async ({ browser, browserName }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
 
         await hideNoCameraIfWebkit(page, browserName);
@@ -91,7 +93,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
         browser,
         browserName,
     }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
 
         await hideNoCameraIfWebkit(page, browserName);
@@ -110,7 +112,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
 
         await expect(page.getByTestId("closeChatButton")).toBeVisible();
 
-        await page.goto(Map.url("empty"));
+        await page.goto(mapUrl);
         await chatUtils.openChat(page);
         await chatUtils.openRoomAreaList(page);
 
@@ -123,7 +125,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
         browser,
         browserName,
     }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
 
         await hideNoCameraIfWebkit(page, browserName);
@@ -164,7 +166,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
     });
 
     test("it shouldn't be moderator in room when he don't have a admin tag", async ({ browserName, browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
 
         await hideNoCameraIfWebkit(page, browserName);
@@ -181,7 +183,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
         await Menu.closeMapEditor(page);
 
         await page.context().close();
-        await using page2 = await getPage(browser, "Bob", Map.url("empty"));
+        await using page2 = await getPage(browser, "Bob", mapUrl);
         await oidcMemberTagLogin(page2);
 
         await hideNoCameraIfWebkit(page2, browserName);

--- a/tests/tests/chat/matrixChatModeration.spec.ts
+++ b/tests/tests/chat/matrixChatModeration.spec.ts
@@ -1,10 +1,12 @@
 import { expect, test } from "@playwright/test";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import Map from "../utils/map";
 import { oidcMatrixUserLogin } from "../utils/oidc";
 import { getPage } from "../utils/auth";
 import ChatUtils from "./chatUtils";
 import matrixApi from "./matrixApi";
+
+const mapUrl = Map.url("matrixChatModeration");
 
 test.setTimeout(120000);
 
@@ -15,8 +17,8 @@ test.describe("chat moderation @matrix @nowebkit", () => {
         async ({ browserName, request, page }) => {
             // WebKit has issue with camera
             test.skip(browserName === "webkit", "WebKit has issues with camera/microphone");
-            await resetWamMaps(request);
-            await page.goto(Map.url("empty"));
+            await uploadEmptyMap(request, "matrixChatModeration");
+            await page.goto(mapUrl);
             await ChatUtils.resetMatrixDatabase();
         },
     );
@@ -26,7 +28,7 @@ test.describe("chat moderation @matrix @nowebkit", () => {
     });
 
     test("should create a public chat room and verify admin permissions", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);
@@ -62,7 +64,7 @@ test.describe("chat moderation @matrix @nowebkit", () => {
     test("should manage participants and permissions in public chat room", async ({ browser }, testInfo) => {
         test.skip(testInfo.project.name === "mobilefirefox", "Skip on mobile Firefox");
 
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await using page = await getPage(browser, "Alice", mapUrl);
         await oidcMatrixUserLogin(page);
         await ChatUtils.openChat(page);
         await ChatUtils.openCreateRoomDialog(page);

--- a/tests/tests/iframe_script.spec.ts
+++ b/tests/tests/iframe_script.spec.ts
@@ -5,6 +5,9 @@ import Menu from "./utils/menu";
 import { getPage } from "./utils/auth";
 import { isMobile } from "./utils/isMobile";
 import Map from "./utils/map";
+import { uploadEmptyMap } from "./utils/map-editor/uploader";
+
+const mapUrl = Map.url("iframeScript");
 
 test.describe("Iframe API @nowebkit", () => {
     test.beforeEach(async ({ page }) => {
@@ -38,8 +41,9 @@ test.describe("Iframe API @nowebkit", () => {
         expect(parameter).toEqual("bar");
     });
 
-    test("disable and enable map editor @oidc", async ({ browser }) => {
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+    test("disable and enable map editor @oidc", async ({ browser, request }) => {
+        await uploadEmptyMap(request, "iframeScript");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Create a script to evaluate function to disable map editor
         await evaluateScript(page, async () => {

--- a/tests/tests/livekit.spec.ts
+++ b/tests/tests/livekit.spec.ts
@@ -8,13 +8,15 @@ import {
     expectWebRtcConnectionsCountToBe,
     expectLivekitRoomsCountToBe,
 } from "./utils/webRtc";
-import { resetWamMaps } from "./utils/map-editor/uploader";
+import { uploadEmptyMap } from "./utils/map-editor/uploader";
 import AreaEditor from "./utils/map-editor/areaEditor";
 import ConfigureMyRoom from "./utils/map-editor/configureMyRoom";
 import Megaphone from "./utils/map-editor/megaphone";
 import MapEditor from "./utils/mapeditor";
 import Menu from "./utils/menu";
 import AreaLivekit from "./utils/AreaLivekit";
+
+const mapUrl = Map.url("livekit");
 
 test.setTimeout(240_000);
 
@@ -211,13 +213,13 @@ test.describe("Meeting actions test", () => {
     });
 
     test("Should create and join livekit room only when there is a speaker @oidc", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "livekit");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         // Because webkit in playwright does not support Camera/Microphone Permission by settings
         await Map.teleportToPosition(page, 0, 0);
 
         // Second browser
-        await using page2 = await getPage(browser, "Admin2", Map.url("empty"));
+        await using page2 = await getPage(browser, "Admin2", mapUrl);
         await Map.teleportToPosition(page2, 4 * 32, 0);
 
         await Menu.openMapEditor(page);
@@ -234,16 +236,16 @@ test.describe("Meeting actions test", () => {
         await Menu.closeMapEditorConfigureMyRoomPopUp(page);
 
         // Go to the empty map
-        await using userAlice = await getPage(browser, "Alice", Map.url("empty"));
+        await using userAlice = await getPage(browser, "Alice", mapUrl);
 
         // Move user Alice to the meeting area
         await Map.teleportToPosition(userAlice, 8 * 32, 0);
 
         // Create and position 4 additional users
-        await using userBob = await getPage(browser, "Bob", Map.url("empty"));
+        await using userBob = await getPage(browser, "Bob", mapUrl);
         await Map.teleportToPosition(userBob, 0, 8 * 32);
 
-        await using userEve = await getPage(browser, "Eve", Map.url("empty"));
+        await using userEve = await getPage(browser, "Eve", mapUrl);
         await Map.teleportToPosition(userEve, 0, 4 * 32);
 
         await Menu.clickSendGlobalMessage(page);
@@ -319,8 +321,8 @@ test.describe("Meeting actions test", () => {
         browser,
         request,
     }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "livekit");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         // Because webkit in playwright does not support Camera/Microphone Permission by settings
         await Map.teleportToPosition(page, 0, 0);
 
@@ -354,10 +356,10 @@ test.describe("Meeting actions test", () => {
     });
 
     test("Should handle rapid transitions between podium and audience zones @oidc", async ({ browser, request }) => {
-        await resetWamMaps(request);
+        await uploadEmptyMap(request, "livekit");
 
         // Admin creates the zones and will be used as a speaker
-        await using speakerAdmin = await getPage(browser, "Admin1", Map.url("empty"));
+        await using speakerAdmin = await getPage(browser, "Admin1", mapUrl);
         await Map.teleportToPosition(speakerAdmin, 10 * 32, 10 * 32); // Temp position outside zones
 
         // Create podium zone (speaker zone) - positioned at y: 2-4 tiles
@@ -388,20 +390,20 @@ test.describe("Meeting actions test", () => {
         await Map.teleportToPosition(speakerAdmin, 4 * 32, 3 * 32);
 
         // Speaker 2 (Alice) in podium zone - only 2 speakers total
-        await using speakerAlice = await getPage(browser, "Alice", Map.url("empty"));
+        await using speakerAlice = await getPage(browser, "Alice", mapUrl);
         await Map.teleportToPosition(speakerAlice, 5 * 32, 3 * 32); // In podium zone
 
         // Audience members (more than speakers to trigger LiveKit)
         // User in audience (Eve) - static
-        await using audienceEve = await getPage(browser, "Eve", Map.url("empty"));
+        await using audienceEve = await getPage(browser, "Eve", mapUrl);
         await Map.teleportToPosition(audienceEve, 4 * 32, 6 * 32); // In audience zone
 
         // User in audience (John) - static
-        await using audienceJohn = await getPage(browser, "John", Map.url("empty"));
+        await using audienceJohn = await getPage(browser, "John", mapUrl);
         await Map.teleportToPosition(audienceJohn, 5 * 32, 6 * 32); // In audience zone
 
         // User in audience (Mallory) - static
-        await using audienceMallory = await getPage(browser, "Mallory", Map.url("empty"));
+        await using audienceMallory = await getPage(browser, "Mallory", mapUrl);
         await Map.teleportToPosition(audienceMallory, 6 * 32, 6 * 32); // In audience zone
 
         // Verify speakers see each other
@@ -420,7 +422,7 @@ test.describe("Meeting actions test", () => {
         await expectLivekitConnectionsCountToBe(speakerAdmin, 1);
 
         // User who will rapidly switch between zones (Bob)
-        await using switchingUserPage = await getPage(browser, "Bob", Map.url("empty"));
+        await using switchingUserPage = await getPage(browser, "Bob", mapUrl);
 
         // Position in audience zone
         const audiencePosition = { x: 7 * 32, y: 6 * 32 };

--- a/tests/tests/map_editor/map_editor_area_rights.spec.ts
+++ b/tests/tests/map_editor/map_editor_area_rights.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import Map from "../utils/map";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import MapEditor from "../utils/mapeditor";
 import Menu from "../utils/menu";
 import { map_storage_url } from "../utils/urls";
@@ -10,6 +10,8 @@ import AreaAccessRights from "../utils/areaAccessRights";
 import { evaluateScript } from "../utils/scripting";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+
+const mapUrl = Map.url("mapEditorAreaRights");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -31,8 +33,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully set Area with right access", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         await Menu.openMapEditor(page);
         await AreaAccessRights.openAreaEditorAndAddAreaWithRights(page, ["admin"], ["admin"]);
@@ -40,7 +42,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
 
         await page.context().close();
 
-        await using page2 = await getPage(browser, "User1", Map.url("empty"));
+        await using page2 = await getPage(browser, "User1", mapUrl);
 
         await Map.walkTo(page2, "ArrowRight", 1000);
         //await Map.walkTo(page, "ArrowUp", 1000);
@@ -51,8 +53,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
     });
 
     test("Access restricted area with right click to move", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         await Menu.openMapEditor(page);
         await AreaAccessRights.openAreaEditorAndAddAreaWithRights(page, ["admin"], ["admin"]);
@@ -99,8 +101,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
     });
 
     test("MapEditor is disabled for basic user because there are no thematics", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        await using page = await getPage(browser, "Alice", mapUrl);
         // In the new design, you cannot access the map menu if the user is a basic user
         await expect(page.getByTestId("map-menu")).toBeHidden();
         /*await Menu.openMapEditor(page);
@@ -115,8 +117,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
 
     test("Area with restricted write access : Trying to just read an object", async ({ browser, request }) => {
         // FIXME work step by step, else does not work
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         // Add area with admin rights
         await Menu.openMapEditor(page);
         await AreaAccessRights.openAreaEditorAndAddAreaWithRights(page, ["admin"], ["admin"]);
@@ -124,7 +126,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         await oidcLogout(page);
 
         // Second browser with member user trying to read the object
-        await using page2 = await getPage(browser, "Member1", Map.url("empty"));
+        await using page2 = await getPage(browser, "Member1", mapUrl);
 
         // Expect user in other page to not have the right
         // to read the object
@@ -146,8 +148,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         browser,
         request,
     }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Add area with admin rights
         await Menu.openMapEditor(page);
@@ -157,7 +159,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         await page.context().close();
 
         // Second browser with member user trying to read the object
-        await using page2 = await getPage(browser, "Member1", Map.url("empty"));
+        await using page2 = await getPage(browser, "Member1", mapUrl);
 
         //wait for cameras to be removed
         await page2.getByTestId("cameras-container").waitFor({ state: "detached" });
@@ -182,8 +184,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
     });
 
     test("Area with restricted write access : Trying to just add an object", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Add area with admin rights
         await Menu.openMapEditor(page);
@@ -192,7 +194,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         await oidcLogout(page);
 
         // Second browser with member user trying to read the object
-        await using page2 = await getPage(browser, "Member1", Map.url("empty"));
+        await using page2 = await getPage(browser, "Member1", mapUrl);
 
         //From browser 2
         //Check that the entity editor is not available
@@ -212,8 +214,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         browser,
         request,
     }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Add area with admin rights
         await Menu.openMapEditor(page);
@@ -225,7 +227,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         await page.context().close();
 
         // Second browser with member user trying to read the object
-        await using page2 = await getPage(browser, "Member1", Map.url("empty"));
+        await using page2 = await getPage(browser, "Member1", mapUrl);
 
         // From browser 2
         // Select entity and push it into the map
@@ -252,8 +254,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
     });
 
     test("Area with restricted write access : Trying to remove an object", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Add area with admin rights
         await Menu.openMapEditor(page);
@@ -264,7 +266,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         await page.context().close();
 
         // Second browser with member user trying to read the object
-        await using page2 = await getPage(browser, "Member1", Map.url("empty"));
+        await using page2 = await getPage(browser, "Member1", mapUrl);
 
         // From browser 2
         // Try to remove entity and click on it to
@@ -288,8 +290,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         browser,
         request,
     }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Add area with admin rights
         await Menu.openMapEditor(page);
@@ -298,7 +300,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         await oidcLogout(page);
 
         // Second browser with member user trying to read the object
-        await using page2 = await getPage(browser, "Member1", Map.url("empty"));
+        await using page2 = await getPage(browser, "Member1", mapUrl);
 
         // Required for Firefox that somehow does not manage to start the webcam twice (hence the "no sound" warning displayed that we must hide if it appears)
         await page2.addLocatorHandler(page2.getByTestId("no-microphone-sound-ignore"), async () => {
@@ -336,8 +338,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         browser,
         request,
     }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Add area with admin rights
         await Menu.openMapEditor(page);
@@ -346,7 +348,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         await oidcLogout(page);
 
         // Second browser with member user trying to read the object
-        await using page2 = await getPage(browser, "Member1", Map.url("empty"));
+        await using page2 = await getPage(browser, "Member1", mapUrl);
 
         // From browser 2
         // Check that the map editor is not available
@@ -364,8 +366,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
     });
 
     test("Claim personal area from allowed user", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        const page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        const page = await getPage(browser, "Admin1", mapUrl);
 
         await Menu.openMapEditor(page);
         await AreaAccessRights.openAreaEditorAndAddArea(page);
@@ -378,7 +380,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         await page.close();
 
         // Second browser with member user trying to read the object
-        const page2 = await getPage(browser, "Member1", Map.url("empty"));
+        const page2 = await getPage(browser, "Member1", mapUrl);
 
         // Move to area and claim it
         await Map.teleportToPosition(
@@ -408,8 +410,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
     });
 
     test("Claim personal area from unauthorized user", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        const page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        const page = await getPage(browser, "Admin1", mapUrl);
 
         await Menu.openMapEditor(page);
         await AreaAccessRights.openAreaEditorAndAddArea(page);
@@ -422,7 +424,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         await page.close();
 
         // Second browser with member user trying to read the object
-        const page2 = await getPage(browser, "Alice", Map.url("empty"));
+        const page2 = await getPage(browser, "Alice", mapUrl);
 
         // Move to area and claim it
         await Map.teleportToPosition(
@@ -438,8 +440,8 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
     });
 
     test("Claim multi personal area", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        const page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorAreaRights");
+        const page = await getPage(browser, "Admin1", mapUrl);
 
         // Add a first area
         await Menu.openMapEditor(page);

--- a/tests/tests/map_editor/map_editor_global_message.spec.ts
+++ b/tests/tests/map_editor/map_editor_global_message.spec.ts
@@ -2,12 +2,14 @@ import { expect, test } from "@playwright/test";
 import Map from "../utils/map";
 import ConfigureMyRoom from "../utils/map-editor/configureMyRoom";
 import Megaphone from "../utils/map-editor/megaphone";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import MapEditor from "../utils/mapeditor";
 import Menu from "../utils/menu";
 import { map_storage_url } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+
+const mapUrl = Map.url("mapEditorGlobalMessage");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -26,14 +28,14 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully test global message text and sound feature", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorGlobalMessage");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Move user and not create discussion with the second user
         await Map.teleportToPosition(page, 5 * 32, 5 * 32);
 
         // Second browser
-        await using page2 = await getPage(browser, "Bob", Map.url("empty"));
+        await using page2 = await getPage(browser, "Bob", mapUrl);
 
         // Open the map editor and configure the megaphone to have access to the global message
         await Menu.openMapEditor(page);

--- a/tests/tests/map_editor/map_editor_highlight.spec.ts
+++ b/tests/tests/map_editor/map_editor_highlight.spec.ts
@@ -1,12 +1,14 @@
 import { test } from "@playwright/test";
 import Map from "../utils/map";
 import AreaEditor from "../utils/map-editor/areaEditor";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import MapEditor from "../utils/mapeditor";
 import Menu from "../utils/menu";
 import { map_storage_url } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+
+const mapUrl = Map.url("mapEditorHighlight");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -25,8 +27,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("highlight property", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorHighlight");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         // Open the map editor
         await Menu.openMapExplorer(page);
         await MapEditor.openAreaEditor(page);

--- a/tests/tests/map_editor/map_editor_interacting_object.spec.ts
+++ b/tests/tests/map_editor/map_editor_interacting_object.spec.ts
@@ -2,13 +2,15 @@ import { expect, test } from "@playwright/test";
 import Map from "../utils/map";
 import AreaEditor from "../utils/map-editor/areaEditor";
 import EntityEditor from "../utils/map-editor/entityEditor";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import MapEditor from "../utils/mapeditor";
 import Menu from "../utils/menu";
 import { map_storage_url } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
 import { dismissDoNotDisturbInfoToast } from "../utils/doNotDisturbInfoToast";
+
+const mapUrl = Map.url("mapEditorInteractingObject");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -27,8 +29,8 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
     // https://github.com/element-hq/synapse/issues/19303 - skip webkit due to synapse v1.144.0 OIDC issues
     test("Success to interact with area @nowebkit", async ({ browser, request }) => {
         // Go to the map
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorInteractingObject");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Create area on the map for the test
         await Menu.openMapEditor(page);
@@ -53,8 +55,8 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
         test.skip(browserName === "webkit", "WebKit click up does not work here");
 
         // Go to the map
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorInteractingObject");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Create entity on the map for the test
         await Menu.openMapEditor(page);
@@ -77,7 +79,7 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
         await page.context().close();
 
         // Open new page
-        const newPage = await getPage(browser, "User1", Map.url("empty"));
+        const newPage = await getPage(browser, "User1", mapUrl);
         await Menu.waitForMapLoad(newPage);
 
         // The screen take one second to be recalculated, so we need to wait for it
@@ -105,8 +107,8 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
         test.skip(browserName === "webkit", "WebKit click up does not work here");
 
         // Go to the map
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorInteractingObject");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Create entity on the map for the test
         await Menu.openMapEditor(page);
@@ -122,7 +124,7 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
         await Menu.closeMapEditor(page);
 
         // // Refresh the page to see the entity
-        // await page.goto(Map.url("empty"));
+        // await page.goto(mapUrl);
         // // Wait for the map to be loaded
         // await Menu.waitForMapLoad(page);
 
@@ -144,7 +146,7 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
         expect(iframeSrcE).toContain("ipsum-lorem");
 
         // Refresh the page to create area
-        await page.goto(Map.url("empty"));
+        await page.goto(mapUrl);
         // Wait for the map to be loaded
         await Menu.waitForMapLoad(page);
 

--- a/tests/tests/map_editor/map_editor_livekit.spec.ts
+++ b/tests/tests/map_editor/map_editor_livekit.spec.ts
@@ -1,13 +1,15 @@
 import { expect, test } from "@playwright/test";
 import Map from "../utils/map";
 import AreaEditor from "../utils/map-editor/areaEditor";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import MapEditor from "../utils/mapeditor";
 import Menu from "../utils/menu";
 import { evaluateScript } from "../utils/scripting";
 import { map_storage_url } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+
+const mapUrl = Map.url("mapEditorLivekit");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -26,8 +28,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully send message in meeting area @nofirefox", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorLivekit");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         //await page.evaluate(() => { localStorage.setItem('debug', '*'); });
         //await page.reload();
 
@@ -39,7 +41,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Menu.closeMapEditor(page);
         await Map.teleportToPosition(page, 4 * 32, 3 * 32);
 
-        await using page2 = await getPage(browser, "Admin2", Map.url("empty"));
+        await using page2 = await getPage(browser, "Admin2", mapUrl);
 
         await Map.teleportToPosition(page2, 4 * 32, 3 * 32);
 
@@ -63,8 +65,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         browser,
         request,
     }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorLivekit");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         //await page.evaluate(() => { localStorage.setItem('debug', '*'); });
         //await page.reload();
 
@@ -77,7 +79,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Menu.closeMapEditor(page);
         await Map.teleportToPosition(page, 4 * 32, 3 * 32);
 
-        await using page2 = await getPage(browser, "Bob", Map.url("empty"));
+        await using page2 = await getPage(browser, "Bob", mapUrl);
 
         await Map.teleportToPosition(page2, 4 * 32, 3 * 32);
 
@@ -111,8 +113,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     test("Successfully enter and leave space very quickly @nofirefox", async ({ browser, request }) => {
         // This test is testing the query abort mechanism when entering/leaving a space very quickly
 
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorLivekit");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         //await page.evaluate(() => { localStorage.setItem('debug', '*'); });
         //await page.reload();
 
@@ -157,7 +159,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Map.teleportToPosition(page, 4 * 32, 3 * 32);
 
         // Now let's see if Bob can see Admin1 properly
-        await using page2 = await getPage(browser, "Bob", Map.url("empty"));
+        await using page2 = await getPage(browser, "Bob", mapUrl);
 
         await Map.teleportToPosition(page2, 4 * 32, 3 * 32);
 

--- a/tests/tests/map_editor/map_editor_lock_area.spec.ts
+++ b/tests/tests/map_editor/map_editor_lock_area.spec.ts
@@ -1,12 +1,14 @@
 import { expect, test } from "@playwright/test";
 import Map from "../utils/map";
 import AreaEditor from "../utils/map-editor/areaEditor";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import MapEditor from "../utils/mapeditor";
 import Menu from "../utils/menu";
 import { map_storage_url } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+
+const mapUrl = Map.url("mapEditorLockArea");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -28,8 +30,8 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         browser,
         request,
     }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorLockArea");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         const areaLeftBoundX = 1 * 32 * 1.5;
 
         // Create an area just to the right of the spawn and make it lockable.
@@ -46,7 +48,7 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         await expect(page.getByTestId("lock-button")).toHaveClass(/bg-danger/);
 
         // Alice tries to enter the locked area with keyboard and is blocked with the correct message.
-        await using page2 = await getPage(browser, "Alice", Map.url("empty"));
+        await using page2 = await getPage(browser, "Alice", mapUrl);
         const aliceStartPosition = await Map.getPosition(page2);
         await Map.walkTo(page2, "ArrowRight", 1000);
 

--- a/tests/tests/map_editor/map_editor_max_users_in_area.spec.ts
+++ b/tests/tests/map_editor/map_editor_max_users_in_area.spec.ts
@@ -1,12 +1,14 @@
 import { expect, test } from "@playwright/test";
 import Map from "../utils/map";
 import AreaEditor from "../utils/map-editor/areaEditor";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import MapEditor from "../utils/mapeditor";
 import Menu from "../utils/menu";
 import { map_storage_url } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+
+const mapUrl = Map.url("mapEditorMaxUsersInArea");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -28,8 +30,8 @@ test.describe("Map editor max users in area @oidc @nomobile @nowebkit", () => {
         browser,
         request,
     }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorMaxUsersInArea");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         const areaLeftBoundX = 1 * 32 * 1.5;
 
         // Create an area next to spawn and set max users to 1.
@@ -48,7 +50,7 @@ test.describe("Map editor max users in area @oidc @nomobile @nowebkit", () => {
         await Map.teleportToPosition(page, 4 * 32 * 1.5, 4 * 32 * 1.5);
 
         // Alice cannot enter while Admin is inside.
-        await using page2 = await getPage(browser, "Alice", Map.url("empty"));
+        await using page2 = await getPage(browser, "Alice", mapUrl);
         const aliceStartPosition = await Map.getPosition(page2);
         await Map.walkTo(page2, "ArrowRight", 1000);
 

--- a/tests/tests/map_editor/map_editor_megaphone_speaker_zone.spec.ts
+++ b/tests/tests/map_editor/map_editor_megaphone_speaker_zone.spec.ts
@@ -3,12 +3,14 @@ import Map from "../utils/map";
 import AreaEditor from "../utils/map-editor/areaEditor";
 import ConfigureMyRoom from "../utils/map-editor/configureMyRoom";
 import Megaphone from "../utils/map-editor/megaphone";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import MapEditor from "../utils/mapeditor";
 import Menu from "../utils/menu";
 import { map_storage_url } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+
+const mapUrl = Map.url("mapEditorMegaphoneSpeakerZone");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -27,13 +29,13 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully set the megaphone feature", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorMegaphoneSpeakerZone");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         // Because webkit in playwright does not support Camera/Microphone Permission by settings
         await Map.teleportToPosition(page, 5 * 32, 5 * 32);
 
         // Second browser
-        await using page2 = await getPage(browser, "Admin2", Map.url("empty"));
+        await using page2 = await getPage(browser, "Admin2", mapUrl);
 
         // await Menu.openMenuAdmin(page);
         await Menu.openMapEditor(page);
@@ -98,13 +100,13 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully set the megaphone feature with auditorium option", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorMegaphoneSpeakerZone");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         // Because webkit in playwright does not support Camera/Microphone Permission by settings
         await Map.teleportToPosition(page, 5 * 32, 5 * 32);
 
         // Second browser
-        await using page2 = await getPage(browser, "Admin2", Map.url("empty"));
+        await using page2 = await getPage(browser, "Admin2", mapUrl);
 
         // await Menu.openMenuAdmin(page);
         await Menu.openMapEditor(page);
@@ -173,8 +175,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
     test('Successfully set "SpeakerZone" in the map editor', async ({ browser, request }) => {
         // skip the test, speaker zone with Jitsi is deprecated
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorMegaphoneSpeakerZone");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         //await page.evaluate(() => { localStorage.setItem('debug', '*'); });
         //await page.reload();
 
@@ -196,7 +198,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await expect(page.locator("#cameras-container").getByText("You")).toBeVisible();
 
         // Second browser
-        await using page2 = await getPage(browser, "Admin2", Map.url("empty"));
+        await using page2 = await getPage(browser, "Admin2", mapUrl);
 
         await Map.teleportToPosition(page2, 4 * 32, 7 * 32);
 
@@ -232,8 +234,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         browser,
         request,
     }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorMegaphoneSpeakerZone");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
         await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
@@ -259,8 +261,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
     test('Successfully set "SpeakerZone" with chat in the map editor', async ({ browser, request }) => {
         // skip the test, speaker zone with Jitsi is deprecated
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorMegaphoneSpeakerZone");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         //await page.evaluate(() => { localStorage.setItem('debug', '*'); });
         //await page.reload();
 
@@ -283,7 +285,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await expect(page.locator("#cameras-container").getByText("You")).toBeVisible();
 
         // Second browser
-        await using page2 = await getPage(browser, "Admin2", Map.url("empty"));
+        await using page2 = await getPage(browser, "Admin2", mapUrl);
 
         await Map.teleportToPosition(page2, 4 * 32, 7 * 32);
 
@@ -329,8 +331,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test('Successfully set "SpeakerZone" with see attendees option in the map editor', async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorMegaphoneSpeakerZone");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         //await page.evaluate(() => { localStorage.setItem('debug', '*'); });
         //await page.reload();
 
@@ -353,7 +355,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await expect(page.locator("#cameras-container").getByText("You")).toBeVisible();
 
         // Second browser
-        await using page2 = await getPage(browser, "Admin2", Map.url("empty"));
+        await using page2 = await getPage(browser, "Admin2", mapUrl);
 
         await Map.teleportToPosition(page2, 4 * 32, 7 * 32);
 
@@ -365,7 +367,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await expect(page.locator("#cameras-container").getByText("Admin2")).toBeVisible({ timeout: 20_000 });
         await expect.poll(async () => await page.getByTestId("webrtc-video").count()).toBe(2);
 
-        await using page3 = await getPage(browser, "John", Map.url("empty"));
+        await using page3 = await getPage(browser, "John", mapUrl);
         await Map.teleportToPosition(page3, 4 * 32, 7 * 32);
 
         // Admin2 can only see Admin1
@@ -416,24 +418,24 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Megaphone auditorium mode with 5 participants", async ({ browser, request }) => {
-        await resetWamMaps(request);
+        await uploadEmptyMap(request, "mapEditorMegaphoneSpeakerZone");
 
         // Create 5 browser pages with different users (using available test users)
         // Available users: Alice, Bob, Eve, Mallory, Admin1, Admin2, Member1, UserMatrix, UserLogin1, John, UserMatrix2, User1
         // Position each participant in different corners of the map to avoid proximity bubbles
-        await using pageSpeaker = await getPage(browser, "Admin1", Map.url("empty"));
+        await using pageSpeaker = await getPage(browser, "Admin1", mapUrl);
         await Map.teleportToPosition(pageSpeaker, 2 * 32, 2 * 32); // Top-left area
 
-        await using pageListener1 = await getPage(browser, "Admin2", Map.url("empty"));
+        await using pageListener1 = await getPage(browser, "Admin2", mapUrl);
         await Map.teleportToPosition(pageListener1, 8 * 32, 2 * 32); // Top-right area
 
-        await using pageListener2 = await getPage(browser, "Alice", Map.url("empty"));
+        await using pageListener2 = await getPage(browser, "Alice", mapUrl);
         await Map.teleportToPosition(pageListener2, 2 * 32, 8 * 32); // Bottom-left area
 
-        await using pageListener3 = await getPage(browser, "Bob", Map.url("empty"));
+        await using pageListener3 = await getPage(browser, "Bob", mapUrl);
         await Map.teleportToPosition(pageListener3, 8 * 32, 8 * 32); // Bottom-right area
 
-        await using pageListener4 = await getPage(browser, "John", Map.url("empty"));
+        await using pageListener4 = await getPage(browser, "John", mapUrl);
         await Map.teleportToPosition(pageListener4, 5 * 32, 5 * 32); // Center area
 
         const listeners = [
@@ -515,7 +517,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         // ============================================================
 
         // Create a new listener that joins after the megaphone session has started
-        await using pageLateListener = await getPage(browser, "Eve", Map.url("empty"));
+        await using pageLateListener = await getPage(browser, "Eve", mapUrl);
 
         // The late listener should see the megaphone button
         await Menu.isThereMegaphoneButton(pageLateListener);
@@ -644,8 +646,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
      * - When they leave the attendees zone completely, they should disconnect from the space
      */
     test("Successfully handle nested speaker zone inside listener zone", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorMegaphoneSpeakerZone");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Open map editor and create zones
         await Menu.openMapEditor(page);
@@ -669,7 +671,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Menu.closeMapEditor(page);
 
         // Second browser - this will be the listener/speaker that tests nested zones
-        await using page2 = await getPage(browser, "Bob", Map.url("empty"));
+        await using page2 = await getPage(browser, "Bob", mapUrl);
 
         // Step 1: Teleport page2 (Bob) to the listener zone (but outside the podium)
         // Position (2, 7) is inside the listener zone but outside the podium zone

--- a/tests/tests/map_editor/map_editor_open_website.spec.ts
+++ b/tests/tests/map_editor/map_editor_open_website.spec.ts
@@ -2,13 +2,15 @@ import { expect, test } from "@playwright/test";
 import Map from "../utils/map";
 import AreaEditor from "../utils/map-editor/areaEditor";
 import EntityEditor from "../utils/map-editor/entityEditor";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import MapEditor from "../utils/mapeditor";
 import Menu from "../utils/menu";
 import { map_storage_url, maps_test_url } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
 import { assertLogMessage, startRecordLogs } from "../utils/log";
+
+const mapUrl = Map.url("mapEditorOpenWebsite");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -30,8 +32,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         browser,
         request,
     }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorOpenWebsite");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
@@ -80,8 +82,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
             "Skip Klaxoon test on forked PR because the secret env variable is not set",
         );
 
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorOpenWebsite");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
@@ -112,8 +114,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         browser,
         request,
     }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorOpenWebsite");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
@@ -209,8 +211,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully set GoogleWorkspace's application entity in the map editor", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorOpenWebsite");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // open map editor
         await Menu.openMapEditor(page);
@@ -279,8 +281,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully set Klaxoon's application entity in the map editor @local", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorOpenWebsite");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // open map editor
         await Menu.openMapEditor(page);

--- a/tests/tests/map_editor/map_editor_searchable.spec.ts
+++ b/tests/tests/map_editor/map_editor_searchable.spec.ts
@@ -2,12 +2,14 @@ import { expect, test } from "@playwright/test";
 import Map from "../utils/map";
 import AreaEditor from "../utils/map-editor/areaEditor";
 import EntityEditor from "../utils/map-editor/entityEditor";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import MapEditor from "../utils/mapeditor";
 import Menu from "../utils/menu";
 import { map_storage_url } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+
+const mapUrl = Map.url("mapEditorSearchable");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -26,8 +28,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully set searchable feature for entity and zone", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorSearchable");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Open the map editor
         await Menu.openMapEditor(page);

--- a/tests/tests/map_editor/map_editor_start_exit.spec.ts
+++ b/tests/tests/map_editor/map_editor_start_exit.spec.ts
@@ -1,13 +1,15 @@
 import { expect, test } from "@playwright/test";
 import Map from "../utils/map";
 import AreaEditor from "../utils/map-editor/areaEditor";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import MapEditor from "../utils/mapeditor";
 import Menu from "../utils/menu";
 import { evaluateScript } from "../utils/scripting";
 import { map_storage_url } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+
+const mapUrl = Map.url("mapEditorStartExit");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -26,8 +28,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully set start area in the map editor", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorStartExit");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
@@ -40,8 +42,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully set and working exit area in the map editor", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorStartExit");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);

--- a/tests/tests/map_editor/map_editor_upload_entities.spec.ts
+++ b/tests/tests/map_editor/map_editor_upload_entities.spec.ts
@@ -3,12 +3,14 @@ import * as path from "path";
 import { expect, test } from "@playwright/test";
 import Map from "../utils/map";
 import EntityEditor from "../utils/map-editor/entityEditor";
-import { resetWamMaps } from "../utils/map-editor/uploader";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
 import MapEditor from "../utils/mapeditor";
 import Menu from "../utils/menu";
 import { map_storage_url } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+
+const mapUrl = Map.url("mapEditorUploadEntities");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -27,8 +29,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully upload a custom entity", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorUploadEntities");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // open map editor
         await Menu.openMapEditor(page);
@@ -46,14 +48,14 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully upload and use custom entity in the map", async ({ browser, request }) => {
-        await resetWamMaps(request);
+        await uploadEmptyMap(request, "mapEditorUploadEntities");
 
         // First browser + moved woka
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await using page = await getPage(browser, "Admin1", mapUrl);
         await Map.teleportToPosition(page, 0, 0);
 
         // Second browser
-        await using page2 = await getPage(browser, "Admin2", Map.url("empty"));
+        await using page2 = await getPage(browser, "Admin2", mapUrl);
 
         // open map editor
         await page.bringToFront();
@@ -97,15 +99,15 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully upload and use custom entity with odd size in the map", async ({ browser, request }) => {
-        await resetWamMaps(request);
+        await uploadEmptyMap(request, "mapEditorUploadEntities");
 
         // First browser + moved woka
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await using page = await getPage(browser, "Admin1", mapUrl);
         await Map.teleportToPosition(page, 0, 0);
 
         // Second browser
         const newBrowser = await browser.newContext();
-        await using page2 = await getPage(browser, "Admin1", Map.url("empty"));
+        await using page2 = await getPage(browser, "Admin1", mapUrl);
 
         // open map editor
         await page.bringToFront();
@@ -155,14 +157,14 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
     test("Successfully upload and edit asset name", async ({ browser, request }) => {
         // Init wam file
-        await resetWamMaps(request);
+        await uploadEmptyMap(request, "mapEditorUploadEntities");
 
         // First browser + moved woka
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await using page = await getPage(browser, "Admin1", mapUrl);
         await Map.teleportToPosition(page, 0, 0);
 
         // Second browser
-        await using page2 = await getPage(browser, "Admin2", Map.url("empty"));
+        await using page2 = await getPage(browser, "Admin2", mapUrl);
 
         // open map editor on both pages
         await Menu.openMapEditor(page);
@@ -200,15 +202,15 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Successfully upload and remove custom entity", async ({ browser, request }) => {
-        await resetWamMaps(request);
+        await uploadEmptyMap(request, "mapEditorUploadEntities");
 
         // First browser + moved woka
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         await Map.teleportToPosition(page, 0, 0);
 
         // Second browser
-        await using page2 = await getPage(browser, "Admin2", Map.url("empty"));
+        await using page2 = await getPage(browser, "Admin2", mapUrl);
 
         // open map editor on both pages
         await Menu.openMapEditor(page);
@@ -238,8 +240,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("drop PDF file onto canvas inside #game", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorUploadEntities");
+        await using page = await getPage(browser, "Admin1", mapUrl);
 
         // Prepare file
         const filePath = path.join(__dirname, "../assets/lorem-ipsum.pdf");

--- a/tests/tests/map_editor/map_editor_visibility.spec.ts
+++ b/tests/tests/map_editor/map_editor_visibility.spec.ts
@@ -4,6 +4,9 @@ import Menu from "../utils/menu";
 import { map_storage_url, publicTestMapUrl } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
+
+const mapUrl = Map.url("mapEditorVisibility");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -34,7 +37,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
     });
 
     test("Assert map explorer visible for guest", async ({ browser, request }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await uploadEmptyMap(request, "mapEditorVisibility");
+        await using page = await getPage(browser, "Alice", mapUrl);
 
         // Open the map editor
         await Menu.openMapExplorer(page);

--- a/tests/tests/mobile/mobile.spec.ts
+++ b/tests/tests/mobile/mobile.spec.ts
@@ -4,6 +4,9 @@ import Map from "../utils/map";
 import { play_url, publicTestMapUrl } from "../utils/urls";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+import { uploadEmptyMap } from "../utils/map-editor/uploader";
+
+const mapUrl = Map.url("mobile");
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -14,8 +17,9 @@ test.describe("Mobile @nowebkit @nodesktop", () => {
     test.beforeEach(async ({ page, browserName }) => {
         test.skip(!isMobile(page) || browserName === "webkit", "Run only on mobile Chromium");
     });
-    test("Successfully bubble discussion with mobile device", async ({ browser }) => {
-        await using page = await getPage(browser, "Bob", Map.url("empty"));
+    test("Successfully bubble discussion with mobile device", async ({ browser, request }) => {
+        await uploadEmptyMap(request, "mobile");
+        await using page = await getPage(browser, "Bob", mapUrl);
 
         const positionToDiscuss = {
             x: 3 * 32,
@@ -31,7 +35,7 @@ test.describe("Mobile @nowebkit @nodesktop", () => {
         await Menu.closeMenu(page);
 
         // Second browser
-        const pageAlice = await getPage(browser, "Alice", Map.url("empty"));
+        const pageAlice = await getPage(browser, "Alice", mapUrl);
         await pageAlice.evaluate(() => localStorage.setItem("debug", "*"));
 
         // Move Alice and create a bubble with another user
@@ -47,7 +51,7 @@ test.describe("Mobile @nowebkit @nodesktop", () => {
         await pageAlice.locator("#cameras-container").locator("button.full-screen-button").nth(1).click();
 
         // Second browser
-        const pageJohn = await getPage(browser, "John", Map.url("empty"));
+        const pageJohn = await getPage(browser, "John", mapUrl);
         await pageJohn.evaluate(() => localStorage.setItem("debug", "*"));
 
         // Move John and create a bubble with another user

--- a/tests/tests/personal_area_claim.spec.ts
+++ b/tests/tests/personal_area_claim.spec.ts
@@ -1,10 +1,12 @@
 import { expect, test } from "@playwright/test";
 import Map from "./utils/map";
-import { resetWamMaps } from "./utils/map-editor/uploader";
+import { uploadEmptyMap } from "./utils/map-editor/uploader";
 import Menu from "./utils/menu";
 import AreaAccessRights from "./utils/areaAccessRights";
 import { getPage } from "./utils/auth";
 import { isMobile } from "./utils/isMobile";
+
+const mapUrl = Map.url("personalAreaClaim");
 
 test.setTimeout(240_000);
 test.describe("Personal area claim @oidc @nomobile @nowebkit", () => {
@@ -21,20 +23,20 @@ test.describe("Personal area claim @oidc @nomobile @nowebkit", () => {
         // When: Alice enters, claims it, then leaves. Joe then enters the same area.
         // Then: The claim popup must NOT be displayed (area is already claimed by Alice).
 
-        await resetWamMaps(request);
+        await uploadEmptyMap(request, "personalAreaClaim");
 
         const areaCenterX = 4 * 32 * 1.5;
         const areaCenterY = 4 * 32 * 1.5;
         const outsideX = 15 * 32 * 1.5;
         const outsideY = 15 * 32 * 1.5;
 
-        await using adminPage = await getPage(browser, "Admin1", Map.url("empty"));
+        await using adminPage = await getPage(browser, "Admin1", mapUrl);
 
         await Menu.openMapEditor(adminPage);
         await AreaAccessRights.openAreaEditorAndAddPersonalAreaWithDynamicClaim(adminPage);
         await Menu.closeMapEditor(adminPage);
 
-        await using memberPage = await getPage(browser, "Member1", Map.url("empty"));
+        await using memberPage = await getPage(browser, "Member1", mapUrl);
 
         await Map.teleportToPosition(memberPage, areaCenterX, areaCenterY);
 

--- a/tests/tests/personal_desk_spawn_on_connect.spec.ts
+++ b/tests/tests/personal_desk_spawn_on_connect.spec.ts
@@ -1,10 +1,12 @@
 import { expect, test } from "@playwright/test";
 import Map from "./utils/map";
-import { resetWamMaps } from "./utils/map-editor/uploader";
+import { uploadEmptyMap } from "./utils/map-editor/uploader";
 import Menu from "./utils/menu";
 import AreaAccessRights from "./utils/areaAccessRights";
 import { getPage } from "./utils/auth";
 import { isMobile } from "./utils/isMobile";
+
+const mapUrl = Map.url("personalDeskSpawnOnConnect");
 
 test.setTimeout(240_000);
 test.describe("Personal desk spawn on connect @oidc @nomobile @nowebkit", () => {
@@ -22,12 +24,12 @@ test.describe("Personal desk spawn on connect @oidc @nomobile @nowebkit", () => 
         // Then: Member1 spawns at start, then automatically walks to their personal desk.
         // We assert: after reload and enough time, the user is inside their personal desk (button "Walk to my desk" is disabled).
 
-        await resetWamMaps(request);
+        await uploadEmptyMap(request, "personalDeskSpawnOnConnect");
 
         const areaCenterX = 4 * 32 * 1.5;
         const areaCenterY = 4 * 32 * 1.5;
 
-        await using adminPage = await getPage(browser, "Admin1", Map.url("empty"));
+        await using adminPage = await getPage(browser, "Admin1", mapUrl);
 
         await Menu.openMapEditor(adminPage);
         await AreaAccessRights.openAreaEditorAndAddPersonalAreaWithDynamicClaim(adminPage);
@@ -35,7 +37,7 @@ test.describe("Personal desk spawn on connect @oidc @nomobile @nowebkit", () => 
 
         await adminPage.context().close();
 
-        await using memberPage = await getPage(browser, "Member1", Map.url("empty"));
+        await using memberPage = await getPage(browser, "Member1", mapUrl);
 
         await Map.teleportToPosition(memberPage, areaCenterX, areaCenterY);
 

--- a/tests/tests/reconnect.spec.ts
+++ b/tests/tests/reconnect.spec.ts
@@ -4,6 +4,9 @@ import Map from "./utils/map";
 import Menu from "./utils/menu";
 import { getPage } from "./utils/auth";
 import { isMobile } from "./utils/isMobile";
+import { uploadEmptyMap } from "./utils/map-editor/uploader";
+
+const mapUrl = Map.url("reconnect");
 
 test.setTimeout(180_000);
 test.describe("Connection @nomobile @nowebkit", () => {
@@ -35,8 +38,12 @@ test.describe("Connection @nomobile @nowebkit", () => {
         await page.context().close();
     });
 
-    test("can succeed on WAM file even if WorkAdventure starts while pusher is down @slow", async ({ browser }) => {
-        await using page = await getPage(browser, "Alice", Map.url("empty"));
+    test("can succeed on WAM file even if WorkAdventure starts while pusher is down @slow", async ({
+        browser,
+        request,
+    }) => {
+        await uploadEmptyMap(request, "reconnect");
+        await using page = await getPage(browser, "Alice", mapUrl);
 
         //Simulation of offline network
         await page.context().setOffline(true);

--- a/tests/tests/recording.spec.ts
+++ b/tests/tests/recording.spec.ts
@@ -5,12 +5,14 @@ import Map from "./utils/map";
 import { getPage } from "./utils/auth";
 import { isMobile } from "./utils/isMobile";
 
-import { resetWamMaps } from "./utils/map-editor/uploader";
+import { uploadEmptyMap } from "./utils/map-editor/uploader";
 
 import ConfigureMyRoom from "./utils/map-editor/configureMyRoom";
 import Megaphone from "./utils/map-editor/megaphone";
 import MapEditor from "./utils/mapeditor";
 import Menu from "./utils/menu";
+
+const mapUrl = Map.url("recording");
 
 test.setTimeout(240_000);
 
@@ -70,9 +72,9 @@ test.describe("Recording test", () => {
     );
 
     test("Recording should start and stop correctly @oidc", async ({ browser, request }) => {
-        await resetWamMaps(request);
+        await uploadEmptyMap(request, "recording");
         // Go to the empty map
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await using page = await getPage(browser, "Admin1", mapUrl);
         // Because webkit in playwright does not support Camera/Microphone Permission by settings
         await Map.teleportToPosition(page, 0, 0);
 
@@ -98,7 +100,7 @@ test.describe("Recording test", () => {
         await page.getByTestId("close-recording-modal").click();
 
         // Second browser
-        await using page2 = await getPage(browser, "Bob", Map.url("empty"));
+        await using page2 = await getPage(browser, "Bob", mapUrl);
         await Map.teleportToPosition(page2, 0, 0);
 
         await expect(page.getByTestId("recordingButton-start")).toBeEnabled();
@@ -131,7 +133,7 @@ test.describe("Recording test", () => {
         await page.getByTestId("recordingButton-start").click();
 
         // Second browser
-        await using page3 = await getPage(browser, "Alice", Map.url("empty"));
+        await using page3 = await getPage(browser, "Alice", mapUrl);
         await Map.teleportToPosition(page3, 0, 0);
         // Wait for moving to the new position
         // eslint-disable-next-line playwright/no-wait-for-timeout
@@ -178,9 +180,9 @@ test.describe("Recording test", () => {
     });
 
     test("Recording configuration @oidc", async ({ browser, request }) => {
-        await resetWamMaps(request);
+        await uploadEmptyMap(request, "recording");
         // Go to the empty map
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await using page = await getPage(browser, "Admin1", mapUrl);
         // Because webkit in playwright does not support Camera/Microphone Permission by settings
         await Map.teleportToPosition(page, 0, 0);
 
@@ -194,7 +196,7 @@ test.describe("Recording test", () => {
         await page.getByRole("button", { name: "Save" }).click();
 
         // Now, let's start a recording to see if the rights are correctly applied.
-        await using page2 = await getPage(browser, "Member1", Map.url("empty"));
+        await using page2 = await getPage(browser, "Member1", mapUrl);
         await Map.teleportToPosition(page2, 0, 0);
 
         // The admin can still see the recording button
@@ -223,12 +225,12 @@ test.describe("Recording test", () => {
         browser,
         request,
     }) => {
-        await resetWamMaps(request);
+        await uploadEmptyMap(request, "recording");
         const speakerPosition = { x: 4 * 32, y: 0 };
         const adminListenerFarPosition = { x: 30 * 32, y: 0 };
         const memberListenerFarPosition = { x: 30 * 32, y: 12 * 32 };
 
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await using page = await getPage(browser, "Admin1", mapUrl);
         await Map.teleportToPosition(page, speakerPosition.x, speakerPosition.y);
 
         await Menu.openMapEditor(page);
@@ -239,9 +241,9 @@ test.describe("Recording test", () => {
         await Megaphone.isMegaphoneEnabled(page);
         await saveMegaphoneSettings(page);
 
-        await using adminListener = await getPage(browser, "Admin2", Map.url("empty"));
+        await using adminListener = await getPage(browser, "Admin2", mapUrl);
         await Map.teleportToPosition(adminListener, adminListenerFarPosition.x, adminListenerFarPosition.y);
-        await using memberListener = await getPage(browser, "Member1", Map.url("empty"));
+        await using memberListener = await getPage(browser, "Member1", mapUrl);
         await Map.teleportToPosition(memberListener, memberListenerFarPosition.x, memberListenerFarPosition.y);
 
         // Start the megaphone and close the setup modal without stopping the stream.

--- a/tests/tests/scripting_area.spec.ts
+++ b/tests/tests/scripting_area.spec.ts
@@ -1,12 +1,14 @@
 import { expect, test } from "@playwright/test";
 import { evaluateScript } from "./utils/scripting";
 import Map from "./utils/map";
-import { resetWamMaps } from "./utils/map-editor/uploader";
+import { uploadEmptyMap } from "./utils/map-editor/uploader";
 import menu from "./utils/menu";
 import mapeditor from "./utils/mapeditor";
 import areaEditor from "./utils/map-editor/areaEditor";
 import { getPage } from "./utils/auth";
 import { isMobile } from "./utils/isMobile";
+
+const mapUrl = Map.url("scriptingArea");
 
 test.describe("Scripting for Map editor @oidc @nomobile @nowebkit", () => {
     test.beforeEach(
@@ -21,8 +23,8 @@ test.describe("Scripting for Map editor @oidc @nomobile @nowebkit", () => {
         test.skip(browserName === "webkit", "WebKit has issues with camera/microphone");
     });
     test("Scripting Area onEnter & onLeave", async ({ browser, request }) => {
-        await resetWamMaps(request);
-        await using page = await getPage(browser, "Admin1", Map.url("empty"));
+        await uploadEmptyMap(request, "scriptingArea");
+        await using page = await getPage(browser, "Admin1", mapUrl);
         await menu.openMapEditor(page);
         await mapeditor.openAreaEditor(page);
         await areaEditor.drawArea(page, { x: 0, y: 7 * 32 * 1.5 }, { x: 5 * 32 * 1.5, y: 9 * 32 * 1.5 });

--- a/tests/tests/scripting_chat.spec.ts
+++ b/tests/tests/scripting_chat.spec.ts
@@ -2,10 +2,12 @@ import { expect, test } from "@playwright/test";
 import { evaluateScript } from "./utils/scripting";
 import Chat from "./utils/chat";
 import Map from "./utils/map";
-import { resetWamMaps } from "./utils/map-editor/uploader";
+import { uploadEmptyMap } from "./utils/map-editor/uploader";
 
 import { getPage } from "./utils/auth";
 import { isMobile } from "./utils/isMobile";
+
+const mapUrl = Map.url("scriptingChat");
 
 test.describe("#Scripting chat functions @nowebkit @nomobile", () => {
     test.beforeEach(
@@ -14,12 +16,12 @@ test.describe("#Scripting chat functions @nowebkit @nomobile", () => {
         async ({ browserName, request, page }) => {
             //WebKit has issue with camera
             test.skip(browserName === "webkit" || isMobile(page), "Skip on WebKit and mobile");
-            await resetWamMaps(request);
+            await uploadEmptyMap(request, "scriptingChat");
             //await chatUtils.resetMatrixDatabase();
         },
     );
     test("can open / close chat + start / stop typing @chat", async ({ browser }) => {
-        await using page = await getPage(browser, "Bob", Map.url("empty"));
+        await using page = await getPage(browser, "Bob", mapUrl);
         //await oidcMatrixUserLogin(page, false);
 
         // Test open chat scripting
@@ -72,7 +74,7 @@ test.describe("#Scripting chat functions @nowebkit @nomobile", () => {
     });
 
     test("can send message to bubble users @chat", async ({ browser }) => {
-        await using bob = await getPage(browser, "Bob", Map.url("empty"));
+        await using bob = await getPage(browser, "Bob", mapUrl);
         //await oidcMatrixUserLogin(bob, false);
         // test to send bubble message when entering proximity meeting
         await evaluateScript(bob, async () => {
@@ -91,7 +93,7 @@ test.describe("#Scripting chat functions @nowebkit @nomobile", () => {
         await Map.teleportToPosition(bob, 32, 32);
 
         // Open new page for alice
-        await using alice = await getPage(browser, "Alice", Map.url("empty"));
+        await using alice = await getPage(browser, "Alice", mapUrl);
         //await oidcMemberTagLogin(alice, false);
 
         const chatMessageReceivedPromise = evaluateScript(alice, async () => {
@@ -139,7 +141,7 @@ test.describe("#Scripting chat functions @nowebkit @nomobile", () => {
         expect(chatMessageReceived.event.author).toBeDefined();
 
         // Let's add a third user, Charlie, to test the welcome message
-        await using charlie = await getPage(browser, "Charlie", Map.url("empty"));
+        await using charlie = await getPage(browser, "Charlie", mapUrl);
         await Map.teleportToPosition(charlie, 32, 32);
 
         await expect(alice.getByText("Charlie joined the discussion")).toBeVisible();

--- a/tests/tests/userlist.spec.ts
+++ b/tests/tests/userlist.spec.ts
@@ -4,6 +4,9 @@ import { publicTestMapUrl } from "./utils/urls";
 import chatUtils from "./utils/chat";
 import { getPage } from "./utils/auth";
 import { isMobile } from "./utils/isMobile";
+import { uploadEmptyMap } from "./utils/map-editor/uploader";
+
+const mapUrl = Map.url("userlist");
 
 test.describe("Walk to @nomobile @nowebkit", () => {
     test.beforeEach(async ({ page, browserName }) => {
@@ -66,18 +69,20 @@ test.describe("Send Message from User List @oidc @matrix @chat", () => {
         page,
         browser,
         browserName,
+        request,
     }, { project }) => {
         test.skip(isMobile(page) || browserName === "webkit", "Skip on mobile or WebKit");
+        await uploadEmptyMap(request, "userlist");
 
         // Alice is not connected
-        await using userAlice = await getPage(browser, "Alice", Map.url("empty"));
+        await using userAlice = await getPage(browser, "Alice", mapUrl);
         const alicePosition = {
             x: 4 * 32,
             y: 5 * 32,
         };
         await Map.teleportToPosition(userAlice, alicePosition.x, alicePosition.y);
 
-        await using userUserLogin1 = await getPage(browser, "Member1", Map.url("empty"));
+        await using userUserLogin1 = await getPage(browser, "Member1", mapUrl);
         await chatUtils.open(userUserLogin1, false);
         await chatUtils.slideToUsers(userUserLogin1);
         // Click on chat button

--- a/tests/tests/utils/map-editor/uploader.ts
+++ b/tests/tests/utils/map-editor/uploader.ts
@@ -14,3 +14,23 @@ export async function resetWamMaps(request: APIRequestContext) {
     });
     expect(uploadFile1.ok()).toBeTruthy();
 }
+
+export async function uploadMap(request: APIRequestContext, mapFile: string, path: string): Promise<void> {
+    const normalizedPath = path.startsWith("maps/") ? path : `maps/${path}`;
+    const mapPath = normalizedPath.endsWith(".wam") ? normalizedPath : `${normalizedPath}.wam`;
+    const mapFileName = mapPath.split("/").at(-1) ?? mapPath;
+    const uploadFile = await request.put(new URL(mapPath, map_storage_url).toString(), {
+        multipart: {
+            file: {
+                name: mapFileName,
+                mimeType: "application/json",
+                buffer: await fs.promises.readFile(mapFile),
+            },
+        },
+    });
+    expect(uploadFile.ok()).toBeTruthy();
+}
+
+export async function uploadEmptyMap(request: APIRequestContext, path: string): Promise<void> {
+    return uploadMap(request, "../map-storage/tests/assets/maps/empty.wam", path);
+}


### PR DESCRIPTION
## What changed

This updates the E2E suite so specs that previously shared `Map.url("empty")` stop colliding on the same mutable WAM map.

Each migrated `.spec.ts` file now:
- uploads its own empty map with a fixed file-level name via `uploadEmptyMap`
- uses a file-level `mapUrl = Map.url("...")`
- stops calling `resetWamMaps` for those mutable-map scenarios

The shared uploader helper was also extended so `uploadEmptyMap(request, "name")` writes to `maps/name.wam`, which matches how `Map.url(...)` resolves private WAM rooms.

## Why

The current suite cannot safely scale to parallel execution because many tests mutate the same `empty` map. Running those files in parallel creates cross-test interference.

Using a dedicated uploaded map per spec isolates the mutable room state while keeping the setup simple.

## Impact

- E2E specs that edit the map no longer share the same mutable `empty` room.
- This reduces inter-file coupling and moves the suite toward safe parallel execution.
- The migration keeps the simpler per-file model you requested rather than generating unique names per test.

## Root cause

Many tests relied on `resetWamMaps` plus `Map.url("empty")`, which funneled multiple mutable scenarios through the same WAM map path.

## Validation

Passed:
- `npx eslint ...` on all modified test files
- `npm run test -- tests/chat/matrixChatArea.spec.ts --project=chromium`
- `npm run test -- tests/chat/matrixChatModeration.spec.ts tests/map_editor/map_editor_lock_area.spec.ts tests/iframe_script.spec.ts tests/reconnect.spec.ts --project=chromium`
  - `tests/iframe_script.spec.ts`, `tests/map_editor/map_editor_lock_area.spec.ts`, and `tests/reconnect.spec.ts` passed

Known failure during verification:
- `tests/chat/matrixChatModeration.spec.ts` still failed on matrix participant assertions (`@john.doe:matrix.workadventure.localhost-participant` not found) after room creation. The map migration itself loaded correctly, so this appears to be specific to that matrix flow rather than the uploaded-map path.
