### PR TITLE
fix(jitsi): emit moderator inside context.user for token_affiliation

### DIFF
--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -779,11 +779,18 @@ export class SocketManager {
             }
         }
 
+        // Jitsi has two prosody plugins that can grant moderator rights from a JWT:
+        //   - token_moderation reads `moderator` at the top level of the token,
+        //   - token_affiliation reads `context.user.moderator`.
+        // Emit both so deployments using either plugin (#5135) work unchanged.
+        // Dropping the top-level field would break installs still on
+        // token_moderation; adding the context-level field is a no-op for them.
         const jwt = new SignJWT({
             context: {
                 user: {
                     id: user.id,
                     name: user.name,
+                    moderator: isAdmin,
                 },
                 features: {
                     livestreaming: isAdmin,


### PR DESCRIPTION
## What

Adds `context.user.moderator` alongside the existing top-level `moderator` claim in the JWT generated by `handleQueryJitsiJwtMessage` (back/src/Services/SocketManager.ts).

## Why

Jitsi exposes two prosody plugins that grant moderator rights from a JWT:
- `token_moderation` reads the top-level `moderator` claim
- `token_affiliation` reads `context.user.moderator`

Self-hosted deploys that pair WorkAdventure with the newer `token_affiliation` plugin (#5135) saw `isAdmin` users land in Jitsi rooms with no moderator permissions because the affiliation plugin couldn't find the claim it expects.

In #5135 @moufmouf called out option 1: emit BOTH fields so existing `token_moderation` installs keep working unchanged. That's what this PR does. No env var, no breaking change for the existing path; the new context-level field is a no-op for installs that don't run `token_affiliation`.

## Test plan

- [x] Manual diff inspection: `moderator: isAdmin` appears in two locations (context.user + top-level) and nowhere else
- [ ] CI: typecheck + back unit tests run on PR
- [ ] Manual integration: a self-hosted install of WorkAdventure + Jitsi + `token_affiliation` shows the moderator user landing with moderator rights

## Notes

- Could not verify locally because `@workadventure/eslint-config` is not published to the public npm registry; relying on CI for typecheck.
- No back/tests cover this code path today (`grep handleQueryJitsiJwt tests/` returns nothing). Adding a unit test would mean stubbing `gameRoom.getJitsiSettings()` + `getModeratorTagForJitsiRoom` + `SignJWT` -- happy to do in a follow-up if the maintainers want it now rather than later.

Closes #5135