### PR TITLE
Matrix room folder reconciliation

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -59,6 +59,7 @@ import { MatrixChatRoom } from "./MatrixChatRoom";
 import type { MatrixSecurity } from "./MatrixSecurity";
 import { matrixSecurity as defaultMatrixSecurity } from "./MatrixSecurity";
 import { MatrixRoomFolder } from "./MatrixRoomFolder";
+import { hasValidViaEntries } from "./MatrixSpaceRelations";
 import { chatUserFactory, mapMatrixPresenceToAvailabilityStatus } from "./MatrixChatUser";
 import {
     pushLocalWokaAndNameToMatrixProfile,
@@ -68,10 +69,12 @@ import {
 const debug = Debug("MatrixChatConnection");
 
 const CLIENT_NOT_INITIALIZED_ERROR_MSG = "MatrixClient not yet initialized";
+type RoomPlacementReconciliationResult = "placed" | "root" | "pending" | "removed";
 
 export type { MatrixPeerProfileDiagnostics, MatrixUserSettingsDiagnostics } from "../ChatConnection";
 
 export class MatrixChatConnection implements ChatConnectionInterface, MatrixChatCapabilities {
+    private static readonly spaceReconciliationDelaysMs = [0, 100, 300, 700, 1500];
     private readonly roomList: MapStore<string, MatrixChatRoom>;
     private client: MatrixClient | undefined;
     private handleRoom: (room: Room) => void;
@@ -89,6 +92,8 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     private isClientReady = false;
     private usersStatus: MapStore<string, AvailabilityStatus>;
     private userIdsNeedingPresenceUpdate = new Set();
+    private readonly roomPlacementRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    private readonly roomPlacementRetryGenerations = new Map<string, number>();
     nbUnreadInvitationsMessages: Readable<number>;
     nbUnreadDirectRoomsMessages: Readable<number>;
     nbUnreadRoomsMessages: Readable<number>;
@@ -337,9 +342,6 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             await this.syncMatrixGlobalProfileFromLocalWokaAndName(false);
             this.attachWokaAvatarMatrixSync();
             this.attachDisplayNameMatrixSync();
-
-            // Refresh all joined folders children to ensure the UI is up to date
-            //this.refreshAllJoinedFoldersChildren();
         } catch (error) {
             this.connectionStatus.set("OFFLINE");
             console.error(error);
@@ -638,10 +640,153 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         const parentIDs =
             room.getLiveTimeline().getState(EventTimeline.FORWARDS)?.getStateEvents(EventType.SpaceParent) || [];
         return parentIDs.reduce((acc, currentMatrixEvent) => {
+            if (!hasValidViaEntries(currentMatrixEvent.getContent())) {
+                return acc;
+            }
             const parentID = currentMatrixEvent.getStateKey();
+            const parentRoom = parentID ? room.client?.getRoom(parentID) : undefined;
+            // A stale m.space.parent can remain after a move; only trust known parents that still expose the child link.
+            if (parentRoom && !this.hasValidChildRelation(parentRoom, room.roomId)) {
+                return acc;
+            }
             if (parentID) acc.push(parentID);
             return acc;
         }, [] as string[]);
+    }
+
+    private hasValidChildRelation(parentRoom: Room, childRoomId: string): boolean {
+        const childEvents =
+            parentRoom.getLiveTimeline().getState(EventTimeline.FORWARDS)?.getStateEvents(EventType.SpaceChild) || [];
+
+        return childEvents.some((childEvent) => {
+            return childEvent.getStateKey() === childRoomId && hasValidViaEntries(childEvent.getContent());
+        });
+    }
+
+    private detachRoomFromRootLists(roomId: string): void {
+        this.roomList.delete(roomId);
+        this.roomFolders.delete(roomId);
+    }
+
+    private clearRoomPlacementRetry(roomId: string): void {
+        // Invalidate in-flight reconciliation promises so they cannot recreate timers after cleanup.
+        this.roomPlacementRetryGenerations.set(roomId, (this.roomPlacementRetryGenerations.get(roomId) ?? 0) + 1);
+        const timer = this.roomPlacementRetryTimers.get(roomId);
+        if (timer !== undefined) {
+            clearTimeout(timer);
+            this.roomPlacementRetryTimers.delete(roomId);
+        }
+    }
+
+    private clearRoomPlacementRetries(): void {
+        for (const roomId of Array.from(this.roomPlacementRetryTimers.keys())) {
+            this.clearRoomPlacementRetry(roomId);
+        }
+    }
+
+    private scheduleRoomPlacementReconciliation(roomId: string): void {
+        this.clearRoomPlacementRetry(roomId);
+        const generation = this.roomPlacementRetryGenerations.get(roomId) ?? 0;
+        const runAttempt = (attemptIndex: number): void => {
+            this.reconcileRoomPlacement(roomId)
+                .then((result) => {
+                    if (this.roomPlacementRetryGenerations.get(roomId) !== generation) {
+                        return;
+                    }
+
+                    if (result !== "pending") {
+                        this.clearRoomPlacementRetry(roomId);
+                        return;
+                    }
+
+                    const nextAttemptIndex = attemptIndex + 1;
+                    if (nextAttemptIndex >= MatrixChatConnection.spaceReconciliationDelaysMs.length) {
+                        this.clearRoomPlacementRetry(roomId);
+                        return;
+                    }
+
+                    const timer = setTimeout(() => {
+                        if (this.roomPlacementRetryGenerations.get(roomId) !== generation) {
+                            return;
+                        }
+                        runAttempt(nextAttemptIndex);
+                    }, MatrixChatConnection.spaceReconciliationDelaysMs[nextAttemptIndex]);
+                    this.roomPlacementRetryTimers.set(roomId, timer);
+                })
+                .catch((error) => {
+                    console.error("Failed to reconcile room placement:", error);
+                    this.clearRoomPlacementRetry(roomId);
+                });
+        };
+        runAttempt(0);
+    }
+
+    private async reconcileRoomPlacement(roomId: string): Promise<RoomPlacementReconciliationResult> {
+        const client = this.client;
+        if (!client) {
+            return "pending";
+        }
+
+        const room = client.getRoom(roomId);
+        if (!room) {
+            return "pending";
+        }
+
+        const membership = room.getMyMembership();
+        if (membership === KnownMembership.Leave || membership === KnownMembership.Ban) {
+            await this.deleteRoom(roomId);
+            return "removed";
+        }
+
+        const parentIds = this.getParentRoomID(room);
+        if (parentIds.length === 0) {
+            await this.removeRoomFromAllFolders(roomId);
+            this.handleOrphanRoom(room);
+            return "root";
+        }
+
+        await this.removeRoomFromAllFolders(roomId);
+        const placementResults = await Promise.all(
+            parentIds.map(async (parentId) => {
+                let parentFolder = await this.findParentFolder(parentId);
+                if (!parentFolder) {
+                    const parentRoom = client.getRoom(parentId);
+                    if (parentRoom) {
+                        await this.manageRoomOrFolder(parentRoom);
+                        parentFolder = await this.findParentFolder(parentId);
+                    }
+                }
+
+                if (parentFolder) {
+                    await this.addRoomToParentFolder(room, parentFolder);
+                    return true;
+                }
+                return false;
+            })
+        );
+
+        if (placementResults.some((didPlaceRoom) => didPlaceRoom)) {
+            this.detachRoomFromRootLists(roomId);
+            return "placed";
+        }
+
+        return "pending";
+    }
+
+    private async removeRoomFromAllFolders(roomId: string): Promise<boolean> {
+        const deleteRoomPromise = Array.from(this.roomFolders.values()).map((roomFolder) => {
+            return roomFolder.deleteNode(roomId);
+        });
+        const responses = await Promise.all(deleteRoomPromise);
+        return responses.some((response) => response);
+    }
+
+    private async removeRoomFromParentFolder(roomId: string, parentId: string): Promise<boolean> {
+        const parentFolder = await this.findParentFolder(parentId);
+        if (!parentFolder) {
+            return false;
+        }
+        return parentFolder.deleteNode(roomId);
     }
 
     private onAccountDataEvent(event: MatrixEvent) {
@@ -696,26 +841,32 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         }
 
         const roomID = event.getStateKey();
-
-        if (!roomID) {
-            return;
-        }
-        const room = this.client.getRoom(roomID);
-        if (!room) {
-            return;
-        }
-
-        this.roomList.delete(roomID);
-        this.roomFolders.delete(roomID);
-
         const parentID = event.getRoomId();
-        if (!parentID) {
+        if (!roomID || !parentID) {
             return;
         }
 
-        this.moveRoomToParentFolder(room, parentID).catch((e) => {
-            console.error("Failed to move room to parent folder : ", e);
-        });
+        if (!hasValidViaEntries(event.getContent())) {
+            this.removeRoomFromParentFolder(roomID, parentID)
+                .catch((e) => {
+                    console.error("Failed to remove room from parent folder : ", e);
+                })
+                .finally(() => {
+                    this.scheduleRoomPlacementReconciliation(roomID);
+                });
+            return;
+        }
+
+        this.reconcileRoomPlacement(roomID)
+            .then((result) => {
+                if (result === "pending") {
+                    this.scheduleRoomPlacementReconciliation(roomID);
+                }
+            })
+            .catch((e) => {
+                console.error("Failed to reconcile room placement : ", e);
+                this.scheduleRoomPlacementReconciliation(roomID);
+            });
     }
     private onClientEventRoom(room: Room) {
         this.manageRoomOrFolder(room).catch((e) => {
@@ -723,23 +874,30 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         });
     }
 
-    private async moveRoomToParentFolder(room: Room, parentID: string): Promise<void> {
+    private async moveRoomToParentFolder(room: Room, parentID: string): Promise<boolean> {
         const isSpaceRoom = room.isSpaceRoom();
         const parentFolder = await this.findParentFolder(parentID);
 
         if (!parentFolder) {
-            return;
+            return false;
         }
 
         this.addRoomToFolder(room, parentFolder, isSpaceRoom);
+        return true;
     }
     private addRoomToFolder(room: Room, targetFolder: MatrixRoomFolder, isSpaceRoom: boolean): void {
         if (isSpaceRoom) {
+            if (targetFolder.folderList.has(room.roomId)) {
+                return;
+            }
             const newFolder = new MatrixRoomFolder(room);
             targetFolder.folderList.set(room.roomId, newFolder);
 
             newFolder.init();
         } else {
+            if (targetFolder.roomList.has(room.roomId)) {
+                return;
+            }
             targetFolder.roomList.set(room.roomId, new MatrixChatRoom(room));
         }
     }
@@ -774,7 +932,6 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             }
 
             await this.addRoomToParentFolder(room, parentFolder);
-            // await parentFolder.refreshAllChildRooms();
             return true;
         } catch (e) {
             console.error("Error in tryAddRoomToParentFolder:", e);
@@ -802,30 +959,37 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
 
         // Add room/folder to parent's lists
         if (isSpaceRoom) {
-            const roomFolder = new MatrixRoomFolder(room);
+            let roomFolder = parentFolder.folderList.get(roomId);
+            if (!roomFolder) {
+                roomFolder = new MatrixRoomFolder(room);
+                parentFolder.folderList.set(roomId, roomFolder);
+            }
             await roomFolder.refreshRooms();
-            // await roomFolder.refreshAllChildRooms();
-            // await roomFolder.refreshSuggestedRooms();
-            parentFolder.folderList.set(roomId, roomFolder);
+            roomFolder.init();
         } else {
-            parentFolder.roomList.set(roomId, new MatrixChatRoom(room));
+            if (!parentFolder.roomList.has(roomId)) {
+                parentFolder.roomList.set(roomId, new MatrixChatRoom(room));
+            }
         }
 
         if (get(parentFolder.myMembership) === KnownMembership.Join) {
-            this.roomList.delete(roomId);
-            this.roomFolders.delete(roomId);
+            this.detachRoomFromRootLists(roomId);
             return;
         }
 
-        const rootList = isSpaceRoom ? this.roomFolders : this.roomList;
-        const RoomClass = isSpaceRoom ? MatrixRoomFolder : MatrixChatRoom;
-        rootList.set(roomId, new RoomClass(room));
+        if (isSpaceRoom) {
+            if (!this.roomFolders.has(roomId)) {
+                const rootFolder = new MatrixRoomFolder(room);
+                rootFolder.init();
+                this.roomFolders.set(roomId, rootFolder);
+            }
+            return;
+        }
+        if (!this.roomList.has(roomId)) {
+            this.roomList.set(roomId, new MatrixChatRoom(room));
+        }
     }
 
-    /**
-     * Re-syncs each joined space folder from local `m.space.child` state so invited/joined
-     * children appear under the right folder before {@link #manageRoomOrFolder} runs.
-     */
     /**
      * Re-reads `m.space.child` for a joined folder and recurses into child folders.
      * @param targetRoomId When set, stops recursing once this room id appears under `folder` (including nested folders).
@@ -981,15 +1145,12 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         );
         const { roomId } = room;
         if (membership !== prevMembership && membership === KnownMembership.Join) {
-            this.roomList.delete(roomId);
-            this.roomFolders.delete(roomId);
+            this.detachRoomFromRootLists(roomId);
 
-            if (this.client?.isInitialSyncComplete()) {
-                this.refreshAllJoinedFoldersChildren(roomId);
-            }
-            this.manageRoomOrFolder(room).catch((e) => {
-                console.error("Failed to manageRoomOrFolder :", e);
-            });
+            // if (this.client?.isInitialSyncComplete()) {
+            // this.refreshAllJoinedFoldersChildren(roomId);
+            // }
+            this.scheduleRoomPlacementReconciliation(roomId);
             return;
         }
 
@@ -1014,14 +1175,11 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
                         });
                     }
 
-                    this.roomList.delete(room.roomId);
-                    this.roomFolders.delete(room.roomId);
+                    this.detachRoomFromRootLists(room.roomId);
                     if (this.client?.isInitialSyncComplete()) {
                         this.refreshAllJoinedFoldersChildren(room.roomId);
                     }
-                    this.manageRoomOrFolder(room).catch((e) => {
-                        console.error("Failed to manageRoomOrFolder : ", e);
-                    });
+                    this.scheduleRoomPlacementReconciliation(room.roomId);
 
                     // Only notify for "live" invitations (after initial sync). Avoids notifying for existing invites on load (plan: live vs historical).
                     if (client.isInitialSyncComplete()) {
@@ -1042,6 +1200,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         }
 
         if (membership === KnownMembership.Leave || membership === KnownMembership.Ban) {
+            this.clearRoomPlacementRetry(roomId);
             this.deleteRoom(roomId).catch((e) => {
                 console.error("Failed to delete room : ", e);
             });
@@ -1498,6 +1657,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     };
 
     clearListener() {
+        this.clearRoomPlacementRetries();
         this.roomList.forEach((room) => {
             this.roomList.delete(room.id);
         });

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -646,12 +646,20 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             const parentID = currentMatrixEvent.getStateKey();
             const parentRoom = parentID ? room.client?.getRoom(parentID) : undefined;
             // A stale m.space.parent can remain after a move; only trust known parents that still expose the child link.
-            if (parentRoom && !this.hasValidChildRelation(parentRoom, room.roomId)) {
+            if (
+                parentRoom &&
+                (!this.hasVisibleMembership(parentRoom) || !this.hasValidChildRelation(parentRoom, room.roomId))
+            ) {
                 return acc;
             }
             if (parentID) acc.push(parentID);
             return acc;
         }, [] as string[]);
+    }
+
+    private hasVisibleMembership(room: Room): boolean {
+        const membership = room.getMyMembership();
+        return membership === KnownMembership.Join || membership === KnownMembership.Invite;
     }
 
     private hasValidChildRelation(parentRoom: Room, childRoomId: string): boolean {
@@ -702,6 +710,10 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
                     const nextAttemptIndex = attemptIndex + 1;
                     if (nextAttemptIndex >= MatrixChatConnection.spaceReconciliationDelaysMs.length) {
                         this.clearRoomPlacementRetry(roomId);
+                        this.moveVisibleRoomToRoot(roomId).catch((error) => {
+                            console.error("Failed to move room to root after placement retries:", error);
+                            Sentry.captureException(error);
+                        });
                         return;
                     }
 
@@ -771,6 +783,26 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         }
 
         return "pending";
+    }
+
+    private async moveVisibleRoomToRoot(roomId: string): Promise<void> {
+        const room = this.client?.getRoom(roomId);
+        if (!room) {
+            return;
+        }
+
+        const membership = room.getMyMembership();
+        if (membership === KnownMembership.Leave || membership === KnownMembership.Ban) {
+            await this.deleteRoom(roomId);
+            return;
+        }
+
+        if (!this.hasVisibleMembership(room)) {
+            return;
+        }
+
+        await this.removeRoomFromAllFolders(roomId);
+        this.handleOrphanRoom(room);
     }
 
     private async removeRoomFromAllFolders(roomId: string): Promise<boolean> {
@@ -1059,6 +1091,43 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         this.createAndAddNewRootRoom(room);
     }
 
+    private getVisibleDescendantIds(folder: MatrixRoomFolder, descendants = new Set<string>()): string[] {
+        for (const room of folder.roomList.values()) {
+            if (get(room.myMembership) === KnownMembership.Join || get(room.myMembership) === KnownMembership.Invite) {
+                descendants.add(room.id);
+            }
+        }
+
+        for (const childFolder of folder.folderList.values()) {
+            if (
+                get(childFolder.myMembership) === KnownMembership.Join ||
+                get(childFolder.myMembership) === KnownMembership.Invite
+            ) {
+                descendants.add(childFolder.id);
+            }
+            this.getVisibleDescendantIds(childFolder, descendants);
+        }
+
+        return Array.from(descendants);
+    }
+
+    private async deleteRoomOrFolderAndReconcileChildren(room: Room): Promise<void> {
+        const node = await this.findRoomOrFolder(room.roomId);
+        const visibleDescendantIds = node instanceof MatrixRoomFolder ? this.getVisibleDescendantIds(node) : [];
+
+        await this.deleteRoom(room.roomId);
+
+        await Promise.all(
+            visibleDescendantIds.map(async (descendantId) => {
+                this.clearRoomPlacementRetry(descendantId);
+                const result = await this.reconcileRoomPlacement(descendantId);
+                if (result === "pending") {
+                    this.scheduleRoomPlacementReconciliation(descendantId);
+                }
+            })
+        );
+    }
+
     private async findRoomOrFolder(roomId: string): Promise<MatrixRoomFolder | MatrixChatRoom | undefined> {
         const roomInRoomList = this.roomList.get(roomId);
         if (roomInRoomList) {
@@ -1201,8 +1270,8 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
 
         if (membership === KnownMembership.Leave || membership === KnownMembership.Ban) {
             this.clearRoomPlacementRetry(roomId);
-            this.deleteRoom(roomId).catch((e) => {
-                console.error("Failed to delete room : ", e);
+            this.deleteRoomOrFolderAndReconcileChildren(room).catch((e) => {
+                console.error("Failed to delete room or folder : ", e);
             });
             return;
         }

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -52,6 +52,7 @@ import type { UserProviderMerger } from "../../UserProviderMerger/UserProviderMe
 import { MatrixChatMessage } from "./MatrixChatMessage";
 import { MatrixChatMessageReaction } from "./MatrixChatMessageReaction";
 import { matrixSecurity } from "./MatrixSecurity";
+import { hasValidViaEntries } from "./MatrixSpaceRelations";
 import { resolveChatUserColor } from "./services/WaMatrixProfileService";
 import { MatrixChatRoomMember } from "./MatrixChatRoomMember";
 
@@ -749,7 +750,7 @@ export class MatrixChatRoom
                 .getLiveTimeline()
                 ?.getState(EventTimeline.FORWARDS)
                 ?.getStateEvents(EventType.SpaceParent) ?? [];
-        return events.some((ev) => Boolean(ev.getStateKey()));
+        return events.some((ev) => Boolean(ev.getStateKey()) && hasValidViaEntries(ev.getContent()));
     }
 
     /** `m.room.create` content `is_direct` (Matrix-native DM flag). */

--- a/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
@@ -11,6 +11,7 @@ import { matrixRateLimiter } from "../../Services/MatrixRateLimiter";
 import { ignoredSuggestedRoomIdsStore } from "../../Stores/ChatStore";
 import type { RoomFolder } from "../ChatConnection";
 import { MatrixChatRoom } from "./MatrixChatRoom";
+import { hasValidViaEntries } from "./MatrixSpaceRelations";
 
 export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
     roomList: MapStore<MatrixChatRoom["id"], MatrixChatRoom> = new MapStore<MatrixChatRoom["id"], MatrixChatRoom>();
@@ -138,7 +139,7 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
             }
 
             const getNodePromise = Array.from(this.folderList.values()).map((folder) => {
-                return folder.getParentOfNode(id);
+                return folder.getNode(id);
             });
 
             const nodes = await Promise.all(getNodePromise);
@@ -245,24 +246,26 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
             ?.getState(EventTimeline.FORWARDS)
             ?.getStateEvents(EventType.SpaceChild);
 
-        childEvents?.forEach((childEvent) => {
-            const roomId = childEvent.event.state_key;
-            const childRoom = this.room.client.getRoom(roomId);
+        childEvents
+            ?.filter((childEvent) => hasValidViaEntries(childEvent.getContent()))
+            .forEach((childEvent) => {
+                const roomId = childEvent.event.state_key;
+                const childRoom = this.room.client.getRoom(roomId);
 
-            if (!childRoom || roomId === this.id) return;
+                if (!childRoom || roomId === this.id) return;
 
-            if (childRoom.isSpaceRoom()) {
-                this.folderList.set(childRoom.roomId, new MatrixRoomFolder(childRoom));
-            } else {
-                const matrixChatRoom = new MatrixChatRoom(childRoom);
-                if (
-                    get(matrixChatRoom.myMembership) === KnownMembership.Join ||
-                    get(matrixChatRoom.myMembership) === KnownMembership.Invite
-                ) {
-                    this.roomList.set(childRoom.roomId, matrixChatRoom);
+                if (childRoom.isSpaceRoom()) {
+                    this.folderList.set(childRoom.roomId, new MatrixRoomFolder(childRoom));
+                } else {
+                    const matrixChatRoom = new MatrixChatRoom(childRoom);
+                    if (
+                        get(matrixChatRoom.myMembership) === KnownMembership.Join ||
+                        get(matrixChatRoom.myMembership) === KnownMembership.Invite
+                    ) {
+                        this.roomList.set(childRoom.roomId, matrixChatRoom);
+                    }
                 }
-            }
-        });
+            });
     }
 
     async refreshRooms() {
@@ -361,6 +364,7 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
         if (!childEvents) return;
 
         const children = childEvents
+            .filter((ev) => hasValidViaEntries(ev.getContent()))
             .map((ev) => {
                 const stateKey = ev.getStateKey();
                 if (!stateKey) return null;

--- a/play/src/front/Chat/Connection/Matrix/MatrixSpaceRelations.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixSpaceRelations.ts
@@ -1,0 +1,10 @@
+export function hasValidViaEntries(content: unknown): boolean {
+    if (typeof content !== "object" || content === null) {
+        return false;
+    }
+    const via = Reflect.get(content, "via");
+    if (!Array.isArray(via) || via.length === 0) {
+        return false;
+    }
+    return via.every((entry) => typeof entry === "string" && entry.length > 0);
+}

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -1,11 +1,12 @@
 import type { MatrixClient } from "matrix-js-sdk";
 import { ClientEvent, EventType, PendingEventOrdering, RoomEvent, SyncState } from "matrix-js-sdk";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { KnownMembership } from "matrix-js-sdk/lib/types";
 import type { Readable } from "svelte/store";
 import { get, readable, writable } from "svelte/store";
 import type { AvailabilityStatus } from "@workadventure/messages";
 import { MatrixChatConnection } from "../MatrixChatConnection";
+import { MatrixRoomFolder } from "../MatrixRoomFolder";
 import type { CreateRoomOptions } from "../../ChatConnection";
 import type { MatrixChatRoom } from "../MatrixChatRoom";
 import type { MatrixSecurity } from "../MatrixSecurity";
@@ -45,6 +46,10 @@ vi.mock("../../../Stores/ChatStore.ts", () => {
 describe("MatrixChatConnection", () => {
     const flushPromises = () => new Promise(setImmediate);
 
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     const basicStatusStore: Readable<
         | AvailabilityStatus.ONLINE
         | AvailabilityStatus.SILENT
@@ -61,6 +66,7 @@ describe("MatrixChatConnection", () => {
 
     const basicMockMatrixSecurity = {
         isEncryptionRequiredAndNotSet: false,
+        updateMatrixClientStore: vi.fn(),
     } as unknown as MatrixSecurity;
 
     const getMatrixConnection = async (
@@ -173,6 +179,7 @@ describe("MatrixChatConnection", () => {
 
             const mockMatrixSecurity = {
                 isEncryptionRequiredAndNotSet: false,
+                updateMatrixClientStore: vi.fn(),
             } as unknown as MatrixSecurity;
 
             const matrixChatConnection = await getMatrixConnection(clientPromise, mockMatrixSecurity);
@@ -190,6 +197,7 @@ describe("MatrixChatConnection", () => {
 
                 const mockMatrixSecurity = {
                     isEncryptionRequiredAndNotSet: expected,
+                    updateMatrixClientStore: vi.fn(),
                 } as unknown as MatrixSecurity;
 
                 const matrixChatConnection = await getMatrixConnection(clientPromise, mockMatrixSecurity);
@@ -940,6 +948,288 @@ describe("MatrixChatConnection", () => {
             expect(mockSetAccountData.mock.calls[0][0]).toBe("m.direct");
             expect(mockSetAccountData.mock.calls[0][1][userId]).toContain(roomId);
             expect(mockSetAccountData.mock.calls[0][1][userId]).toContain(roomId2);
+        });
+    });
+
+    describe("space topology handling", () => {
+        it("should remove existing child when folder getChildren sees an m.space.child event without via", () => {
+            const roomId = "!child:server";
+            const childRoom = {
+                roomId,
+                getMyMembership: vi.fn().mockReturnValue(KnownMembership.Join),
+                isSpaceRoom: vi.fn().mockReturnValue(false),
+            };
+            const parentRoom = {
+                client: {
+                    getRoomUpgradeHistory: vi.fn().mockReturnValue([childRoom]),
+                },
+                getLiveTimeline: vi.fn().mockReturnValue({
+                    getState: vi.fn().mockReturnValue({
+                        getStateEvents: vi.fn().mockReturnValue([
+                            {
+                                getStateKey: vi.fn().mockReturnValue(roomId),
+                                getContent: vi.fn().mockReturnValue({}),
+                            },
+                        ]),
+                    }),
+                }),
+            };
+            const staleRoom = { destroy: vi.fn() };
+            const folder = Object.create(MatrixRoomFolder.prototype) as MatrixRoomFolder;
+            folder["room"] = parentRoom as never;
+            folder.roomList = new Map([[roomId, staleRoom]]) as never;
+            folder.folderList = new Map() as never;
+
+            folder.getChildren();
+
+            expect(folder.roomList.has(roomId)).toBeFalsy();
+            expect(staleRoom.destroy).toHaveBeenCalledOnce();
+        });
+
+        it("should remove an invalidated m.space.child from its parent folder and reschedule placement reconciliation", async () => {
+            const roomId = "!child:server";
+            const parentId = "!space:server";
+            const staleRoom = { destroy: vi.fn() };
+            const parentFolder = Object.assign(Object.create(MatrixRoomFolder.prototype), {
+                id: parentId,
+                roomList: new Map([[roomId, staleRoom]]),
+                folderList: new Map(),
+                deleteNode: vi.fn().mockResolvedValue(true),
+            }) as MatrixRoomFolder & { deleteNode: ReturnType<typeof vi.fn> };
+
+            const mockMatrixClient = {
+                isGuest: vi.fn().mockReturnValue(true),
+                on: vi.fn(),
+                off: vi.fn(),
+                store: {
+                    startup: vi.fn(),
+                },
+                initRustCrypto: vi.fn(),
+                startClient: vi.fn(),
+                isInitialSyncComplete: vi.fn().mockReturnValue(true),
+                getVisibleRooms: vi.fn().mockReturnValue([]),
+                getRoom: vi.fn(),
+            } as unknown as MatrixClient;
+
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
+            matrixChatConnection["roomFolders"].set(parentId, parentFolder as never);
+            const scheduleReconciliationSpy = vi.spyOn(
+                matrixChatConnection as unknown as { scheduleRoomPlacementReconciliation: (id: string) => void },
+                "scheduleRoomPlacementReconciliation"
+            );
+
+            const event = {
+                getType: vi.fn().mockReturnValue(EventType.SpaceChild),
+                getStateKey: vi.fn().mockReturnValue(roomId),
+                getRoomId: vi.fn().mockReturnValue(parentId),
+                getContent: vi.fn().mockReturnValue({}),
+            };
+
+            matrixChatConnection["onRoomStateEvent"](event as never);
+            await flushPromises();
+
+            expect(parentFolder.deleteNode).toHaveBeenCalledWith(roomId);
+            expect(scheduleReconciliationSpy).toHaveBeenCalledWith(roomId);
+        });
+
+        it("should keep retrying room placement while reconciliation is pending", async () => {
+            vi.useFakeTimers();
+            const roomId = "!child:server";
+            const mockMatrixClient = {
+                isGuest: vi.fn().mockReturnValue(true),
+                on: vi.fn(),
+                off: vi.fn(),
+                store: {
+                    startup: vi.fn(),
+                },
+                initRustCrypto: vi.fn(),
+                startClient: vi.fn(),
+                isInitialSyncComplete: vi.fn().mockReturnValue(true),
+                getVisibleRooms: vi.fn().mockReturnValue([]),
+                getRoom: vi.fn(),
+            } as unknown as MatrixClient;
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
+            const reconcileRoomPlacement = vi.fn().mockResolvedValue("pending");
+            matrixChatConnection["reconcileRoomPlacement"] = reconcileRoomPlacement as never;
+
+            matrixChatConnection["scheduleRoomPlacementReconciliation"](roomId);
+            await vi.advanceTimersByTimeAsync(100);
+
+            expect(reconcileRoomPlacement).toHaveBeenCalledTimes(2);
+        });
+
+        it("should stop retrying room placement when reconciliation succeeds", async () => {
+            vi.useFakeTimers();
+            const roomId = "!child:server";
+            const mockMatrixClient = {
+                isGuest: vi.fn().mockReturnValue(true),
+                on: vi.fn(),
+                off: vi.fn(),
+                store: {
+                    startup: vi.fn(),
+                },
+                initRustCrypto: vi.fn(),
+                startClient: vi.fn(),
+                isInitialSyncComplete: vi.fn().mockReturnValue(true),
+                getVisibleRooms: vi.fn().mockReturnValue([]),
+                getRoom: vi.fn(),
+            } as unknown as MatrixClient;
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
+            const reconcileRoomPlacement = vi.fn().mockResolvedValue("placed");
+            matrixChatConnection["reconcileRoomPlacement"] = reconcileRoomPlacement as never;
+
+            matrixChatConnection["scheduleRoomPlacementReconciliation"](roomId);
+            await vi.advanceTimersByTimeAsync(1600);
+
+            expect(reconcileRoomPlacement).toHaveBeenCalledOnce();
+        });
+
+        it("should not recreate a placement retry timer when an old reconciliation resolves after cleanup", async () => {
+            vi.useFakeTimers();
+            const roomId = "!child:server";
+            const mockMatrixClient = {
+                isGuest: vi.fn().mockReturnValue(true),
+                on: vi.fn(),
+                off: vi.fn(),
+                store: {
+                    startup: vi.fn(),
+                },
+                initRustCrypto: vi.fn(),
+                startClient: vi.fn(),
+                isInitialSyncComplete: vi.fn().mockReturnValue(true),
+                getVisibleRooms: vi.fn().mockReturnValue([]),
+                getRoom: vi.fn(),
+            } as unknown as MatrixClient;
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
+            let resolveReconciliation: (result: "pending") => void = () => undefined;
+            matrixChatConnection["reconcileRoomPlacement"] = vi.fn().mockReturnValue(
+                new Promise((resolve) => {
+                    resolveReconciliation = resolve;
+                })
+            ) as never;
+
+            matrixChatConnection["scheduleRoomPlacementReconciliation"](roomId);
+            matrixChatConnection["clearRoomPlacementRetry"](roomId);
+            resolveReconciliation("pending");
+            await vi.advanceTimersByTimeAsync(1600);
+
+            expect(matrixChatConnection["roomPlacementRetryTimers"].has(roomId)).toBeFalsy();
+            expect(matrixChatConnection["reconcileRoomPlacement"]).toHaveBeenCalledOnce();
+        });
+
+        it("should keep root room when m.space.child event has no via", async () => {
+            const roomId = "!child:server";
+            const parentId = "!space:server";
+            const matrixRoom = {
+                roomId,
+                isSpaceRoom: vi.fn().mockReturnValue(false),
+                getMyMembership: vi.fn().mockReturnValue(KnownMembership.Join),
+            };
+
+            const mockMatrixClient = {
+                isGuest: vi.fn().mockReturnValue(true),
+                on: vi.fn(),
+                off: vi.fn(),
+                store: {
+                    startup: vi.fn(),
+                },
+                initRustCrypto: vi.fn(),
+                startClient: vi.fn(),
+                isInitialSyncComplete: vi.fn().mockReturnValue(true),
+                getVisibleRooms: vi.fn().mockReturnValue([]),
+                getRoom: vi.fn().mockImplementation((id: string) => (id === roomId ? matrixRoom : undefined)),
+            } as unknown as MatrixClient;
+
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
+            const rootRoom = { id: roomId, destroy: vi.fn() } as unknown as MatrixChatRoom;
+            matrixChatConnection["roomList"].set(roomId, rootRoom);
+
+            const event = {
+                getType: vi.fn().mockReturnValue(EventType.SpaceChild),
+                getStateKey: vi.fn().mockReturnValue(roomId),
+                getRoomId: vi.fn().mockReturnValue(parentId),
+                getContent: vi.fn().mockReturnValue({}),
+            };
+
+            matrixChatConnection["onRoomStateEvent"](event as never);
+
+            expect(matrixChatConnection["roomList"].has(roomId)).toBeTruthy();
+        });
+
+        it("should keep root room when parent folder is not found", async () => {
+            const roomId = "!child:server";
+            const parentId = "!space:server";
+            const matrixRoom = {
+                roomId,
+                isSpaceRoom: vi.fn().mockReturnValue(false),
+                getMyMembership: vi.fn().mockReturnValue(KnownMembership.Join),
+            };
+
+            const mockMatrixClient = {
+                isGuest: vi.fn().mockReturnValue(true),
+                on: vi.fn(),
+                off: vi.fn(),
+                store: {
+                    startup: vi.fn(),
+                },
+                initRustCrypto: vi.fn(),
+                startClient: vi.fn(),
+                isInitialSyncComplete: vi.fn().mockReturnValue(true),
+                getVisibleRooms: vi.fn().mockReturnValue([]),
+                getRoom: vi.fn().mockImplementation((id: string) => (id === roomId ? matrixRoom : undefined)),
+            } as unknown as MatrixClient;
+
+            const matrixChatConnection = await getMatrixConnection(Promise.resolve(mockMatrixClient));
+            const rootRoom = { id: roomId, destroy: vi.fn() } as unknown as MatrixChatRoom;
+            matrixChatConnection["roomList"].set(roomId, rootRoom);
+            const scheduleReconciliationSpy = vi.spyOn(
+                matrixChatConnection as unknown as { scheduleRoomPlacementReconciliation: (id: string) => void },
+                "scheduleRoomPlacementReconciliation"
+            );
+
+            const event = {
+                getType: vi.fn().mockReturnValue(EventType.SpaceChild),
+                getStateKey: vi.fn().mockReturnValue(roomId),
+                getRoomId: vi.fn().mockReturnValue(parentId),
+                getContent: vi.fn().mockReturnValue({ via: ["server"] }),
+            };
+
+            matrixChatConnection["onRoomStateEvent"](event as never);
+            await flushPromises();
+
+            expect(matrixChatConnection["roomList"].has(roomId)).toBeTruthy();
+            expect(scheduleReconciliationSpy).toHaveBeenCalledWith(roomId);
+        });
+
+        it("should init existing nested folder when adding a space child", async () => {
+            const roomId = "!child-space:server";
+            const existingChildFolder = {
+                refreshRooms: vi.fn().mockResolvedValue(undefined),
+                init: vi.fn(),
+            };
+            const folderList = {
+                get: vi.fn().mockReturnValue(existingChildFolder),
+                set: vi.fn(),
+            };
+            const parentFolder = {
+                folderList,
+                roomList: new Map(),
+                myMembership: readable(KnownMembership.Invite),
+            };
+            const spaceRoom = {
+                roomId,
+                isSpaceRoom: vi.fn().mockReturnValue(true),
+            };
+
+            const matrixChatConnection = await getMatrixConnection(
+                Promise.resolve({ isGuest: vi.fn().mockReturnValue(true) } as unknown as MatrixClient)
+            );
+            matrixChatConnection["roomFolders"].set(roomId, { id: roomId, destroy: vi.fn() } as never);
+
+            await matrixChatConnection["addRoomToParentFolder"](spaceRoom as never, parentFolder as never);
+
+            expect(existingChildFolder.refreshRooms).toHaveBeenCalledOnce();
+            expect(existingChildFolder.init).toHaveBeenCalledOnce();
         });
     });
 });

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -986,6 +986,301 @@ describe("MatrixChatConnection", () => {
             expect(staleRoom.destroy).toHaveBeenCalledOnce();
         });
 
+        it("should ignore a parent relation when the parent has no matching m.space.child", () => {
+            const roomId = "!child:server";
+            const staleParentId = "!space-parent:server";
+            const directParentId = "!space-direct-parent:server";
+
+            const makeStateEvent = (stateKey: string, content: unknown) => ({
+                getStateKey: vi.fn().mockReturnValue(stateKey),
+                getContent: vi.fn().mockReturnValue(content),
+            });
+            const makeRoomWithChildren = (childEvents: ReturnType<typeof makeStateEvent>[]) => ({
+                getMyMembership: vi.fn().mockReturnValue(KnownMembership.Join),
+                getLiveTimeline: vi.fn().mockReturnValue({
+                    getState: vi.fn().mockReturnValue({
+                        getStateEvents: vi.fn().mockReturnValue(childEvents),
+                    }),
+                }),
+            });
+
+            const staleParentRoom = makeRoomWithChildren([makeStateEvent(directParentId, { via: ["server"] })]);
+            const directParentRoom = makeRoomWithChildren([makeStateEvent(roomId, { via: ["server"] })]);
+            const matrixClient = {
+                getRoom: vi.fn().mockImplementation((id: string) => {
+                    if (id === staleParentId) return staleParentRoom;
+                    if (id === directParentId) return directParentRoom;
+                    return undefined;
+                }),
+            };
+            const room = {
+                roomId,
+                client: matrixClient,
+                getLiveTimeline: vi.fn().mockReturnValue({
+                    getState: vi.fn().mockReturnValue({
+                        getStateEvents: vi
+                            .fn()
+                            .mockReturnValue([
+                                makeStateEvent(staleParentId, { via: ["server"] }),
+                                makeStateEvent(directParentId, { via: ["server"] }),
+                            ]),
+                    }),
+                }),
+            };
+            const matrixChatConnection = new MatrixChatConnection(
+                Promise.resolve(matrixClient as unknown as MatrixClient),
+                basicStatusStore,
+                basicMockMatrixSecurity
+            );
+
+            expect(matrixChatConnection["getParentRoomID"](room as never)).toEqual([directParentId]);
+        });
+
+        it("should ignore a parent relation when the parent space is left", () => {
+            const roomId = "!child:server";
+            const leftParentId = "!space-left-parent:server";
+
+            const childEvent = {
+                getStateKey: vi.fn().mockReturnValue(roomId),
+                getContent: vi.fn().mockReturnValue({ via: ["server"] }),
+            };
+            const leftParentRoom = {
+                getMyMembership: vi.fn().mockReturnValue(KnownMembership.Leave),
+                getLiveTimeline: vi.fn().mockReturnValue({
+                    getState: vi.fn().mockReturnValue({
+                        getStateEvents: vi.fn().mockReturnValue([childEvent]),
+                    }),
+                }),
+            };
+            const matrixClient = {
+                getRoom: vi.fn().mockImplementation((id: string) => {
+                    if (id === leftParentId) return leftParentRoom;
+                    return undefined;
+                }),
+            };
+            const room = {
+                roomId,
+                client: matrixClient,
+                getLiveTimeline: vi.fn().mockReturnValue({
+                    getState: vi.fn().mockReturnValue({
+                        getStateEvents: vi.fn().mockReturnValue([
+                            {
+                                getStateKey: vi.fn().mockReturnValue(leftParentId),
+                                getContent: vi.fn().mockReturnValue({ via: ["server"] }),
+                            },
+                        ]),
+                    }),
+                }),
+            };
+            const matrixChatConnection = new MatrixChatConnection(
+                Promise.resolve(matrixClient as unknown as MatrixClient),
+                basicStatusStore,
+                basicMockMatrixSecurity
+            );
+
+            expect(matrixChatConnection["getParentRoomID"](room as never)).toEqual([]);
+        });
+
+        it("should return the nested folder itself when searching a deep folder node", async () => {
+            const rootFolder = Object.assign(Object.create(MatrixRoomFolder.prototype), {
+                id: "!space-root:server",
+                roomList: new Map(),
+                folderList: new Map(),
+                loadRoomsAndFolderPromise: { promise: Promise.resolve() },
+            }) as MatrixRoomFolder;
+            const intermediateFolder = Object.assign(Object.create(MatrixRoomFolder.prototype), {
+                id: "!space-intermediate:server",
+                roomList: new Map(),
+                folderList: new Map(),
+                loadRoomsAndFolderPromise: { promise: Promise.resolve() },
+            }) as MatrixRoomFolder;
+            const nestedFolder = Object.assign(Object.create(MatrixRoomFolder.prototype), {
+                id: "!space-nested:server",
+                roomList: new Map(),
+                folderList: new Map(),
+                loadRoomsAndFolderPromise: { promise: Promise.resolve() },
+            }) as MatrixRoomFolder;
+            rootFolder.folderList.set(intermediateFolder.id, intermediateFolder);
+            intermediateFolder.folderList.set(nestedFolder.id, nestedFolder);
+
+            await expect(rootFolder.getNode(nestedFolder.id)).resolves.toBe(nestedFolder);
+        });
+
+        it("should reconcile joined child rooms when leaving a folder", async () => {
+            const folderId = "!space-left:server";
+            const childRoomId = "!child:server";
+            const childNode = {
+                id: childRoomId,
+                myMembership: readable(KnownMembership.Join),
+            };
+            const folder = Object.assign(Object.create(MatrixRoomFolder.prototype), {
+                id: folderId,
+                roomList: new Map([[childRoomId, childNode]]),
+                folderList: new Map(),
+                loadRoomsAndFolderPromise: { promise: Promise.resolve() },
+            }) as MatrixRoomFolder;
+            const matrixChatConnection = new MatrixChatConnection(
+                Promise.resolve({} as MatrixClient),
+                basicStatusStore,
+                basicMockMatrixSecurity
+            );
+            matrixChatConnection["roomFolders"].set(folderId, folder);
+            const reconcileRoomPlacement = vi
+                .spyOn(
+                    matrixChatConnection as unknown as {
+                        reconcileRoomPlacement: (roomId: string) => Promise<"root">;
+                    },
+                    "reconcileRoomPlacement"
+                )
+                .mockResolvedValue("root");
+
+            matrixChatConnection["onRoomEventMembership"](
+                { roomId: folderId, name: "Left space" } as never,
+                KnownMembership.Leave,
+                KnownMembership.Join
+            );
+            await flushPromises();
+
+            expect(matrixChatConnection["roomFolders"].has(folderId)).toBeFalsy();
+            expect(reconcileRoomPlacement).toHaveBeenCalledWith(childRoomId);
+        });
+
+        it("should reparent child rooms to the visible parent space when leaving a nested folder", async () => {
+            const parentFolderId = "!space-parent:server";
+            const leftFolderId = "!space-left:server";
+            const childRoomId = "!child:server";
+            const childNode = {
+                id: childRoomId,
+                myMembership: readable(KnownMembership.Join),
+            };
+            const leftFolder = Object.assign(Object.create(MatrixRoomFolder.prototype), {
+                id: leftFolderId,
+                roomList: new Map([[childRoomId, childNode]]),
+                folderList: new Map(),
+                myMembership: readable(KnownMembership.Leave),
+                loadRoomsAndFolderPromise: { promise: Promise.resolve() },
+            }) as MatrixRoomFolder;
+            const parentFolder = Object.assign(Object.create(MatrixRoomFolder.prototype), {
+                id: parentFolderId,
+                roomList: new Map(),
+                folderList: new Map([[leftFolderId, leftFolder]]),
+                myMembership: readable(KnownMembership.Join),
+                loadRoomsAndFolderPromise: { promise: Promise.resolve() },
+            }) as MatrixRoomFolder;
+            parentFolder.deleteNode = vi.fn().mockImplementation((id: string) => {
+                parentFolder.folderList.delete(id);
+                return true;
+            });
+            const makeStateEvent = (stateKey: string, content: unknown) => ({
+                getStateKey: vi.fn().mockReturnValue(stateKey),
+                getContent: vi.fn().mockReturnValue(content),
+            });
+            const makeParentRoom = (membership: KnownMembership) => ({
+                getMyMembership: vi.fn().mockReturnValue(membership),
+                getLiveTimeline: vi.fn().mockReturnValue({
+                    getState: vi.fn().mockReturnValue({
+                        getStateEvents: vi.fn().mockReturnValue([makeStateEvent(childRoomId, { via: ["server"] })]),
+                    }),
+                }),
+            });
+            const matrixClient = {
+                getRoom: vi.fn(),
+            };
+            const childRoom = {
+                roomId: childRoomId,
+                client: matrixClient,
+                isSpaceRoom: vi.fn().mockReturnValue(false),
+                getMyMembership: vi.fn().mockReturnValue(KnownMembership.Join),
+                getLiveTimeline: vi.fn().mockReturnValue({
+                    getState: vi.fn().mockReturnValue({
+                        getStateEvents: vi
+                            .fn()
+                            .mockReturnValue([
+                                makeStateEvent(leftFolderId, { via: ["server"] }),
+                                makeStateEvent(parentFolderId, { via: ["server"] }),
+                            ]),
+                    }),
+                }),
+            };
+            matrixClient.getRoom.mockImplementation((id: string) => {
+                if (id === childRoomId) return childRoom;
+                if (id === leftFolderId) return makeParentRoom(KnownMembership.Leave);
+                if (id === parentFolderId) return makeParentRoom(KnownMembership.Join);
+                return undefined;
+            });
+            const matrixChatConnection = new MatrixChatConnection(
+                Promise.resolve(matrixClient as unknown as MatrixClient),
+                basicStatusStore,
+                basicMockMatrixSecurity
+            );
+            matrixChatConnection["client"] = matrixClient as never;
+            matrixChatConnection["roomFolders"].set(parentFolderId, parentFolder);
+            const addRoomToParentFolder = vi
+                .spyOn(
+                    matrixChatConnection as unknown as {
+                        addRoomToParentFolder: (room: unknown, folder: MatrixRoomFolder) => Promise<void>;
+                    },
+                    "addRoomToParentFolder"
+                )
+                .mockResolvedValue(undefined);
+
+            matrixChatConnection["onRoomEventMembership"](
+                { roomId: leftFolderId, name: "Left nested space" } as never,
+                KnownMembership.Leave,
+                KnownMembership.Join
+            );
+            await flushPromises();
+
+            expect(addRoomToParentFolder).toHaveBeenCalledOnce();
+            expect(addRoomToParentFolder.mock.calls[0][0]).toBe(childRoom);
+            expect(addRoomToParentFolder.mock.calls[0][1]).toBe(parentFolder);
+        });
+
+        it("should fallback a pending joined room to root after bounded placement retries", async () => {
+            vi.useFakeTimers();
+            const roomId = "!child:server";
+            const unknownParentId = "!unknown-parent:server";
+            const room = {
+                roomId,
+                isSpaceRoom: vi.fn().mockReturnValue(false),
+                getMyMembership: vi.fn().mockReturnValue(KnownMembership.Join),
+                getLiveTimeline: vi.fn().mockReturnValue({
+                    getState: vi.fn().mockReturnValue({
+                        getStateEvents: vi.fn().mockReturnValue([
+                            {
+                                getStateKey: vi.fn().mockReturnValue(unknownParentId),
+                                getContent: vi.fn().mockReturnValue({ via: ["server"] }),
+                            },
+                        ]),
+                    }),
+                }),
+            };
+            const matrixClient = {
+                getRoom: vi.fn().mockImplementation((id: string) => {
+                    if (id === roomId) return room;
+                    return undefined;
+                }),
+            };
+            const matrixChatConnection = new MatrixChatConnection(
+                Promise.resolve(matrixClient as unknown as MatrixClient),
+                basicStatusStore,
+                basicMockMatrixSecurity
+            );
+            matrixChatConnection["client"] = matrixClient as never;
+            vi.spyOn(matrixChatConnection as never, "removeRoomFromAllFolders").mockResolvedValue(false);
+            const handleOrphanRoom = vi
+                .spyOn(
+                    matrixChatConnection as unknown as { handleOrphanRoom: (room: unknown) => void },
+                    "handleOrphanRoom"
+                )
+                .mockImplementation(() => undefined);
+
+            matrixChatConnection["scheduleRoomPlacementReconciliation"](roomId);
+            await vi.advanceTimersByTimeAsync(3000);
+
+            expect(handleOrphanRoom).toHaveBeenCalledWith(room);
+        });
+
         it("should remove an invalidated m.space.child from its parent folder and reschedule placement reconciliation", async () => {
             const roomId = "!child:server";
             const parentId = "!space:server";


### PR DESCRIPTION
## Problem

Joined or invited Matrix rooms could remain missing from the expected space, or stay visible under an outdated space relation when `m.space.child` / `m.space.parent` events arrived late or were invalidated.

## Solution

Make Matrix room placement deterministic by validating space relations consistently and using an explicit bounded reconciliation flow for room-to-space placement.

## Changes

- Add a shared Matrix space relation helper to validate `via` entries.
- Filter invalid `m.space.child` / `m.space.parent` relations across room folders and room type detection.
- Replace ad-hoc room placement retry logic with `reconcileRoomPlacement()` returning explicit placement states.
- Remove rooms from stale folders when a space child relation is invalidated.
- Keep bounded retry behavior for pending placement convergence.
- Add regression tests for invalid relations, stale folder removal, and retry stop/continue behavior.