### PR TITLE
Refactoring player start position

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -804,10 +804,6 @@ export class GameScene extends DirtyScene {
         this.subscribeToGameMapChanged();
         this.subscribeToEntitiesManagerObservables();
 
-        // We create the player and position it on the map before connecting to the room to avoid any delay in the player
-        // display when the connection is established. The player will be moved to the correct position when we
-        // now the exact start position (after receiving the map updates)
-        this.createCurrentPlayer();
         this.removeAllRemotePlayers(); //cleanup the list  of remote players in case the scene was rebooted
 
         this.tryMovePlayerWithMoveToParameter();
@@ -817,8 +813,6 @@ export class GameScene extends DirtyScene {
             { width: this.Map.widthInPixels, height: this.Map.heightInPixels },
             waScaleManager
         );
-
-        this.activatablesManager = new ActivatablesManager(this.CurrentPlayer);
 
         biggestAvailableAreaStore.recompute();
         if (ENABLE_MAP_EDITOR) {
@@ -1869,7 +1863,9 @@ export class GameScene extends DirtyScene {
                     urlManager.getStartPositionNameFromUrl()
                 );
 
-                this.CurrentPlayer.teleportTo(startPosition.x, startPosition.y);
+                this.createCurrentPlayer(startPosition);
+                this.activatablesManager = new ActivatablesManager(this.CurrentPlayer);
+
                 this.cameraManager.startFollowPlayer(this.CurrentPlayer);
 
                 this.mapEditorModeManager?.subscribeToRoomConnection(this.connection);
@@ -3812,14 +3808,14 @@ ${escapedMessage}
         }
     }
 
-    private createCurrentPlayer() {
+    private createCurrentPlayer(startPosition: PositionInterface) {
         //TODO create animation moving between exit and start
         try {
             this.CurrentPlayer = new Player(
                 this,
                 // We start creating the player before we know its exact position in order to start lazy loading the texture.
-                0,
-                0,
+                startPosition.x,
+                startPosition.y,
                 this.playerName,
                 this.currentPlayerTexturesPromise,
                 PositionMessage_Direction.DOWN,


### PR DESCRIPTION
Refactoring player start position. We are now only creating the player when we know its position. This avoids a bug were the camera would scroll crazily from top left corner on reconnect.