### PR TITLE
fix: room area listener in direct message group

### DIFF
--- a/play/src/front/Chat/Components/Room/Room.svelte
+++ b/play/src/front/Chat/Components/Room/Room.svelte
@@ -16,6 +16,7 @@
 
     export let room: ChatRoom & ChatRoomMembershipManagement & ChatRoomModeration & ChatRoomNotificationControl;
 
+    const roomType = room.type;
     let hasUnreadMessage = room.hasUnreadMessages;
     const roomUnreadCount = room.unreadNotificationCount;
     let roomName = room.name;
@@ -49,7 +50,7 @@
             compact
             pictureStore={room.pictureStore}
             fallbackName={$roomName}
-            color={room.type === "direct" ? $peerAvatarColorStore ?? defaultColor : null}
+            color={$roomType === "direct" ? $peerAvatarColorStore ?? defaultColor : null}
         />
 
         {#if $isEncrypted}

--- a/play/src/front/Chat/Components/Room/RoomInvitation.svelte
+++ b/play/src/front/Chat/Components/Room/RoomInvitation.svelte
@@ -8,6 +8,7 @@
     import { IconLoader } from "@wa-icons";
 
     export let room: ChatRoom & ChatRoomMembershipManagement;
+    const roomType = room.type;
     let roomName = room.name;
     let loadingInvitation = false;
     $: peerAvatarColorStore = room.avatarFallbackColor;
@@ -48,7 +49,7 @@
             compact
             pictureStore={room.pictureStore}
             fallbackName={$roomName}
-            color={room.type === "direct" ? $peerAvatarColorStore ?? defaultColor : null}
+            color={$roomType === "direct" ? $peerAvatarColorStore ?? defaultColor : null}
         />
     </div>
     <div class="m-0 grow text-sm font-bold">

--- a/play/src/front/Chat/Components/Room/RoomMenu/RoomMenu.svelte
+++ b/play/src/front/Chat/Components/Room/RoomMenu/RoomMenu.svelte
@@ -39,6 +39,7 @@
     } from "@wa-icons";
 
     export let room: ChatRoom & ChatRoomMembershipManagement & ChatRoomNotificationControl & ChatRoomModeration;
+    const roomType = room.type;
     const areNotificationsMuted = room.areNotificationsMuted;
     let optionButtonRef: HTMLButtonElement | undefined = undefined;
     let hideOptions = true;
@@ -138,7 +139,7 @@
         return usersList;
     })();
 
-    $: matrixChatUser = room.type === "direct" ? members.find((u) => u.id !== localUserStore.getChatId()) : undefined;
+    $: matrixChatUser = $roomType === "direct" ? members.find((u) => u.id !== localUserStore.getChatId()) : undefined;
 
     $: chatUser = usersWithRoomPlayUri.find((u) => u.chatId === matrixChatUser?.id);
     $: isInTheSameMap = chatUser?.playUri === gameManager.getCurrentGameScene().roomUrl;
@@ -189,7 +190,7 @@
     $: matrixChatConnection = $isMatrixChatEnabledStore ? matrixConnectionFromGameManager() : undefined;
 
     $: showMatrixPeerProfileDebug =
-        DEBUG_MODE && matrixChatConnection !== undefined && room.type === "direct" && Boolean(matrixChatUser?.id);
+        DEBUG_MODE && matrixChatConnection !== undefined && $roomType === "direct" && Boolean(matrixChatUser?.id);
 
     function openMatrixPeerProfileDebug() {
         if (!matrixChatConnection || matrixChatUser?.id === undefined) {
@@ -219,7 +220,7 @@
     class:absolute={optionButtonRef !== undefined}
     class:hidden={hideOptions}
 >
-    {#if room.type === "direct"}
+    {#if $roomType === "direct"}
         <!-- Create Room Option to talk to the user -->
         <RoomOption
             IconComponent={IconCamera}

--- a/play/src/front/Chat/Connection/ChatConnection.ts
+++ b/play/src/front/Chat/Connection/ChatConnection.ts
@@ -69,7 +69,8 @@ export interface ChatRoomMember {
 export interface ChatRoom {
     readonly id: string;
     readonly name: Readable<string>;
-    readonly type: "direct" | "multiple";
+    /** Reactive: DM vs group can change (e.g. after ban/leave changes active member count). */
+    readonly type: Readable<"direct" | "multiple">;
     readonly hasUnreadMessages: Readable<boolean>;
     readonly unreadNotificationCount: Readable<number>;
     readonly pictureStore: PictureStore;

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -1,5 +1,5 @@
 import type { Readable, Unsubscriber, Writable } from "svelte/store";
-import { derived, get, writable } from "svelte/store";
+import { derived, get, readable, writable } from "svelte/store";
 import type {
     EmittedEvents,
     ICreateRoomOpts,
@@ -128,11 +128,9 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         this.roomList = new AutoDestroyingMapStore<string, MatrixChatRoom>();
         this.matrixRateLimiter = MatrixRateLimiter.getInstance();
         this.clientPromise = clientPromise;
-        this.directRooms = derived(this.roomList, (roomList) => {
-            return Array.from(roomList.values()).filter(
-                (room) => get(room.myMembership) === KnownMembership.Join && room.type === "direct"
-            );
-        });
+        this.directRooms = this.createJoinedRoomsReadable(
+            (room) => get(room.myMembership) === KnownMembership.Join && get(room.type) === "direct"
+        );
 
         this.directRoomsUsers = derived(
             [this.directRooms, this.statusStore],
@@ -179,11 +177,9 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             }
         );
 
-        this.rooms = derived(this.roomList, (roomList) => {
-            return Array.from(roomList.values()).filter(
-                (room) => get(room.myMembership) === KnownMembership.Join && room.type === "multiple"
-            );
-        });
+        this.rooms = this.createJoinedRoomsReadable(
+            (room) => get(room.myMembership) === KnownMembership.Join && get(room.type) === "multiple"
+        );
 
         this.hasUnreadMessages = derived(
             this.roomList,
@@ -296,6 +292,38 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
 
         this.statusUnsubscriber = this.statusStore.subscribe((status: AvailabilityStatus) => {
             this.setPresence(status);
+        });
+    }
+
+    /**
+     * Recomputes when the room list changes or when any room's membership / DM-vs-group {@link MatrixChatRoom.type}
+     * changes (so UI lists move rooms between Direct messages and Group conversations).
+     */
+    private createJoinedRoomsReadable(predicate: (room: MatrixChatRoom) => boolean): Readable<MatrixChatRoom[]> {
+        return readable<MatrixChatRoom[]>([], (set) => {
+            let childUnsubs: Unsubscriber[] = [];
+            const clearChildSubs = () => {
+                childUnsubs.forEach((u) => u());
+                childUnsubs = [];
+            };
+            const listRooms = () => Array.from(get(this.roomList).values());
+            const bump = () => {
+                set(listRooms().filter(predicate));
+            };
+            const rewireRoomSignals = () => {
+                clearChildSubs();
+                for (const room of listRooms()) {
+                    childUnsubs.push(room.myMembership.subscribe(bump));
+                    childUnsubs.push(room.type.subscribe(bump));
+                }
+                bump();
+            };
+            const unsubList = this.roomList.subscribe(rewireRoomSignals);
+            rewireRoomSignals();
+            return () => {
+                unsubList();
+                clearChildSubs();
+            };
         });
     }
 
@@ -1179,7 +1207,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
                     .filter((member) => member.id && ["join", "invite"].includes(get(member.membership)))
                     .map((member) => member.id);
                 return (
-                    room.type === "direct" &&
+                    get(room.type) === "direct" &&
                     memberIDs.some((memberId) => memberId === userID && memberIDs.length === 2)
                 );
             })

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -730,7 +730,34 @@ export class MatrixChatRoom
         return;
     }
 
+    /**
+     * True when this room is linked to a Matrix space (`m.space.parent`), e.g. map area chats created
+     * under the room-area folder. Those rooms must stay "multiple" in the WA UI even with only two
+     * members (user + admin bot); the old `members.length === 2` heuristic would wrongly list them as DMs.
+     */
+    private hasMatrixSpaceParent(): boolean {
+        const events =
+            this.matrixRoom
+                .getLiveTimeline()
+                ?.getState(EventTimeline.FORWARDS)
+                ?.getStateEvents(EventType.SpaceParent) ?? [];
+        return events.some((ev) => Boolean(ev.getStateKey()));
+    }
+
+    /** `m.room.create` content `is_direct` (Matrix-native DM flag). */
+    private isRoomCreatedAsDirect(): boolean {
+        const events =
+            this.matrixRoom.getLiveTimeline()?.getState(EventTimeline.FORWARDS)?.getStateEvents(EventType.RoomCreate) ??
+            [];
+        const ev = events.find((e) => e.getStateKey() === "") ?? events[0];
+        return ev?.getContent()?.is_direct === true;
+    }
+
     private getMatrixRoomType(): "direct" | "multiple" {
+        if (this.hasMatrixSpaceParent()) {
+            return "multiple";
+        }
+
         const dmInviter = this.matrixRoom.getDMInviter();
         if (dmInviter) {
             return "direct";
@@ -752,7 +779,7 @@ export class MatrixChatRoom
             (member) => directRoomsPerUsers && directRoomsPerUsers[member.userId]?.includes(this.id)
         );
 
-        if (isDirectBasedOnRoomData || members.length === 2) {
+        if (isDirectBasedOnRoomData || (members.length === 2 && this.isRoomCreatedAsDirect())) {
             return "direct";
         }
 

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -23,8 +23,9 @@ import {
     TimelineWindow,
     EventTimeline,
 } from "matrix-js-sdk";
+import { KnownMembership } from "matrix-js-sdk/lib/@types/membership";
 import type { Readable, Writable } from "svelte/store";
-import { derived, get, readable, writable } from "svelte/store";
+import { derived, get, readable, readonly, writable } from "svelte/store";
 import type { MediaEventContent, MediaEventInfo } from "matrix-js-sdk/lib/@types/media";
 import { MapStore, SearchableArrayStore } from "@workadventure/store-utils";
 import type { RoomMessageEventContent } from "matrix-js-sdk/lib/@types/events";
@@ -63,7 +64,8 @@ export class MatrixChatRoom
 {
     readonly id: string;
     readonly name: Writable<string>;
-    readonly type: "multiple" | "direct";
+    private readonly roomTypeStore: Writable<"multiple" | "direct">;
+    readonly type: Readable<"multiple" | "direct">;
     readonly hasUnreadMessages: Writable<boolean>;
     readonly unreadNotificationCount: Writable<number>;
     pictureStore: PictureStore;
@@ -100,6 +102,7 @@ export class MatrixChatRoom
      */
     private readonly userProviderMergerStore = writable<UserProviderMerger | undefined>(undefined);
     private dmMergerUsersByRoomUnsub: (() => void) | undefined;
+    private dmMergerRoomTypeUnsub: (() => void) | undefined;
 
     constructor(
         private matrixRoom: Room,
@@ -135,7 +138,8 @@ export class MatrixChatRoom
     ) {
         this.id = matrixRoom.roomId;
         this.name = writable(matrixRoom.name);
-        this.type = this.getMatrixRoomType();
+        this.roomTypeStore = writable(this.getMatrixRoomType());
+        this.type = readonly(this.roomTypeStore);
         this.hasUnreadMessages = writable(matrixRoom.getUnreadNotificationCount() > 0);
         this.unreadNotificationCount = writable(matrixRoom.getUnreadNotificationCount());
         const roomAvatarStore: PictureStore = readable(
@@ -154,37 +158,28 @@ export class MatrixChatRoom
         ]);
         this.membersForMessageAvatars = this.members;
 
-        if (this.type === "direct") {
-            const myUserIdForDmPicture = this.matrixRoom.client.getUserId();
-            const otherMemberInitial = get(this.members).find((m) => m.id !== myUserIdForDmPicture);
-            const initialDirectPicture =
-                get(roomAvatarStore) ?? (otherMemberInitial ? get(otherMemberInitial.pictureStore) : undefined);
-            this.pictureStore = readable<string | undefined>(initialDirectPicture, (set) => {
-                let unsubOtherPicture: (() => void) | undefined;
-                const unsubMembers = this.members.subscribe(() => {
-                    unsubOtherPicture?.();
-                    unsubOtherPicture = undefined;
-                    const myUserId = this.matrixRoom.client.getUserId();
-                    const other = get(this.members).find((m) => m.id !== myUserId);
-                    if (!other) {
-                        set(get(roomAvatarStore));
-                        return;
-                    }
-                    unsubOtherPicture = other.pictureStore.subscribe((memberUrl) => {
-                        set(get(roomAvatarStore) ?? memberUrl);
-                    });
-                });
-                return () => {
-                    unsubMembers();
-                    unsubOtherPicture?.();
-                };
-            });
-        } else {
-            this.pictureStore = roomAvatarStore;
-        }
+        /** Channel: room avatar. DM: room avatar or peer Matrix avatar (peer read via `get`; list row refreshes on `members` / type changes). */
+        this.pictureStore = derived(
+            [this.roomTypeStore, roomAvatarStore, this.members],
+            ([roomType, roomAvatar, members]) => {
+                if (roomType !== "direct") {
+                    return roomAvatar;
+                }
+                const myUserId = this.matrixRoom.client.getUserId();
+                const other = members.find((m) => m.id !== myUserId);
+                if (!other) {
+                    return roomAvatar;
+                }
+                return roomAvatar ?? get(other.pictureStore);
+            }
+        );
 
-        if (this.type === "direct") {
-            this.avatarFallbackColor = derived([this.members, this.userProviderMergerStore], ([members, merger]) => {
+        this.avatarFallbackColor = derived(
+            [this.roomTypeStore, this.members, this.userProviderMergerStore],
+            ([roomType, members, merger]) => {
+                if (roomType !== "direct") {
+                    return undefined;
+                }
                 const myUserId = this.matrixRoom.client.getUserId();
                 const other = members.find((m) => m.id !== myUserId);
                 if (!other) {
@@ -202,28 +197,26 @@ export class MatrixChatRoom
                     }
                 }
                 return resolveChatUserColor(other.id, mergerColor, this.matrixRoom.client);
-            });
-        } else {
-            this.avatarFallbackColor = readable(undefined);
-        }
+            }
+        );
 
-        if (this.type === "direct") {
-            this.peerWaDisplayNameIfDifferent = derived(
-                this.members,
-                (members, set: (value: string | undefined) => void) => {
-                    const myUserId = this.matrixRoom.client.getUserId();
-                    const other = members.find((m) => m.id !== myUserId);
-                    if (!other) {
-                        set(undefined);
-                        return () => {};
-                    }
-                    return other.waDisplayNameIfDifferent.subscribe((v) => set(v));
-                },
-                undefined as string | undefined
-            );
-        } else {
-            this.peerWaDisplayNameIfDifferent = readable(undefined);
-        }
+        this.peerWaDisplayNameIfDifferent = derived(
+            [this.roomTypeStore, this.members],
+            ([roomType, members], set: (value: string | undefined) => void) => {
+                if (roomType !== "direct") {
+                    set(undefined);
+                    return () => {};
+                }
+                const myUserId = this.matrixRoom.client.getUserId();
+                const other = members.find((m) => m.id !== myUserId);
+                if (!other) {
+                    set(undefined);
+                    return () => {};
+                }
+                return other.waDisplayNameIfDifferent.subscribe((v) => set(v));
+            },
+            undefined as string | undefined
+        );
 
         this.hasPreviousMessage = writable(false);
 
@@ -294,14 +287,23 @@ export class MatrixChatRoom
             .userProviderMerger.then((merger) => {
                 this.userProviderMergerStore.set(merger);
                 get(this.members).forEach((m) => m.setUserProviderMergerContext(merger));
-                if (this.type === "direct") {
+
+                const syncDmMergerAvatarSub = () => {
+                    this.dmMergerUsersByRoomUnsub?.();
+                    this.dmMergerUsersByRoomUnsub = undefined;
+                    if (get(this.roomTypeStore) !== "direct") {
+                        return;
+                    }
                     this.dmMergerUsersByRoomUnsub = merger.usersByRoomStore.subscribe(() => {
                         const myUserId = this.matrixRoom.client.getUserId();
                         get(this.members)
                             .filter((mem) => mem.id !== myUserId)
                             .forEach((mem) => mem.refreshAvatarFromRoomMember());
                     });
-                }
+                };
+                syncDmMergerAvatarSub();
+                this.dmMergerRoomTypeUnsub?.();
+                this.dmMergerRoomTypeUnsub = this.roomTypeStore.subscribe(syncDmMergerAvatarSub);
             })
             .catch(() => {
                 /* chat list can work without merger */
@@ -370,6 +372,7 @@ export class MatrixChatRoom
 
     protected onRoomMyMembership(room: Room) {
         this.myMembership.set(room.getMyMembership());
+        this.refreshRoomType();
     }
 
     private onRoomNewMember(event: MatrixEvent, state: RoomState, member: RoomMember) {
@@ -379,6 +382,7 @@ export class MatrixChatRoom
             newWrapper.setUserProviderMergerContext(merger);
         }
         this.members.update((members) => [...members, newWrapper]);
+        this.refreshRoomType();
     }
 
     /** Room member state updates (e.g. avatar_url) without a separate RoomMember "name" event. */
@@ -386,6 +390,7 @@ export class MatrixChatRoom
         if (event.getType() !== EventType.RoomMember) {
             return;
         }
+        this.refreshRoomType();
         const myUserId = this.matrixRoom.client.getUserId();
         if (member.userId === myUserId) {
             return;
@@ -395,6 +400,9 @@ export class MatrixChatRoom
             .forEach((m) => m.refreshAvatarFromRoomMember());
     }
     private onRoomStateEvent(event: MatrixEvent, state: RoomState, lastStateEvent: MatrixEvent | null) {
+        if (event.getType() === EventType.SpaceParent) {
+            this.refreshRoomType();
+        }
         if (get(this.isEncrypted)) return;
         const isEncrypted = !!state.getStateEvents(EventType.RoomEncryption)[0];
         if (isEncrypted) this.isEncrypted.set(isEncrypted);
@@ -753,6 +761,18 @@ export class MatrixChatRoom
         return ev?.getContent()?.is_direct === true;
     }
 
+    /**
+     * Members that still participate or may join (`join` / `invite`). Left and banned users are
+     * excluded so DM vs group heuristics match what users see in the conversation.
+     */
+    private getMembersForRoomTypeHeuristics(): RoomMember[] {
+        return this.matrixRoom
+            .getMembers()
+            .filter(
+                (member) => member.membership === KnownMembership.Join || member.membership === KnownMembership.Invite
+            );
+    }
+
     private getMatrixRoomType(): "direct" | "multiple" {
         if (this.hasMatrixSpaceParent()) {
             return "multiple";
@@ -763,7 +783,7 @@ export class MatrixChatRoom
             return "direct";
         }
 
-        const members = this.matrixRoom.getMembers();
+        const members = this.getMembersForRoomTypeHeuristics();
         const isDirectBasedOnInviter = members.some((member) => member.getDMInviter() !== undefined);
         if (isDirectBasedOnInviter) {
             return "direct";
@@ -779,11 +799,18 @@ export class MatrixChatRoom
             (member) => directRoomsPerUsers && directRoomsPerUsers[member.userId]?.includes(this.id)
         );
 
-        if (isDirectBasedOnRoomData || (members.length === 2 && this.isRoomCreatedAsDirect())) {
+        if (isDirectBasedOnRoomData || members.length === 2 || this.isRoomCreatedAsDirect()) {
             return "direct";
         }
 
         return "multiple";
+    }
+
+    private refreshRoomType(): void {
+        const next = this.getMatrixRoomType();
+        if (next !== get(this.roomTypeStore)) {
+            this.roomTypeStore.set(next);
+        }
     }
 
     async sendFiles(files: FileList) {

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -74,22 +74,22 @@ describe("MatrixChatConnection", () => {
     describe("Constructor", () => {
         const directChatRoom = {
             id: "directChatRoom",
-            type: "direct",
+            type: readable("direct"),
             myMembership: readable(KnownMembership.Join),
         } as unknown as MatrixChatRoom;
         const InviteDirectChatRoom = {
             id: "InviteDirectChatRoom",
-            type: "direct",
+            type: readable("direct"),
             myMembership: readable(KnownMembership.Invite),
         } as unknown as MatrixChatRoom;
         const multipleChatRoom = {
             id: "multipleChatRoom",
-            type: "multiple",
+            type: readable("multiple"),
             myMembership: readable(KnownMembership.Join),
         } as unknown as MatrixChatRoom;
         const InviteMultipleChatRoom = {
             id: "InviteMultipleChatRoom",
-            type: "multiple",
+            type: readable("multiple"),
             myMembership: readable(KnownMembership.Invite),
         } as unknown as MatrixChatRoom;
 

--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -96,7 +96,7 @@ const MAX_PARTICIPANTS_FOR_SOUND_NOTIFICATIONS = 5;
 export class ProximityChatRoom implements ChatRoom {
     id = "proximity";
     name = writable("Proximity Chat");
-    type: "direct" | "multiple" = "multiple";
+    type = readable<"direct" | "multiple">("multiple");
     hasUnreadMessages = writable(false);
     unreadMessagesCount = writable(0);
     unreadNotificationCount = writable(0);

--- a/play/src/front/Components/ProximityNotification/ProximityNotification.svelte
+++ b/play/src/front/Components/ProximityNotification/ProximityNotification.svelte
@@ -10,6 +10,7 @@
 
     export let notification: ProximityNotification;
 
+    const roomType = notification.room.type;
     $: roomName = notification.room.name;
 
     const NOTIFICATION_DURATION = 10000; // 10 seconds
@@ -89,7 +90,7 @@
             class="font-bold mb-1 text-base text-white truncate font-['Roboto_Condensed'] tracking-normal align-middle"
         >
             {notification.userName}
-            {#if notification.room.type !== "direct"}
+            {#if $roomType !== "direct"}
                 {$LL.chat.notification.in()}
                 {$roomName}
             {/if}


### PR DESCRIPTION
## Summary

Improves Matrix chat room placement and classification in the WorkAdventure UI: invited/joined rooms are more likely to appear under the correct space folder, area-based rooms are no longer mislabeled as **Direct messages**, and debug logging is removed.

## Changes

### 1. Space folder refresh on membership (`MatrixChatConnection`)

- On **`RoomEvent.MyMembership`** for **`invite`** and **`join`**, call **`refreshAllJoinedFoldersChildren()`** before **`manageRoomOrFolder`**, so joined space folders re-sync their children from local **`m.space.child`** state via **`MatrixRoomFolder.getChildren()`**.
- In **`handleOrphanRoom`**, skip **`createAndAddNewRootRoom`** when the room id is **already under** a folder in the **`roomFolders`** tree, avoiding duplicates after the refresh.

### 2. DM vs group channel classification (`MatrixChatRoom`)

- **`getMatrixRoomType()`** previously treated **any room with exactly two members** as a direct chat (`members.length === 2`). That misclassified **map area** rooms with only **you + the Matrix admin bot** as DMs.
- **Rooms with a Matrix space parent (`m.space.parent`)** are always classified as **`multiple`** (group / folder UI).
- The two-member shortcut now requires **`m.room.create`** with **`is_direct: true`**, or membership in **`m.direct`**, matching Matrix semantics and keeping real DMs created with `is_direct` / account data correct.

### 3. Cleanup

- Removed debug **`console.log` / `console.trace`** from Matrix chat modules (`MatrixChatConnection`, `MatrixChatRoom`, `MatrixRoomFolder`).

## How to test

1. **Invite / join** a child room of a space you are already joined to: it should list under that space folder, not only under “Group conversations”.
2. **Enter an area** that creates/opens a Matrix room with **two members** (user + admin): it should appear under **group / space** navigation, **not** under **Direct messages**.
3. **Start a normal DM** from the UI: it should still appear under **Direct messages**.

## Notes

- If the **parent space** is not visible to the client (not a member / not synced), folder placement may still fall back to the root list until the parent is available—unchanged limitation.
- Area rooms created **without** `m.space.parent` (e.g. misconfiguration) still benefit from the stricter **`is_direct` / `m.direct`** rule instead of the old blanket “2 members = DM” heuristic.