### PR TITLE
Fixing viewport and depths

### DIFF
--- a/play/src/front/Phaser/Entity/RemotePlayer.ts
+++ b/play/src/front/Phaser/Entity/RemotePlayer.ts
@@ -85,7 +85,7 @@ export class RemotePlayer extends Character implements ActivatableInterface {
         this.setX(position.x);
         this.setY(position.y);
 
-        this.setDepth(position.y); //this is to make sure the perspective (player models closer the bottom of the screen will appear in front of models nearer the top of the screen).
+        this.setDepth(position.y + 16); //this is to make sure the perspective (player models closer the bottom of the screen will appear in front of models nearer the top of the screen).
 
         if (this.companion) {
             this.companion.setTarget(position.x, position.y, position.direction);
@@ -187,7 +187,7 @@ export class RemotePlayer extends Character implements ActivatableInterface {
             if (this.pathToFollow.length === 1) {
                 this.x = this.pathToFollow[0].x;
                 this.y = this.pathToFollow[0].y;
-                this.setDepth(this.y);
+                this.setDepth(this.y + 16);
                 this.finishFollowingPath();
                 return;
             }
@@ -207,7 +207,6 @@ export class RemotePlayer extends Character implements ActivatableInterface {
             (this.currentPathSegmentDistanceFromStart / pathSegmentLength) * (segmentEndPos.y - segmentStartPos.y);
 
         this.moveToPos(newX, newY);
-        this.setDepth(this.y);
         this.scene.markDirty();
     }
 
@@ -216,6 +215,7 @@ export class RemotePlayer extends Character implements ActivatableInterface {
         const oldY = this.y;
         this.x = x;
         this.y = y;
+        this.setDepth(this.y + 16);
 
         if (Math.abs(x - oldX) > Math.abs((y - oldY) * 1.1)) {
             if (x < oldX) {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -807,7 +807,7 @@ export class GameScene extends DirtyScene {
         // We create the player and position it on the map before connecting to the room to avoid any delay in the player
         // display when the connection is established. The player will be moved to the correct position when we
         // now the exact start position (after receiving the map updates)
-        this.createCurrentPlayer({ x: 0, y: 0 });
+        this.createCurrentPlayer();
         this.removeAllRemotePlayers(); //cleanup the list  of remote players in case the scene was rebooted
 
         this.tryMovePlayerWithMoveToParameter();
@@ -1844,12 +1844,6 @@ export class GameScene extends DirtyScene {
      * Initializes the connection to Pusher.
      */
     private connect(): void {
-        const camera = this.cameraManager.getCamera();
-        // camera.preRender() must be called before accessing worldView to ensure it's up to date, because it won't be set up until the first render.
-        // See: https://docs.phaser.io/phaser/concepts/cameras#world-view
-        // @ts-ignore preRender is protected, but the Phaser docs advertises this, so we ignore the warning.
-        camera.preRender();
-
         connectionManager
             .connectToRoomSocket(
                 this.roomUrl,
@@ -1875,8 +1869,7 @@ export class GameScene extends DirtyScene {
                     urlManager.getStartPositionNameFromUrl()
                 );
 
-                this.CurrentPlayer.x = startPosition.x;
-                this.CurrentPlayer.y = startPosition.y;
+                this.CurrentPlayer.teleportTo(startPosition.x, startPosition.y);
                 this.cameraManager.startFollowPlayer(this.CurrentPlayer);
 
                 this.mapEditorModeManager?.subscribeToRoomConnection(this.connection);
@@ -2197,9 +2190,6 @@ export class GameScene extends DirtyScene {
             throw new Error("No connection found when joining room");
         }
 
-        const camera = this.cameraManager.getCamera();
-        const worldView = camera.worldView;
-
         if (gameManager.currentStartedRoom.backgroundColor != undefined) {
             this.cameras.main.setBackgroundColor(gameManager.currentStartedRoom.backgroundColor);
         }
@@ -2212,12 +2202,7 @@ export class GameScene extends DirtyScene {
                 direction: PositionMessage_Direction.DOWN,
                 moving: false,
             },
-            {
-                left: worldView.x,
-                top: worldView.y,
-                right: worldView.right,
-                bottom: worldView.bottom,
-            },
+            this.getViewport(true),
             get(availabilityStatusStore),
             connectionManager.tabId
         );
@@ -3825,13 +3810,14 @@ ${escapedMessage}
         }
     }
 
-    private createCurrentPlayer(startPosition: PositionInterface) {
+    private createCurrentPlayer() {
         //TODO create animation moving between exit and start
         try {
             this.CurrentPlayer = new Player(
                 this,
-                startPosition.x,
-                startPosition.y,
+                // We start creating the player before we know its exact position in order to start lazy loading the texture.
+                0,
+                0,
                 this.playerName,
                 this.currentPlayerTexturesPromise,
                 PositionMessage_Direction.DOWN,
@@ -3891,27 +3877,43 @@ ${escapedMessage}
     private doPushPlayerPosition(event: HasPlayerMovedInterface): void {
         this.lastMoveEventSent = event;
         this.lastSentTick = this.currentTick;
+
+        this.connection?.sharePosition(event.x, event.y, event.direction, event.moving, this.getViewport());
+        iframeListener.hasPlayerMoved(event);
+    }
+
+    private getViewport(forceRecomputeCamera = false): ViewportInterface {
+        if (!this.scene.scene.renderer) {
+            const x = this.lastMoveEventSent?.x ?? this.CurrentPlayer.x;
+            const y = this.lastMoveEventSent?.y ?? this.CurrentPlayer.y;
+
+            // In the very special case where we have no renderer, the viewport will not move along the Woka.
+            // We need to adjust it manually. We set it to something very large to make sure the Woka sees
+            // everything around (useful for bots, even if so far, it is a trick)
+            return {
+                left: x - 3_000,
+                top: y - 3_000,
+                right: x + 3_000,
+                bottom: y + 3_000,
+            };
+        }
+
         const camera = this.cameras.main;
+
+        if (forceRecomputeCamera) {
+            // When calling this before the first render, camera.preRender() must be called before accessing worldView to ensure it's up to date.
+            // See: https://docs.phaser.io/phaser/concepts/cameras#world-view
+            // @ts-ignore preRender is protected, but the Phaser docs advertises this, so we ignore the warning.
+            camera.preRender();
+        }
+
         const worldView = camera.worldView;
-        let viewport = {
+        return {
             left: worldView.x,
             top: worldView.y,
             right: worldView.right,
             bottom: worldView.bottom,
         };
-        if (!this.scene.scene.renderer) {
-            // In the very special case where we have no renderer, the viewport will not move along the Woka.
-            // We need to adjust it manually. We set it to something very large to make sure the Woka sees
-            // everything around (useful for bots, even if so far, it is a trick)
-            viewport = {
-                left: event.x - 3_000,
-                top: event.y - 3_000,
-                right: event.x + 3_000,
-                bottom: event.y + 3_000,
-            };
-        }
-        this.connection?.sharePosition(event.x, event.y, event.direction, event.moving, viewport);
-        iframeListener.hasPlayerMoved(event);
     }
 
     private doAddPlayer(addPlayerData: AddPlayerInterface): void {

--- a/play/src/front/Phaser/Player/Player.ts
+++ b/play/src/front/Phaser/Player/Player.ts
@@ -297,7 +297,10 @@ export class Player extends Character {
         }
         passStatusToOnline();
         this.playAnimation(this._lastDirection, true);
-        this.setDepth(this.y + 16);
+        this.scene.physics.world.once(Phaser.Physics.Arcade.Events.WORLD_STEP, () => {
+            // We wait for the physics engine to recompute the correct player position, then we update the depth.
+            this.setDepth(body.position.y + 16);
+        });
 
         if (this.companion) {
             this.companion.setTarget(this.x, this.y, this._lastDirection);


### PR DESCRIPTION
Fixing the computation of the viewport on startup. This solves remote users not being visible until we move. Also fixing a super long standing bug where the depth of the sprites would not be perfect (remote players where 16 pixels to high and local player depth was one frame late)