### PR TITLE
fix(matrix): Harden Matrix chat teardown and verification listeners

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/AskStartVerificationModal.svelte
+++ b/play/src/front/Chat/Connection/Matrix/AskStartVerificationModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onDestroy } from "svelte";
     import type { ShowSasCallbacks, Verifier } from "matrix-js-sdk/lib/crypto-api";
     import { VerificationRequestEvent, VerifierEvent, VerificationPhase } from "matrix-js-sdk/lib/crypto-api";
     import { VerificationMethod } from "matrix-js-sdk/lib/types";
@@ -7,7 +8,7 @@
     import LL from "../../../../i18n/i18n-svelte";
     import type { AskStartVerificationModalProps } from "./MatrixSecurity";
     import { matrixSecurity } from "./MatrixSecurity";
-    import { modals, onBeforeClose } from "@wa-modals";
+    import { modals } from "@wa-modals";
 
     interface Props {
         isOpen: boolean;
@@ -21,6 +22,7 @@
     let verifier: Verifier | undefined = $state();
     let listenersAttached = false;
     let verificationHandedOffToEmojiDialog = false;
+    let isDestroyed = false;
 
     const cleanupVerificationListeners = () => {
         if (!listenersAttached) {
@@ -43,8 +45,12 @@
         }
 
         try {
-            verifier = await request.startVerification(VerificationMethod.Sas);
+            const startedVerifier = await request.startVerification(VerificationMethod.Sas);
+            if (isDestroyed) {
+                return;
+            }
             cleanupVerificationListeners();
+            verifier = startedVerifier;
             request.on(VerificationRequestEvent.Change, handleChangeVerificationRequestEvent);
             verifier.on(VerifierEvent.ShowSas, handleVerifierEventShowSas);
             listenersAttached = true;
@@ -110,13 +116,8 @@
         }
     }
 
-    onBeforeClose(() => {
-        if (!verificationHandedOffToEmojiDialog) {
-            cleanupVerificationListeners();
-        }
-    });
-
     onDestroy(() => {
+        isDestroyed = true;
         if (!verificationHandedOffToEmojiDialog) {
             cleanupVerificationListeners();
         }

--- a/play/src/front/Chat/Connection/Matrix/AskStartVerificationModal.svelte
+++ b/play/src/front/Chat/Connection/Matrix/AskStartVerificationModal.svelte
@@ -7,7 +7,7 @@
     import LL from "../../../../i18n/i18n-svelte";
     import type { AskStartVerificationModalProps } from "./MatrixSecurity";
     import { matrixSecurity } from "./MatrixSecurity";
-    import { modals } from "@wa-modals";
+    import { modals, onBeforeClose } from "@wa-modals";
 
     interface Props {
         isOpen: boolean;
@@ -19,6 +19,19 @@
     let errorLabel: string | undefined = $state("");
     const doneDeferred = new Deferred<void>();
     let verifier: Verifier | undefined = $state();
+    let listenersAttached = false;
+    let verificationHandedOffToEmojiDialog = false;
+
+    const cleanupVerificationListeners = () => {
+        if (!listenersAttached) {
+            return;
+        }
+
+        listenersAttached = false;
+        verifier?.off(VerifierEvent.ShowSas, handleVerifierEventShowSas);
+        request.off(VerificationRequestEvent.Change, handleChangeVerificationRequestEvent);
+        verifier = undefined;
+    };
 
     async function acceptToStartVerification() {
         try {
@@ -29,11 +42,16 @@
             return;
         }
 
-        verifier = await request.startVerification(VerificationMethod.Sas);
-
-        request.on(VerificationRequestEvent.Change, handleChangeVerificationRequestEvent);
-
-        verifier.on(VerifierEvent.ShowSas, handleVerifierEventShowSas);
+        try {
+            verifier = await request.startVerification(VerificationMethod.Sas);
+            cleanupVerificationListeners();
+            request.on(VerificationRequestEvent.Change, handleChangeVerificationRequestEvent);
+            verifier.on(VerifierEvent.ShowSas, handleVerifierEventShowSas);
+            listenersAttached = true;
+        } catch (error) {
+            console.error("Failed to start verification request:", error);
+            errorLabel = "Failed to start verification request ...";
+        }
     }
 
     const handleVerifierEventShowSas = (showSasCallbacks: ShowSasCallbacks) => {
@@ -52,6 +70,7 @@
 
         if (!emojis) return;
 
+        verificationHandedOffToEmojiDialog = true;
         modals.close();
 
         matrixSecurity.openVerificationEmojiDialog({
@@ -66,21 +85,18 @@
             console.error("error with verify ...", error);
             errorLabel = "Failed to start verification ...";
             doneDeferred.reject();
-            verifier?.off(VerifierEvent.ShowSas, handleVerifierEventShowSas);
-            request.off(VerificationRequestEvent.Change, handleChangeVerificationRequestEvent);
+            cleanupVerificationListeners();
         });
     };
     const handleChangeVerificationRequestEvent = () => {
         if (request.phase === VerificationPhase.Done) {
             doneDeferred.resolve();
-            verifier?.off(VerifierEvent.ShowSas, handleVerifierEventShowSas);
-            request.off(VerificationRequestEvent.Change, handleChangeVerificationRequestEvent);
+            cleanupVerificationListeners();
         }
         if (request.phase === VerificationPhase.Cancelled) {
             errorLabel = "request was cancelled ...";
             doneDeferred.reject();
-            verifier?.off(VerifierEvent.ShowSas, handleVerifierEventShowSas);
-            request.off(VerificationRequestEvent.Change, handleChangeVerificationRequestEvent);
+            cleanupVerificationListeners();
         }
     };
 
@@ -93,6 +109,18 @@
             modals.close();
         }
     }
+
+    onBeforeClose(() => {
+        if (!verificationHandedOffToEmojiDialog) {
+            cleanupVerificationListeners();
+        }
+    });
+
+    onDestroy(() => {
+        if (!verificationHandedOffToEmojiDialog) {
+            cleanupVerificationListeners();
+        }
+    });
 </script>
 
 <Popup {isOpen}>

--- a/play/src/front/Chat/Connection/Matrix/DeviceVerificationPendingModal.svelte
+++ b/play/src/front/Chat/Connection/Matrix/DeviceVerificationPendingModal.svelte
@@ -15,14 +15,27 @@
     let { isOpen, startVerificationPromise, isInitiatedByMe = false }: Props = $props();
 
     $effect(() => {
+        let isActive = true;
+
         startVerificationPromise
             .then((verificationEmojiProps) => {
+                if (!isActive) {
+                    return;
+                }
                 modals.close();
                 matrixSecurity.openVerificationEmojiDialog(verificationEmojiProps);
             })
             .catch((error) => {
+                if (!isActive) {
+                    return;
+                }
                 console.error(error);
+                modals.close();
             });
+
+        return () => {
+            isActive = false;
+        };
     });
 </script>
 

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -1208,7 +1208,6 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         this.enqueueMatrixClientRoomManage(room);
     }
 
-    
     private setRootRoom(room: MatrixChatRoom): void {
         const roomId = room.id;
         const existingRoom = this.roomList.get(roomId);
@@ -1367,12 +1366,12 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
                 const rootFolder = new MatrixRoomFolder(room);
                 rootFolder.init();
                 this.registerFolderShell(rootFolder);
-                this.roomFolders.set(roomId, rootFolder);
+                this.setRootFolder(rootFolder);
             }
             return;
         }
         if (!this.roomList.has(roomId)) {
-            this.roomList.set(roomId, new MatrixChatRoom(room));
+            this.setRootRoom(new MatrixChatRoom(room));
         }
     }
 

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -158,7 +158,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         private matrixSecurity: MatrixSecurity = defaultMatrixSecurity,
     ) {
         this.connectionStatus = writable("CONNECTING");
-        this.roomList = new AutoDestroyingMapStore<string, MatrixChatRoom>();
+        this.roomList = new MapStore<string, MatrixChatRoom>();
         this.clientPromise = clientPromise;
         this.directRooms = this.createJoinedRoomsReadable(
             (room) => get(room.myMembership) === KnownMembership.Join && get(room.type) === "direct",
@@ -912,6 +912,9 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     }
 
     private detachRoomFromRootLists(roomId: string): void {
+        this.roomList.get(roomId)?.destroy();
+        this.roomFolders.get(roomId)?.destroy();
+
         this.roomList.delete(roomId);
         this.roomFolders.delete(roomId);
     }
@@ -1201,6 +1204,73 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         this.enqueueMatrixClientRoomManage(room);
     }
 
+    
+    private setRootRoom(room: MatrixChatRoom): void {
+        const roomId = room.id;
+        const existingRoom = this.roomList.get(roomId);
+        if (existingRoom && existingRoom !== room) {
+            existingRoom.destroy();
+        }
+        this.roomList.delete(roomId);
+
+        const existingFolder = this.roomFolders.get(roomId);
+        if (existingFolder) {
+            existingFolder.destroy();
+        }
+        this.roomFolders.delete(roomId);
+
+        this.roomList.set(roomId, room);
+    }
+
+    private setRootFolder(folder: MatrixRoomFolder): void {
+        const folderId = folder.id;
+        const existingFolder = this.roomFolders.get(folderId);
+        if (existingFolder && existingFolder !== folder) {
+            existingFolder.destroy();
+        }
+        this.roomFolders.delete(folderId);
+
+        const existingRoom = this.roomList.get(folderId);
+        if (existingRoom) {
+            existingRoom.destroy();
+        }
+        this.roomList.delete(folderId);
+
+        this.roomFolders.set(folderId, folder);
+    }
+
+    private deleteRootRoom(roomId: string): boolean {
+        const existingRoom = this.roomList.get(roomId);
+        if (!existingRoom) {
+            return false;
+        }
+        existingRoom.destroy();
+        this.roomList.delete(roomId);
+        return true;
+    }
+
+    private deleteRootFolder(roomId: string): boolean {
+        const existingFolder = this.roomFolders.get(roomId);
+        if (!existingFolder) {
+            return false;
+        }
+        existingFolder.destroy();
+        this.roomFolders.delete(roomId);
+        return true;
+    }
+
+    private removeFromRootLists(roomId: string): void {
+        this.deleteRootRoom(roomId);
+        this.deleteRootFolder(roomId);
+    }
+
+    private clearRootLists(): void {
+        Array.from(this.roomList.values()).forEach((room) => room.destroy());
+        this.roomList.clear();
+        Array.from(this.roomFolders.values()).forEach((folder) => folder.destroy());
+        this.roomFolders.clear();
+    }
+
     private async manageRoomOrFolder(room: Room): Promise<void> {
         const parentsIds = this.getParentRoomID(room);
 
@@ -1272,14 +1342,14 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             let roomFolder = parentFolder.folderList.get(roomId);
             if (!roomFolder) {
                 roomFolder = new MatrixRoomFolder(room);
-                parentFolder.folderList.set(roomId, roomFolder);
+                parentFolder.setFolderNode(roomFolder);
             }
             this.registerFolderShell(roomFolder);
             // Keep child space shells cheap; remote hierarchy is loaded only when the space is opened.
             roomFolder.init();
         } else {
             if (!parentFolder.roomList.has(roomId)) {
-                parentFolder.roomList.set(roomId, new MatrixChatRoom(room));
+                parentFolder.setRoomNode(new MatrixChatRoom(room));
             }
         }
 
@@ -1434,7 +1504,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     private createAndAddNewRootFolder(room: Room): void {
         if (this.roomFolders.get(room.roomId)) return;
         const newFolder = new MatrixRoomFolder(room);
-        this.roomFolders.set(newFolder.id, newFolder);
+        this.setRootFolder(newFolder);
         this.registerFolderShell(newFolder);
         newFolder.init();
 
@@ -1445,8 +1515,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
                     return;
                 }
                 roomIDs.forEach((roomID) => {
-                    this.roomList.delete(roomID);
-                    this.roomFolders.delete(roomID);
+                    this.removeFromRootLists(roomID);
                 });
             })
             .catch((e) => {
@@ -1456,7 +1525,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     }
     private createAndAddNewRootRoom(room: Room): MatrixChatRoom {
         const newRoom = new MatrixChatRoom(room);
-        this.roomList.set(newRoom.id, newRoom);
+        this.setRootRoom(newRoom);
         if (get(selectedRoomStore)?.id === newRoom.id) {
             selectedRoomStore.set(newRoom);
         }
@@ -1470,11 +1539,12 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         });
     }
     private async deleteRoom(roomId: string) {
-        const isRootRoom = this.roomList.delete(roomId);
+        const isRootRoom = this.deleteRootRoom(roomId);
         if (isRootRoom) {
             return;
         }
-        const isRootFolder = this.roomFolders.delete(roomId);
+
+        const isRootFolder = this.deleteRootFolder(roomId);
 
         if (isRootFolder) {
             this.unregisterFolderShell(roomId);
@@ -1640,7 +1710,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
                     await this.waitForNextSync();
                     return result;
                 } catch {
-                    this.roomFolders.delete(result.room_id);
+                    this.deleteRootFolder(result.room_id);
                     return Promise.reject(new Error(get(LL).chat.addRoomToFolderError()));
                 }
             }
@@ -1979,8 +2049,9 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
 
         this.roomFolders.forEach((folder) => {
             this.unregisterFolderShell(folder.id);
-            this.roomFolders.delete(folder.id);
+            folder.destroy();
         });
+        this.roomFolders.clear();
         const visibleSpaces = client.getVisibleRooms().filter((room) => room.isSpaceRoom());
 
         visibleSpaces.forEach((space) => {
@@ -1989,7 +2060,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
                 const spaceFolder = new MatrixRoomFolder(space);
                 spaceFolder.init();
                 this.registerFolderShell(spaceFolder);
-                this.roomFolders.set(spaceFolder.id, spaceFolder);
+                this.setRootFolder(spaceFolder);
             }
         });
     }
@@ -2013,22 +2084,26 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         this.parentRoomIdsByRoomId.clear();
         this.childRoomIdsBySpaceId.clear();
         this.folderShellsByRoomId.clear();
-        this.roomList.forEach((room) => {
-            this.roomList.delete(room.id);
-        });
-        this.client?.off(ClientEvent.Room, this.handleRoom);
-        this.client?.off(ClientEvent.DeleteRoom, this.handleDeleteRoom);
-        this.client?.off(RoomEvent.MyMembership, this.handleMyMembership);
-        this.client?.off("RoomState.events" as EmittedEvents, this.handleRoomStateEvent);
-        this.client?.off(RoomEvent.Name, this.handleName);
-        this.client?.off(UserEvent.Presence, this.handleUserPresence);
-        this.client?.off(CryptoEvent.VerificationRequestReceived, this.handleVerificationRequestReceived);
+        this.clearRootLists();
+
+        const client = this.client;
+        client?.off(ClientEvent.Room, this.handleRoom);
+        client?.off(ClientEvent.DeleteRoom, this.handleDeleteRoom);
+        client?.off(RoomEvent.MyMembership, this.handleMyMembership);
+        client?.off("RoomState.events" as EmittedEvents, this.handleRoomStateEvent);
+        client?.off(RoomEvent.Name, this.handleName);
+        client?.off(ClientEvent.AccountData, this.handleAccountDataEvent);
+        client?.off(UserEvent.Presence, this.handleUserPresence);
+        client?.off(CryptoEvent.VerificationRequestReceived, this.handleVerificationRequestReceived);
         if (this.directRoomsUnreadAggregateUnsubscriber) {
             this.directRoomsUnreadAggregateUnsubscriber();
             this.directRoomsUnreadAggregateUnsubscriber = undefined;
         }
         this.resetNbUnreadDirectRoomsMessagesAggregate();
-        if (this.statusUnsubscriber) this.statusUnsubscriber();
+        if (this.statusUnsubscriber) {
+            this.statusUnsubscriber();
+            this.statusUnsubscriber = undefined;
+        }
         if (this.wokaAvatarMatrixSyncUnsubscriber) {
             this.wokaAvatarMatrixSyncUnsubscriber();
             this.wokaAvatarMatrixSyncUnsubscriber = undefined;
@@ -2041,15 +2116,13 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             this.displayNameMatrixSyncUnsubscriber();
             this.displayNameMatrixSyncUnsubscriber = undefined;
         }
+        this.userIdsNeedingPresenceUpdate.clear();
     }
     async destroy(): Promise<void> {
-        await this.client?.logout(true);
-    }
-}
-
-class AutoDestroyingMapStore<K, V extends Required<{ destroy: () => void }>> extends MapStore<K, V> {
-    override delete(key: K): boolean {
-        this.get(key)?.destroy();
-        return super.delete(key);
+        const client = this.client;
+        this.clearListener();
+        this.client = undefined;
+        this.isClientReady = false;
+        await client?.logout(true);
     }
 }

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -82,6 +82,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     private static readonly spaceReconciliationDelaysMs = [0, 100, 300, 700, 1500];
     private readonly roomList: MapStore<string, MatrixChatRoom>;
     private client: MatrixClient | undefined;
+    private handleSync: (state: SyncState, prevState: SyncState | null, res?: { error?: unknown }) => void;
     private handleRoom: (room: Room) => void;
     private handleDeleteRoom: (roomId: string) => void;
     private handleMyMembership: (room: Room, membership: string, prevMembership: string | undefined) => void;
@@ -261,6 +262,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         this.handleMyMembership = this.onRoomEventMembership.bind(this);
         this.handleRoomStateEvent = this.onRoomStateEvent.bind(this);
         this.handleName = this.onRoomNameEvent.bind(this);
+        this.handleSync = this.onClientSync.bind(this);
         this.handleAccountDataEvent = this.onAccountDataEvent.bind(this);
         this.handleUserPresence = this.onUserPresenceEvent.bind(this);
         this.handleVerificationRequestReceived = this.onVerificationRequestReceived.bind(this);
@@ -729,35 +731,37 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         }
     }
 
+    private onClientSync(state: SyncState, prevState: SyncState | null, res?: { error?: unknown }): void {
+        if (!this.client) return;
+        switch (state) {
+            case SyncState.Prepared:
+                this.connectionStatus.set("ONLINE");
+                this.isClientReady = true;
+                break;
+            case SyncState.Error:
+                this.connectionStatus.set("ON_ERROR");
+                if (res?.error) {
+                    console.error("Matrix sync error (previous state: ", prevState, "): ", res.error);
+                    Sentry.captureException(res.error);
+                }
+                break;
+            case SyncState.Reconnecting:
+                this.connectionStatus.set("CONNECTING");
+                break;
+            case SyncState.Stopped:
+                this.connectionStatus.set("OFFLINE");
+                break;
+            case SyncState.Syncing:
+                if (get(this.connectionStatus) !== "ONLINE" && this.isClientReady) {
+                    this.connectionStatus.set("ONLINE");
+                }
+                break;
+        }
+    }
+
     async startMatrixClient() {
         if (!this.client) return;
-        this.client.on(ClientEvent.Sync, (state, prevState, res) => {
-            if (!this.client) return;
-            switch (state) {
-                case SyncState.Prepared:
-                    this.connectionStatus.set("ONLINE");
-                    this.isClientReady = true;
-                    break;
-                case SyncState.Error:
-                    this.connectionStatus.set("ON_ERROR");
-                    if (res?.error) {
-                        console.error("Matrix sync error (previous state: ", prevState, "): ", res?.error);
-                        Sentry.captureException(res?.error);
-                    }
-                    break;
-                case SyncState.Reconnecting:
-                    this.connectionStatus.set("CONNECTING");
-                    break;
-                case SyncState.Stopped:
-                    this.connectionStatus.set("OFFLINE");
-                    break;
-                case SyncState.Syncing:
-                    if (get(this.connectionStatus) !== "ONLINE" && this.isClientReady) {
-                        this.connectionStatus.set("ONLINE");
-                    }
-                    break;
-            }
-        });
+        this.client.on(ClientEvent.Sync, this.handleSync);
 
         this.client.on(ClientEvent.Room, this.handleRoom);
         this.client.on(ClientEvent.DeleteRoom, this.handleDeleteRoom);
@@ -1482,6 +1486,11 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     }
 
     private async findRoomOrFolder(roomId: string): Promise<MatrixRoomFolder | MatrixChatRoom | undefined> {
+        const managedNode = this.findManagedNodeById(roomId);
+        if (managedNode) {
+            return managedNode;
+        }
+
         const roomInRoomList = this.roomList.get(roomId);
         if (roomInRoomList) {
             return roomInRoomList;
@@ -1611,11 +1620,14 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
                     // Only notify for "live" invitations (after initial sync). Avoids notifying for existing invites on load (plan: live vs historical).
                     if (client.isInitialSyncComplete()) {
                         const roomName = room.name?.trim() || get(LL).chat.roomInvitation.unknownRoom();
-                        const chatRoom = new MatrixChatRoom(room);
                         chatNotificationStore.addNotification(
                             get(LL).chat.roomInvitation.notificationTitle(),
                             get(LL).chat.roomInvitation.notification({ roomName }),
-                            chatRoom,
+                            {
+                                roomId: room.roomId,
+                                roomName,
+                                roomType: "multiple",
+                            },
                             undefined,
                             false,
                         );
@@ -2031,16 +2043,34 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         return user && user.some((user) => user.id === address);
     }
 
-    getRoomByID(roomId: string): ChatRoom {
-        if (!this.client) {
-            throw new Error(CLIENT_NOT_INITIALIZED_ERROR_MSG);
-        }
-        const room = this.client.getRoom(roomId);
-        if (!room) {
-            throw new Error("Room not found");
+    private findManagedNodeById(roomId: string): MatrixRoomFolder | MatrixChatRoom | undefined {
+        const room = this.roomList.get(roomId);
+        if (room) {
+            return room;
         }
 
-        return new MatrixChatRoom(room);
+        const folder = this.roomFolders.get(roomId);
+        if (folder) {
+            return folder;
+        }
+
+        for (const rootFolder of this.roomFolders.values()) {
+            const node = rootFolder.findLoadedNode(roomId);
+            if (node) {
+                return node;
+            }
+        }
+
+        return undefined;
+    }
+
+    getRoomByID(roomId: string): ChatRoom {
+        const managedNode = this.findManagedNodeById(roomId);
+        if (!managedNode) {
+            throw new Error("Managed room not found");
+        }
+
+        return managedNode;
     }
 
     private rebuildSpaceHierarchy() {
@@ -2087,6 +2117,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         this.clearRootLists();
 
         const client = this.client;
+        client?.off(ClientEvent.Sync, this.handleSync);
         client?.off(ClientEvent.Room, this.handleRoom);
         client?.off(ClientEvent.DeleteRoom, this.handleDeleteRoom);
         client?.off(RoomEvent.MyMembership, this.handleMyMembership);

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
@@ -25,7 +25,7 @@ export class MatrixChatMessage implements ChatMessage {
     isMyMessage: boolean;
     date: Date | null;
     isQuotedMessage: boolean | undefined;
-    quotedMessage: ChatMessage | undefined;
+    quotedMessage: MatrixChatMessage | undefined;
     type: ChatMessageType;
     isDeleted: Writable<boolean>;
     isModified: Writable<boolean>;
@@ -101,6 +101,13 @@ export class MatrixChatMessage implements ChatMessage {
         this.loadAttachmentMediaIfNeeded();
     }
 
+    private setQuotedMessage(quotedMessage: MatrixChatMessage | undefined): void {
+        if (this.quotedMessage && this.quotedMessage !== quotedMessage) {
+            this.quotedMessage.destroy();
+        }
+        this.quotedMessage = quotedMessage;
+    }
+
     private getMessageContent(): ChatMessageContent {
         const unsigned = this.event.getUnsigned();
         const relation = unsigned["m.relations"];
@@ -117,12 +124,14 @@ export class MatrixChatMessage implements ChatMessage {
         const quotedMessage = this.getQuotedMessage();
 
         if (quotedMessage !== undefined && content.formatted_body) {
-            this.quotedMessage = quotedMessage;
+            this.setQuotedMessage(quotedMessage);
             return {
                 body: content.formatted_body.replace(/^(<mx-reply>).*(<\/mx-reply>)/, ""),
                 url: undefined,
             };
         }
+
+        this.setQuotedMessage(undefined);
 
         if (this.type === "image") {
             return {
@@ -250,7 +259,7 @@ export class MatrixChatMessage implements ChatMessage {
         });
     }
 
-    private getQuotedMessage() {
+    private getQuotedMessage(): MatrixChatMessage | undefined {
         if (!shouldRenderQuotedReply(this.event)) {
             return;
         }

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
@@ -39,6 +39,7 @@ export class MatrixChatMessage implements ChatMessage {
     private attachmentMediaCleanup: () => void = () => undefined;
     private attachmentMediaAbortController: AbortController | undefined;
     private readonly decryptedListener = () => this.updateMessageContentOnDecryptedEvent();
+    private destroyed = false;
 
     constructor(
         private event: MatrixEvent,
@@ -335,11 +336,25 @@ export class MatrixChatMessage implements ChatMessage {
     }
 
     destroy() {
+        if (this.destroyed) {
+            return;
+        }
+        this.destroyed = true;
+
         this.event.off(MatrixEventEvent.Decrypted, this.decryptedListener);
+        this.relations?.destroy();
+        this.relations = undefined;
+        this.quotedMessage?.destroy();
+        this.quotedMessage = undefined;
+        this.reactions.clear();
         this.imageMediaAbortController?.abort();
         this.imageMediaCleanup();
+        this.imageMediaAbortController = undefined;
+        this.imageMediaCleanup = () => undefined;
         this.attachmentMediaAbortController?.abort();
         this.attachmentMediaCleanup();
+        this.attachmentMediaAbortController = undefined;
+        this.attachmentMediaCleanup = () => undefined;
     }
 
     public getMatrixEvent(): MatrixEvent {

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -934,6 +934,9 @@ export class MatrixChatRoom
                 return;
             }
             this.dmMergerUsersByRoomUnsub = merger.usersByRoomStore.subscribe(() => {
+                                   if (this.destroyed) {
+                        return;
+                    }
                 this.directRoomPeerAvatarStore?.refresh().catch(() => undefined);
                 const myUserId = this.matrixRoom.client.getUserId();
                 get(this.members)
@@ -966,7 +969,13 @@ export class MatrixChatRoom
         if (this.matrixRoom.hasEncryptionStateEvent()) {
             await this.matrixRoom.decryptAllEvents();
         }
+        if (this.destroyed) {
+            return;
+        }
         await this.timelineWindow.load();
+        if (this.destroyed) {
+            return;
+        }
         const events = this.timelineWindow.getEvents();
 
         const decryptMessagesPromises: Promise<MatrixChatMessage | undefined>[] = [];
@@ -977,6 +986,10 @@ export class MatrixChatRoom
 
         const result = await Promise.all(decryptMessagesPromises);
         const messages = result.filter((message): message is MatrixChatMessage => message !== undefined);
+        if (this.destroyed) {
+            messages.forEach((message) => message.destroy());
+            return;
+        }
         this.messages.push(...messages);
         await this.processPollEvents(events);
         await this.syncTimelinePollItemsFromEvents(events);
@@ -995,10 +1008,16 @@ export class MatrixChatRoom
         event: MatrixEvent,
         messages: SearchableArrayStore<string, MatrixChatMessage>,
     ): Promise<MatrixChatMessage | undefined> {
+        if (this.destroyed) {
+            return undefined;
+        }
         if (event.isEncrypted()) {
             await this.matrixRoom.client.decryptEventIfNeeded(event).catch(() => {
                 console.error("Failed to decrypt");
             });
+        }
+        if (this.destroyed) {
+            return undefined;
         }
         if (
             event.getType() === "m.room.message" &&
@@ -1597,6 +1616,9 @@ export class MatrixChatRoom
         if (get(this.hasPreviousMessage)) {
             const existingEventsBeforePagination = this.timelineWindow.getEvents();
             await this.timelineWindow.paginate(Direction.Backward, 8);
+            if (this.destroyed) {
+                return;
+            }
             this.timelineWindow.unpaginate(existingEventsBeforePagination.length, false);
             const paginatedEvents = this.timelineWindow.getEvents();
             const tempMatrixChatMessages: Promise<MatrixChatMessage | undefined>[] = [];
@@ -1607,11 +1629,15 @@ export class MatrixChatRoom
             const result = await Promise.all(tempMatrixChatMessages);
 
             const messages = result.filter((message): message is MatrixChatMessage => message !== undefined);
+            if (this.destroyed) {
+                messages.forEach((message) => message.destroy());
+                return;
+            }
             this.messages.unshift(...messages);
             await this.processPollEvents(paginatedEvents);
             await this.syncTimelinePollItemsFromEvents(paginatedEvents);
             this.hasPreviousMessage.set(this.timelineWindow.canPaginate(Direction.Backward));
-            if (messages.length === 0) {
+            if (messages.length === 0 && !this.destroyed) {
                 await this.loadMorePreviousMessages();
             }
         }
@@ -2025,6 +2051,8 @@ export class MatrixChatRoom
         this.stopVisibleProfileSync();
         this.currentUserRoomMember?.off(RoomMemberEvent.PowerLevel, this.handleCurrentUserRoomMemberPowerLevel);
         this.currentUserRoomMember = undefined;
+        this.dmMergerRoomTypeUnsub?.();
+        this.dmMergerRoomTypeUnsub = undefined;
         this.matrixRoom.currentState.off(RoomStateEvent.Members, this.handleRoomStateMembers);
         this.matrixRoom.off(RoomEvent.Timeline, this.handleRoomTimeline);
         this.matrixRoom.off(PollEvent.New, this.handleNewPoll);
@@ -2237,6 +2265,9 @@ export class MatrixChatRoom
             return message;
         }
         const event = await this.getMatrixEventById(messageId);
+        if (this.destroyed) {
+            return undefined;
+        }
         if (event) {
             return this.createChatMessageFromEvent(event);
         }

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -1154,6 +1154,12 @@ export class MatrixChatRoom
         });
         await richPoll.refresh();
 
+        if (this.destroyed) {
+            // The room was torn down while hydrating: don't track a poll that destroy() already skipped.
+            richPoll.destroy();
+            return richPoll;
+        }
+
         if (existingPoll instanceof MatrixChatLightPoll) {
             existingPoll.destroy();
         }
@@ -1293,7 +1299,14 @@ export class MatrixChatRoom
         if (merger) {
             newWrapper.setUserProviderMergerContext(merger);
         }
-        this.members.update((members) => [...members, newWrapper]);
+        this.members.update((members) => {
+            // Destroy any superseded wrapper for the same user before adding the new one, otherwise
+            // repeated NewMember events (e.g. rejoin, or a member already added by initializeMembers)
+            // leak the RoomMember/User listeners and merger subscriptions of the orphaned wrapper.
+            members.filter((existing) => existing.id === newWrapper.id).forEach((existing) => existing.destroy());
+            const remaining = members.filter((existing) => existing.id !== newWrapper.id);
+            return [...remaining, newWrapper];
+        });
         this.refreshRoomType();
         this.refreshJoinedMemberCount();
     }
@@ -1700,6 +1713,10 @@ export class MatrixChatRoom
         let thread = this.matrixRoom.getThread(rootMessageId);
         const rootEvent = await this.getMatrixEventById(rootMessageId);
 
+        if (this.destroyed) {
+            return undefined;
+        }
+
         if (!thread && (!rootEvent || rootEvent.getType() !== EventType.RoomMessage)) {
             return undefined;
         }
@@ -1719,6 +1736,14 @@ export class MatrixChatRoom
         const threadConversation = new MatrixChatThread(thread, this);
         this.openThreadConversations.set(rootMessageId, threadConversation);
         await threadConversation.refreshRootMessage();
+
+        if (this.destroyed) {
+            // Room torn down mid-refresh: destroy() already cleared the map, so drop this straggler too.
+            this.openThreadConversations.delete(rootMessageId);
+            threadConversation.destroy();
+            return undefined;
+        }
+
         this.refreshThreadSummary(rootMessageId);
 
         return threadConversation;

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -180,6 +180,7 @@ export class MatrixChatRoom
     private currentUserRoomMember: RoomMember | undefined;
     private currentUserPermissionLevel: Writable<ChatPermissionLevel | undefined> = writable(undefined);
     private handleCurrentUserRoomMemberPowerLevel = this.onCurrentUserRoomMemberPowerLevel.bind(this);
+    private destroyed = false;
 
     constructor(
         private matrixRoom: Room,
@@ -2016,6 +2017,11 @@ export class MatrixChatRoom
     }
 
     destroy() {
+        if (this.destroyed) {
+            return;
+        }
+        this.destroyed = true;
+
         this.stopVisibleProfileSync();
         this.currentUserRoomMember?.off(RoomMemberEvent.PowerLevel, this.handleCurrentUserRoomMemberPowerLevel);
         this.currentUserRoomMember = undefined;
@@ -2034,11 +2040,14 @@ export class MatrixChatRoom
         this.threadList.set([]);
         this.openThreadConversations.forEach((threadConversation) => threadConversation.destroy());
         this.openThreadConversations.clear();
-        get(this.members).forEach((member) => {
+
+        const members = get(this.members);
+        members.forEach((member) => {
             member.destroy();
         });
+        this.members.set([]);
+
         this.messages.forEach((message) => {
-            message.relations?.destroy();
             message.destroy();
         });
         this.timelinePolls.forEach((poll) => {
@@ -2049,6 +2058,12 @@ export class MatrixChatRoom
                 poll.destroy();
             }
         });
+        this.messages.clear();
+        this.notSentEvents.clear();
+        this.inMemoryEventsContent.clear();
+        this.hasUnreadMessages.set(false);
+        this.unreadNotificationCount.set(0);
+        this.hasPreviousMessage.set(false);
     }
 
     startTyping(): Promise<object> {

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -934,9 +934,9 @@ export class MatrixChatRoom
                 return;
             }
             this.dmMergerUsersByRoomUnsub = merger.usersByRoomStore.subscribe(() => {
-                                   if (this.destroyed) {
-                        return;
-                    }
+                if (this.destroyed) {
+                    return;
+                }
                 this.directRoomPeerAvatarStore?.refresh().catch(() => undefined);
                 const myUserId = this.matrixRoom.client.getUserId();
                 get(this.members)

--- a/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
@@ -111,65 +111,6 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
         super.destroy();
     }
 
-    setRoomNode(room: MatrixChatRoom): void {
-        const existingRoom = this.roomList.get(room.id);
-        if (existingRoom && existingRoom !== room) {
-            existingRoom.destroy();
-        }
-        this.roomList.delete(room.id);
-
-        const existingFolder = this.folderList.get(room.id);
-        if (existingFolder) {
-            existingFolder.destroy();
-        }
-        this.folderList.delete(room.id);
-
-        this.roomList.set(room.id, room);
-    }
-
-    setFolderNode(folder: MatrixRoomFolder): void {
-        const existingFolder = this.folderList.get(folder.id);
-        if (existingFolder && existingFolder !== folder) {
-            existingFolder.destroy();
-        }
-        this.folderList.delete(folder.id);
-
-        const existingRoom = this.roomList.get(folder.id);
-        if (existingRoom) {
-            existingRoom.destroy();
-        }
-        this.roomList.delete(folder.id);
-
-        this.folderList.set(folder.id, folder);
-    }
-
-    private deleteRoomNode(id: string): boolean {
-        const existingRoom = this.roomList.get(id);
-        if (!existingRoom) {
-            return false;
-        }
-        existingRoom.destroy();
-        this.roomList.delete(id);
-        return true;
-    }
-
-    private deleteFolderNode(id: string): boolean {
-        const existingFolder = this.folderList.get(id);
-        if (!existingFolder) {
-            return false;
-        }
-        existingFolder.destroy();
-        this.folderList.delete(id);
-        return true;
-    }
-
-    private clearNodes(): void {
-        Array.from(this.roomList.values()).forEach((room) => room.destroy());
-        this.roomList.clear();
-        Array.from(this.folderList.values()).forEach((folder) => folder.destroy());
-        this.folderList.clear();
-    }
-
     init() {
         try {
             this.loadRoomsAndFolderPromise.resolve();
@@ -215,14 +156,16 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
     async deleteNode(id: string): Promise<boolean> {
         try {
             await this.loadRoomsAndFolderPromise.promise;
-            const isDeletedInRoomList = this.deleteRoomNode(id);
-            if (isDeletedInRoomList) {
-                return true;
+            const roomNode = this.roomList.get(id);
+            if (roomNode) {
+                roomNode.destroy();
+                return this.roomList.delete(id);
             }
 
-            const isDeletedInFolderList = this.deleteFolderNode(id);
-            if (isDeletedInFolderList) {
-                return true;
+            const folderNode = this.folderList.get(id);
+            if (folderNode) {
+                folderNode.destroy();
+                return this.folderList.delete(id);
             }
 
             const deleteNodePromise = Array.from(this.folderList.values()).map((folder) => {
@@ -307,14 +250,14 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
                 if (!childRoom || roomId === this.id) return;
 
                 if (childRoom.isSpaceRoom()) {
-                    this.setFolderNode(new MatrixRoomFolder(childRoom));
+                    this.folderList.set(childRoom.roomId, new MatrixRoomFolder(childRoom));
                 } else {
                     const matrixChatRoom = new MatrixChatRoom(childRoom);
                     if (
                         get(matrixChatRoom.myMembership) === KnownMembership.Join ||
                         get(matrixChatRoom.myMembership) === KnownMembership.Invite
                     ) {
-                        this.setRoomNode(matrixChatRoom);
+                        this.roomList.set(childRoom.roomId, matrixChatRoom);
                     }
                 }
             });
@@ -491,12 +434,5 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
                 this.roomList.set(child.roomId, new MatrixChatRoom(child));
             }
         });
-    }
-
-    override destroy() {
-        this.clearNodes();
-        this.availableRooms.set([]);
-        this.allSuggestedRooms.set([]);
-        super.destroy();
     }
 }

--- a/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
@@ -111,6 +111,65 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
         super.destroy();
     }
 
+    setRoomNode(room: MatrixChatRoom): void {
+        const existingRoom = this.roomList.get(room.id);
+        if (existingRoom && existingRoom !== room) {
+            existingRoom.destroy();
+        }
+        this.roomList.delete(room.id);
+
+        const existingFolder = this.folderList.get(room.id);
+        if (existingFolder) {
+            existingFolder.destroy();
+        }
+        this.folderList.delete(room.id);
+
+        this.roomList.set(room.id, room);
+    }
+
+    setFolderNode(folder: MatrixRoomFolder): void {
+        const existingFolder = this.folderList.get(folder.id);
+        if (existingFolder && existingFolder !== folder) {
+            existingFolder.destroy();
+        }
+        this.folderList.delete(folder.id);
+
+        const existingRoom = this.roomList.get(folder.id);
+        if (existingRoom) {
+            existingRoom.destroy();
+        }
+        this.roomList.delete(folder.id);
+
+        this.folderList.set(folder.id, folder);
+    }
+
+    private deleteRoomNode(id: string): boolean {
+        const existingRoom = this.roomList.get(id);
+        if (!existingRoom) {
+            return false;
+        }
+        existingRoom.destroy();
+        this.roomList.delete(id);
+        return true;
+    }
+
+    private deleteFolderNode(id: string): boolean {
+        const existingFolder = this.folderList.get(id);
+        if (!existingFolder) {
+            return false;
+        }
+        existingFolder.destroy();
+        this.folderList.delete(id);
+        return true;
+    }
+
+    private clearNodes(): void {
+        Array.from(this.roomList.values()).forEach((room) => room.destroy());
+        this.roomList.clear();
+        Array.from(this.folderList.values()).forEach((folder) => folder.destroy());
+        this.folderList.clear();
+    }
+
     init() {
         try {
             this.loadRoomsAndFolderPromise.resolve();
@@ -156,16 +215,14 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
     async deleteNode(id: string): Promise<boolean> {
         try {
             await this.loadRoomsAndFolderPromise.promise;
-            const roomNode = this.roomList.get(id);
-            if (roomNode) {
-                roomNode.destroy();
-                return this.roomList.delete(id);
+            const isDeletedInRoomList = this.deleteRoomNode(id);
+            if (isDeletedInRoomList) {
+                return true;
             }
 
-            const folderNode = this.folderList.get(id);
-            if (folderNode) {
-                folderNode.destroy();
-                return this.folderList.delete(id);
+            const isDeletedInFolderList = this.deleteFolderNode(id);
+            if (isDeletedInFolderList) {
+                return true;
             }
 
             const deleteNodePromise = Array.from(this.folderList.values()).map((folder) => {
@@ -250,14 +307,14 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
                 if (!childRoom || roomId === this.id) return;
 
                 if (childRoom.isSpaceRoom()) {
-                    this.folderList.set(childRoom.roomId, new MatrixRoomFolder(childRoom));
+                    this.setFolderNode(new MatrixRoomFolder(childRoom));
                 } else {
                     const matrixChatRoom = new MatrixChatRoom(childRoom);
                     if (
                         get(matrixChatRoom.myMembership) === KnownMembership.Join ||
                         get(matrixChatRoom.myMembership) === KnownMembership.Invite
                     ) {
-                        this.roomList.set(childRoom.roomId, matrixChatRoom);
+                        this.setRoomNode(matrixChatRoom);
                     }
                 }
             });
@@ -434,5 +491,12 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
                 this.roomList.set(child.roomId, new MatrixChatRoom(child));
             }
         });
+    }
+
+    override destroy() {
+        this.clearNodes();
+        this.availableRooms.set([]);
+        this.allSuggestedRooms.set([]);
+        super.destroy();
     }
 }

--- a/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
@@ -100,14 +100,9 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
     }
 
     override destroy(): void {
-        for (const id of Array.from(this.folderList.keys())) {
-            this.folderList.get(id)?.destroy();
-            this.folderList.delete(id);
-        }
-        for (const id of Array.from(this.roomList.keys())) {
-            this.roomList.get(id)?.destroy();
-            this.roomList.delete(id);
-        }
+        this.clearNodes();
+        this.availableRooms.set([]);
+        this.allSuggestedRooms.set([]);
         super.destroy();
     }
 
@@ -153,19 +148,72 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
         }
     }
 
+    setRoomNode(room: MatrixChatRoom): void {
+        const existingRoom = this.roomList.get(room.id);
+        if (existingRoom && existingRoom !== room) {
+            existingRoom.destroy();
+        }
+        this.roomList.delete(room.id);
+
+        const existingFolder = this.folderList.get(room.id);
+        if (existingFolder) {
+            existingFolder.destroy();
+        }
+        this.folderList.delete(room.id);
+
+        this.roomList.set(room.id, room);
+    }
+
+    setFolderNode(folder: MatrixRoomFolder): void {
+        const existingFolder = this.folderList.get(folder.id);
+        if (existingFolder && existingFolder !== folder) {
+            existingFolder.destroy();
+        }
+        this.folderList.delete(folder.id);
+
+        const existingRoom = this.roomList.get(folder.id);
+        if (existingRoom) {
+            existingRoom.destroy();
+        }
+        this.roomList.delete(folder.id);
+
+        this.folderList.set(folder.id, folder);
+    }
+
+    findLoadedNode(id: string): MatrixRoomFolder | MatrixChatRoom | undefined {
+        if (this.id === id) {
+            return this;
+        }
+
+        const roomNode = this.roomList.get(id);
+        if (roomNode) {
+            return roomNode;
+        }
+
+        const folderNode = this.folderList.get(id);
+        if (folderNode) {
+            return folderNode;
+        }
+
+        for (const folder of this.folderList.values()) {
+            const node = folder.findLoadedNode(id);
+            if (node) {
+                return node;
+            }
+        }
+
+        return undefined;
+    }
+
     async deleteNode(id: string): Promise<boolean> {
         try {
             await this.loadRoomsAndFolderPromise.promise;
-            const roomNode = this.roomList.get(id);
-            if (roomNode) {
-                roomNode.destroy();
-                return this.roomList.delete(id);
+            if (this.deleteRoomNode(id)) {
+                return true;
             }
 
-            const folderNode = this.folderList.get(id);
-            if (folderNode) {
-                folderNode.destroy();
-                return this.folderList.delete(id);
+            if (this.deleteFolderNode(id)) {
+                return true;
             }
 
             const deleteNodePromise = Array.from(this.folderList.values()).map((folder) => {
@@ -181,6 +229,33 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
         }
 
         return false;
+    }
+
+    private deleteRoomNode(id: string): boolean {
+        const existingRoom = this.roomList.get(id);
+        if (!existingRoom) {
+            return false;
+        }
+        existingRoom.destroy();
+        this.roomList.delete(id);
+        return true;
+    }
+
+    private deleteFolderNode(id: string): boolean {
+        const existingFolder = this.folderList.get(id);
+        if (!existingFolder) {
+            return false;
+        }
+        existingFolder.destroy();
+        this.folderList.delete(id);
+        return true;
+    }
+
+    private clearNodes(): void {
+        Array.from(this.roomList.values()).forEach((room) => room.destroy());
+        this.roomList.clear();
+        Array.from(this.folderList.values()).forEach((folder) => folder.destroy());
+        this.folderList.clear();
     }
 
     async getParentOfNode(id: string): Promise<MatrixRoomFolder | undefined> {
@@ -250,14 +325,14 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
                 if (!childRoom || roomId === this.id) return;
 
                 if (childRoom.isSpaceRoom()) {
-                    this.folderList.set(childRoom.roomId, new MatrixRoomFolder(childRoom));
+                    this.setFolderNode(new MatrixRoomFolder(childRoom));
                 } else {
                     const matrixChatRoom = new MatrixChatRoom(childRoom);
                     if (
                         get(matrixChatRoom.myMembership) === KnownMembership.Join ||
                         get(matrixChatRoom.myMembership) === KnownMembership.Invite
                     ) {
-                        this.roomList.set(childRoom.roomId, matrixChatRoom);
+                        this.setRoomNode(matrixChatRoom);
                     }
                 }
             });
@@ -411,14 +486,12 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
 
         for (const id of Array.from(this.roomList.keys())) {
             if (!childIds.has(id)) {
-                this.roomList.get(id)?.destroy();
-                this.roomList.delete(id);
+                this.deleteRoomNode(id);
             }
         }
         for (const id of Array.from(this.folderList.keys())) {
             if (!childIds.has(id)) {
-                this.folderList.get(id)?.destroy();
-                this.folderList.delete(id);
+                this.deleteFolderNode(id);
             }
         }
 
@@ -427,11 +500,11 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
                 let spaceFolder = this.folderList.get(child.roomId);
                 if (!spaceFolder) {
                     spaceFolder = new MatrixRoomFolder(child);
-                    this.folderList.set(child.roomId, spaceFolder);
+                    this.setFolderNode(spaceFolder);
                 }
                 spaceFolder.init();
             } else if (!this.roomList.has(child.roomId)) {
-                this.roomList.set(child.roomId, new MatrixChatRoom(child));
+                this.setRoomNode(new MatrixChatRoom(child));
             }
         });
     }

--- a/play/src/front/Chat/Connection/Matrix/MatrixSecurity.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixSecurity.ts
@@ -3,6 +3,8 @@ import type {
     EmojiMapping,
     GeneratedSecretStorageKey,
     KeyBackupInfo,
+    ShowSasCallbacks,
+    Verifier,
     VerificationRequest,
 } from "matrix-js-sdk/lib/crypto-api";
 import {
@@ -299,59 +301,138 @@ export class MatrixSecurity {
             });
 
             const doneVerificationDeferred = new Deferred<void>();
+            let verifier: Verifier | undefined;
+            let startVerificationSettled = false;
+            let doneVerificationSettled = false;
+            let isVerificationFlowCleanedUp = false;
 
-            verificationRequest.on(VerificationRequestEvent.Change, () => {
+            const resolveStartVerification = (verificationEmojiProps: VerificationEmojiDialogProps) => {
+                if (startVerificationSettled) {
+                    return;
+                }
+                startVerificationSettled = true;
+                startVerificationDeferred.resolve(verificationEmojiProps);
+            };
+
+            const rejectStartVerification = (error: Error) => {
+                if (startVerificationSettled) {
+                    return;
+                }
+                startVerificationSettled = true;
+                startVerificationDeferred.reject(error);
+            };
+
+            const resolveDoneVerification = () => {
+                if (doneVerificationSettled) {
+                    return;
+                }
+                doneVerificationSettled = true;
+                doneVerificationDeferred.resolve();
+            };
+
+            const rejectDoneVerification = (error: Error) => {
+                if (doneVerificationSettled) {
+                    return;
+                }
+                doneVerificationSettled = true;
+                doneVerificationDeferred.reject(error);
+            };
+
+            const cleanupVerificationFlow = () => {
+                if (isVerificationFlowCleanedUp) {
+                    return;
+                }
+                isVerificationFlowCleanedUp = true;
+                verificationRequest.off(VerificationRequestEvent.Change, handleVerificationRequestChange);
+                verifier?.off(VerifierEvent.ShowSas, handleVerifierShowSas);
+                verifier = undefined;
+                this.isVerifyingDevice = false;
+            };
+
+            const handleVerifierShowSas = (showSasCallbacks: ShowSasCallbacks) => {
+                const emojis = showSasCallbacks.sas.emoji;
+                const confirmationCallback = async () => {
+                    await showSasCallbacks.confirm();
+                };
+                const mismatchCallback = () => {
+                    //TODO : use showSasCallbacks.mismatch(); after matris-js-sdk update
+                    //showSasCallbacks.mismatch();
+                    return verificationRequest.cancel({ reason: "m.mismatched_sas" });
+                };
+
+                if (!emojis || this.isVerifyingDevice) return;
+
+                this.isVerifyingDevice = true;
+
+                resolveStartVerification({
+                    emojis,
+                    confirmationCallback,
+                    mismatchCallback,
+                    donePromise: doneVerificationDeferred.promise,
+                    isThisDeviceVerification: verificationRequest.initiatedByMe,
+                });
+            };
+
+            const attachVerifier = (nextVerifier: Verifier) => {
+                if (verifier === nextVerifier) {
+                    return;
+                }
+
+                verifier?.off(VerifierEvent.ShowSas, handleVerifierShowSas);
+                verifier = nextVerifier;
+                verifier.on(VerifierEvent.ShowSas, handleVerifierShowSas);
+                verifier.verify().catch((error) => {
+                    const verificationError =
+                        error instanceof Error ? error : new Error("Failed to verify this device");
+                    rejectStartVerification(verificationError);
+                    rejectDoneVerification(verificationError);
+                    cleanupVerificationFlow();
+                });
+            };
+
+            const handleVerificationRequestChange = () => {
                 if (verificationRequest.phase === VerificationPhase.Started) {
-                    const verifier = verificationRequest.verifier;
+                    const nextVerifier = verificationRequest.verifier;
 
-                    if (!verifier) throw new Error("Verifier is undefined");
+                    if (!nextVerifier) {
+                        const verifierError = new Error("Verifier is undefined");
+                        rejectStartVerification(verifierError);
+                        rejectDoneVerification(verifierError);
+                        cleanupVerificationFlow();
+                        return;
+                    }
 
                     switch (verificationRequest.chosenMethod) {
                         case VerificationMethod.Sas:
-                            verifier.on(VerifierEvent.ShowSas, (showSasCallbacks) => {
-                                const emojis = showSasCallbacks.sas.emoji;
-                                const confirmationCallback = async () => {
-                                    await showSasCallbacks.confirm();
-                                };
-                                const mismatchCallback = () => {
-                                    //TODO : use showSasCallbacks.mismatch(); after matris-js-sdk update
-                                    //showSasCallbacks.mismatch();
-                                    return verificationRequest.cancel({ reason: "m.mismatched_sas" });
-                                };
-
-                                if (!emojis || this.isVerifyingDevice) return;
-
-                                this.isVerifyingDevice = true;
-
-                                startVerificationDeferred.resolve({
-                                    emojis,
-                                    confirmationCallback,
-                                    mismatchCallback,
-                                    donePromise: doneVerificationDeferred.promise,
-                                    isThisDeviceVerification: verificationRequest.initiatedByMe,
-                                });
-                            });
-
-                            verifier.verify().catch((error) => {
-                                doneVerificationDeferred.reject(error);
-                            });
-                            break;
-                        default:
-                            throw new Error("The chosen verification method is not implemented");
+                            attachVerifier(nextVerifier);
+                            return;
+                        default: {
+                            const unsupportedMethodError = new Error(
+                                "The chosen verification method is not implemented"
+                            );
+                            rejectStartVerification(unsupportedMethodError);
+                            rejectDoneVerification(unsupportedMethodError);
+                            cleanupVerificationFlow();
+                            return;
+                        }
                     }
                 }
 
                 if (verificationRequest.phase === VerificationPhase.Done) {
-                    doneVerificationDeferred.resolve();
-                    this.isVerifyingDevice = false;
+                    resolveDoneVerification();
                     this.isEncryptionRequiredAndNotSet.set(false);
+                    cleanupVerificationFlow();
                 }
 
                 if (verificationRequest.phase === VerificationPhase.Cancelled) {
-                    doneVerificationDeferred.reject(new Error("verification request cancelled"));
-                    this.isVerifyingDevice = false;
+                    const cancellationError = new Error("verification request cancelled");
+                    rejectStartVerification(cancellationError);
+                    rejectDoneVerification(cancellationError);
+                    cleanupVerificationFlow();
                 }
-            });
+            };
+
+            verificationRequest.on(VerificationRequestEvent.Change, handleVerificationRequestChange);
         } catch (error) {
             console.error("Failed to verify this device", error);
         }

--- a/play/src/front/Chat/Connection/Matrix/MatrixSecurity.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixSecurity.ts
@@ -408,7 +408,7 @@ export class MatrixSecurity {
                             return;
                         default: {
                             const unsupportedMethodError = new Error(
-                                "The chosen verification method is not implemented"
+                                "The chosen verification method is not implemented",
                             );
                             rejectStartVerification(unsupportedMethodError);
                             rejectDoneVerification(unsupportedMethodError);

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -9,7 +9,6 @@ import { MatrixChatConnection } from "../MatrixChatConnection";
 import { MatrixRoomFolder } from "../MatrixRoomFolder";
 import type { CreateRoomOptions } from "../../ChatConnection";
 import type { MatrixChatRoom } from "../MatrixChatRoom";
-import type { MatrixRoomFolder } from "../MatrixRoomFolder";
 import type { MatrixSecurity } from "../MatrixSecurity";
 import type { RequestedStatus } from "../../../../Rules/StatusRules/statusRules";
 
@@ -70,10 +69,10 @@ describe("MatrixChatConnection", () => {
         subscribe: vi.fn(),
     };
 
-    const basicMockMatrixSecurity: Partial<MatrixSecurity> = {
+    const basicMockMatrixSecurity = {
         isEncryptionRequiredAndNotSet: writable(false),
         updateMatrixClientStore: vi.fn(),
-    };
+    } as unknown as MatrixSecurity;
 
     const getMatrixConnection = async (
         clientPromise: Promise<MatrixClient>,
@@ -485,7 +484,7 @@ describe("MatrixChatConnection", () => {
             expect(offMock).toHaveBeenCalledWith(ClientEvent.Sync, matrixChatConnection["handleSync"]);
             expect(offMock).toHaveBeenCalledWith(
                 ClientEvent.AccountData,
-                matrixChatConnection["handleAccountDataEvent"]
+                matrixChatConnection["handleAccountDataEvent"],
             );
         });
 
@@ -1273,8 +1272,8 @@ describe("MatrixChatConnection", () => {
                 folderList: new Map(),
                 loadRoomsAndFolderPromise: { promise: Promise.resolve() },
             }) as MatrixRoomFolder;
-            rootFolder.folderList.set(intermediateFolder.id, intermediateFolder);
-            intermediateFolder.folderList.set(nestedFolder.id, nestedFolder);
+            rootFolder.setFolderNode(intermediateFolder);
+            intermediateFolder.setFolderNode(nestedFolder);
 
             await expect(rootFolder.getNode(nestedFolder.id)).resolves.toBe(nestedFolder);
         });
@@ -1285,11 +1284,13 @@ describe("MatrixChatConnection", () => {
             const childNode = {
                 id: childRoomId,
                 myMembership: readable(KnownMembership.Join),
+                destroy: vi.fn(),
             };
             const folder = Object.assign(Object.create(MatrixRoomFolder.prototype), {
                 id: folderId,
                 roomList: new Map([[childRoomId, childNode]]),
                 folderList: new Map(),
+                destroy: vi.fn(),
                 loadRoomsAndFolderPromise: { promise: Promise.resolve() },
             }) as MatrixRoomFolder;
             const matrixChatConnection = new MatrixChatConnection(
@@ -1325,6 +1326,7 @@ describe("MatrixChatConnection", () => {
             const childNode = {
                 id: childRoomId,
                 myMembership: readable(KnownMembership.Join),
+                destroy: vi.fn(),
             };
             const leftFolder = Object.assign(Object.create(MatrixRoomFolder.prototype), {
                 id: leftFolderId,

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -71,7 +71,10 @@ describe("MatrixChatConnection", () => {
         clientPromise: Promise<MatrixClient>,
         matrixSecurity = basicMockMatrixSecurity,
     ) => {
-        const matrixChatConnection = new MatrixChatConnection(clientPromise, basicStatusStore, matrixSecurity);
+        const matrixChatConnection = new MatrixChatConnection(clientPromise, basicStatusStore, {
+            updateMatrixClientStore: vi.fn(),
+            ...matrixSecurity,
+        } as MatrixSecurity);
         await matrixChatConnection.init();
         return matrixChatConnection;
     };
@@ -217,6 +220,7 @@ describe("MatrixChatConnection", () => {
         );
 
         it("should call startMatrixClient when client promise resolve", async () => {
+            vi.restoreAllMocks();
             const mockMatrixClient = {} as unknown as MatrixClient;
 
             const clientPromise = Promise.resolve(mockMatrixClient);
@@ -224,19 +228,42 @@ describe("MatrixChatConnection", () => {
             const startMatrixClientSpy = vi.spyOn(MatrixChatConnection.prototype, "startMatrixClient");
 
             await getMatrixConnection(clientPromise);
-
             await clientPromise;
+
             expect(startMatrixClientSpy).toHaveBeenCalledOnce();
         });
         it("should not call startMatrixClient when client promise reject", async () => {
+            vi.restoreAllMocks();
             const clientPromise = Promise.reject(new Error(""));
 
             const startMatrixClientSpy = vi.spyOn(MatrixChatConnection.prototype, "startMatrixClient");
 
             await getMatrixConnection(clientPromise);
+            await expect(clientPromise).rejects.toThrowError("");
 
-            await expect(clientPromise).rejects.toThrow();
             expect(startMatrixClientSpy).not.toHaveBeenCalled();
+        });
+
+        it("should destroy the previous room wrapper when replacing a room with the same id", async () => {
+            const mockMatrixClient = {} as unknown as MatrixClient;
+            const clientPromise = Promise.resolve(mockMatrixClient);
+            const matrixChatConnection = await getMatrixConnection(clientPromise);
+
+            const firstRoomDestroyMock = vi.fn();
+            const firstRoom = {
+                id: "room-id",
+                destroy: firstRoomDestroyMock,
+            } as unknown as MatrixChatRoom;
+            const secondRoom = {
+                id: "room-id",
+                destroy: vi.fn(),
+            } as unknown as MatrixChatRoom;
+
+            matrixChatConnection["setRootRoom"](firstRoom);
+            matrixChatConnection["setRootRoom"](secondRoom);
+
+            expect(firstRoomDestroyMock).toHaveBeenCalledOnce();
+            expect(matrixChatConnection["roomList"].get(firstRoom.id)).toBe(secondRoom);
         });
     });
 
@@ -350,6 +377,77 @@ describe("MatrixChatConnection", () => {
                 threadSupport: true,
                 pendingEventOrdering: PendingEventOrdering.Detached,
             });
+        });
+    });
+
+    describe("lifecycle cleanup", () => {
+        it("clearListener should destroy tracked rooms and detach every registered client listener", async () => {
+            const offMock = vi.fn();
+            const mockMatrixClient = {
+                isGuest: vi.fn(),
+                off: offMock,
+                on: vi.fn(),
+                store: {
+                    startup: vi.fn(),
+                },
+                initRustCrypto: vi.fn(),
+                startClient: vi.fn(),
+                isInitialSyncComplete: vi.fn().mockReturnValue(true),
+            } as unknown as MatrixClient;
+
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
+
+            const roomDestroyMock = vi.fn();
+            const room = {
+                id: "room-id",
+                destroy: roomDestroyMock,
+            } as unknown as MatrixChatRoom;
+            const folderDestroyMock = vi.fn();
+            const folder = {
+                id: "folder-id",
+                destroy: folderDestroyMock,
+            } as unknown as MatrixChatRoom;
+
+            matrixChatConnection["roomList"].set(room.id, room);
+            matrixChatConnection["roomFolders"].set(folder.id, folder);
+            matrixChatConnection["userIdsNeedingPresenceUpdate"].add("@alice:matrix.example");
+
+            matrixChatConnection.clearListener();
+
+            expect(roomDestroyMock).toHaveBeenCalledOnce();
+            expect(folderDestroyMock).toHaveBeenCalledOnce();
+            expect(matrixChatConnection["roomList"].size).toBe(0);
+            expect(matrixChatConnection["roomFolders"].size).toBe(0);
+            expect(matrixChatConnection["userIdsNeedingPresenceUpdate"].size).toBe(0);
+            expect(offMock).toHaveBeenCalledWith(
+                ClientEvent.AccountData,
+                matrixChatConnection["handleAccountDataEvent"]
+            );
+        });
+
+        it("destroy should clear local listeners before logging out", async () => {
+            const logoutMock = vi.fn().mockResolvedValue(undefined);
+            const mockMatrixClient = {
+                isGuest: vi.fn(),
+                off: vi.fn(),
+                on: vi.fn(),
+                logout: logoutMock,
+                store: {
+                    startup: vi.fn(),
+                },
+                initRustCrypto: vi.fn(),
+                startClient: vi.fn(),
+                isInitialSyncComplete: vi.fn().mockReturnValue(true),
+            } as unknown as MatrixClient;
+
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
+            const clearListenerSpy = vi.spyOn(matrixChatConnection, "clearListener");
+
+            await matrixChatConnection.destroy();
+
+            expect(clearListenerSpy).toHaveBeenCalledOnce();
+            expect(logoutMock).toHaveBeenCalledOnce();
+            expect(logoutMock).toHaveBeenCalledWith(true);
         });
     });
 

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -9,13 +9,21 @@ import { MatrixChatConnection } from "../MatrixChatConnection";
 import { MatrixRoomFolder } from "../MatrixRoomFolder";
 import type { CreateRoomOptions } from "../../ChatConnection";
 import type { MatrixChatRoom } from "../MatrixChatRoom";
+import type { MatrixRoomFolder } from "../MatrixRoomFolder";
 import type { MatrixSecurity } from "../MatrixSecurity";
 import type { RequestedStatus } from "../../../../Rules/StatusRules/statusRules";
 
 vi.mock("../../../../Phaser/Game/GameManager", () => {
     return {
         gameManager: {
-            getCurrentGameScene: () => ({}),
+            getCurrentGameScene: () => ({
+                playSound: vi.fn(),
+                userProviderMerger: Promise.resolve({
+                    usersByRoomStore: {
+                        subscribe: vi.fn(() => () => undefined),
+                    },
+                }),
+            }),
         },
     };
 });
@@ -62,19 +70,20 @@ describe("MatrixChatConnection", () => {
         subscribe: vi.fn(),
     };
 
-    const basicMockMatrixSecurity = {
-        isEncryptionRequiredAndNotSet: false,
+    const basicMockMatrixSecurity: Partial<MatrixSecurity> = {
+        isEncryptionRequiredAndNotSet: writable(false),
         updateMatrixClientStore: vi.fn(),
-    } as unknown as MatrixSecurity;
+    };
 
     const getMatrixConnection = async (
         clientPromise: Promise<MatrixClient>,
-        matrixSecurity = basicMockMatrixSecurity,
+        matrixSecurity: Partial<MatrixSecurity> = basicMockMatrixSecurity,
     ) => {
-        const matrixChatConnection = new MatrixChatConnection(clientPromise, basicStatusStore, {
-            updateMatrixClientStore: vi.fn(),
+        const matrixSecurityMock = {
+            ...basicMockMatrixSecurity,
             ...matrixSecurity,
-        } as MatrixSecurity);
+        } as unknown as MatrixSecurity;
+        const matrixChatConnection = new MatrixChatConnection(clientPromise, basicStatusStore, matrixSecurityMock);
         await matrixChatConnection.init();
         return matrixChatConnection;
     };
@@ -191,9 +200,9 @@ describe("MatrixChatConnection", () => {
             const clientPromise = Promise.resolve(mockMatrixClient);
 
             const mockMatrixSecurity = {
-                isEncryptionRequiredAndNotSet: false,
+                isEncryptionRequiredAndNotSet: writable(false),
                 updateMatrixClientStore: vi.fn(),
-            } as unknown as MatrixSecurity;
+            } as Partial<MatrixSecurity>;
 
             const matrixChatConnection = await getMatrixConnection(clientPromise, mockMatrixSecurity);
 
@@ -209,13 +218,15 @@ describe("MatrixChatConnection", () => {
                 const clientPromise = Promise.resolve(mockMatrixClient);
 
                 const mockMatrixSecurity = {
-                    isEncryptionRequiredAndNotSet: expected,
+                    isEncryptionRequiredAndNotSet: writable(expected),
                     updateMatrixClientStore: vi.fn(),
-                } as unknown as MatrixSecurity;
+                } as Partial<MatrixSecurity>;
 
                 const matrixChatConnection = await getMatrixConnection(clientPromise, mockMatrixSecurity);
 
-                expect(matrixChatConnection["isEncryptionRequiredAndNotSet"]).toBe(expected);
+                expect(matrixChatConnection["isEncryptionRequiredAndNotSet"]).toBe(
+                    mockMatrixSecurity.isEncryptionRequiredAndNotSet,
+                );
             },
         );
 
@@ -264,6 +275,58 @@ describe("MatrixChatConnection", () => {
 
             expect(firstRoomDestroyMock).toHaveBeenCalledOnce();
             expect(matrixChatConnection["roomList"].get(firstRoom.id)).toBe(secondRoom);
+        });
+
+        it("should return the already managed room wrapper from getRoomByID", async () => {
+            const mockMatrixRoom = {
+                roomId: "room-id",
+                name: "Managed room",
+                getUnreadNotificationCount: vi.fn().mockReturnValue(0),
+                getAvatarUrl: vi.fn(),
+                getMyMembership: vi.fn().mockReturnValue(KnownMembership.Join),
+                getMembers: vi.fn().mockReturnValue([]),
+                getLiveTimeline: vi.fn().mockReturnValue({
+                    getTimelineSet: vi.fn(),
+                    getState: vi.fn().mockReturnValue({
+                        hasSufficientPowerLevelFor: vi.fn().mockReturnValue(false),
+                    }),
+                }),
+                hasEncryptionStateEvent: vi.fn().mockReturnValue(false),
+                getPendingEvents: vi.fn().mockReturnValue([]),
+                isSpaceRoom: vi.fn().mockReturnValue(false),
+                currentState: {
+                    on: vi.fn(),
+                    off: vi.fn(),
+                },
+                on: vi.fn(),
+                off: vi.fn(),
+                client: {
+                    baseUrl: "https://matrix.example",
+                    getUserId: vi.fn().mockReturnValue("@alice:matrix.example"),
+                    getSafeUserId: vi.fn().mockReturnValue("@alice:matrix.example"),
+                    getAccountData: vi.fn().mockReturnValue({
+                        getContent: () => ({
+                            global: {
+                                override: [],
+                            },
+                        }),
+                    }),
+                    mxcUrlToHttp: vi.fn(),
+                    isInitialSyncComplete: vi.fn().mockReturnValue(false),
+                },
+            };
+            const mockMatrixClient = {
+                getRoom: vi.fn().mockReturnValue(mockMatrixRoom),
+            } as unknown as MatrixClient;
+
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
+            const managedRoom = {
+                id: "room-id",
+            } as unknown as MatrixChatRoom;
+
+            matrixChatConnection["setRootRoom"](managedRoom);
+
+            expect(matrixChatConnection.getRoomByID("room-id")).toBe(managedRoom);
         });
     });
 
@@ -406,7 +469,7 @@ describe("MatrixChatConnection", () => {
             const folder = {
                 id: "folder-id",
                 destroy: folderDestroyMock,
-            } as unknown as MatrixChatRoom;
+            } as unknown as MatrixRoomFolder;
 
             matrixChatConnection["roomList"].set(room.id, room);
             matrixChatConnection["roomFolders"].set(folder.id, folder);
@@ -419,6 +482,7 @@ describe("MatrixChatConnection", () => {
             expect(matrixChatConnection["roomList"].size).toBe(0);
             expect(matrixChatConnection["roomFolders"].size).toBe(0);
             expect(matrixChatConnection["userIdsNeedingPresenceUpdate"].size).toBe(0);
+            expect(offMock).toHaveBeenCalledWith(ClientEvent.Sync, matrixChatConnection["handleSync"]);
             expect(offMock).toHaveBeenCalledWith(
                 ClientEvent.AccountData,
                 matrixChatConnection["handleAccountDataEvent"]

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatMessage.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatMessage.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MatrixEvent, Room } from "matrix-js-sdk";
+import { MatrixChatMessage } from "../MatrixChatMessage";
+
+function createTextEvent(
+    overrides: Partial<MatrixEvent> & {
+        replyEventId?: string;
+        formattedBody?: string;
+    } = {}
+): MatrixEvent {
+    const originalContent = {
+        body: "hello",
+        msgtype: "m.text",
+        formatted_body: overrides.formattedBody,
+    };
+
+    return {
+        getId: vi.fn().mockReturnValue("event-id"),
+        getDate: vi.fn().mockReturnValue(new Date("2024-01-01T00:00:00.000Z")),
+        getSender: vi.fn().mockReturnValue("@alice:matrix.example"),
+        getUnsigned: vi.fn().mockReturnValue({}),
+        isDecryptionFailure: vi.fn().mockReturnValue(false),
+        getOriginalContent: vi.fn().mockReturnValue(originalContent),
+        replacingEventId: vi.fn().mockReturnValue(undefined),
+        isRedacted: vi.fn().mockReturnValue(false),
+        on: vi.fn(),
+        off: vi.fn(),
+        replyEventId: overrides.replyEventId,
+        ...overrides,
+    } as unknown as MatrixEvent;
+}
+
+function createRoom(replyEvents: MatrixEvent[] = []): Room {
+    const findEventById = vi.fn();
+    replyEvents.forEach((event) => {
+        findEventById.mockReturnValueOnce(event);
+    });
+
+    return {
+        client: {
+            getUserId: vi.fn().mockReturnValue("@alice:matrix.example"),
+            getSafeUserId: vi.fn().mockReturnValue("@alice:matrix.example"),
+            getUser: vi.fn(),
+            mxcUrlToHttp: vi.fn(),
+        },
+        roomId: "!room:matrix.example",
+        myUserId: "@alice:matrix.example",
+        getMember: vi.fn(),
+        findEventById,
+        getLiveTimeline: vi.fn().mockReturnValue({
+            getState: vi.fn().mockReturnValue({
+                hasSufficientPowerLevelFor: vi.fn().mockReturnValue(false),
+            }),
+        }),
+        getUnfilteredTimelineSet: vi.fn().mockReturnValue({
+            relations: {
+                getChildEventsForEvent: vi.fn().mockReturnValue(undefined),
+            },
+        }),
+    } as unknown as Room;
+}
+
+describe("MatrixChatMessage", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("destroys the previous quoted message when recomputing a different reply target", () => {
+        const firstQuotedEvent = createTextEvent({
+            replyEventId: undefined,
+        });
+        const secondQuotedEvent = createTextEvent({
+            getId: vi.fn().mockReturnValue("quoted-2"),
+            replyEventId: undefined,
+        });
+        const parentEvent = createTextEvent({
+            replyEventId: "quoted-1",
+            formattedBody: "<mx-reply>old</mx-reply>new body",
+        });
+        const room = createRoom([firstQuotedEvent, secondQuotedEvent]);
+
+        const message = new MatrixChatMessage(parentEvent, room);
+        const firstQuotedMessage = message.quotedMessage as MatrixChatMessage;
+        const destroySpy = vi.spyOn(firstQuotedMessage, "destroy");
+
+        message["updateMessageContentOnDecryptedEvent"]();
+
+        expect(destroySpy).toHaveBeenCalledOnce();
+        expect(message.quotedMessage).not.toBe(firstQuotedMessage);
+    });
+
+    it("clears and destroys the quoted message when the reply markup disappears", () => {
+        const quotedEvent = createTextEvent({
+            replyEventId: undefined,
+        });
+        const parentEvent = createTextEvent({
+            replyEventId: "quoted-1",
+            formattedBody: "<mx-reply>old</mx-reply>new body",
+        });
+        const room = createRoom([quotedEvent]);
+
+        const message = new MatrixChatMessage(parentEvent, room);
+        const quotedMessage = message.quotedMessage as MatrixChatMessage;
+        const destroySpy = vi.spyOn(quotedMessage, "destroy");
+
+        parentEvent.getOriginalContent = vi.fn().mockReturnValue({
+            body: "plain body",
+            msgtype: "m.text",
+        });
+        message["updateMessageContentOnDecryptedEvent"]();
+
+        expect(destroySpy).toHaveBeenCalledOnce();
+        expect(message.quotedMessage).toBeUndefined();
+    });
+});

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatMessage.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatMessage.test.ts
@@ -6,7 +6,7 @@ function createTextEvent(
     overrides: Partial<MatrixEvent> & {
         replyEventId?: string;
         formattedBody?: string;
-    } = {}
+    } = {},
 ): MatrixEvent {
     const originalContent = {
         body: "hello",

--- a/play/src/front/Components/ProximityNotification/ProximityNotification.svelte
+++ b/play/src/front/Components/ProximityNotification/ProximityNotification.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
     import { fade } from "svelte/transition";
     import { onMount } from "svelte";
+    import { get } from "svelte/store";
     import type { ProximityNotification } from "../../Stores/ProximityNotificationStore";
     import { chatNotificationStore } from "../../Stores/ProximityNotificationStore";
     import { chatVisibilityStore } from "../../Stores/ChatStore";
     import { selectedRoomStore } from "../../Chat/Stores/SelectRoomStore";
     import { navChat } from "../../Chat/Stores/ChatStore";
+    import { gameManager } from "../../Phaser/Game/GameManager";
     import LL from "../../../i18n/i18n-svelte";
     import { focusNotificationMessage } from "./NotificationRoomFocus";
 
@@ -15,8 +17,8 @@
 
     let { notification }: Props = $props();
 
-    let roomType = $derived(notification.room.type);
-    let roomName = $derived(notification.room.name);
+    let roomType = $derived(notification.room ? get(notification.room.type) : notification.roomType ?? "multiple");
+    let roomName = $derived(notification.room ? get(notification.room.name) : notification.roomName);
 
     const NOTIFICATION_DURATION = 10000; // 10 seconds
 
@@ -30,12 +32,20 @@
         };
     });
 
-    function handleClick() {
+    async function handleClick() {
         chatVisibilityStore.set(true);
         navChat.switchToChat();
 
         if (notification.openRoomOnClick !== false) {
-            const room = notification.room;
+            let room = notification.room;
+            if (!room && notification.roomId) {
+                const chatConnection = await gameManager.getChatConnection();
+                room = chatConnection.getRoomByID(notification.roomId);
+            }
+            if (!room) {
+                selectedRoomStore.set(undefined);
+                return;
+            }
             chatNotificationStore.clearRoom(room.id);
             room.setTimelineAsRead();
             selectedRoomStore.set(room);
@@ -46,19 +56,23 @@
             selectedRoomStore.set(undefined);
         }
     }
+
+    function handleKeyboardClick(event: KeyboardEvent) {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            handleClick().catch((error) => {
+                console.error("Failed to handle chat notification click", error);
+            });
+        }
+    }
 </script>
 
 <div
     class="proximity-notification bg-contrast/50 rounded backdrop-blur-md flex gap-3 py-3 pl-5 pr-2 shadow-xl pointer-events-auto z-[900] cursor-pointer hover:bg-contrast/90 transition-colors text-white w-[60%] min-w-[300px] max-w-[600px]"
-    onclick={handleClick}
+    onclick={() => handleClick().catch((error) => console.error("Failed to handle chat notification click", error))}
     role="button"
     tabindex="0"
-    onkeydown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            handleClick();
-        }
-    }}
+    onkeydown={handleKeyboardClick}
     out:fade={{ duration: 150 }}
 >
     <div class="mt-1 text-white text-xl flex-shrink-0">💬</div>
@@ -68,9 +82,9 @@
             class="font-bold mb-1 text-base text-white truncate font-['Roboto_Condensed'] tracking-normal align-middle"
         >
             {notification.userName}
-            {#if $roomType !== "direct"}
+            {#if roomType !== "direct"}
                 {$LL.chat.notification.in()}
-                {$roomName}
+                {roomName}
             {/if}
         </div>
         <div

--- a/play/src/front/Components/ProximityNotification/ProximityNotification.svelte
+++ b/play/src/front/Components/ProximityNotification/ProximityNotification.svelte
@@ -17,7 +17,7 @@
 
     let { notification }: Props = $props();
 
-    let roomType = $derived(notification.room ? get(notification.room.type) : notification.roomType ?? "multiple");
+    let roomType = $derived(notification.room ? get(notification.room.type) : (notification.roomType ?? "multiple"));
     let roomName = $derived(notification.room ? get(notification.room.name) : notification.roomName);
 
     const NOTIFICATION_DURATION = 10000; // 10 seconds

--- a/play/src/front/Stores/ProximityNotificationStore.ts
+++ b/play/src/front/Stores/ProximityNotificationStore.ts
@@ -70,7 +70,10 @@ function createChatNotificationStore() {
         },
         clearRoom: (roomId: string): void => {
             update((notifications: ProximityNotification[]) => {
-                return notifications.filter((notification) => notification.room.id !== roomId);
+                return notifications.filter((notification) => {
+                    const notificationRoomId = notification.room?.id ?? notification.roomId;
+                    return notificationRoomId !== roomId;
+                });
             });
         },
     };

--- a/play/src/front/Stores/ProximityNotificationStore.ts
+++ b/play/src/front/Stores/ProximityNotificationStore.ts
@@ -2,12 +2,21 @@ import { writable } from "svelte/store";
 import { v4 as uuidv4 } from "uuid";
 import type { ChatRoom } from "../Chat/Connection/ChatConnection";
 
+type NotificationNavigationTarget = {
+    roomId: string;
+    roomName: string;
+    roomType?: "direct" | "multiple";
+};
+
 export interface ProximityNotification {
     id: string;
     userName: string;
     message: string;
     messageId?: string;
-    room: ChatRoom;
+    room?: ChatRoom;
+    roomId?: string;
+    roomName?: string;
+    roomType?: "direct" | "multiple";
     /** When false, click only opens the chat panel (e.g. for room invitations). Default true. */
     openRoomOnClick?: boolean;
 }
@@ -23,7 +32,7 @@ function createChatNotificationStore() {
         addNotification: (
             userName: string,
             message: string,
-            room: ChatRoom,
+            target: ChatRoom | NotificationNavigationTarget,
             messageId?: string,
             openRoomOnClick = true,
         ): string => {
@@ -33,7 +42,21 @@ function createChatNotificationStore() {
                 const filteredNotifications = messageId
                     ? notifications.filter((n) => n.messageId !== messageId)
                     : notifications;
-                return [...filteredNotifications, { id, userName, message, messageId, room, openRoomOnClick }];
+                return [
+                    ...filteredNotifications,
+                    {
+                        id,
+                        userName,
+                        message,
+                        messageId,
+                        openRoomOnClick,
+                        ...("setTimelineAsRead" in target
+                            ? {
+                                  room: target,
+                              }
+                            : target),
+                    },
+                ];
             });
             return id;
         },


### PR DESCRIPTION
## Problem

Matrix chat objects could outlive their UI subscriptions: replacing or removing rooms from stores did not always run teardown, which risks leaked listeners and stale room references. Managed-room lifecycle and device verification flows needed clearer cleanup. Proximity chat notifications stored a full `ChatRoom` object, which could keep destroyed rooms alive when only navigation metadata was needed.

## Solution

Ensure `destroy` runs when Matrix-backed stores replace or remove rooms/messages/folders. Tighten managed-room lifecycle and verification listener registration/cleanup in connection/security and modals. Let proximity notifications carry either a live `ChatRoom` or lightweight `{ roomId, roomName, roomType }` for navigation without pinning room instances.

## Changes

- **MatrixChatConnection / MatrixChatRoom / MatrixChatMessage / MatrixRoomFolder**: call `destroy` on replacements and removals; refine lifecycle around managed rooms and folders.
- **MatrixSecurity**, **AskStartVerificationModal**, **DeviceVerificationPendingModal**: clean up verification-related listeners and modal behavior.
- **ProximityNotificationStore** & **ProximityNotification.svelte**: support notification targets without holding a `ChatRoom` when appropriate.
- **Tests**: extend `MatrixChatConnection.test.ts`, add/adjust `MatrixChatMessage.test.ts` for the new lifecycle guarantees.

## Commits included

- `fix(matrix-chat): ensure destroy is called on matrix store replacements and removals`
- `fix(matrix): clean up managed room lifecycle and verification listeners`