### PR TITLE
docs(env): add WAM URL format to START_ROOM_URL comment

### DIFF
--- a/contrib/docker/.env.prod.template
+++ b/contrib/docker/.env.prod.template
@@ -26,7 +26,7 @@ ADMIN_URL=
 # The directory to store data in
 DATA_DIR=./wa
 
-# The URL used by default, in the form: "/_/global/map/url.tmj"
+# The URL used by default, in the form: "/_/global/map/url.tmj" or "/~/map.wam"
 START_ROOM_URL=/_/global/workadventure.github.io/map-starter-kit/office.tmj
 
 # If you want to have a contact page in your menu,


### PR DESCRIPTION
It took me a while to understand that the map storage use the `/~/` prefix. This change may help others too.