### PR TITLE
fix: handle OIDC tags claim as JSON-encoded string

### DIFF
--- a/play/src/pusher/services/JWTTokenManager.ts
+++ b/play/src/pusher/services/JWTTokenManager.ts
@@ -7,13 +7,37 @@ export const AuthTokenData = z.object({
     accessToken: z.string().optional(),
     username: z.string().optional(),
     locale: z.string().optional(),
-    tags: z.string().array().optional(),
+    tags: z.preprocess(
+        (val) => {
+            if (typeof val === "string") {
+                try {
+                    return JSON.parse(val);
+                } catch {
+                    return [val];
+                }
+            }
+            return val;
+        },
+        z.string().array()
+    ).optional(),
     matrixUserId: z.string().optional(),
 });
 export type AuthTokenData = z.infer<typeof AuthTokenData>;
 
 export const AccessTokenData = z.object({
-    tags: z.string().array().optional(),
+    tags: z.preprocess(
+        (val) => {
+            if (typeof val === "string") {
+                try {
+                    return JSON.parse(val);
+                } catch {
+                    return [val];
+                }
+            }
+            return val;
+        },
+        z.string().array()
+    ).optional(),
 });
 export type AccessTokenData = z.infer<typeof AccessTokenData>;
 

--- a/play/src/pusher/services/JWTTokenManager.ts
+++ b/play/src/pusher/services/JWTTokenManager.ts
@@ -7,8 +7,8 @@ export const AuthTokenData = z.object({
     accessToken: z.string().optional(),
     username: z.string().optional(),
     locale: z.string().optional(),
-    tags: z.preprocess(
-        (val) => {
+    tags: z
+        .preprocess((val) => {
             if (typeof val === "string") {
                 try {
                     return JSON.parse(val);
@@ -17,16 +17,15 @@ export const AuthTokenData = z.object({
                 }
             }
             return val;
-        },
-        z.string().array()
-    ).optional(),
+        }, z.string().array())
+        .optional(),
     matrixUserId: z.string().optional(),
 });
 export type AuthTokenData = z.infer<typeof AuthTokenData>;
 
 export const AccessTokenData = z.object({
-    tags: z.preprocess(
-        (val) => {
+    tags: z
+        .preprocess((val) => {
             if (typeof val === "string") {
                 try {
                     return JSON.parse(val);
@@ -35,9 +34,8 @@ export const AccessTokenData = z.object({
                 }
             }
             return val;
-        },
-        z.string().array()
-    ).optional(),
+        }, z.string().array())
+        .optional(),
 });
 export type AccessTokenData = z.infer<typeof AccessTokenData>;
 


### PR DESCRIPTION
Some OIDC providers (HashiCorp Vault, custom implementations) return the tags claim as a JSON-encoded string (`"[\"admin\",\"recorder\"]"`) instead of a native JSON array (`["admin","recorder"]`). This caused a Zod validation error and HTTP 500 on login.

Added `z.preprocess` to both `AuthTokenData` and `AccessTokenData` tags schemas in `JWTTokenManager.ts` to handle three cases:
1. JSON-encoded string array - parsed via `JSON.parse`
2. Plain string - wrapped in a single-element array
3. Native array - passed through unchanged

Closes #5635