### PR TITLE
Refactor AdminUserProvider to implement user caching

### DIFF
--- a/play/src/front/Chat/UserProvider/AdminUserProvider.ts
+++ b/play/src/front/Chat/UserProvider/AdminUserProvider.ts
@@ -1,26 +1,35 @@
-import type { Writable } from "svelte/store";
+import type { Readable } from "svelte/store";
 import { readable, writable } from "svelte/store";
 import type { ChatMember } from "@workadventure/messages";
 import { AvailabilityStatus } from "@workadventure/messages";
+import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import type { PartialChatUser } from "../Connection/ChatConnection";
 import type { RoomConnection } from "../../Connection/RoomConnection";
 import type { UserProviderInterface } from "./UserProviderInterface";
 
 export class AdminUserProvider implements UserProviderInterface {
-    users: Writable<PartialChatUser[]>;
-    private _setUsers: ((value: PartialChatUser[]) => void) | undefined;
+    users: Readable<PartialChatUser[]>;
+    private currentSearchText = "";
+    private setUsers: ((users: PartialChatUser[]) => void) | undefined;
+    private cachedUsers: PartialChatUser[] | undefined;
+    private queryAbortController: AbortController | undefined;
 
     constructor(private connection: RoomConnection) {
-        this.users = writable([] as PartialChatUser[], (set) => {
-            this._setUsers = set;
-            connection
-                .queryChatMembers("")
-                .then(({ members }) => {
-                    set(this.mapChatMembersToChatUser(members));
-                })
-                .catch((error) => {
-                    throw new Error("An error occurred while processing chat members: " + error);
-                });
+        this.users = readable([] as PartialChatUser[], (set) => {
+            this.setUsers = set;
+
+            // The first time we subscribe to this store, we make a request to the server to fetch the list of members from the Admin API
+            // The result is cached, so that subsequent subscriptions to this store don't trigger additional requests to the server.
+            // The cache is invalidated when the filter is changed.
+            if (this.cachedUsers !== undefined) {
+                set(this.cachedUsers);
+            } else if (!this.queryAbortController) {
+                this.loadUsers(this.currentSearchText).catch((error) => console.error(error));
+            }
+
+            return () => {
+                this.setUsers = undefined;
+            };
         });
     }
 
@@ -44,19 +53,50 @@ export class AdminUserProvider implements UserProviderInterface {
         }, [] as PartialChatUser[]);
     }
 
-    setFilter(searchText: string): Promise<void> {
-        return new Promise((res, rej) => {
-            this.connection
-                .queryChatMembers(searchText)
-                .then(({ members }) => {
-                    if (this._setUsers) {
-                        this._setUsers(this.mapChatMembersToChatUser(members));
-                        res();
-                    }
-                })
-                .catch((error) => {
-                    rej(new Error("An error occurred while processing chat members: " + error));
-                });
-        });
+    async setFilter(searchText: string): Promise<void> {
+        this.currentSearchText = searchText;
+        this.cachedUsers = undefined;
+        this.abortPendingRequest();
+
+        if (!this.setUsers) {
+            return;
+        }
+
+        await this.loadUsers(searchText);
+    }
+
+    private async loadUsers(searchText: string): Promise<void> {
+        const abortController = new AbortController();
+        this.queryAbortController = abortController;
+
+        try {
+            const { members } = await this.connection.queryChatMembers(searchText, abortController.signal);
+            const users = this.mapChatMembersToChatUser(members);
+
+            if (this.currentSearchText !== searchText || this.queryAbortController !== abortController) {
+                return;
+            }
+
+            this.cachedUsers = users;
+            this.setUsers?.(users);
+        } catch (error) {
+            if (error instanceof AbortError) {
+                return;
+            }
+            throw new Error("An error occurred while processing chat members: " + error, { cause: error });
+        } finally {
+            if (this.queryAbortController === abortController) {
+                this.queryAbortController = undefined;
+            }
+        }
+    }
+
+    private abortPendingRequest(): void {
+        if (!this.queryAbortController || this.queryAbortController.signal.aborted) {
+            return;
+        }
+
+        this.queryAbortController.abort(new AbortError("Chat members query superseded"));
+        this.queryAbortController = undefined;
     }
 }

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -1757,13 +1757,16 @@ export class RoomConnection implements RoomConnection {
         return answer.getMemberAnswer.member;
     }
 
-    public async queryChatMembers(searchText: string): Promise<ChatMembersAnswer> {
-        const answer = await this.query({
-            $case: "chatMembersQuery",
-            chatMembersQuery: {
-                searchText,
+    public async queryChatMembers(searchText: string, signal?: AbortSignal): Promise<ChatMembersAnswer> {
+        const answer = await this.query(
+            {
+                $case: "chatMembersQuery",
+                chatMembersQuery: {
+                    searchText,
+                },
             },
-        });
+            { signal }
+        );
         if (answer.$case !== "chatMembersAnswer") {
             throw new Error("Unexpected answer");
         }


### PR DESCRIPTION
The goal is to avoid overloading the AdminAPI with requests to the list of members that does not change much in a session. Touching the filter will refresh it.

Supersedes #5998 (simpler approach)