### PR TITLE
Log back stream close reasons

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -54,7 +54,7 @@ import type { EventSocket, RoomSocket, VariableSocket } from "../RoomManager";
 import { adminApi } from "../Services/AdminApi";
 import { MapLoadingError } from "../Services/MapLoadingError";
 import { getMapStorageClient } from "../Services/MapStorageClient";
-import { emitError, emitErrorOnRoomSocket } from "../Services/MessageHelpers";
+import { emitError, emitErrorOnRoomSocket, endUserConnectionWithReason } from "../Services/MessageHelpers";
 import { ModeratorTagFinder } from "../Services/ModeratorTagFinder";
 import { VariableError } from "../Services/VariableError";
 import { VariablesManager } from "../Services/VariablesManager";
@@ -252,7 +252,7 @@ export class GameRoom implements BrothersFinder {
                     deleteMapMessage: {},
                 },
             });
-            user.socket.end();
+            endUserConnectionWithReason(user.socket, "Map was deleted.");
         });
     }
 
@@ -292,8 +292,10 @@ export class GameRoom implements BrothersFinder {
                 );
                 // Remove the stale user from the room
                 this.leave(existingUser);
-                // Close the stale connection
-                existingUser.socket.end();
+                endUserConnectionWithReason(
+                    existingUser.socket,
+                    `A new connection from the same browser tab replaced this connection for user ${joinRoomMessage.userUuid}.`
+                );
             }
         }
 

--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -29,7 +29,12 @@ import type { Empty } from "@workadventure/messages/src/ts-proto-generated/googl
 import * as Sentry from "@sentry/node";
 import { asError } from "catch-unknown";
 import { socketManager } from "./Services/SocketManager";
-import { emitError, emitErrorOnAdminSocket, emitErrorOnRoomSocket } from "./Services/MessageHelpers";
+import {
+    emitError,
+    emitErrorOnAdminSocket,
+    emitErrorOnRoomSocket,
+    endUserConnectionWithReason,
+} from "./Services/MessageHelpers";
 import type { User, UserSocket } from "./Model/User";
 import type { GameRoom } from "./Model/GameRoom";
 import { Admin } from "./Model/Admin";
@@ -220,7 +225,7 @@ const roomManager = {
                     );
                     Sentry.captureException(e);
                     emitError(call, e);
-                    call.end();
+                    closeConnection(`Error while handling joinRoom message: ${asError(e).message}`);
                 }
             })().catch((e) => {
                 console.error(e);
@@ -228,7 +233,7 @@ const roomManager = {
             });
         });
 
-        const closeConnection = () => {
+        const closeConnection = (reason?: string) => {
             if (user !== null && room !== null) {
                 socketManager.leaveRoom(room, user);
             }
@@ -239,7 +244,11 @@ const roomManager = {
                 clearTimeout(pongTimeoutId);
                 pongTimeoutId = undefined;
             }
-            call.end();
+            if (reason !== undefined) {
+                endUserConnectionWithReason(call, reason);
+            } else {
+                call.end();
+            }
             room = null;
             user = null;
         };
@@ -295,16 +304,17 @@ const roomManager = {
                     "at : ",
                     today.toLocaleString("en-GB")
                 );
+                const reason =
+                    "Connection lost with user. The user did not send a pong message in time. You should never see this message in the browser.";
                 call.write({
                     message: {
                         $case: "errorMessage",
                         errorMessage: {
-                            message:
-                                "Connection lost with user. The user did not send a pong message in time. You should never see this message in the browser.",
+                            message: reason,
                         },
                     },
                 });
-                closeConnection();
+                closeConnection(reason);
             }, PONG_TIMEOUT);
         }, PING_INTERVAL);
     },

--- a/back/src/Services/MessageHelpers.ts
+++ b/back/src/Services/MessageHelpers.ts
@@ -34,6 +34,21 @@ export function emitError(Client: UserSocket, error: unknown): void {
     console.warn(message);
 }
 
+export function endUserConnectionWithReason(Client: UserSocket, reason: string): void {
+    if (Client.writable) {
+        Client.write({
+            message: {
+                $case: "backConnectionCloseReasonMessage",
+                backConnectionCloseReasonMessage: {
+                    reason,
+                },
+            },
+        });
+    }
+
+    Client.end();
+}
+
 export function emitErrorOnAdminSocket(Client: AdminSocket, error: unknown): void {
     const message = getMessageFromError(error);
 

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -80,7 +80,7 @@ import { eventProcessor } from "../Model/EventProcessorInit";
 import { gaugeManager } from "./GaugeManager";
 import { clientEventsEmitter } from "./ClientEventsEmitter";
 import { getMapStorageClient } from "./MapStorageClient";
-import { emitError } from "./MessageHelpers";
+import { emitError, endUserConnectionWithReason } from "./MessageHelpers";
 import { cpuTracker } from "./CpuTracker";
 
 const debug = Debug("socketmanager");
@@ -897,8 +897,7 @@ export class SocketManager {
         setTimeout(() => {
             // Let's leave the room now.
             room.leave(user);
-            // Let's close the connection when the user is banned.
-            user.socket.end();
+            endUserConnectionWithReason(user.socket, `User was banned: ${banUserMessageToSend.message}`);
         }, 10000);
     }
 
@@ -1124,7 +1123,7 @@ export class SocketManager {
                     type: "banned",
                 },
             });
-            recipient.socket.end();
+            endUserConnectionWithReason(recipient.socket, `User was banned: ${message}`);
         }
     }
 

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -1193,6 +1193,15 @@ message DuplicateUserConnectedMessage {
 }
 
 /**
+ * Internal message sent by the back to the pusher just before closing the
+ * joinRoom stream. The pusher must consume it and never forward it to the
+ * front.
+ */
+message BackConnectionCloseReasonMessage {
+  string reason = 1;
+}
+
+/**
  * Messages going from back and pusher to the front
  */
 message ServerToClientMessage {
@@ -1228,6 +1237,7 @@ message ServerToClientMessage {
     MeetingInvitationRequestTooHighMessage meetingInvitationRequestTooHighMessage = 39;
     MeetingInvitationRequestClosedMessage meetingInvitationRequestClosedMessage = 40;
     DuplicateUserConnectedMessage duplicateUserConnectedMessage = 41;
+    BackConnectionCloseReasonMessage backConnectionCloseReasonMessage = 42;
   }
 }
 

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -771,6 +771,10 @@ export class RoomConnection implements RoomConnection {
                         this._externalModuleMessage.next(message.externalModuleMessage);
                         break;
                     }
+                    case "backConnectionCloseReasonMessage": {
+                        console.warn("Received an internal back connection close reason message on the front.");
+                        break;
+                    }
                     default: {
                         // Security check: if we forget a "case", the line below will catch the error at compile-time.
                         const _exhaustiveCheck: never = message;

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -253,6 +253,7 @@ export class SocketManager implements ZoneEventListener {
             streamToBack = apiClient.joinRoom();
             clientEventsEmitter.emitClientJoin(socketData.userUuid, socketData.roomId);
             joinRoomEventEmitted = true;
+            let backConnectionCloseReason: string | undefined;
 
             socketData.backConnection = streamToBack;
 
@@ -277,6 +278,10 @@ export class SocketManager implements ZoneEventListener {
                             this.refreshRoomData(refreshMessage.roomId, refreshMessage.versionNumber);
                             break;
                         }
+                        case "backConnectionCloseReasonMessage": {
+                            backConnectionCloseReason = message.message.backConnectionCloseReasonMessage.reason;
+                            return;
+                        }
                     }
 
                     // Let's pass data over from the back to the client.
@@ -287,10 +292,12 @@ export class SocketManager implements ZoneEventListener {
                 .on("end", () => {
                     // Let's close the front connection if the back connection is closed. This way, we can retry connecting from the start.
                     if (!socketData.disconnecting) {
+                        const connectionCloseReason =
+                            backConnectionCloseReason ?? "No close reason received from back server.";
                         console.warn(
                             `Connection lost to back server '${apiClient.getChannel().getTarget()}' for room '${
                                 socketData.roomId
-                            }' and user '${socketData.userUuid}'/'${socketData.name}'`
+                            }' and user '${socketData.userUuid}'/'${socketData.name}'. Reason: ${connectionCloseReason}`
                         );
                         this.closeWebsocketConnection(client, 1011, "Connection lost to back server");
                     }


### PR DESCRIPTION
## What changed

- Added an internal `BackConnectionCloseReasonMessage` to `ServerToClientMessage`.
- Added a back helper that writes the close reason before intentionally ending a user stream.
- Used that helper for known back-side disconnect paths: join-room errors, pong timeout, map deletion, stale same-tab replacement, and bans.
- Updated pusher to consume the internal close-reason message, avoid forwarding it to the front, and include the reason in the back stream `end` log.
- Added a defensive front-side handler in case the internal message ever leaks past pusher.

## Why

Pusher currently logs `Connection lost to back server` on stream end without knowing whether the back closed the stream on purpose or why. Sending one final internal message before closing gives the pusher log enough context to distinguish expected and unexpected closes.

## Validation

- `npm run typecheck --workspace back`
- `npx eslint src/Services/MessageHelpers.ts src/RoomManager.ts src/Model/GameRoom.ts src/Services/SocketManager.ts` from `back/`
- `npx eslint src/pusher/services/SocketManager.ts src/front/Connection/RoomConnection.ts` from `play/`
- Commit hook also ran package precommit tasks, including play `i18n:check`.

Note: full play typecheck was previously blocked by existing i18n/type-generation errors unrelated to this change.
