### PR TITLE
Lazy load Matrix avatars

### DIFF
--- a/play/src/front/Chat/Components/Avatar.svelte
+++ b/play/src/front/Chat/Components/Avatar.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+    import { get } from "svelte/store";
     import { getColorByString } from "../../Utils/ColorGenerator";
     import type { PictureStore } from "../../Stores/PictureStore";
+    import { isLazyPictureStore } from "../../Stores/PictureStore";
 
     export let pictureStore: PictureStore | undefined;
     export let fallbackName = "A";
@@ -13,18 +15,68 @@
     export let compact = false;
 
     let forceFallback = false;
+    let previousPictureUrl: string | undefined;
 
     $: sizeClass = compact
         ? "h-7 w-7 min-h-[1.75rem] min-w-[1.75rem] shrink-0 rounded-md overflow-hidden"
         : "h-10 w-10 min-h-10 min-w-10 shrink-0 rounded-sm overflow-hidden";
+
+    $: if ($pictureStore !== previousPictureUrl) {
+        previousPictureUrl = $pictureStore;
+        forceFallback = false;
+    }
+
+    function loadLazyPictureStore(node: HTMLElement, store: PictureStore | undefined) {
+        let observer: IntersectionObserver | undefined;
+
+        const cleanup = () => {
+            observer?.disconnect();
+            observer = undefined;
+        };
+
+        const update = (nextStore: PictureStore | undefined) => {
+            cleanup();
+            if (!isLazyPictureStore(nextStore)) {
+                return;
+            }
+            if (get(nextStore)) {
+                return;
+            }
+            if (typeof IntersectionObserver === "undefined") {
+                nextStore.load().catch((error) => console.warn("Failed to load avatar", error));
+                return;
+            }
+            observer = new IntersectionObserver(
+                (entries) => {
+                    if (!entries.some((entry) => entry.isIntersecting)) {
+                        return;
+                    }
+                    nextStore.load().catch((error) => console.warn("Failed to load avatar", error));
+                    cleanup();
+                },
+                { rootMargin: "200px" }
+            );
+            observer.observe(node);
+        };
+
+        update(store);
+
+        return {
+            update,
+            destroy: cleanup,
+        };
+    }
 </script>
 
 {#if $pictureStore && !forceFallback}
     <img
+        use:loadLazyPictureStore={pictureStore}
         src={$pictureStore}
         alt="User avatar"
         class="object-contain object-center bg-white {sizeClass}"
         draggable="false"
+        loading="lazy"
+        decoding="async"
         style:background-color={`${color ? color : `${getColorByString(fallbackName)}`}`}
         on:error={(event) => {
             console.warn(`Failed to load avatar image for ${fallbackName}`, event);
@@ -33,6 +85,7 @@
     />
 {:else}
     <div
+        use:loadLazyPictureStore={pictureStore}
         class:chatAvatar={isChatAvatar}
         class="text-center uppercase text-white flex items-center justify-center font-bold aspect-square {sizeClass}"
         draggable="false"

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -45,7 +45,7 @@ import { gameManager } from "../../../Phaser/Game/GameManager";
 import { localUserStore } from "../../../Connection/LocalUserStore";
 import { MessageNotification } from "../../../Notification/MessageNotification";
 import { notificationManager } from "../../../Notification/NotificationManager";
-import type { PictureStore } from "../../../Stores/PictureStore";
+import type { LazyPictureStore, PictureStore } from "../../../Stores/PictureStore";
 import { isLazyPictureStore } from "../../../Stores/PictureStore";
 import { chatNotificationStore } from "../../../Stores/ProximityNotificationStore";
 import { chatVisibilityStore } from "../../../Stores/ChatStore";
@@ -70,7 +70,7 @@ export class MatrixChatRoom
     readonly type: Readable<"multiple" | "direct">;
     readonly hasUnreadMessages: Writable<boolean>;
     readonly unreadNotificationCount: Writable<number>;
-    pictureStore: PictureStore;
+    pictureStore: LazyPictureStore;
     readonly avatarFallbackColor: Readable<string | undefined>;
     messages: SearchableArrayStore<string, MatrixChatMessage>;
     members: Writable<MatrixChatRoomMember[]>;

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -46,6 +46,7 @@ import { localUserStore } from "../../../Connection/LocalUserStore";
 import { MessageNotification } from "../../../Notification/MessageNotification";
 import { notificationManager } from "../../../Notification/NotificationManager";
 import type { PictureStore } from "../../../Stores/PictureStore";
+import { isLazyPictureStore } from "../../../Stores/PictureStore";
 import { chatNotificationStore } from "../../../Stores/ProximityNotificationStore";
 import { chatVisibilityStore } from "../../../Stores/ChatStore";
 import type { UserProviderMerger } from "../../UserProviderMerger/UserProviderMerger";
@@ -159,21 +160,49 @@ export class MatrixChatRoom
         ]);
         this.membersForMessageAvatars = this.members;
 
-        /** Channel: room avatar. DM: room avatar or peer Matrix avatar (peer read via `get`; list row refreshes on `members` / type changes). */
-        this.pictureStore = derived(
+        /** Channel: room avatar. DM: room avatar or peer Matrix avatar, with load delegated to the peer lazy store. */
+        const roomPictureStore = derived(
             [this.roomTypeStore, roomAvatarStore, this.members],
-            ([roomType, roomAvatar, members]) => {
+            ([roomType, roomAvatar, members], set: (value: string | undefined) => void) => {
                 if (roomType !== "direct") {
-                    return roomAvatar;
+                    set(roomAvatar);
+                    return;
                 }
                 const myUserId = this.matrixRoom.client.getUserId();
                 const other = members.find((m) => m.id !== myUserId);
                 if (!other) {
-                    return roomAvatar;
+                    set(roomAvatar);
+                    return;
                 }
-                return roomAvatar ?? get(other.pictureStore);
-            }
+                if (roomAvatar) {
+                    set(roomAvatar);
+                    return;
+                }
+                return other.pictureStore.subscribe(set);
+            },
+            undefined
         );
+        this.pictureStore = {
+            subscribe: roomPictureStore.subscribe,
+            load: async () => {
+                const other = this.getDirectRoomPeerMember();
+                if (!get(roomAvatarStore) && isLazyPictureStore(other?.pictureStore)) {
+                    await other.pictureStore.load();
+                }
+            },
+            refresh: async () => {
+                const other = this.getDirectRoomPeerMember();
+                if (!get(roomAvatarStore) && isLazyPictureStore(other?.pictureStore)) {
+                    await other.pictureStore.refresh();
+                }
+            },
+            invalidate: () => {
+                const other = this.getDirectRoomPeerMember();
+                if (!get(roomAvatarStore) && isLazyPictureStore(other?.pictureStore)) {
+                    other.pictureStore.invalidate();
+                }
+            },
+        };
 
         this.avatarFallbackColor = derived(
             [this.roomTypeStore, this.members, this.userProviderMergerStore],
@@ -338,6 +367,14 @@ export class MatrixChatRoom
         const messages = result.filter((message): message is MatrixChatMessage => message !== undefined);
         this.messages.push(...messages);
         this.hasPreviousMessage.set(this.timelineWindow.canPaginate(Direction.Backward));
+    }
+
+    private getDirectRoomPeerMember(): MatrixChatRoomMember | undefined {
+        if (get(this.roomTypeStore) !== "direct") {
+            return undefined;
+        }
+        const myUserId = this.matrixRoom.client.getUserId();
+        return get(this.members).find((member) => member.id !== myUserId);
     }
 
     private async readEventsToAddMessagesAndReactions(

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoomMember.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoomMember.ts
@@ -5,13 +5,11 @@ import { derived, get, writable } from "svelte/store";
 
 import type { ChatRoomMember, ChatRoomMembership, memberTypingInformation } from "../ChatConnection";
 import { ChatPermissionLevel } from "../ChatConnection";
-import type { PictureStore } from "../../../Stores/PictureStore";
+import type { LazyPictureStore, PictureStore } from "../../../Stores/PictureStore";
 import type { UserProviderMerger } from "../../UserProviderMerger/UserProviderMerger";
 import { localUserStore } from "../../../Connection/LocalUserStore";
 import { resolveChatUserColor } from "./services/WaMatrixProfileService";
 import { matrixAvatarProfile } from "./services/MatrixAvatarProfile";
-
-const singletonMapTimeOutGetAvatar = new Map<string, NodeJS.Timeout>();
 
 export class MatrixChatRoomMember implements ChatRoomMember {
     private handleRoomMemberMembership = this.onRoomMemberMembership.bind(this);
@@ -26,7 +24,7 @@ export class MatrixChatRoomMember implements ChatRoomMember {
     readonly permissionLevel: Writable<ChatPermissionLevel>;
     readonly isTypingInformation: Writable<{ id: string; name: string | null; pictureStore: PictureStore } | null> =
         writable(null);
-    readonly pictureStore: Writable<string | undefined>;
+    readonly pictureStore: LazyPictureStore;
     readonly avatarFallbackColor: Readable<string | undefined>;
     readonly waDisplayNameIfDifferent: Readable<string | undefined>;
 
@@ -37,8 +35,15 @@ export class MatrixChatRoomMember implements ChatRoomMember {
         this.name = writable(this.roomMember.name);
         this.membership = writable(this.roomMember.membership);
         this.permissionLevel = writable(MatrixChatRoomMember.getPermissionLevel(this.roomMember.powerLevelNorm));
-        this.pictureStore = writable(undefined);
-        this.refreshAvatarFromRoomMember();
+        this.pictureStore = matrixAvatarProfile.createLazyAvatarStore(this.id, () =>
+            matrixAvatarProfile.resolveAvatarUrl(
+                this.id,
+                this.roomMember,
+                this.baseUrl,
+                this.matrixClient,
+                this.mergerContext
+            )
+        );
         this.startHandlingChatRoomMemberEvents();
         const matrixUser = this.matrixClient.getUser(this.id);
         if (matrixUser) {
@@ -124,15 +129,7 @@ export class MatrixChatRoomMember implements ChatRoomMember {
     }
 
     refreshAvatarFromRoomMember(): void {
-        const avatarUrl = matrixAvatarProfile.getAvatarUrl(
-            this.id,
-            this.roomMember,
-            this.baseUrl,
-            this.matrixClient,
-            this.mergerContext
-        );
-        if (avatarUrl == undefined) return;
-        this.pictureStore.set(avatarUrl);
+        this.pictureStore.invalidate();
     }
 
     private onMatrixUserAvatar(): void {
@@ -197,10 +194,6 @@ export class MatrixChatRoomMember implements ChatRoomMember {
         if (matrixUser) {
             matrixUser.off(UserEvent.AvatarUrl, this.handleMatrixUserAvatar);
         }
-        const timeout = singletonMapTimeOutGetAvatar.get(this.id);
-        if (timeout) {
-            clearTimeout(timeout);
-            singletonMapTimeOutGetAvatar.delete(this.id);
-        }
+        this.pictureStore.destroy?.();
     }
 }

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatUser.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatUser.ts
@@ -1,8 +1,9 @@
 import type { MatrixClient, User } from "matrix-js-sdk";
 import { SetPresence } from "matrix-js-sdk";
-import { readable, writable } from "svelte/store";
+import { writable } from "svelte/store";
 import { AvailabilityStatus } from "@workadventure/messages";
 import type { ChatUser } from "../ChatConnection";
+import { matrixAvatarProfile } from "./services/MatrixAvatarProfile";
 
 export const chatUserFactory: (matrixChatUser: User, matrixClient: MatrixClient) => ChatUser = (
     matrixChatUser,
@@ -13,7 +14,9 @@ export const chatUserFactory: (matrixChatUser: User, matrixClient: MatrixClient)
         username: matrixChatUser.rawDisplayName,
         roomName: undefined,
         playUri: undefined,
-        pictureStore: readable(matrixClient.mxcUrlToHttp(matrixChatUser.avatarUrl ?? "", 48, 48) ?? undefined),
+        pictureStore: matrixAvatarProfile.createLazyAvatarStore(matrixChatUser.userId, () =>
+            matrixAvatarProfile.resolveUserAvatarUrl(matrixChatUser.userId, matrixClient)
+        ),
         color: undefined,
         spaceUserId: undefined,
         availabilityStatus: writable(mapMatrixPresenceToAvailabilityStatus(matrixChatUser.presence)),

--- a/play/src/front/Chat/Connection/Matrix/services/MatrixAvatarProfile.ts
+++ b/play/src/front/Chat/Connection/Matrix/services/MatrixAvatarProfile.ts
@@ -19,11 +19,32 @@ type LazyAvatarStoreState = {
     hasLoaded: boolean;
 };
 
+function formatAvatarUrlForDebug(url: string | undefined): string | undefined {
+    if (url === undefined) {
+        return undefined;
+    }
+    if (url.startsWith("data:")) {
+        const mediaTypeEnd = url.indexOf(",");
+        const mediaType = mediaTypeEnd >= 0 ? url.slice(0, mediaTypeEnd) : "data:";
+        return `${mediaType},... (${url.length} chars)`;
+    }
+
+    try {
+        const parsedUrl = new URL(url, window.location.href);
+        parsedUrl.search = "";
+        parsedUrl.hash = "";
+        return parsedUrl.toString();
+    } catch {
+        return url;
+    }
+}
+
 export class MatrixAvatarProfile {
     private readonly avatarUrlCache = new Map<string, AvatarCacheEntry>();
     private readonly lazyAvatarStoresByUser = new Map<string, Set<LazyAvatarStoreState>>();
 
     createLazyAvatarStore(matrixUserId: string, resolveAvatarUrl: () => string | undefined): LazyPictureStore {
+        debug("Create lazy avatar store for %s", matrixUserId);
         const store = writable<string | undefined>(undefined);
         const state: LazyAvatarStoreState = {
             set: store.set,
@@ -35,8 +56,10 @@ export class MatrixAvatarProfile {
         this.lazyAvatarStoresByUser.set(matrixUserId, stores);
 
         const loadFromCache = async (forceRefresh = false): Promise<void> => {
+            debug("Load lazy avatar store for %s forceRefresh=%s", matrixUserId, forceRefresh);
             state.hasLoaded = true;
             const avatarUrl = await this.getCachedAvatarUrl(matrixUserId, state.resolveAvatarUrl, forceRefresh);
+            debug("Lazy avatar store loaded for %s => %s", matrixUserId, formatAvatarUrlForDebug(avatarUrl));
             state.set(avatarUrl);
         };
 
@@ -44,16 +67,20 @@ export class MatrixAvatarProfile {
             subscribe: store.subscribe,
             load: () => loadFromCache(false),
             refresh: () => {
+                debug("Refresh lazy avatar store for %s hasLoaded=%s", matrixUserId, state.hasLoaded);
                 this.markAvatarUrlStale(matrixUserId);
                 if (!state.hasLoaded) {
+                    debug("Skip refresh for %s because store has not been loaded yet", matrixUserId);
                     return Promise.resolve();
                 }
                 return loadFromCache(true);
             },
             invalidate: () => {
+                debug("Invalidate lazy avatar store for %s", matrixUserId);
                 this.invalidateAvatarUrl(matrixUserId);
             },
             destroy: () => {
+                debug("Destroy lazy avatar store for %s", matrixUserId);
                 stores.delete(state);
                 if (stores.size === 0) {
                     this.lazyAvatarStoresByUser.delete(matrixUserId);
@@ -76,31 +103,41 @@ export class MatrixAvatarProfile {
             matrixClient,
             mergerContext
         );
-        debug("Return avatar url for", matrixUserId, "=>", avatarUrl);
+        debug("Return avatar url for %s => %s", matrixUserId, formatAvatarUrlForDebug(avatarUrl));
         return avatarUrl;
     }
 
     resolveUserAvatarUrl(matrixUserId: string, matrixClient: MatrixClient): string | undefined {
         const avatarUrl = resolveDirectMessagePeerAvatarUrl(matrixUserId, undefined, matrixClient, undefined);
-        debug("Return user avatar url for", matrixUserId, "=>", avatarUrl);
+        debug("Return user avatar url for %s => %s", matrixUserId, formatAvatarUrlForDebug(avatarUrl));
         return avatarUrl;
     }
 
     invalidateAvatarUrl(matrixUserId: string): void {
+        debug("Invalidate avatar URL cache for %s", matrixUserId);
         this.markAvatarUrlStale(matrixUserId);
         const stores = this.lazyAvatarStoresByUser.get(matrixUserId);
         stores?.forEach((store) => {
             if (!store.hasLoaded) {
+                debug("Skip invalidated store refresh for %s because store has not been loaded yet", matrixUserId);
                 return;
             }
+            debug("Refresh invalidated loaded store for %s", matrixUserId);
             this.getCachedAvatarUrl(matrixUserId, store.resolveAvatarUrl, true)
-                .then((avatarUrl) => store.set(avatarUrl))
-                .catch((error) => console.warn("Failed to refresh Matrix avatar", error));
+                .then((avatarUrl) => {
+                    debug("Invalidated store refreshed for %s => %s", matrixUserId, formatAvatarUrlForDebug(avatarUrl));
+                    store.set(avatarUrl);
+                })
+                .catch((error) => {
+                    debug("Failed to refresh Matrix avatar for %s: %o", matrixUserId, error);
+                    console.warn("Failed to refresh Matrix avatar", error);
+                });
         });
     }
 
     private markAvatarUrlStale(matrixUserId: string): void {
         const entry = this.avatarUrlCache.get(matrixUserId);
+        debug("Mark avatar URL cache stale for %s previousValid=%s", matrixUserId, entry?.valid ?? false);
         this.avatarUrlCache.set(matrixUserId, {
             value: entry?.value,
             valid: false,
@@ -114,17 +151,20 @@ export class MatrixAvatarProfile {
     ): Promise<string | undefined> {
         const entry = this.avatarUrlCache.get(matrixUserId);
         if (!forceRefresh && entry?.valid && entry.value !== undefined) {
-            debug("Return cached avatar url for", matrixUserId, "=>", entry.value);
+            debug("Return cached avatar url for %s => %s", matrixUserId, formatAvatarUrlForDebug(entry.value));
             return Promise.resolve(entry.value);
         }
         if (entry?.pending) {
+            debug("Return pending avatar URL promise for %s", matrixUserId);
             return entry.pending;
         }
 
+        debug("Resolve avatar URL for %s forceRefresh=%s previousValid=%s", matrixUserId, forceRefresh, !!entry?.valid);
         const pending = Promise.resolve()
             .then(resolveAvatarUrl)
             .then(
                 (avatarUrl) => {
+                    debug("Resolved avatar URL for %s => %s", matrixUserId, formatAvatarUrlForDebug(avatarUrl));
                     this.avatarUrlCache.set(matrixUserId, {
                         value: avatarUrl,
                         valid: true,
@@ -132,6 +172,7 @@ export class MatrixAvatarProfile {
                     return avatarUrl;
                 },
                 (error) => {
+                    debug("Failed to resolve avatar URL for %s: %o", matrixUserId, error);
                     const currentEntry = this.avatarUrlCache.get(matrixUserId);
                     if (currentEntry?.pending === pending) {
                         this.avatarUrlCache.delete(matrixUserId);

--- a/play/src/front/Chat/Connection/Matrix/services/MatrixAvatarProfile.ts
+++ b/play/src/front/Chat/Connection/Matrix/services/MatrixAvatarProfile.ts
@@ -1,25 +1,74 @@
 import type { MatrixClient, RoomMember } from "matrix-js-sdk";
 import Debug from "debug";
+import { writable } from "svelte/store";
+import type { LazyPictureStore } from "../../../../Stores/PictureStore";
 import type { UserProviderMerger } from "../../../UserProviderMerger/UserProviderMerger";
 import { resolveDirectMessagePeerAvatarUrl } from "./WaMatrixProfileService";
 
 const debug = Debug("MatrixChatConnection");
 
-export class MatrixAvatarProfile {
-    private readonly singletonMapTimeOutGetAvatar = new Map<string, { expire: number; resolve: string | undefined }>();
+type AvatarCacheEntry = {
+    value: string | undefined;
+    valid: boolean;
+    pending?: Promise<string | undefined>;
+};
 
-    getAvatarUrl(
+type LazyAvatarStoreState = {
+    set: (avatarUrl: string | undefined) => void;
+    resolveAvatarUrl: () => string | undefined;
+    hasLoaded: boolean;
+};
+
+export class MatrixAvatarProfile {
+    private readonly avatarUrlCache = new Map<string, AvatarCacheEntry>();
+    private readonly lazyAvatarStoresByUser = new Map<string, Set<LazyAvatarStoreState>>();
+
+    createLazyAvatarStore(matrixUserId: string, resolveAvatarUrl: () => string | undefined): LazyPictureStore {
+        const store = writable<string | undefined>(undefined);
+        const state: LazyAvatarStoreState = {
+            set: store.set,
+            resolveAvatarUrl,
+            hasLoaded: false,
+        };
+        const stores = this.lazyAvatarStoresByUser.get(matrixUserId) ?? new Set<LazyAvatarStoreState>();
+        stores.add(state);
+        this.lazyAvatarStoresByUser.set(matrixUserId, stores);
+
+        const loadFromCache = async (forceRefresh = false): Promise<void> => {
+            state.hasLoaded = true;
+            const avatarUrl = await this.getCachedAvatarUrl(matrixUserId, state.resolveAvatarUrl, forceRefresh);
+            state.set(avatarUrl);
+        };
+
+        return {
+            subscribe: store.subscribe,
+            load: () => loadFromCache(false),
+            refresh: () => {
+                this.markAvatarUrlStale(matrixUserId);
+                if (!state.hasLoaded) {
+                    return Promise.resolve();
+                }
+                return loadFromCache(true);
+            },
+            invalidate: () => {
+                this.invalidateAvatarUrl(matrixUserId);
+            },
+            destroy: () => {
+                stores.delete(state);
+                if (stores.size === 0) {
+                    this.lazyAvatarStoresByUser.delete(matrixUserId);
+                }
+            },
+        };
+    }
+
+    resolveAvatarUrl(
         matrixUserId: string,
         roomMember: RoomMember,
         baseUrl: string,
         matrixClient: MatrixClient,
         mergerContext: UserProviderMerger | undefined
     ): string | undefined {
-        const entry = this.singletonMapTimeOutGetAvatar.get(matrixUserId);
-        if (entry && entry.expire > Date.now()) {
-            debug("Return cached avatar url for", matrixUserId, "=>", entry.resolve);
-            return entry.resolve;
-        }
         const http = roomMember.getAvatarUrl(baseUrl, 96, 96, "scale", false, false);
         const avatarUrl = resolveDirectMessagePeerAvatarUrl(
             matrixUserId,
@@ -27,9 +76,77 @@ export class MatrixAvatarProfile {
             matrixClient,
             mergerContext
         );
-        this.singletonMapTimeOutGetAvatar.set(matrixUserId, { expire: Date.now() + 5000, resolve: avatarUrl });
         debug("Return avatar url for", matrixUserId, "=>", avatarUrl);
         return avatarUrl;
+    }
+
+    resolveUserAvatarUrl(matrixUserId: string, matrixClient: MatrixClient): string | undefined {
+        const avatarUrl = resolveDirectMessagePeerAvatarUrl(matrixUserId, undefined, matrixClient, undefined);
+        debug("Return user avatar url for", matrixUserId, "=>", avatarUrl);
+        return avatarUrl;
+    }
+
+    invalidateAvatarUrl(matrixUserId: string): void {
+        this.markAvatarUrlStale(matrixUserId);
+        const stores = this.lazyAvatarStoresByUser.get(matrixUserId);
+        stores?.forEach((store) => {
+            if (!store.hasLoaded) {
+                return;
+            }
+            this.getCachedAvatarUrl(matrixUserId, store.resolveAvatarUrl, true)
+                .then((avatarUrl) => store.set(avatarUrl))
+                .catch((error) => console.warn("Failed to refresh Matrix avatar", error));
+        });
+    }
+
+    private markAvatarUrlStale(matrixUserId: string): void {
+        const entry = this.avatarUrlCache.get(matrixUserId);
+        this.avatarUrlCache.set(matrixUserId, {
+            value: entry?.value,
+            valid: false,
+        });
+    }
+
+    private getCachedAvatarUrl(
+        matrixUserId: string,
+        resolveAvatarUrl: () => string | undefined,
+        forceRefresh: boolean
+    ): Promise<string | undefined> {
+        const entry = this.avatarUrlCache.get(matrixUserId);
+        if (!forceRefresh && entry?.valid && entry.value !== undefined) {
+            debug("Return cached avatar url for", matrixUserId, "=>", entry.value);
+            return Promise.resolve(entry.value);
+        }
+        if (entry?.pending) {
+            return entry.pending;
+        }
+
+        const pending = Promise.resolve()
+            .then(resolveAvatarUrl)
+            .then(
+                (avatarUrl) => {
+                    this.avatarUrlCache.set(matrixUserId, {
+                        value: avatarUrl,
+                        valid: true,
+                    });
+                    return avatarUrl;
+                },
+                (error) => {
+                    const currentEntry = this.avatarUrlCache.get(matrixUserId);
+                    if (currentEntry?.pending === pending) {
+                        this.avatarUrlCache.delete(matrixUserId);
+                    }
+                    throw error;
+                }
+            );
+
+        this.avatarUrlCache.set(matrixUserId, {
+            value: entry?.value,
+            valid: false,
+            pending,
+        });
+
+        return pending;
     }
 }
 

--- a/play/src/front/Stores/PictureStore.ts
+++ b/play/src/front/Stores/PictureStore.ts
@@ -4,3 +4,14 @@ import type { Readable } from "svelte/store";
  * A store that contains the player/companion avatar picture
  */
 export type PictureStore = Readable<string | undefined>;
+
+export type LazyPictureStore = PictureStore & {
+    load: () => Promise<void>;
+    refresh: () => Promise<void>;
+    invalidate: () => void;
+    destroy?: () => void;
+};
+
+export function isLazyPictureStore(pictureStore: PictureStore | undefined): pictureStore is LazyPictureStore {
+    return typeof (pictureStore as Partial<LazyPictureStore> | undefined)?.load === "function";
+}


### PR DESCRIPTION
## Problem
Matrix avatars were resolved eagerly when chat users and room members were created, which could trigger too many image loads during application startup. This becomes especially costly for users with many rooms, where most avatars may never be displayed.

## Solution
Introduce lazy avatar stores and load avatars only when the avatar component becomes visible, while preserving cache invalidation and refresh behavior.

## Changes
- Add `LazyPictureStore` support for deferred avatar loading.
- Load chat avatars via `IntersectionObserver` in the avatar component.
- Cache and deduplicate Matrix avatar URL resolution.
- Delegate direct room avatar loading to the peer member lazy avatar store.
- Add tests for lazy avatar loading, caching, invalidation, and room member construction.