### PR TITLE
Stabilize E2E game coordinate clicks

### DIFF
--- a/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/EntityEditorTool.ts
@@ -28,6 +28,8 @@ import { AreaPreview } from "../../../Components/MapEditor/AreaPreview";
 import { mapEditorActivated } from "../../../../Stores/MenuStore";
 import { EntityRelatedEditorTool } from "./EntityRelatedEditorTool";
 
+const ENTITY_EDITOR_AREA_PREVIEW_DEPTH = -1;
+
 export class EntityEditorTool extends EntityRelatedEditorTool {
     private handleUpdateEntity: (entityData: EntityData) => void;
     private handleCopyEntity: (data: CopyEntityEventData) => void;
@@ -353,7 +355,9 @@ export class EntityEditorTool extends EntityRelatedEditorTool {
         pointer: Phaser.Input.Pointer,
         gameObjects: Phaser.GameObjects.GameObject[]
     ): void {
-        if (get(mapEditorEntityModeStore) === "EDIT" && gameObjects.length === 0) {
+        const clickedAreaPreview = this.isAreaPreviewClicked(pointer, gameObjects);
+
+        if (get(mapEditorEntityModeStore) === "EDIT" && gameObjects.length === 0 && !clickedAreaPreview) {
             mapEditorEntityModeStore.set("ADD");
             if (document.activeElement instanceof HTMLElement) {
                 document.activeElement.blur();
@@ -364,8 +368,7 @@ export class EntityEditorTool extends EntityRelatedEditorTool {
         if (!this.entityPrefabPreview || !this.entityPrefab) {
             // Check that the user can open map editor to edit an area
             if (get(mapEditorActivated)) {
-                const areaEditorToolObjects = gameObjects.filter((obj) => obj instanceof AreaPreview);
-                if (areaEditorToolObjects.length > 0 && get(mapEditorSelectedToolStore) !== EditorToolName.AreaEditor) {
+                if (clickedAreaPreview && get(mapEditorSelectedToolStore) !== EditorToolName.AreaEditor) {
                     this.scene.getMapEditorModeManager().equipTool(EditorToolName.AreaEditor);
                 }
             }
@@ -458,6 +461,8 @@ export class EntityEditorTool extends EntityRelatedEditorTool {
             this.shiftKey,
             this.ctrlKey
         );
+        areaPreview.setDepth(ENTITY_EDITOR_AREA_PREVIEW_DEPTH);
+        areaPreview.disableInteractive();
         this.areaPreviews.push(areaPreview);
         return areaPreview;
     }
@@ -480,6 +485,18 @@ export class EntityEditorTool extends EntityRelatedEditorTool {
         return Array.from(areasPreview.values()).filter((area: AreaData) => {
             return x >= area.x && x <= area.x + area.width && y >= area.y && y <= area.y + area.height;
         });
+    }
+
+    private isAreaPreviewClicked(pointer: Phaser.Input.Pointer, gameObjects: Phaser.GameObjects.GameObject[]): boolean {
+        if (gameObjects.some((obj) => obj instanceof AreaPreview)) {
+            return true;
+        }
+
+        if (gameObjects.length > 0) {
+            return false;
+        }
+
+        return this.getAreasFromPosition(pointer.worldX, pointer.worldY).length > 0;
     }
 
     private canEntityBePlaced(): boolean {

--- a/play/src/front/Utils/E2EHooks.ts
+++ b/play/src/front/Utils/E2EHooks.ts
@@ -15,56 +15,12 @@ interface E2ECoordinateOptions {
     tolerance?: number;
 }
 
-interface E2ECameraAnimationState {
-    fade: boolean;
-    flash: boolean;
-    pan: boolean;
-    rotate: boolean;
-    shake: boolean;
-    zoom: boolean;
-    any: boolean;
-}
-
-interface E2ECoordinateSnapshot extends Coordinates {
-    game: Coordinates;
-    camera: {
-        x: number;
-        y: number;
-        width: number;
-        height: number;
-        scrollX: number;
-        scrollY: number;
-        zoomX: number;
-        zoomY: number;
-        rotation: number;
-        worldView: {
-            x: number;
-            y: number;
-            width: number;
-            height: number;
-        };
-        animations: E2ECameraAnimationState;
-    };
-    canvas: {
-        left: number;
-        top: number;
-        width: number;
-        height: number;
-        internalWidth: number;
-        internalHeight: number;
-        scaleX: number;
-        scaleY: number;
-    };
-    roundTrip: Coordinates;
-}
-
 interface CameraEffectWithIsRunning {
     isRunning?: boolean;
 }
 
 interface CameraWithTransform extends Phaser.Cameras.Scene2D.Camera {
     matrix: Phaser.GameObjects.Components.TransformMatrix;
-    rotation: number;
 }
 
 const DEFAULT_COORDINATE_STABILITY_TIMEOUT_MS = 10_000;
@@ -89,26 +45,19 @@ function isEffectRunning(effect: CameraEffectWithIsRunning | undefined): boolean
     return effect?.isRunning === true;
 }
 
-function getCameraAnimationState(camera: Phaser.Cameras.Scene2D.Camera): E2ECameraAnimationState {
-    const animations = {
-        fade: isEffectRunning(camera.fadeEffect),
-        flash: isEffectRunning(camera.flashEffect),
-        pan: isEffectRunning(camera.panEffect),
-        rotate: isEffectRunning(camera.rotateToEffect),
-        shake: isEffectRunning(camera.shakeEffect),
-        zoom: isEffectRunning(camera.zoomEffect),
-        any: false,
-    };
+function hasRunningCameraEffect(camera: Phaser.Cameras.Scene2D.Camera): boolean {
+    return (
+        isEffectRunning(camera.fadeEffect) ||
+        isEffectRunning(camera.flashEffect) ||
+        isEffectRunning(camera.panEffect) ||
+        isEffectRunning(camera.rotateToEffect) ||
+        isEffectRunning(camera.shakeEffect) ||
+        isEffectRunning(camera.zoomEffect)
+    );
+}
 
-    animations.any =
-        animations.fade ||
-        animations.flash ||
-        animations.pan ||
-        animations.rotate ||
-        animations.shake ||
-        animations.zoom;
-
-    return animations;
+function currentCameraHasRunningEffect(): boolean {
+    return hasRunningCameraEffect(gameManager.getCurrentGameScene().getCameraManager().getCamera());
 }
 
 function getGameCanvas(): HTMLCanvasElement {
@@ -121,7 +70,7 @@ function getGameCanvas(): HTMLCanvasElement {
     return canvas;
 }
 
-function getGameToBrowserCoordinatesSnapshot(gameCoordinates: Coordinates): E2ECoordinateSnapshot {
+function getGameToBrowserCoordinatesSnapshot(gameCoordinates: Coordinates): Coordinates {
     const scene = gameManager.getCurrentGameScene();
     const camera = scene.getCameraManager().getCamera();
     const cameraWithTransform = camera as CameraWithTransform;
@@ -164,42 +113,6 @@ function getGameToBrowserCoordinatesSnapshot(gameCoordinates: Coordinates): E2EC
     return {
         x,
         y,
-        game: {
-            x: gameCoordinates.x,
-            y: gameCoordinates.y,
-        },
-        camera: {
-            x: camera.x,
-            y: camera.y,
-            width: camera.width,
-            height: camera.height,
-            scrollX: camera.scrollX,
-            scrollY: camera.scrollY,
-            zoomX: camera.zoomX,
-            zoomY: camera.zoomY,
-            rotation: cameraWithTransform.rotation,
-            worldView: {
-                x: camera.worldView.x,
-                y: camera.worldView.y,
-                width: camera.worldView.width,
-                height: camera.worldView.height,
-            },
-            animations: getCameraAnimationState(camera),
-        },
-        canvas: {
-            left: canvasRect.left,
-            top: canvasRect.top,
-            width: canvasRect.width,
-            height: canvasRect.height,
-            internalWidth: canvasInternalWidth,
-            internalHeight: canvasInternalHeight,
-            scaleX,
-            scaleY,
-        },
-        roundTrip: {
-            x: roundTrip.x,
-            y: roundTrip.y,
-        },
     };
 }
 
@@ -218,12 +131,14 @@ async function gameToBrowserCoordinates(
 
     const waitForStableCoordinates = async (): Promise<Coordinates> => {
         const firstSnapshot = getGameToBrowserCoordinatesSnapshot(gameCoordinates);
+        const cameraWasAnimating = currentCameraHasRunningEffect();
 
         await waitForNextFrame();
 
         const secondSnapshot = getGameToBrowserCoordinatesSnapshot(gameCoordinates);
         const coordinatesAreStable = areCoordinatesClose(firstSnapshot, secondSnapshot, tolerance);
-        const cameraIsStable = !firstSnapshot.camera.animations.any && !secondSnapshot.camera.animations.any;
+        const cameraIsAnimating = currentCameraHasRunningEffect();
+        const cameraIsStable = !cameraWasAnimating && !cameraIsAnimating;
 
         if (coordinatesAreStable && cameraIsStable) {
             return {
@@ -238,6 +153,8 @@ async function gameToBrowserCoordinates(
                     JSON.stringify({
                         firstSnapshot,
                         secondSnapshot,
+                        cameraWasAnimating,
+                        cameraIsAnimating,
                         tolerance,
                     })
             );

--- a/play/src/front/Utils/E2EHooks.ts
+++ b/play/src/front/Utils/E2EHooks.ts
@@ -4,6 +4,252 @@ let webRtcConnectionsCount = 0;
 let livekitConnectionsCount = 0;
 let livekitRoomCount = 0;
 
+interface Coordinates {
+    x: number;
+    y: number;
+}
+
+interface E2ECoordinateOptions {
+    timeoutMs?: number;
+    retryIntervalMs?: number;
+    tolerance?: number;
+}
+
+interface E2ECameraAnimationState {
+    fade: boolean;
+    flash: boolean;
+    pan: boolean;
+    rotate: boolean;
+    shake: boolean;
+    zoom: boolean;
+    any: boolean;
+}
+
+interface E2ECoordinateSnapshot extends Coordinates {
+    game: Coordinates;
+    camera: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+        scrollX: number;
+        scrollY: number;
+        zoomX: number;
+        zoomY: number;
+        rotation: number;
+        worldView: {
+            x: number;
+            y: number;
+            width: number;
+            height: number;
+        };
+        animations: E2ECameraAnimationState;
+    };
+    canvas: {
+        left: number;
+        top: number;
+        width: number;
+        height: number;
+        internalWidth: number;
+        internalHeight: number;
+        scaleX: number;
+        scaleY: number;
+    };
+    roundTrip: Coordinates;
+}
+
+interface CameraEffectWithIsRunning {
+    isRunning?: boolean;
+}
+
+interface CameraWithTransform extends Phaser.Cameras.Scene2D.Camera {
+    matrix: Phaser.GameObjects.Components.TransformMatrix;
+    rotation: number;
+}
+
+const DEFAULT_COORDINATE_STABILITY_TIMEOUT_MS = 10_000;
+const DEFAULT_COORDINATE_STABILITY_RETRY_INTERVAL_MS = 500;
+const DEFAULT_COORDINATE_STABILITY_TOLERANCE = 1;
+
+function wait(delayMs: number): Promise<void> {
+    return new Promise((resolve) => {
+        window.setTimeout(resolve, delayMs);
+    });
+}
+
+function waitForNextFrame(): Promise<void> {
+    return new Promise((resolve) => {
+        gameManager.getCurrentGameScene().events.once(Phaser.Scenes.Events.POST_UPDATE, () => {
+            resolve();
+        });
+    });
+}
+
+function isEffectRunning(effect: CameraEffectWithIsRunning | undefined): boolean {
+    return effect?.isRunning === true;
+}
+
+function getCameraAnimationState(camera: Phaser.Cameras.Scene2D.Camera): E2ECameraAnimationState {
+    const animations = {
+        fade: isEffectRunning(camera.fadeEffect),
+        flash: isEffectRunning(camera.flashEffect),
+        pan: isEffectRunning(camera.panEffect),
+        rotate: isEffectRunning(camera.rotateToEffect),
+        shake: isEffectRunning(camera.shakeEffect),
+        zoom: isEffectRunning(camera.zoomEffect),
+        any: false,
+    };
+
+    animations.any =
+        animations.fade ||
+        animations.flash ||
+        animations.pan ||
+        animations.rotate ||
+        animations.shake ||
+        animations.zoom;
+
+    return animations;
+}
+
+function getGameCanvas(): HTMLCanvasElement {
+    const canvas = document.querySelector<HTMLCanvasElement>("#game canvas");
+
+    if (!canvas) {
+        throw new Error('Unable to convert game coordinates: "#game canvas" was not found.');
+    }
+
+    return canvas;
+}
+
+function getGameToBrowserCoordinatesSnapshot(gameCoordinates: Coordinates): E2ECoordinateSnapshot {
+    const scene = gameManager.getCurrentGameScene();
+    const camera = scene.getCameraManager().getCamera();
+    const cameraWithTransform = camera as CameraWithTransform;
+
+    // camera.preRender() must be called before accessing worldView or the camera matrix to ensure it is up to date.
+    // See the same pattern in GameScene.connect().
+    // @ts-ignore preRender is protected, but Phaser documents it as the way to refresh worldView.
+    camera.preRender();
+
+    const canvas = getGameCanvas();
+    const canvasRect = canvas.getBoundingClientRect();
+    const canvasInternalWidth = canvas.width || camera.width;
+    const canvasInternalHeight = canvas.height || camera.height;
+    const scaleX = canvasRect.width / canvasInternalWidth;
+    const scaleY = canvasRect.height / canvasInternalHeight;
+    const canvasPoint = cameraWithTransform.matrix.transformPoint(
+        gameCoordinates.x - camera.scrollX,
+        gameCoordinates.y - camera.scrollY,
+        { x: 0, y: 0 }
+    );
+    const x = canvasRect.left + canvasPoint.x * scaleX;
+    const y = canvasRect.top + canvasPoint.y * scaleY;
+    const roundTrip = camera.getWorldPoint(canvasPoint.x, canvasPoint.y);
+
+    if (!areCoordinatesClose(gameCoordinates, roundTrip, DEFAULT_COORDINATE_STABILITY_TOLERANCE)) {
+        throw new Error(
+            "Unable to convert game coordinates: camera coordinate round trip did not return the original point. " +
+                JSON.stringify({
+                    gameCoordinates,
+                    canvasPoint,
+                    roundTrip: {
+                        x: roundTrip.x,
+                        y: roundTrip.y,
+                    },
+                    tolerance: DEFAULT_COORDINATE_STABILITY_TOLERANCE,
+                })
+        );
+    }
+
+    return {
+        x,
+        y,
+        game: {
+            x: gameCoordinates.x,
+            y: gameCoordinates.y,
+        },
+        camera: {
+            x: camera.x,
+            y: camera.y,
+            width: camera.width,
+            height: camera.height,
+            scrollX: camera.scrollX,
+            scrollY: camera.scrollY,
+            zoomX: camera.zoomX,
+            zoomY: camera.zoomY,
+            rotation: cameraWithTransform.rotation,
+            worldView: {
+                x: camera.worldView.x,
+                y: camera.worldView.y,
+                width: camera.worldView.width,
+                height: camera.worldView.height,
+            },
+            animations: getCameraAnimationState(camera),
+        },
+        canvas: {
+            left: canvasRect.left,
+            top: canvasRect.top,
+            width: canvasRect.width,
+            height: canvasRect.height,
+            internalWidth: canvasInternalWidth,
+            internalHeight: canvasInternalHeight,
+            scaleX,
+            scaleY,
+        },
+        roundTrip: {
+            x: roundTrip.x,
+            y: roundTrip.y,
+        },
+    };
+}
+
+function areCoordinatesClose(first: Coordinates, second: Coordinates, tolerance: number): boolean {
+    return Math.abs(first.x - second.x) <= tolerance && Math.abs(first.y - second.y) <= tolerance;
+}
+
+async function gameToBrowserCoordinates(
+    gameCoordinates: Coordinates,
+    options: E2ECoordinateOptions = {}
+): Promise<Coordinates> {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_COORDINATE_STABILITY_TIMEOUT_MS;
+    const retryIntervalMs = options.retryIntervalMs ?? DEFAULT_COORDINATE_STABILITY_RETRY_INTERVAL_MS;
+    const tolerance = options.tolerance ?? DEFAULT_COORDINATE_STABILITY_TOLERANCE;
+    const startedAt = Date.now();
+
+    const waitForStableCoordinates = async (): Promise<Coordinates> => {
+        const firstSnapshot = getGameToBrowserCoordinatesSnapshot(gameCoordinates);
+
+        await waitForNextFrame();
+
+        const secondSnapshot = getGameToBrowserCoordinatesSnapshot(gameCoordinates);
+        const coordinatesAreStable = areCoordinatesClose(firstSnapshot, secondSnapshot, tolerance);
+        const cameraIsStable = !firstSnapshot.camera.animations.any && !secondSnapshot.camera.animations.any;
+
+        if (coordinatesAreStable && cameraIsStable) {
+            return {
+                x: secondSnapshot.x,
+                y: secondSnapshot.y,
+            };
+        }
+
+        if (Date.now() - startedAt >= timeoutMs) {
+            throw new Error(
+                `Unable to convert game coordinates to stable browser coordinates within ${timeoutMs}ms. ` +
+                    JSON.stringify({
+                        firstSnapshot,
+                        secondSnapshot,
+                        tolerance,
+                    })
+            );
+        }
+
+        await wait(retryIntervalMs);
+        return waitForStableCoordinates();
+    };
+
+    return waitForStableCoordinates();
+}
+
 /**
  * [DEBUG] Forces a WebRTC peer failure to test the retry mechanism.
  * This function finds the first SimplePeer with active video peers and triggers a forced failure.
@@ -115,13 +361,7 @@ export function decrementLivekitRoomCount() {
  * We should refrain from growing this object too much but it can be useful in very specific circumstances (usually linked to Phaser testing)
  */
 export const e2eHooks = {
-    async waitForNextFrame(): Promise<void> {
-        return new Promise((resolve) => {
-            gameManager.getCurrentGameScene().events.once(Phaser.Scenes.Events.POST_UPDATE, () => {
-                resolve();
-            });
-        });
-    },
+    waitForNextFrame,
     getWebRtcConnectionsCount(): number {
         return webRtcConnectionsCount;
     },
@@ -131,6 +371,7 @@ export const e2eHooks = {
     getLivekitRoomsCount(): number {
         return livekitRoomCount;
     },
+    gameToBrowserCoordinates,
     /**
      * [DEBUG] Forces a WebRTC peer failure to test the retry mechanism.
      */

--- a/tests/tests/chat/matrixChatArea.spec.ts
+++ b/tests/tests/chat/matrixChatArea.spec.ts
@@ -48,7 +48,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
         await Menu.openMapEditor(page);
 
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(page, "matrixRoomPropertyData");
         await AreaEditor.setMatrixChatRoomProperty(page, true, "name of new room");
 
@@ -71,7 +71,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
         await Menu.openMapEditor(page);
 
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(page, "matrixRoomPropertyData");
         await AreaEditor.setMatrixChatRoomProperty(page, true, "name of new room");
 
@@ -101,7 +101,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
         await Menu.openMapEditor(page);
 
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(page, "matrixRoomPropertyData");
         await AreaEditor.setMatrixChatRoomProperty(page, true, "name of new room");
 
@@ -133,7 +133,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
         await Menu.openMapEditor(page);
 
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(page, "matrixRoomPropertyData");
 
         //TODO : find a better way to wait for the room to be created
@@ -174,7 +174,7 @@ test.describe("matrix chat area property @matrix @nowebit @nomobile", () => {
         await Menu.openMapEditor(page);
 
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(page, "matrixRoomPropertyData");
         await AreaEditor.setMatrixChatRoomProperty(page, true, "name of new room");
 

--- a/tests/tests/livekit.spec.ts
+++ b/tests/tests/livekit.spec.ts
@@ -363,20 +363,12 @@ test.describe("Meeting actions test", () => {
         // Create podium zone (speaker zone) - positioned at y: 2-4 tiles
         await Menu.openMapEditor(speakerAdmin);
         await MapEditor.openAreaEditor(speakerAdmin);
-        await AreaEditor.drawArea(
-            speakerAdmin,
-            { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 },
-            { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 },
-        );
+        await AreaEditor.drawArea(speakerAdmin, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(speakerAdmin, "speakerMegaphone");
         await AreaEditor.setPodiumNameProperty(speakerAdmin, `${browser.browserType().name()}RapidTestZone`);
 
         // Create audience zone (listener zone) - positioned at y: 5-7 tiles (adjacent to podium)
-        await AreaEditor.drawArea(
-            speakerAdmin,
-            { x: 1 * 32 * 1.5, y: 5 * 32 * 1.5 },
-            { x: 9 * 32 * 1.5, y: 7 * 32 * 1.5 },
-        );
+        await AreaEditor.drawArea(speakerAdmin, { x: 1 * 32, y: 5 * 32 }, { x: 9 * 32, y: 7 * 32 });
         await AreaEditor.addProperty(speakerAdmin, "listenerMegaphone");
         await AreaEditor.setMatchingPodiumZoneProperty(
             speakerAdmin,

--- a/tests/tests/map_editor/map_editor_area_rights.spec.ts
+++ b/tests/tests/map_editor/map_editor_area_rights.spec.ts
@@ -10,6 +10,7 @@ import AreaAccessRights from "../utils/areaAccessRights";
 import { evaluateScript } from "../utils/scripting";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
+import { clickCoordinates } from "../utils/gameCoordinates";
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -76,11 +77,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         //Need to wait for player move action
         // eslint-disable-next-line
         await page.waitForTimeout(1000);
-        await page.mouse.click(
-            AreaAccessRights.mouseCoordinatesToClickOnEntityInsideArea.x,
-            AreaAccessRights.mouseCoordinatesToClickOnEntityInsideArea.y,
-            { button: "right" },
-        );
+        await clickCoordinates(page, AreaAccessRights.mouseCoordinatesToClickOnEntityInsideArea, { button: "right" });
         //Need to wait for player move action
         // eslint-disable-next-line
         await page.waitForTimeout(1000);
@@ -449,11 +446,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
 
         // Add a second area
         await Menu.openMapEditor(page);
-        await AreaAccessRights.openAreaEditorAndAddArea(
-            page,
-            { x: 1 * 32 * 1.5, y: 9 * 32 * 1.5 },
-            { x: 9 * 32 * 1.5, y: 10 * 32 * 1.5 },
-        );
+        await AreaAccessRights.openAreaEditorAndAddArea(page, { x: 1 * 32, y: 9 * 32 }, { x: 9 * 32, y: 10 * 32 });
         await page.getByTestId("personalAreaPropertyData").click();
         await Menu.closeMapEditor(page);
 

--- a/tests/tests/map_editor/map_editor_highlight.spec.ts
+++ b/tests/tests/map_editor/map_editor_highlight.spec.ts
@@ -30,7 +30,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         // Open the map editor
         await Menu.openMapExplorer(page);
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 0 * 32 * 1.5, y: 5 * 32 * 1.5 }, { x: 5 * 32 * 1.5, y: 9 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 0 * 32, y: 5 * 32 }, { x: 5 * 32, y: 9 * 32 });
         await AreaEditor.addProperty(page, "highlight");
 
         await page.getByRole("slider", { name: "Opacity : 60 %" }).fill("0.3");

--- a/tests/tests/map_editor/map_editor_interacting_object.spec.ts
+++ b/tests/tests/map_editor/map_editor_interacting_object.spec.ts
@@ -33,7 +33,7 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
         // Create area on the map for the test
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 8 * 32 * 1.5, y: 8 * 32 * 1.5 }, { x: 10 * 32 * 1.5, y: 10 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 8 * 32, y: 8 * 32 }, { x: 10 * 32, y: 10 * 32 });
         await AreaEditor.setAreaName(page, "MyLinkZone");
         await AreaEditor.addProperty(page, "openWebsite");
         await AreaEditor.setOpenLinkProperty(page, "https://workadventu.re", "Show action toast with message");
@@ -60,10 +60,10 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
         await Menu.openMapEditor(page);
         await MapEditor.openEntityEditor(page);
         await EntityEditor.selectEntity(page, 0, "small table");
-        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.5);
+        await EntityEditor.moveAndClick(page, 1, 8.5 * 32);
         await EntityEditor.clearEntitySelection(page);
-        // await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.5);
-        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.45);
+        // await EntityEditor.moveAndClick(page, 1, 8.5 * 32);
+        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 - 10);
         await EntityEditor.setEntityName(page, "My Open Link");
         await EntityEditor.addProperty(page, "openWebsite");
         await EntityEditor.setOpenLinkProperty(page, "https://workadventu.re");
@@ -84,7 +84,7 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
         //eslint-disable-next-line playwright/no-wait-for-timeout
         await newPage.waitForTimeout(1000);
         // Move to the entity
-        await EntityEditor.moveAndRightClick(newPage, 0, 8.5 * 32 * 1.5);
+        await EntityEditor.moveAndRightClick(newPage, 0, 8.5 * 32);
 
         // Wait for the text to be visible
         try {
@@ -92,7 +92,7 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
         } catch (error) {
             console.error("Error waiting for text to be visible", error);
             // Try again once
-            await EntityEditor.moveAndRightClick(newPage, 0, 8.5 * 32 * 1.5);
+            await EntityEditor.moveAndRightClick(newPage, 0, 8.5 * 32);
             //eslint-disable-next-line playwright/no-conditional-expect
             await expect(newPage.getByText("SPACE to interact with it 👀")).toBeVisible();
         }
@@ -112,10 +112,10 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
         await Menu.openMapEditor(page);
         await MapEditor.openEntityEditor(page);
         await EntityEditor.selectEntity(page, 0, "small table");
-        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.5);
+        await EntityEditor.moveAndClick(page, 1, 8.5 * 32);
         await EntityEditor.clearEntitySelection(page);
-        // await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.5);
-        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.45);
+        // await EntityEditor.moveAndClick(page, 1, 8.5 * 32);
+        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 - 10);
         await EntityEditor.setEntityName(page, "My Open Link");
         await EntityEditor.addProperty(page, "openFile");
         await EntityEditor.setOpenFileProperty(page);
@@ -127,7 +127,7 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
         // await Menu.waitForMapLoad(page);
 
         // Move to the entity
-        await EntityEditor.moveAndRightClick(page, 0, 8.5 * 32 * 1.5);
+        await EntityEditor.moveAndRightClick(page, 0, 8.5 * 32);
 
         // Wait for the text to be visible
         await expect(page.getByText("SPACE to interact with it 👀")).toBeVisible({ timeout: 30000 });
@@ -154,7 +154,7 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
         // Create area on the map for the test
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 8 * 32 * 1.5, y: 8 * 32 * 1.5 }, { x: 10 * 32 * 1.5, y: 10 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 8 * 32, y: 8 * 32 }, { x: 10 * 32, y: 10 * 32 });
         await AreaEditor.setAreaName(page, "MyLinkZone");
         await AreaEditor.addProperty(page, "openFile");
         await AreaEditor.setOpenFileProperty(page, "Show immediately on enter");
@@ -188,7 +188,7 @@ test.describe("Map editor interacting with object @oidc @nomobile", () => {
 
         // Now let's check Entity PDF file deletion
         await page.keyboard.press("e");
-        await EntityEditor.moveAndClick(page, 16, 600);
+        await EntityEditor.moveAndClick(page, 16, 600, "browser");
         await page.keyboard.press("Delete");
 
         // Check if the PDF files from entity iframe are accessible

--- a/tests/tests/map_editor/map_editor_livekit.spec.ts
+++ b/tests/tests/map_editor/map_editor_livekit.spec.ts
@@ -34,7 +34,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
         // await expect(page.locator('canvas')).toBeVisible();
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(page, "livekitRoomProperty");
         await Menu.closeMapEditor(page);
         await Map.teleportToPosition(page, 4 * 32, 3 * 32);
@@ -71,7 +71,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
         // await expect(page.locator('canvas')).toBeVisible();
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(page, "livekitRoomProperty");
         await page.getByRole("textbox", { name: "Room Name", exact: true }).fill("foobar");
         await Menu.closeMapEditor(page);
@@ -119,7 +119,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
         // await expect(page.locator('canvas')).toBeVisible();
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(page, "livekitRoomProperty");
         await page.getByRole("textbox", { name: "Room Name", exact: true }).fill("foobar");
         await Menu.closeMapEditor(page);

--- a/tests/tests/map_editor/map_editor_lock_area.spec.ts
+++ b/tests/tests/map_editor/map_editor_lock_area.spec.ts
@@ -30,17 +30,17 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
     }) => {
         await resetWamMaps(request);
         await using page = await getPage(browser, "Admin1", Map.url("empty"));
-        const areaLeftBoundX = 1 * 32 * 1.5;
+        const areaLeftBoundX = 1 * 32;
 
         // Create an area just to the right of the spawn and make it lockable.
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 10 * 32 * 1.5, y: 7 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 10 * 32, y: 7 * 32 });
         await AreaEditor.addProperty(page, "lockableAreaPropertyData");
         await Menu.closeMapEditor(page);
 
         // Move admin in the area and lock it.
-        await Map.teleportToPosition(page, 4 * 32 * 1.5, 4 * 32 * 1.5);
+        await Map.teleportToPosition(page, 4 * 32, 4 * 32);
         await expect(page.getByTestId("lock-button")).toBeVisible();
         await page.getByTestId("lock-button").click();
         await expect(page.getByTestId("lock-button")).toHaveClass(/bg-danger/);
@@ -117,7 +117,7 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         await expect(page2.getByTestId("lock-button")).toHaveClass(/opacity-50/);
 
         // Admin goes back to the area and locks it.
-        await Map.teleportToPosition(page, 4 * 32 * 1.5, 4 * 32 * 1.5);
+        await Map.teleportToPosition(page, 4 * 32, 4 * 32);
         await expect(page.getByTestId("lock-button")).toBeVisible();
         await page.getByTestId("lock-button").click();
         await expect(page.getByTestId("lock-button")).toHaveClass(/bg-danger/);
@@ -134,17 +134,12 @@ test.describe("Map editor lockable area @oidc @nomobile @nowebkit", () => {
         });
         await expect(page.getByText("Tags allowed to lock/unlock")).toBeVisible();
 
-        await AreaEditor.moveArea(
-            page,
-            { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 },
-            { x: 10 * 32 * 1.5, y: 7 * 32 * 1.5 },
-            { x: 0, y: 5 * 32 * 1.5 },
-        );
+        await AreaEditor.moveArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 10 * 32, y: 7 * 32 }, { x: 0, y: 5 * 32 });
         await Menu.closeMapEditor(page);
 
         await Map.walkTo(page2, "ArrowDown", 2000);
         const alicePositionAfterAreaMove = await Map.getPosition(page2);
-        expect(alicePositionAfterAreaMove.y).toBeGreaterThan(6 * 32 * 1.5);
+        expect(alicePositionAfterAreaMove.y).toBeGreaterThan(6 * 32);
         await expect(page2.getByText("This area is locked. You cannot enter.")).toBeHidden();
 
         await page2.context().close();

--- a/tests/tests/map_editor/map_editor_max_users_in_area.spec.ts
+++ b/tests/tests/map_editor/map_editor_max_users_in_area.spec.ts
@@ -30,12 +30,12 @@ test.describe("Map editor max users in area @oidc @nomobile @nowebkit", () => {
     }) => {
         await resetWamMaps(request);
         await using page = await getPage(browser, "Admin1", Map.url("empty"));
-        const areaLeftBoundX = 1 * 32 * 1.5;
+        const areaLeftBoundX = 1 * 32;
 
         // Create an area next to spawn and set max users to 1.
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 10 * 32 * 1.5, y: 7 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 10 * 32, y: 7 * 32 });
         await AreaEditor.addProperty(page, "maxUsersInAreaPropertyData");
 
         const maxUsersInput = page.locator("#maxUsersInArea");
@@ -45,7 +45,7 @@ test.describe("Map editor max users in area @oidc @nomobile @nowebkit", () => {
         await Menu.closeMapEditor(page);
 
         // Admin enters the area and occupies the only available spot.
-        await Map.teleportToPosition(page, 4 * 32 * 1.5, 4 * 32 * 1.5);
+        await Map.teleportToPosition(page, 4 * 32, 4 * 32);
 
         // Alice cannot enter while Admin is inside.
         await using page2 = await getPage(browser, "Alice", Map.url("empty"));

--- a/tests/tests/map_editor/map_editor_megaphone_speaker_zone.spec.ts
+++ b/tests/tests/map_editor/map_editor_megaphone_speaker_zone.spec.ts
@@ -181,10 +181,10 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
         // await expect(page.locator('canvas')).toBeVisible();
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(page, "speakerMegaphone");
         await AreaEditor.setPodiumNameProperty(page, `${browser.browserType().name()}SpeakerZone`);
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 6 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 9 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 6 * 32 }, { x: 9 * 32, y: 9 * 32 });
         await AreaEditor.addProperty(page, "listenerMegaphone");
         await AreaEditor.setMatchingPodiumZoneProperty(
             page,
@@ -236,7 +236,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await using page = await getPage(browser, "Admin1", Map.url("empty"));
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(page, "speakerMegaphone");
         await AreaEditor.setPodiumNameProperty(
             page,
@@ -244,7 +244,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
             false,
             false,
         );
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 6 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 9 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 6 * 32 }, { x: 9 * 32, y: 9 * 32 });
         await AreaEditor.addProperty(page, "listenerMegaphone");
         await AreaEditor.setMatchingPodiumZoneProperty(
             page,
@@ -267,10 +267,10 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
         // await expect(page.locator('canvas')).toBeVisible();
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(page, "speakerMegaphone");
         await AreaEditor.setPodiumNameProperty(page, `${browser.browserType().name()}SpeakerZone`, true);
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 6 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 9 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 6 * 32 }, { x: 9 * 32, y: 9 * 32 });
         await AreaEditor.addProperty(page, "listenerMegaphone");
         await AreaEditor.setMatchingPodiumZoneProperty(
             page,
@@ -337,10 +337,10 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
         // await expect(page.locator('canvas')).toBeVisible();
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.addProperty(page, "speakerMegaphone");
         await AreaEditor.setPodiumNameProperty(page, `${browser.browserType().name()}SpeakerZone`, true, true);
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 6 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 9 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 6 * 32 }, { x: 9 * 32, y: 9 * 32 });
         await AreaEditor.addProperty(page, "listenerMegaphone");
         await AreaEditor.setMatchingPodiumZoneProperty(
             page,
@@ -653,13 +653,13 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
         // Draw a smaller speaker zone (podium) INSIDE the listener zone
         // Zone covers from (3,6) to (7,8) in tile coordinates - completely inside the listener zone
-        await AreaEditor.drawArea(page, { x: 3 * 32 * 1.5, y: 6 * 32 * 1.5 }, { x: 7 * 32 * 1.5, y: 8 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 3 * 32, y: 6 * 32 }, { x: 7 * 32, y: 8 * 32 });
         await AreaEditor.addProperty(page, "speakerMegaphone");
         await AreaEditor.setPodiumNameProperty(page, `${browser.browserType().name()}NestedPodium`);
 
         // Draw a large listener zone (attendees) - this will contain the speaker zone
         // Zone covers from (1,5) to (9,9) in tile coordinates
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 5 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 9 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 5 * 32 }, { x: 9 * 32, y: 9 * 32 });
         await AreaEditor.addProperty(page, "listenerMegaphone");
         await AreaEditor.setMatchingPodiumZoneProperty(
             page,

--- a/tests/tests/map_editor/map_editor_open_website.spec.ts
+++ b/tests/tests/map_editor/map_editor_open_website.spec.ts
@@ -35,7 +35,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 8 * 32 * 1.5, y: 8 * 32 * 1.5 }, { x: 10 * 32 * 1.5, y: 10 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 8 * 32, y: 8 * 32 }, { x: 10 * 32, y: 10 * 32 });
         await AreaEditor.setAreaName(page, "My app zone");
 
         await AreaEditor.addProperty(page, "openWebsite");
@@ -85,7 +85,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 8 * 32 * 1.5, y: 8 * 32 * 1.5 }, { x: 10 * 32 * 1.5, y: 10 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 8 * 32, y: 8 * 32 }, { x: 10 * 32, y: 10 * 32 });
         await AreaEditor.setAreaName(page, "My app zone");
 
         // add property Klaxoon
@@ -117,7 +117,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 8 * 32 * 1.5, y: 8 * 32 * 1.5 }, { x: 10 * 32 * 1.5, y: 10 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 8 * 32, y: 8 * 32 }, { x: 10 * 32, y: 10 * 32 });
 
         await AreaEditor.setAreaName(page, "My app zone");
 
@@ -218,11 +218,11 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
         // select entity and push it into the map
         await EntityEditor.selectEntity(page, 0, "small table");
-        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.5 - 15);
+        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 - 10);
 
         // quit object selector
         await EntityEditor.clearEntitySelection(page);
-        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.5 - 15);
+        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 - 10);
 
         // add property Google Docs
         await EntityEditor.addProperty(page, "openWebsiteGoogleDocs");
@@ -264,7 +264,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Menu.closeMapEditor(page);
 
         // click on the object and open popup
-        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.5 - 15);
+        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 - 10);
 
         // check if the popup with application is opened and can be close
         await expect(page.getByRole("button", { name: "Open Google Drive" })).toBeVisible();
@@ -288,11 +288,11 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
         // select entity and push it into the map
         await EntityEditor.selectEntity(page, 0, "small table");
-        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.5 - 15);
+        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 - 10);
 
         // quit object selector
         await EntityEditor.clearEntitySelection(page);
-        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.5 - 15);
+        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 - 10);
 
         // add property Klaxoon
         await EntityEditor.addProperty(page, "openWebsiteKlaxoon");
@@ -307,7 +307,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Menu.closeMapEditor(page);
 
         // click on the object and open popup
-        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.5 - 15);
+        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 - 10);
 
         // check if the cowebsite is opened
         await expect(page.locator("#cowebsites-container")).toBeVisible();

--- a/tests/tests/map_editor/map_editor_searchable.spec.ts
+++ b/tests/tests/map_editor/map_editor_searchable.spec.ts
@@ -34,7 +34,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
         // Area
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 }, { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 1 * 32, y: 2 * 32 }, { x: 9 * 32, y: 4 * 32 });
         await AreaEditor.setAreaName(page, "My Focusable Zone");
         await AreaEditor.setAreaDescription(
             page,
@@ -46,9 +46,9 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         // Entity
         await MapEditor.openEntityEditor(page);
         await EntityEditor.selectEntity(page, 0, "small table");
-        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.5 - 15);
+        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 - 10);
         await EntityEditor.clearEntitySelection(page);
-        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 * 1.5 - 15);
+        await EntityEditor.moveAndClick(page, 1, 8.5 * 32 - 10);
         await EntityEditor.setEntityName(page, "My Play Audio Entity");
         await EntityEditor.setEntityDescription(
             page,

--- a/tests/tests/map_editor/map_editor_start_exit.spec.ts
+++ b/tests/tests/map_editor/map_editor_start_exit.spec.ts
@@ -45,7 +45,7 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
         await Menu.openMapEditor(page);
         await MapEditor.openAreaEditor(page);
-        await AreaEditor.drawArea(page, { x: 8 * 32 * 1.5, y: 8 * 32 * 1.5 }, { x: 10 * 32 * 1.5, y: 10 * 32 * 1.5 });
+        await AreaEditor.drawArea(page, { x: 8 * 32, y: 8 * 32 }, { x: 10 * 32, y: 10 * 32 });
         await AreaEditor.addProperty(page, "exitAreaProperty");
         await AreaEditor.setExitProperty(page, "maps/start_defined.wam", "MyStartZone");
         await Menu.closeMapEditor(page);

--- a/tests/tests/map_editor/map_editor_upload_entities.spec.ts
+++ b/tests/tests/map_editor/map_editor_upload_entities.spec.ts
@@ -65,11 +65,11 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
         // Select uploaded entity and move it to the map
         await EntityEditor.selectEntity(page, 0, EntityEditor.getTestAssetName());
-        await EntityEditor.moveAndClick(page, 2 * 32 * 1.5, 8.5 * 32 * 1.5);
+        await EntityEditor.moveAndClick(page, 2 * 32, 8.5 * 32);
 
         // Add open link interaction on uploaded asset
         await EntityEditor.clearEntitySelection(page);
-        await EntityEditor.moveAndClick(page, 2 * 32 * 1.5, 8.5 * 32 * 1.5 - 16);
+        await EntityEditor.moveAndClick(page, 2 * 32, 8.5 * 32 - 11);
         await EntityEditor.addProperty(page, "openWebsite");
 
         // fill link
@@ -79,8 +79,8 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await Menu.closeMapEditor(page);
 
         // click on the object and open popup on both pages
-        await EntityEditor.moveAndClick(page, 2 * 32 * 1.5, 8.5 * 32 * 1.5 - 16);
-        await EntityEditor.moveAndClick(page2, 2 * 32 * 1.5, 8.5 * 32 * 1.5 - 16);
+        await EntityEditor.moveAndClick(page, 2 * 32, 8.5 * 32 - 11);
+        await EntityEditor.moveAndClick(page2, 2 * 32, 8.5 * 32 - 11);
 
         // Check if the cowebsite is opened
         await expect(page.locator("#cowebsites-container")).toBeVisible();
@@ -117,11 +117,11 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
 
         // Select uploaded entity and move it to the map
         await EntityEditor.selectEntity(page, 0, EntityEditor.getTestAssetName() + "OddSize");
-        await EntityEditor.moveAndClick(page, 6 * 32, 10 * 32);
+        await EntityEditor.moveAndClick(page, 6 * 32, 10 * 32, "browser");
 
         // Add open link interaction on uploaded asset
         await EntityEditor.clearEntitySelection(page);
-        await EntityEditor.moveAndClick(page, 6 * 32, 10 * 32);
+        await EntityEditor.moveAndClick(page, 6 * 32, 10 * 32, "browser");
         await EntityEditor.addProperty(page, "openWebsite");
 
         // fill link
@@ -133,10 +133,10 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         await page.getByTestId("camera-container").waitFor({ state: "detached" });
 
         // click on the object and open popup on both pages
-        await EntityEditor.moveAndClick(page, 6 * 32, 10 * 32);
+        await EntityEditor.moveAndClick(page, 6 * 32, 10 * 32, "browser");
 
         await page2.getByTestId("camera-container").waitFor({ state: "detached" });
-        await EntityEditor.moveAndClick(page2, 6 * 32, 10 * 32);
+        await EntityEditor.moveAndClick(page2, 6 * 32, 10 * 32, "browser");
 
         // Check if the cowebsite is opened
         await expect(page.locator("#cowebsites-container")).toBeVisible();

--- a/tests/tests/meeting.spec.ts
+++ b/tests/tests/meeting.spec.ts
@@ -267,7 +267,7 @@ test.describe("Meeting actions test @nomobile @nowebkit", () => {
     // Create a new area
     await Mapeditor.openAreaEditor(page);
     // Draw the area
-    await AreaEditor.drawArea(page, {x: 0*32*1.5, y: 5}, {x: 9*32*1.5, y: 4*32*1.5});
+    await AreaEditor.drawArea(page, {x: 0*32, y: 5}, {x: 9*32, y: 4*32});
     // Add a property Speaker zone to create new Jitsi meeting zone
     await AreaEditor.addProperty(page, 'Speaker zone');
     // Set the speaker zone property

--- a/tests/tests/personal_area_claim.spec.ts
+++ b/tests/tests/personal_area_claim.spec.ts
@@ -23,10 +23,10 @@ test.describe("Personal area claim @oidc @nomobile @nowebkit", () => {
 
         await resetWamMaps(request);
 
-        const areaCenterX = 4 * 32 * 1.5;
-        const areaCenterY = 4 * 32 * 1.5;
-        const outsideX = 15 * 32 * 1.5;
-        const outsideY = 15 * 32 * 1.5;
+        const areaCenterX = 4 * 32;
+        const areaCenterY = 4 * 32;
+        const outsideX = 15 * 32;
+        const outsideY = 15 * 32;
 
         await using adminPage = await getPage(browser, "Admin1", Map.url("empty"));
 

--- a/tests/tests/personal_desk_spawn_on_connect.spec.ts
+++ b/tests/tests/personal_desk_spawn_on_connect.spec.ts
@@ -24,8 +24,8 @@ test.describe("Personal desk spawn on connect @oidc @nomobile @nowebkit", () => 
 
         await resetWamMaps(request);
 
-        const areaCenterX = 4 * 32 * 1.5;
-        const areaCenterY = 4 * 32 * 1.5;
+        const areaCenterX = 4 * 32;
+        const areaCenterY = 4 * 32;
 
         await using adminPage = await getPage(browser, "Admin1", Map.url("empty"));
 

--- a/tests/tests/scripting_area.spec.ts
+++ b/tests/tests/scripting_area.spec.ts
@@ -25,7 +25,7 @@ test.describe("Scripting for Map editor @oidc @nomobile @nowebkit", () => {
         await using page = await getPage(browser, "Admin1", Map.url("empty"));
         await menu.openMapEditor(page);
         await mapeditor.openAreaEditor(page);
-        await areaEditor.drawArea(page, { x: 0, y: 7 * 32 * 1.5 }, { x: 5 * 32 * 1.5, y: 9 * 32 * 1.5 });
+        await areaEditor.drawArea(page, { x: 0, y: 7 * 32 }, { x: 5 * 32, y: 9 * 32 });
         await areaEditor.setAreaName(page, "MyZone");
 
         await evaluateScript(page, () => {

--- a/tests/tests/utils/AreaLivekit.ts
+++ b/tests/tests/utils/AreaLivekit.ts
@@ -10,16 +10,16 @@ interface Coordinates {
 
 class AreaLivekit {
     private areaSize: { topLeft: Coordinates; bottomRight: Coordinates } = {
-        topLeft: { x: 1, y: 2 * 32 * 1.5 },
-        bottomRight: { x: 9 * 32 * 1.5, y: 4 * 32 * 1.5 },
+        topLeft: { x: 1, y: 2 * 32 },
+        bottomRight: { x: 9 * 32, y: 4 * 32 },
     };
 
-    public entityPositionInArea: Coordinates = { x: 4 * 32 * 1.5, y: 3 * 32 * 1.5 };
-    public entityPositionOutsideArea: Coordinates = { x: 6 * 32 * 1.5, y: 8 * 32 * 1.5 };
+    public entityPositionInArea: Coordinates = { x: 4 * 32, y: 3 * 32 };
+    public entityPositionOutsideArea: Coordinates = { x: 6 * 32, y: 8 * 32 };
 
     public mouseCoordinatesToClickOnEntityInsideArea = {
         x: this.entityPositionInArea.x + 10,
-        y: this.entityPositionInArea.y - 50,
+        y: this.entityPositionInArea.y - 16,
     };
 
     public mouseCoordinatesToClickOnEntityOutsideArea = {

--- a/tests/tests/utils/areaAccessRights.ts
+++ b/tests/tests/utils/areaAccessRights.ts
@@ -12,12 +12,12 @@ interface Coordinates {
 
 class AreaAccessRights {
     private areaSize: { topLeft: Coordinates; bottomRight: Coordinates } = {
-        topLeft: { x: 1 * 32 * 1.5, y: 2 * 32 * 1.5 },
-        bottomRight: { x: 9 * 32 * 1.5, y: 7 * 32 * 1.5 },
+        topLeft: { x: 1 * 32, y: 2 * 32 },
+        bottomRight: { x: 9 * 32, y: 7 * 32 },
     };
 
-    public entityPositionInArea: Coordinates = { x: 4 * 32 * 1.5, y: 4 * 32 * 1.5 };
-    public entityPositionOutsideArea: Coordinates = { x: 8 * 32 * 1.5, y: 8 * 32 * 1.5 };
+    public entityPositionInArea: Coordinates = { x: 4 * 32, y: 4 * 32 };
+    public entityPositionOutsideArea: Coordinates = { x: 8 * 32, y: 8 * 32 };
 
     public mouseCoordinatesToClickOnEntityInsideArea = {
         x: this.entityPositionInArea.x + 10,

--- a/tests/tests/utils/doNotDisturbInfoToast.ts
+++ b/tests/tests/utils/doNotDisturbInfoToast.ts
@@ -8,11 +8,12 @@ import type { Page } from "@playwright/test";
 export async function dismissDoNotDisturbInfoToast(page: Page, timeoutMs: number = 5_000): Promise<void> {
     const onlineButton = page.getByTestId("do-not-disturb-activate");
     const microphone = page.getByTestId("microphone-button");
-    await Promise.race([
-        onlineButton.waitFor({ state: "visible", timeout: timeoutMs }),
-        microphone.waitFor({ state: "visible", timeout: timeoutMs }),
-    ]);
-    if (await onlineButton.isVisible()) {
+    const visibleControl = await Promise.race([
+        onlineButton.waitFor({ state: "visible", timeout: timeoutMs }).then(() => "online" as const),
+        microphone.waitFor({ state: "visible", timeout: timeoutMs }).then(() => "microphone" as const),
+    ]).catch(() => undefined);
+
+    if (visibleControl === "online") {
         await onlineButton.click();
     }
 }

--- a/tests/tests/utils/gameCoordinates.ts
+++ b/tests/tests/utils/gameCoordinates.ts
@@ -1,0 +1,55 @@
+import type { Page } from "@playwright/test";
+
+export interface Coordinates {
+    x: number;
+    y: number;
+}
+
+export type CoordinateSpace = "game" | "browser";
+
+export async function gameToBrowserCoordinates(page: Page, coordinates: Coordinates): Promise<Coordinates> {
+    return page.evaluate((coordinates) => {
+        const hooks = (
+            window as unknown as {
+                e2eHooks: {
+                    gameToBrowserCoordinates(coordinates: Coordinates): Promise<Coordinates>;
+                };
+            }
+        ).e2eHooks;
+
+        return hooks.gameToBrowserCoordinates(coordinates);
+    }, coordinates);
+}
+
+export async function coordinatesToBrowserCoordinates(
+    page: Page,
+    coordinates: Coordinates,
+    coordinateSpace: CoordinateSpace = "game",
+): Promise<Coordinates> {
+    if (coordinateSpace === "browser") {
+        return coordinates;
+    }
+
+    return gameToBrowserCoordinates(page, coordinates);
+}
+
+export async function moveMouseToCoordinates(
+    page: Page,
+    coordinates: Coordinates,
+    coordinateSpace: CoordinateSpace = "game",
+): Promise<Coordinates> {
+    const browserCoordinates = await coordinatesToBrowserCoordinates(page, coordinates, coordinateSpace);
+    await page.mouse.move(browserCoordinates.x, browserCoordinates.y);
+    return browserCoordinates;
+}
+
+export async function clickCoordinates(
+    page: Page,
+    coordinates: Coordinates,
+    options?: Parameters<Page["mouse"]["click"]>[2],
+    coordinateSpace: CoordinateSpace = "game",
+): Promise<Coordinates> {
+    const browserCoordinates = await coordinatesToBrowserCoordinates(page, coordinates, coordinateSpace);
+    await page.mouse.click(browserCoordinates.x, browserCoordinates.y, options);
+    return browserCoordinates;
+}

--- a/tests/tests/utils/map-editor/areaEditor.ts
+++ b/tests/tests/utils/map-editor/areaEditor.ts
@@ -2,6 +2,9 @@ import path from "path";
 import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 import Menu from "../menu";
+import { gameToBrowserCoordinates, moveMouseToCoordinates } from "../gameCoordinates";
+
+const CAMERA_PREVIEW_BROWSER_HEIGHT = 5 * 32 * 1.5;
 
 class AreaEditor {
     async selectMegaphoneItemInCMR(page: Page) {
@@ -11,17 +14,23 @@ class AreaEditor {
     async drawArea(page: Page, topLeft: { x: number; y: number }, bottomRight: { x: number; y: number }) {
         await page.mouse.move(1, 1);
         let cameraTurnedOff = false;
+        let browserTopLeft = await gameToBrowserCoordinates(page, topLeft);
+        let browserBottomRight = await gameToBrowserCoordinates(page, bottomRight);
+
         // If the area is towards the top of the screen, we turn off camera,
-        if (bottomRight.y < 5 * 32 * 1.5 || topLeft.y < 5 * 32 * 1.5) {
+        if (browserBottomRight.y < CAMERA_PREVIEW_BROWSER_HEIGHT || browserTopLeft.y < CAMERA_PREVIEW_BROWSER_HEIGHT) {
             await Menu.turnOffCamera(page);
             cameraTurnedOff = true;
-            await expect(page.getByText("You")).toBeHidden({
+            await expect(page.locator("#cameras-container").getByText("You", { exact: true })).toBeHidden({
                 timeout: 20_000,
             });
+            browserTopLeft = await gameToBrowserCoordinates(page, topLeft);
+            browserBottomRight = await gameToBrowserCoordinates(page, bottomRight);
         }
-        await page.mouse.move(topLeft.x, topLeft.y);
+
+        await page.mouse.move(browserTopLeft.x, browserTopLeft.y);
         await page.mouse.down();
-        await page.mouse.move(bottomRight.x, bottomRight.y);
+        await page.mouse.move(browserBottomRight.x, browserBottomRight.y);
         await page.mouse.up();
 
         if (cameraTurnedOff) {
@@ -35,9 +44,12 @@ class AreaEditor {
         bottomRight: { x: number; y: number },
         moveBy: { x: number; y: number },
     ) {
-        await page.mouse.move((topLeft.x + bottomRight.x) / 2, (topLeft.y + bottomRight.y) / 2);
+        const center = { x: (topLeft.x + bottomRight.x) / 2, y: (topLeft.y + bottomRight.y) / 2 };
+        const target = { x: center.x + moveBy.x, y: center.y + moveBy.y };
+
+        await moveMouseToCoordinates(page, center);
         await page.mouse.down();
-        await page.mouse.move((topLeft.x + bottomRight.x) / 2 + moveBy.x, (topLeft.y + bottomRight.y) / 2 + moveBy.y);
+        await moveMouseToCoordinates(page, target);
         await page.mouse.up();
     }
 

--- a/tests/tests/utils/map-editor/entityEditor.ts
+++ b/tests/tests/utils/map-editor/entityEditor.ts
@@ -1,6 +1,8 @@
 import * as path from "path";
 import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
+import type { CoordinateSpace } from "../gameCoordinates";
+import { moveMouseToCoordinates } from "../gameCoordinates";
 
 class EntityEditor {
     async selectEntity(page: Page, nb: number, search?: string) {
@@ -50,19 +52,21 @@ class EntityEditor {
         return page.getByTestId("entity-item").nth(0);
     }
 
-    async moveAndClick(page: Page, x: number, y: number) {
+    async moveAndClick(page: Page, x: number, y: number, coordinateSpace: CoordinateSpace = "game") {
         await this.wait2Frames(page);
-        await page.mouse.move(x, y);
-        await page.mouse.move(x, y);
+        const coordinates = { x, y };
+        const browserCoordinates = await moveMouseToCoordinates(page, coordinates, coordinateSpace);
+        await page.mouse.move(browserCoordinates.x, browserCoordinates.y);
         await page.mouse.down({ button: "left" });
         await page.mouse.up({ button: "left" });
         await this.wait2Frames(page);
     }
 
-    async moveAndRightClick(page: Page, x: number, y: number) {
+    async moveAndRightClick(page: Page, x: number, y: number, coordinateSpace: CoordinateSpace = "game") {
         await this.wait2Frames(page);
-        await page.mouse.move(x, y);
-        await page.mouse.move(x, y);
+        const coordinates = { x, y };
+        const browserCoordinates = await moveMouseToCoordinates(page, coordinates, coordinateSpace);
+        await page.mouse.move(browserCoordinates.x, browserCoordinates.y);
         await page.mouse.down({ button: "right" });
         await page.mouse.up({ button: "right" });
         await this.wait2Frames(page);

--- a/tests/tests/utils/map.ts
+++ b/tests/tests/utils/map.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { evaluateScript } from "./scripting";
 import { RENDERER_MODE } from "./environment";
 import { play_url } from "./urls";
+import { clickCoordinates } from "./gameCoordinates";
 
 class Map {
     async walkTo(page: Page, key: string, delay = 0) {
@@ -9,7 +10,7 @@ class Map {
     }
 
     async rightClickToPosition(page: Page, x: number, y: number, delay = 0) {
-        await page.mouse.click(x, y, { delay, button: "right" });
+        await clickCoordinates(page, { x, y }, { delay, button: "right" });
     }
 
     async walkToPosition(page: Page, x: number, y: number) {


### PR DESCRIPTION
## What changed

- Added `window.e2eHooks.gameToBrowserCoordinates(...)` to convert Phaser game/world coordinates into browser click coordinates using the current canvas bounds and Phaser camera transform.
- Made coordinate conversion wait for stable camera/canvas state by comparing coordinates across a frame and retrying every 500ms until stable or timeout.
- Added Playwright-side coordinate helpers and migrated shared area/entity/map mouse helpers to accept game coordinates.
- Removed hardcoded `* 1.5` game-to-browser coordinate conversions from the migrated E2E specs and shared test utilities.

## Why

Many E2E tests clicked inside the Phaser canvas by multiplying game coordinates by the current 1.5 zoom. That is fragile when camera zoom, scroll, canvas layout, or camera animations change. Centralizing the transform makes these tests less dependent on current rendering assumptions.

## Validation

- `cd play && npm run typecheck`
- `cd play && npx eslint src/front/Utils/E2EHooks.ts`
- `cd tests && npx eslint tests/utils/gameCoordinates.ts tests/utils/map-editor/areaEditor.ts tests/utils/map-editor/entityEditor.ts tests/utils/map.ts tests/utils/AreaLivekit.ts tests/utils/areaAccessRights.ts`
- `cd tests && npx eslint` on the changed E2E specs
- precommit hooks ran on commit, including lint-staged, `i18n:check`, schema export, and env docs generation

Full Playwright E2E was not run locally in this turn.