### PR TITLE
perf: lazy load Matrix chat room initialization

### DIFF
--- a/play/src/front/Chat/Components/Avatar.svelte
+++ b/play/src/front/Chat/Components/Avatar.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import Debug from "debug";
     import { get } from "svelte/store";
     import { getColorByString } from "../../Utils/ColorGenerator";
     import type { PictureStore } from "../../Stores/PictureStore";
@@ -15,10 +14,6 @@
      */
     export let compact = false;
 
-    const debug = Debug("MatrixChatConnection:Avatar");
-    const debugThrottleByKey = new Map<string, number>();
-    const DEBUG_THROTTLE_MS = 1_000;
-
     let forceFallback = false;
     let previousPictureUrl: string | undefined;
 
@@ -29,20 +24,6 @@
     $: if ($pictureStore !== previousPictureUrl) {
         previousPictureUrl = $pictureStore;
         forceFallback = false;
-    }
-
-    function logAvatarDebug(event: "load-request" | "loaded" | "error") {
-        if (!debug.enabled) {
-            return;
-        }
-        const key = `${event}:${fallbackName}`;
-        const now = Date.now();
-        const previous = debugThrottleByKey.get(key) ?? 0;
-        if (now - previous < DEBUG_THROTTLE_MS) {
-            return;
-        }
-        debugThrottleByKey.set(key, now);
-        debug("%s avatar %s", event, fallbackName);
     }
 
     function loadLazyPictureStore(node: HTMLElement, store: PictureStore | undefined) {
@@ -62,7 +43,6 @@
                 return;
             }
             if (typeof IntersectionObserver === "undefined") {
-                logAvatarDebug("load-request");
                 nextStore.load().catch((error) => console.warn("Failed to load avatar", error));
                 return;
             }
@@ -71,7 +51,6 @@
                     if (!entries.some((entry) => entry.isIntersecting)) {
                         return;
                     }
-                    logAvatarDebug("load-request");
                     nextStore.load().catch((error) => console.warn("Failed to load avatar", error));
                     cleanup();
                 },
@@ -99,9 +78,7 @@
         loading="lazy"
         decoding="async"
         style:background-color={`${color ? color : `${getColorByString(fallbackName)}`}`}
-        on:load={() => logAvatarDebug("loaded")}
         on:error={(event) => {
-            logAvatarDebug("error");
             console.warn(`Failed to load avatar image for ${fallbackName}`, event);
             forceFallback = true;
         }}

--- a/play/src/front/Chat/Components/Avatar.svelte
+++ b/play/src/front/Chat/Components/Avatar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import Debug from "debug";
     import { get } from "svelte/store";
     import { getColorByString } from "../../Utils/ColorGenerator";
     import type { PictureStore } from "../../Stores/PictureStore";
@@ -14,6 +15,10 @@
      */
     export let compact = false;
 
+    const debug = Debug("MatrixChatConnection:Avatar");
+    const debugThrottleByKey = new Map<string, number>();
+    const DEBUG_THROTTLE_MS = 1_000;
+
     let forceFallback = false;
     let previousPictureUrl: string | undefined;
 
@@ -24,6 +29,20 @@
     $: if ($pictureStore !== previousPictureUrl) {
         previousPictureUrl = $pictureStore;
         forceFallback = false;
+    }
+
+    function logAvatarDebug(event: "load-request" | "loaded" | "error") {
+        if (!debug.enabled) {
+            return;
+        }
+        const key = `${event}:${fallbackName}`;
+        const now = Date.now();
+        const previous = debugThrottleByKey.get(key) ?? 0;
+        if (now - previous < DEBUG_THROTTLE_MS) {
+            return;
+        }
+        debugThrottleByKey.set(key, now);
+        debug("%s avatar %s", event, fallbackName);
     }
 
     function loadLazyPictureStore(node: HTMLElement, store: PictureStore | undefined) {
@@ -43,6 +62,7 @@
                 return;
             }
             if (typeof IntersectionObserver === "undefined") {
+                logAvatarDebug("load-request");
                 nextStore.load().catch((error) => console.warn("Failed to load avatar", error));
                 return;
             }
@@ -51,6 +71,7 @@
                     if (!entries.some((entry) => entry.isIntersecting)) {
                         return;
                     }
+                    logAvatarDebug("load-request");
                     nextStore.load().catch((error) => console.warn("Failed to load avatar", error));
                     cleanup();
                 },
@@ -78,7 +99,9 @@
         loading="lazy"
         decoding="async"
         style:background-color={`${color ? color : `${getColorByString(fallbackName)}`}`}
+        on:load={() => logAvatarDebug("loaded")}
         on:error={(event) => {
+            logAvatarDebug("error");
             console.warn(`Failed to load avatar image for ${fallbackName}`, event);
             forceFallback = true;
         }}

--- a/play/src/front/Chat/Components/Room/ManageParticipantsModal.svelte
+++ b/play/src/front/Chat/Components/Room/ManageParticipantsModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { closeModal } from "svelte-modals";
     import { fade } from "svelte/transition";
+    import { onMount } from "svelte";
     import { get } from "svelte/store";
     import Popup from "../../../Components/Modal/Popup.svelte";
     import type { ChatRoomMembershipManagement, ChatRoomModeration } from "../../Connection/ChatConnection";
@@ -16,9 +17,28 @@
 
     let invitations: { value: string; label: string }[] = [];
     let sendingInvitationsToRoom = false;
+    let loadingMembers = true;
     let invitationToRoomError: string | undefined = undefined;
+    let membersLoadingError: string | undefined = undefined;
 
     const hasPermissionToInvite = room.hasPermissionTo("invite");
+    onMount(() => {
+        loadMembers().catch((error) => console.error(error));
+    });
+
+    async function loadMembers() {
+        try {
+            loadingMembers = true;
+            membersLoadingError = undefined;
+            await room.ensureMembersInitialized();
+        } catch (error) {
+            console.error(error);
+            membersLoadingError = error instanceof Error ? error.message : String(error);
+        } finally {
+            loadingMembers = false;
+        }
+    }
+
     async function inviteUsersAndCloseModalOnSuccess() {
         try {
             sendingInvitationsToRoom = true;
@@ -59,7 +79,21 @@
             <IconLink class="h-4 w-4 shrink-0 opacity-50 transition group-hover:opacity-90" aria-hidden="true" />
         </button>
 
-        {#if sendingInvitationsToRoom}
+        {#if loadingMembers}
+            <div class="flex flex-col items-center justify-center gap-3 py-10">
+                <div class="animate-[spin_2s_linear_infinite] text-white/80">
+                    <IconLoader font-size="2em" />
+                </div>
+                <p class="text-sm text-white/60">{$LL.chat.createRoom.loadingCreation()}</p>
+            </div>
+        {:else if membersLoadingError}
+            <div class="flex flex-col items-center justify-center gap-3 py-8">
+                <p class="text-sm text-red-100">{$LL.chat.manageRoomUsers.error()} : {membersLoadingError}</p>
+                <button type="button" class="btn btn-secondary" on:click={loadMembers}>
+                    {$LL.chat.load()}
+                </button>
+            </div>
+        {:else if sendingInvitationsToRoom}
             <div class="flex flex-col items-center justify-center gap-3 py-10">
                 <div class="animate-[spin_2s_linear_infinite] text-white/80">
                     <IconLoader font-size="2em" />

--- a/play/src/front/Chat/Components/Room/Room.svelte
+++ b/play/src/front/Chat/Components/Room/Room.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import highlightWords from "highlight-words";
     import { defaultColor } from "@workadventure/shared-utils";
+    import { onDestroy, onMount } from "svelte";
     import type {
         ChatRoom,
         ChatRoomMembershipManagement,
@@ -32,6 +33,16 @@
     $: peerAvatarColorStore = room.avatarFallbackColor;
     $: peerWaParensStore = room.peerWaDisplayNameIfDifferent;
     $: peerWaDisplayNameParens = peerWaParensStore ? $peerWaParensStore : undefined;
+
+    let deactivateVisibleProfileSync: (() => void) | undefined;
+
+    onMount(() => {
+        deactivateVisibleProfileSync = room.activateVisibleProfileSync?.();
+    });
+
+    onDestroy(() => {
+        deactivateVisibleProfileSync?.();
+    });
 </script>
 
 <div

--- a/play/src/front/Chat/Components/Room/RoomMenu/RoomMenu.svelte
+++ b/play/src/front/Chat/Components/Room/RoomMenu/RoomMenu.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import { onDestroy, onMount } from "svelte";
     import { openModal } from "svelte-modals";
-    import { get } from "svelte/store";
     import type { Readable } from "svelte/store";
     import { AskPositionMessage_AskType } from "@workadventure/messages";
     import {
@@ -41,6 +40,7 @@
     export let room: ChatRoom & ChatRoomMembershipManagement & ChatRoomNotificationControl & ChatRoomModeration;
     const roomType = room.type;
     const areNotificationsMuted = room.areNotificationsMuted;
+    const roomMembers = room.members;
     let optionButtonRef: HTMLButtonElement | undefined = undefined;
     let hideOptions = true;
     let usersByRoomStore:
@@ -82,6 +82,9 @@
         if (optionButtonRef === undefined) {
             return;
         }
+        if (hideOptions) {
+            room.ensureMembersInitialized().catch((error) => console.error(error));
+        }
         hideOptions = !hideOptions;
     }
 
@@ -122,7 +125,7 @@
         });
     }
 
-    $: members = get(room.members);
+    $: members = $roomMembers;
     $: usersByRoomMap = usersByRoomStore && $usersByRoomStore ? $usersByRoomStore : new Map();
 
     // Flatten usersByRoomMap into a list of users with playUri from their room

--- a/play/src/front/Chat/Components/Room/RoomMenu/RoomMenu.svelte
+++ b/play/src/front/Chat/Components/Room/RoomMenu/RoomMenu.svelte
@@ -125,7 +125,6 @@
         });
     }
 
-    $: members = $roomMembers;
     $: usersByRoomMap = usersByRoomStore && $usersByRoomStore ? $usersByRoomStore : new Map();
 
     // Flatten usersByRoomMap into a list of users with playUri from their room
@@ -142,7 +141,8 @@
         return usersList;
     })();
 
-    $: matrixChatUser = $roomType === "direct" ? members.find((u) => u.id !== localUserStore.getChatId()) : undefined;
+    $: matrixChatUser =
+        $roomType === "direct" ? $roomMembers.find((u) => u.id !== localUserStore.getChatId()) : undefined;
 
     $: chatUser = usersWithRoomPlayUri.find((u) => u.chatId === matrixChatUser?.id);
     $: isInTheSameMap = chatUser?.playUri === gameManager.getCurrentGameScene().roomUrl;

--- a/play/src/front/Chat/Components/Room/RoomTimeline.svelte
+++ b/play/src/front/Chat/Components/Room/RoomTimeline.svelte
@@ -42,6 +42,8 @@
     $: messages = room?.messages;
     $: roomName = room?.name;
     $: typingMembers = room.typingMembers;
+    $: initializationState = room.initializationState;
+    $: initializationError = room.initializationError;
 
     type RenderItem =
         | { kind: "separator"; key: string; label: string }
@@ -145,6 +147,7 @@
 
         const loadMessages = async () => {
             try {
+                await room.ensureTimelineInitialized();
                 if (get(room.isEncrypted) && get(matrixSecurity.isEncryptionRequiredAndNotSet)) {
                     return;
                 }
@@ -168,6 +171,10 @@
         }
     }
 
+    function retryInitialization() {
+        room.ensureTimelineInitialized().catch((error) => console.error(error));
+    }
+
     beforeUpdate(() => {
         if (messageListRef) {
             oldScrollHeight = messageListRef.scrollHeight;
@@ -178,7 +185,9 @@
     });
 
     afterUpdate(() => {
-        room.setTimelineAsRead();
+        if ($initializationState === "ready") {
+            room.setTimelineAsRead();
+        }
         if (autoScroll) {
             scrollToMessageListBottom();
         } else if (onScrollTop) {
@@ -340,7 +349,24 @@
                     ? 'items-center justify-center pb-4'
                     : 'max-w-6xl'}"
             >
-                {#if $messages.length === 0}
+                {#if $initializationState === "loading" || $initializationState === "idle"}
+                    <li class="flex flex-col items-center justify-center gap-3 text-center px-3 max-w-md">
+                        <IconLoader class="animate-[spin_2s_linear_infinite]" font-size={32} />
+                    </li>
+                {:else if $initializationState === "error"}
+                    <li class="flex flex-col items-center justify-center gap-3 text-center px-3 max-w-md">
+                        <div class="text-lg font-bold text-center">{$LL.chat.connectionError()}</div>
+                        <div class="text-sm opacity-50 text-center">
+                            {$initializationError?.message ?? ""}
+                        </div>
+                        <button
+                            class="px-3 py-2 rounded bg-white/10 hover:bg-white/20 text-sm"
+                            on:click={retryInitialization}
+                        >
+                            Retry
+                        </button>
+                    </li>
+                {:else if $messages.length === 0}
                     {#if room instanceof ProximityChatRoom}
                         <li class="text-center px-3 max-w-md">
                             <img draggable="false" src={getCloseImg} alt="Discussion bubble" />
@@ -394,11 +420,15 @@
             </ul>
         </div>
 
-        {#if $typingMembers.length > 0}
+        {#if $initializationState === "ready" && $typingMembers.length > 0}
             <TypingUsers typingMembers={$typingMembers} />
         {/if}
         {#key room}
-            <MessageInputBar disabled={$shouldRetrySendingEvents} {room} bind:this={messageInputBarRef} />
+            <MessageInputBar
+                disabled={$shouldRetrySendingEvents || $initializationState !== "ready"}
+                {room}
+                bind:this={messageInputBarRef}
+            />
         {/key}
     {/if}
 </div>

--- a/play/src/front/Chat/Components/RoomFolder.svelte
+++ b/play/src/front/Chat/Components/RoomFolder.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     import { get } from "svelte/store";
     import type { RoomFolder, ChatRoom, ChatRoomModeration } from "../Connection/ChatConnection";
     import LL from "../../../i18n/i18n-svelte";
@@ -9,11 +10,11 @@
     import ShowMore from "./ShowMore.svelte";
     import RoomInvitation from "./Room/RoomInvitation.svelte";
     import RoomSuggested from "./Room/RoomSuggested.svelte";
-    import { IconChevronUp } from "@wa-icons";
+    import { IconChevronUp, IconLoader } from "@wa-icons";
 
     export let rootFolder: boolean;
     export let folder: RoomFolder & ChatRoomModeration;
-    $: ({ name, folders, invitations, rooms, id, suggestedRooms, joinableRooms } = folder);
+    $: ({ name, folders, invitations, rooms, id, suggestedRooms, joinableRooms, joinableRoomsLoading } = folder);
     let isOpen: boolean = localUserStore.hasFolderOpened(folder.id) ?? false;
     let joinableRoomsOpen = false;
     const isFoldersOpen: { [key: string]: boolean } = {};
@@ -38,6 +39,7 @@
         isOpen = !isOpen;
         if (isOpen) {
             localUserStore.addFolderOpened(id);
+            loadOpenedFolderContent();
         } else {
             localUserStore.removeFolderOpened(id);
         }
@@ -46,6 +48,19 @@
     function toggleJoinableRooms() {
         joinableRoomsOpen = !joinableRoomsOpen;
     }
+
+    function loadOpenedFolderContent() {
+        folder.ensureChildrenLoaded();
+        folder.ensureJoinableRoomsLoaded().catch((error) => {
+            console.error("Failed to load joinable rooms", error);
+        });
+    }
+
+    onMount(() => {
+        if (isOpen) {
+            loadOpenedFolderContent();
+        }
+    });
 </script>
 
 <div class={`${!rootFolder ? "mx-2 p-1 bg-contrast-300/10 rounded-lg mb-4" : ""}`}>
@@ -84,7 +99,7 @@
     <div class="flex flex-col">
         {#if isOpen}
             <div class="flex flex-col">
-                {#if $suggestedRooms.length > 0 || filteredJoinableRooms.length > 0}
+                {#if $joinableRoomsLoading || $suggestedRooms.length > 0 || filteredJoinableRooms.length > 0}
                     <div class="mx-2 p-1 bg-secondary/30 rounded-lg mb-4 border border-solid border-secondary/80">
                         <div
                             class="group relative px-3 m-0 rounded-md text-white/75 hover:text-white h-8 hover:bg-contrast-200/10 w-full flex space-x-2 items-center"
@@ -112,7 +127,11 @@
                         </div>
                         {#if joinableRoomsOpen}
                             <div class="flex flex-col overflow-auto ps-3 pe-4 pb-3">
-                                {#if $suggestedRooms.length > 0}
+                                {#if $joinableRoomsLoading}
+                                    <div class="flex items-center justify-center p-2 text-white/70">
+                                        <IconLoader class="animate-spin" />
+                                    </div>
+                                {:else if $suggestedRooms.length > 0}
                                     <div class="bg-white/10 rounded-md">
                                         <span class="text-sm opacity-80 p-2">
                                             {$LL.chat.suggestedRooms()} :

--- a/play/src/front/Chat/Connection/ChatConnection.ts
+++ b/play/src/front/Chat/Connection/ChatConnection.ts
@@ -44,6 +44,7 @@ export type PartialAdminUser = Partial<AdminUser> & { uuid: string };
 export type PartialAnyKindOfUser = PartialChatUser | PartialAdminUser;
 
 export type ChatRoomMembership = "ban" | "leave" | "knock" | "join" | "invite" | string;
+export type ChatRoomInitializationState = "idle" | "loading" | "ready" | "error";
 
 export enum ChatPermissionLevel {
     USER = "USER",
@@ -73,6 +74,10 @@ export interface ChatRoom {
     readonly type: Readable<"direct" | "multiple">;
     readonly hasUnreadMessages: Readable<boolean>;
     readonly unreadNotificationCount: Readable<number>;
+    readonly initializationState: Readable<ChatRoomInitializationState>;
+    readonly initializationError?: Readable<Error | undefined>;
+    readonly ensureInitialized: () => Promise<void>;
+    readonly ensureTimelineInitialized: () => Promise<void>;
     readonly pictureStore: PictureStore;
     /** Direct rooms: peer user color from the same source as the user list (UserProviderMerger), for Avatar background. */
     readonly avatarFallbackColor: Readable<string | undefined>;
@@ -102,6 +107,7 @@ export interface ChatRoomMembershipManagement {
     readonly name: Readable<string>;
     readonly myMembership: Readable<ChatRoomMembership>;
     readonly members: Readable<ChatRoomMember[]>;
+    readonly ensureMembersInitialized: () => Promise<void>;
     readonly joinRoom: () => Promise<void>;
     readonly leaveRoom: () => Promise<void>;
 }

--- a/play/src/front/Chat/Connection/ChatConnection.ts
+++ b/play/src/front/Chat/Connection/ChatConnection.ts
@@ -89,6 +89,7 @@ export interface ChatRoom {
     readonly membersForMessageAvatars?: Readable<readonly ChatRoomMember[]>;
     /** Direct Matrix rooms: peer WA display name when it differs from Matrix name (for DM row subtitle). */
     readonly peerWaDisplayNameIfDifferent?: Readable<string | undefined>;
+    readonly activateVisibleProfileSync?: () => () => void;
     readonly messages: Readable<readonly ChatMessage[]>;
     readonly sendMessage: (message: string) => void;
     readonly sendFiles: (files: FileList) => Promise<void>;
@@ -182,7 +183,10 @@ export interface RoomFolder extends ChatRoom, ChatRoomMembershipManagement, Chat
     invitations: Readable<ChatRoom[]>;
     suggestedRooms: Readable<{ name: string; id: string; avatarUrl: string }[]>;
     joinableRooms: Readable<{ name: string; id: string; avatarUrl: string }[]>;
+    joinableRoomsLoading: Readable<boolean>;
     hasChildRoomsError: Writable<boolean>;
+    ensureChildrenLoaded: () => void;
+    ensureJoinableRoomsLoaded: () => Promise<void>;
 }
 
 export interface CreateRoomOptions {

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -70,6 +70,12 @@ const debug = Debug("MatrixChatConnection");
 
 const CLIENT_NOT_INITIALIZED_ERROR_MSG = "MatrixClient not yet initialized";
 type RoomPlacementReconciliationResult = "placed" | "root" | "pending" | "removed";
+type RawUnreadRoom = {
+    count: number;
+    membership: string;
+    isDirect: boolean;
+    isSpace: boolean;
+};
 
 export type { MatrixPeerProfileDiagnostics, MatrixUserSettingsDiagnostics } from "../ChatConnection";
 
@@ -94,6 +100,11 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     private userIdsNeedingPresenceUpdate = new Set();
     private readonly roomPlacementRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
     private readonly roomPlacementRetryGenerations = new Map<string, number>();
+    private readonly parentRoomIdsByRoomId = new Map<string, Set<string>>();
+    private readonly childRoomIdsBySpaceId = new Map<string, Set<string>>();
+    private readonly folderShellsByRoomId = new Map<string, MatrixRoomFolder>();
+    private readonly rawUnreadRooms = writable<Map<string, RawUnreadRoom>>(new Map());
+    private readonly rawUnreadRoomUnsubscribers = new Map<string, () => void>();
     nbUnreadInvitationsMessages: Readable<number>;
     nbUnreadDirectRoomsMessages: Readable<number>;
     nbUnreadRoomsMessages: Readable<number>;
@@ -186,20 +197,8 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             (room) => get(room.myMembership) === KnownMembership.Join && get(room.type) === "multiple"
         );
 
-        this.hasUnreadMessages = derived(
-            this.roomList,
-            (roomList, set) => {
-                // Create a listener for each `hasUnreadMessages` store
-                const unsubscribes = Array.from(roomList.values()).map((room) =>
-                    room.hasUnreadMessages.subscribe(() => {
-                        set(Array.from(roomList.values()).some((someRoom) => get(someRoom.hasUnreadMessages)));
-                    })
-                );
-
-                // Cleanup function
-                return () => unsubscribes.forEach((unsub) => unsub());
-            },
-            false
+        this.hasUnreadMessages = derived(this.rawUnreadRooms, (rawUnreadRooms) =>
+            Array.from(rawUnreadRooms.values()).some((room) => room.count > 0)
         );
 
         this.folders = derived(
@@ -220,26 +219,11 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
                 shouldRetrySendingEvents.some((shouldRetrySendingEvent) => shouldRetrySendingEvent)
         );
 
-        this.nbUnreadInvitationsMessages = derived(
-            this.invitations,
-            (invitations, set) => {
-                // Subscribe to all invitation unreadNotificationCount stores
-                const unsubscribes = invitations.map((room) =>
-                    room.unreadNotificationCount.subscribe(() => {
-                        const total = invitations.reduce(
-                            (acc: number, r: ChatRoom) => acc + get(r.unreadNotificationCount),
-                            0
-                        );
-                        set(total);
-                    })
-                );
-                // Initial calculation
-                const total = invitations.reduce((acc: number, r: ChatRoom) => acc + get(r.unreadNotificationCount), 0);
-                set(total);
-                // Cleanup function
-                return () => unsubscribes.forEach((unsub) => unsub());
-            },
-            0
+        this.nbUnreadInvitationsMessages = derived(this.rawUnreadRooms, (rawUnreadRooms) =>
+            Array.from(rawUnreadRooms.values()).reduce(
+                (total, room) => total + (room.membership === KnownMembership.Invite ? room.count : 0),
+                0
+            )
         );
 
         this.nbUnreadDirectRoomsMessages = derived(
@@ -264,26 +248,13 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             0
         );
 
-        this.nbUnreadRoomsMessages = derived(
-            this.rooms,
-            (rooms, set) => {
-                // Subscribe to all room unreadNotificationCount stores
-                const unsubscribes = rooms.map((room) =>
-                    room.unreadNotificationCount.subscribe(() => {
-                        const total = rooms.reduce(
-                            (acc: number, r: ChatRoom) => acc + get(r.unreadNotificationCount),
-                            0
-                        );
-                        set(total);
-                    })
-                );
-                // Initial calculation
-                const total = rooms.reduce((acc: number, r: ChatRoom) => acc + get(r.unreadNotificationCount), 0);
-                set(total);
-                // Cleanup function
-                return () => unsubscribes.forEach((unsub) => unsub());
-            },
-            0
+        this.nbUnreadRoomsMessages = derived(this.rawUnreadRooms, (rawUnreadRooms) =>
+            Array.from(rawUnreadRooms.values()).reduce((total, room) => {
+                if (room.membership !== KnownMembership.Join || room.isDirect || room.isSpace) {
+                    return total;
+                }
+                return total + room.count;
+            }, 0)
         );
 
         this.handleRoom = this.onClientEventRoom.bind(this);
@@ -332,12 +303,162 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         });
     }
 
+    private trackRawUnreadRoom(room: Room): void {
+        if (typeof room.on !== "function" || typeof room.off !== "function") {
+            return;
+        }
+        if (this.rawUnreadRoomUnsubscribers.has(room.roomId)) {
+            this.updateRawUnreadRoom(room);
+            return;
+        }
+
+        const update = () => this.updateRawUnreadRoom(room);
+        room.on(RoomEvent.UnreadNotifications, update);
+        this.rawUnreadRoomUnsubscribers.set(room.roomId, () => room.off(RoomEvent.UnreadNotifications, update));
+        update();
+    }
+
+    private untrackRawUnreadRoom(roomId: string): void {
+        this.rawUnreadRoomUnsubscribers.get(roomId)?.();
+        this.rawUnreadRoomUnsubscribers.delete(roomId);
+        this.rawUnreadRooms.update((rooms) => {
+            if (!rooms.has(roomId)) {
+                return rooms;
+            }
+            const next = new Map(rooms);
+            next.delete(roomId);
+            return next;
+        });
+    }
+
+    private updateRawUnreadRoom(room: Room): void {
+        if (
+            typeof room.getMyMembership !== "function" ||
+            typeof room.getUnreadNotificationCount !== "function" ||
+            typeof room.isSpaceRoom !== "function"
+        ) {
+            return;
+        }
+        const membership = room.getMyMembership();
+        if (membership === KnownMembership.Leave || membership === KnownMembership.Ban) {
+            this.untrackRawUnreadRoom(room.roomId);
+            return;
+        }
+
+        const directRoomIds = this.getDirectRoomIds();
+        const rawUnreadRoom: RawUnreadRoom = {
+            count: room.getUnreadNotificationCount(),
+            membership,
+            isDirect: directRoomIds.has(room.roomId),
+            isSpace: room.isSpaceRoom(),
+        };
+
+        this.rawUnreadRooms.update((rooms) => {
+            const next = new Map(rooms);
+            next.set(room.roomId, rawUnreadRoom);
+            return next;
+        });
+    }
+
+    private refreshRawUnreadRoomKinds(): void {
+        if (!this.client || typeof this.client.getVisibleRooms !== "function") {
+            return;
+        }
+        this.client.getVisibleRooms().forEach((room) => this.updateRawUnreadRoom(room));
+    }
+
+    private getDirectRoomIds(): Set<string> {
+        const directRoomsPerUsers = this.client?.getAccountData(EventType.Direct)?.getContent() ?? {};
+        return new Set(Object.values(directRoomsPerUsers).flat() as string[]);
+    }
+
+    private registerFolderShell(folder: MatrixRoomFolder): void {
+        this.folderShellsByRoomId.set(folder.id, folder);
+    }
+
+    private unregisterFolderShell(roomId: string): void {
+        this.folderShellsByRoomId.delete(roomId);
+    }
+
+    private setParentRelations(roomId: string, parentIds: string[]): void {
+        const previousParentIds = this.parentRoomIdsByRoomId.get(roomId) ?? new Set<string>();
+        for (const parentId of previousParentIds) {
+            const childIds = this.childRoomIdsBySpaceId.get(parentId);
+            childIds?.delete(roomId);
+            if (childIds?.size === 0) {
+                this.childRoomIdsBySpaceId.delete(parentId);
+            }
+        }
+
+        const uniqueParentIds = new Set(parentIds);
+        if (uniqueParentIds.size === 0) {
+            this.parentRoomIdsByRoomId.delete(roomId);
+            return;
+        }
+
+        this.parentRoomIdsByRoomId.set(roomId, uniqueParentIds);
+        for (const parentId of uniqueParentIds) {
+            const childIds = this.childRoomIdsBySpaceId.get(parentId) ?? new Set<string>();
+            childIds.add(roomId);
+            this.childRoomIdsBySpaceId.set(parentId, childIds);
+        }
+    }
+
+    private updateChildRelation(parentId: string, childId: string, isLinked: boolean): void {
+        const parentIds = new Set(this.parentRoomIdsByRoomId.get(childId) ?? []);
+        const childIds = new Set(this.childRoomIdsBySpaceId.get(parentId) ?? []);
+
+        if (isLinked) {
+            parentIds.add(parentId);
+            childIds.add(childId);
+        } else {
+            parentIds.delete(parentId);
+            childIds.delete(childId);
+        }
+
+        if (parentIds.size === 0) {
+            this.parentRoomIdsByRoomId.delete(childId);
+        } else {
+            this.parentRoomIdsByRoomId.set(childId, parentIds);
+        }
+
+        if (childIds.size === 0) {
+            this.childRoomIdsBySpaceId.delete(parentId);
+        } else {
+            this.childRoomIdsBySpaceId.set(parentId, childIds);
+        }
+    }
+
+    private removeRoomFromPlacementIndex(roomId: string): void {
+        this.setParentRelations(roomId, []);
+        this.childRoomIdsBySpaceId.delete(roomId);
+        for (const [childId, parentIds] of this.parentRoomIdsByRoomId) {
+            if (!parentIds.has(roomId)) {
+                continue;
+            }
+            const nextParentIds = new Set(parentIds);
+            nextParentIds.delete(roomId);
+            if (nextParentIds.size === 0) {
+                this.parentRoomIdsByRoomId.delete(childId);
+            } else {
+                this.parentRoomIdsByRoomId.set(childId, nextParentIds);
+            }
+        }
+        this.unregisterFolderShell(roomId);
+    }
+
     async init(): Promise<void> {
         try {
             this.client = await this.clientPromise;
             this.matrixSecurity.updateMatrixClientStore(this.client);
             await this.startMatrixClient();
             this.isGuest.set(this.client.isGuest());
+            if (typeof this.client.getVisibleRooms === "function") {
+                this.client.getVisibleRooms().forEach((room) => {
+                    this.trackRawUnreadRoom(room);
+                    this.indexRoomPlacement(room);
+                });
+            }
             this.rebuildSpaceHierarchy();
             await this.syncMatrixGlobalProfileFromLocalWokaAndName(false);
             this.attachWokaAvatarMatrixSync();
@@ -636,7 +757,10 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         });
     }
 
-    private getParentRoomID(room: Room): string[] {
+    private readParentRoomIdsFromRoomState(room: Room): string[] {
+        if (typeof room.getLiveTimeline !== "function") {
+            return [];
+        }
         const parentIDs =
             room.getLiveTimeline().getState(EventTimeline.FORWARDS)?.getStateEvents(EventType.SpaceParent) || [];
         return parentIDs.reduce((acc, currentMatrixEvent) => {
@@ -655,6 +779,21 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             if (parentID) acc.push(parentID);
             return acc;
         }, [] as string[]);
+    }
+
+    private indexRoomPlacement(room: Room): void {
+        this.setParentRelations(room.roomId, this.readParentRoomIdsFromRoomState(room));
+    }
+
+    private getParentRoomID(room: Room): string[] {
+        const indexedParentIds = this.parentRoomIdsByRoomId.get(room.roomId);
+        if (indexedParentIds) {
+            return Array.from(indexedParentIds);
+        }
+
+        const parentIds = this.readParentRoomIdsFromRoomState(room);
+        this.setParentRelations(room.roomId, parentIds);
+        return parentIds;
     }
 
     private hasVisibleMembership(room: Room): boolean {
@@ -770,7 +909,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
                 }
 
                 if (parentFolder) {
-                    await this.addRoomToParentFolder(room, parentFolder);
+                    this.addRoomToParentFolder(room, parentFolder);
                     return true;
                 }
                 return false;
@@ -822,6 +961,9 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     }
 
     private onAccountDataEvent(event: MatrixEvent) {
+        if (event.getType() === EventType.Direct) {
+            this.refreshRawUnreadRoomKinds();
+        }
         if (event.getType() === "m.push_rules") {
             const content = event.getContent();
 
@@ -879,6 +1021,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         }
 
         if (!hasValidViaEntries(event.getContent())) {
+            this.updateChildRelation(parentID, roomID, false);
             this.removeRoomFromParentFolder(roomID, parentID)
                 .catch((e) => {
                     console.error("Failed to remove room from parent folder : ", e);
@@ -889,6 +1032,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             return;
         }
 
+        this.updateChildRelation(parentID, roomID, true);
         this.reconcileRoomPlacement(roomID)
             .then((result) => {
                 if (result === "pending") {
@@ -901,6 +1045,8 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             });
     }
     private onClientEventRoom(room: Room) {
+        this.trackRawUnreadRoom(room);
+        this.indexRoomPlacement(room);
         this.manageRoomOrFolder(room).catch((e) => {
             console.error("Failed to manage : ", e);
         });
@@ -918,12 +1064,16 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         return true;
     }
     private addRoomToFolder(room: Room, targetFolder: MatrixRoomFolder, isSpaceRoom: boolean): void {
+        if (targetFolder.hasLoadedChildren?.() === false) {
+            return;
+        }
         if (isSpaceRoom) {
             if (targetFolder.folderList.has(room.roomId)) {
                 return;
             }
             const newFolder = new MatrixRoomFolder(room);
             targetFolder.folderList.set(room.roomId, newFolder);
+            this.registerFolderShell(newFolder);
 
             newFolder.init();
         } else {
@@ -963,7 +1113,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
                 return false;
             }
 
-            await this.addRoomToParentFolder(room, parentFolder);
+            this.addRoomToParentFolder(room, parentFolder);
             return true;
         } catch (e) {
             console.error("Error in tryAddRoomToParentFolder:", e);
@@ -972,6 +1122,11 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     }
 
     private async findParentFolder(parentRoomID: string): Promise<MatrixRoomFolder | null> {
+        const indexedFolder = this.folderShellsByRoomId.get(parentRoomID);
+        if (indexedFolder) {
+            return indexedFolder;
+        }
+
         const folderPromises = Array.from(this.roomFolders.values()).map(async (folder) =>
             folder.id === parentRoomID ? Promise.resolve(folder) : await folder.getNode(parentRoomID)
         );
@@ -985,9 +1140,14 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         return null;
     }
 
-    private async addRoomToParentFolder(room: Room, parentFolder: MatrixRoomFolder): Promise<void> {
+    private addRoomToParentFolder(room: Room, parentFolder: MatrixRoomFolder): void {
         const isSpaceRoom = room.isSpaceRoom();
         const roomId = room.roomId;
+
+        if (parentFolder.hasLoadedChildren?.() === false) {
+            this.detachRoomFromRootLists(roomId);
+            return;
+        }
 
         // Add room/folder to parent's lists
         if (isSpaceRoom) {
@@ -996,7 +1156,8 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
                 roomFolder = new MatrixRoomFolder(room);
                 parentFolder.folderList.set(roomId, roomFolder);
             }
-            await roomFolder.refreshRooms();
+            this.registerFolderShell(roomFolder);
+            // Keep child space shells cheap; remote hierarchy is loaded only when the space is opened.
             roomFolder.init();
         } else {
             if (!parentFolder.roomList.has(roomId)) {
@@ -1013,6 +1174,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             if (!this.roomFolders.has(roomId)) {
                 const rootFolder = new MatrixRoomFolder(room);
                 rootFolder.init();
+                this.registerFolderShell(rootFolder);
                 this.roomFolders.set(roomId, rootFolder);
             }
             return;
@@ -1029,6 +1191,9 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
      */
     private refreshJoinedFolderSubtree(folder: MatrixRoomFolder, targetRoomId?: string): boolean {
         if (get(folder.myMembership) !== KnownMembership.Join) {
+            return false;
+        }
+        if (folder.hasLoadedChildren?.() === false) {
             return false;
         }
         folder.getChildren();
@@ -1152,6 +1317,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         if (this.roomFolders.get(room.roomId)) return;
         const newFolder = new MatrixRoomFolder(room);
         this.roomFolders.set(newFolder.id, newFolder);
+        this.registerFolderShell(newFolder);
         newFolder.init();
 
         newFolder
@@ -1179,6 +1345,8 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         return newRoom;
     }
     private onClientEventDeleteRoom(roomId: string) {
+        this.untrackRawUnreadRoom(roomId);
+        this.removeRoomFromPlacementIndex(roomId);
         this.deleteRoom(roomId).catch((e) => {
             console.error("Failed to delete room : ", e);
         });
@@ -1191,6 +1359,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         const isRootFolder = this.roomFolders.delete(roomId);
 
         if (isRootFolder) {
+            this.unregisterFolderShell(roomId);
             return;
         }
 
@@ -1205,6 +1374,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     }
 
     private onRoomEventMembership(room: Room, membership: string, prevMembership: string | undefined): void {
+        this.updateRawUnreadRoom(room);
         debug(
             "Receive an event to update the membership of the room or folder :",
             room.name,
@@ -1270,6 +1440,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
 
         if (membership === KnownMembership.Leave || membership === KnownMembership.Ban) {
             this.clearRoomPlacementRetry(roomId);
+            this.removeRoomFromPlacementIndex(roomId);
             this.deleteRoomOrFolderAndReconcileChildren(room).catch((e) => {
                 console.error("Failed to delete room or folder : ", e);
             });
@@ -1685,32 +1856,21 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
 
     private rebuildSpaceHierarchy() {
         const client = this.client;
-        if (!client) return;
+        if (!client || typeof client.getVisibleRooms !== "function") return;
 
         this.roomFolders.forEach((folder) => {
+            this.unregisterFolderShell(folder.id);
             this.roomFolders.delete(folder.id);
         });
         const visibleSpaces = client.getVisibleRooms().filter((room) => room.isSpaceRoom());
 
         visibleSpaces.forEach((space) => {
-            const spaceFolder = new MatrixRoomFolder(space);
-            //TODO: maybe delay init until folder is opened
-            spaceFolder.init();
+            this.indexRoomPlacement(space);
             if (this.getParentRoomID(space).length === 0) {
+                const spaceFolder = new MatrixRoomFolder(space);
+                spaceFolder.init();
+                this.registerFolderShell(spaceFolder);
                 this.roomFolders.set(spaceFolder.id, spaceFolder);
-                // Process room IDs asynchronously without blocking
-                spaceFolder
-                    .getRoomsIdInNode()
-                    .then((roomIDs) => {
-                        roomIDs.forEach((roomID) => {
-                            this.roomList.delete(roomID);
-                            this.roomFolders.delete(roomID);
-                        });
-                    })
-                    .catch((error) => {
-                        console.error("Failed to get room IDs for space folder:", error);
-                        Sentry.captureException(error);
-                    });
             }
         });
     }
@@ -1727,6 +1887,12 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
 
     clearListener() {
         this.clearRoomPlacementRetries();
+        this.rawUnreadRoomUnsubscribers.forEach((unsubscribe) => unsubscribe());
+        this.rawUnreadRoomUnsubscribers.clear();
+        this.rawUnreadRooms.set(new Map());
+        this.parentRoomIdsByRoomId.clear();
+        this.childRoomIdsBySpaceId.clear();
+        this.folderShellsByRoomId.clear();
         this.roomList.forEach((room) => {
             this.roomList.delete(room.id);
         });

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatMessageReaction.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatMessageReaction.ts
@@ -84,6 +84,7 @@ export class MatrixChatMessageReaction implements ChatMessageReaction {
             await this.matrixRoom.client
                 .redactEvent(this.matrixRoom.roomId, myReactionEventId)
                 .catch((error) => console.error(error));
+            this.removeUser(this.matrixRoom.myUserId);
         } catch (error) {
             console.error(error);
         }

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -112,6 +112,8 @@ export class MatrixChatRoom
     private readonly userProviderMergerStore = writable<UserProviderMerger | undefined>(undefined);
     private dmMergerUsersByRoomUnsub: (() => void) | undefined;
     private dmMergerRoomTypeUnsub: (() => void) | undefined;
+    private userProviderMergerPromise: Promise<UserProviderMerger | undefined>;
+    private visibleProfileSyncUsers = 0;
     private initializationPromise: Promise<void> | undefined;
     private membersInitializationPromise: Promise<void> | undefined;
     private membersInitialized = false;
@@ -328,34 +330,16 @@ export class MatrixChatRoom
 
         this.startHandlingChatRoomShellEvents();
 
-        gameManager
+        this.userProviderMergerPromise = gameManager
             .getCurrentGameScene()
             .userProviderMerger.then((merger) => {
                 this.userProviderMergerStore.set(merger);
                 get(this.members).forEach((m) => m.setUserProviderMergerContext(merger));
-
-                const syncDmMergerAvatarSub = () => {
-                    this.dmMergerUsersByRoomUnsub?.();
-                    this.dmMergerUsersByRoomUnsub = undefined;
-                    if (get(this.roomTypeStore) !== "direct") {
-                        return;
-                    }
-                    this.dmMergerUsersByRoomUnsub = merger.usersByRoomStore.subscribe(() => {
-                        this.directRoomPeerAvatarStore?.refresh().catch((error) => {
-                            console.warn("Failed to refresh Matrix direct room avatar", error);
-                        });
-                        const myUserId = this.matrixRoom.client.getUserId();
-                        get(this.members)
-                            .filter((mem) => mem.id !== myUserId)
-                            .forEach((mem) => mem.refreshAvatarFromRoomMember());
-                    });
-                };
-                syncDmMergerAvatarSub();
-                this.dmMergerRoomTypeUnsub?.();
-                this.dmMergerRoomTypeUnsub = this.roomTypeStore.subscribe(syncDmMergerAvatarSub);
+                return merger;
             })
             .catch(() => {
                 /* chat list can work without merger */
+                return undefined;
             });
 
         this.matrixRoom
@@ -408,7 +392,6 @@ export class MatrixChatRoom
         this.initializationError.set(undefined);
         this.debugInitialization("timeline");
         this.initializationPromise = (async () => {
-            await this.ensureMembersInitialized();
             await matrixSecurity.restoreRoomsMessages();
             await this.initMatrixRoomMessagesAndReactions();
             this.initializationState.set("ready");
@@ -444,6 +427,60 @@ export class MatrixChatRoom
             return wrappedMember;
         });
         this.members.set(members);
+    }
+
+    activateVisibleProfileSync(): () => void {
+        let cleaned = false;
+        this.visibleProfileSyncUsers += 1;
+        this.startVisibleProfileSync().catch(() => {
+            /* chat list can work without merger */
+        });
+
+        return () => {
+            if (cleaned) {
+                return;
+            }
+            cleaned = true;
+            this.visibleProfileSyncUsers = Math.max(0, this.visibleProfileSyncUsers - 1);
+            if (this.visibleProfileSyncUsers === 0) {
+                this.stopVisibleProfileSync();
+            }
+        };
+    }
+
+    private async startVisibleProfileSync(): Promise<void> {
+        if (this.dmMergerRoomTypeUnsub) {
+            return;
+        }
+
+        const merger = get(this.userProviderMergerStore) ?? (await this.userProviderMergerPromise);
+        if (!merger || this.visibleProfileSyncUsers === 0 || this.dmMergerRoomTypeUnsub) {
+            return;
+        }
+
+        const syncDmMergerAvatarSub = () => {
+            this.dmMergerUsersByRoomUnsub?.();
+            this.dmMergerUsersByRoomUnsub = undefined;
+            if (get(this.roomTypeStore) !== "direct" || this.visibleProfileSyncUsers === 0) {
+                return;
+            }
+            this.dmMergerUsersByRoomUnsub = merger.usersByRoomStore.subscribe(() => {
+                this.directRoomPeerAvatarStore?.refresh().catch(() => undefined);
+                const myUserId = this.matrixRoom.client.getUserId();
+                get(this.members)
+                    .filter((mem) => mem.id !== myUserId)
+                    .forEach((mem) => mem.refreshAvatarFromRoomMember());
+            });
+        };
+
+        this.dmMergerRoomTypeUnsub = this.roomTypeStore.subscribe(syncDmMergerAvatarSub);
+    }
+
+    private stopVisibleProfileSync(): void {
+        this.dmMergerUsersByRoomUnsub?.();
+        this.dmMergerUsersByRoomUnsub = undefined;
+        this.dmMergerRoomTypeUnsub?.();
+        this.dmMergerRoomTypeUnsub = undefined;
     }
 
     private async initMatrixRoomMessagesAndReactions() {
@@ -496,6 +533,7 @@ export class MatrixChatRoom
     private startHandlingChatRoomShellEvents() {
         this.matrixRoom.on(RoomEvent.Timeline, this.handleRoomTimeline);
         this.matrixRoom.on(RoomEvent.Name, this.handleRoomName);
+        this.matrixRoom.on(RoomEvent.Redaction, this.handleRoomRedaction);
         this.matrixRoom.on(RoomStateEvent.Events, this.handleStateEvent);
         this.matrixRoom.on(RoomEvent.MyMembership, this.handleMyMembership);
         this.matrixRoom.on(RoomEvent.UnreadNotifications, this.updateUnreadNotificationCount);
@@ -507,7 +545,6 @@ export class MatrixChatRoom
             return;
         }
         this.initializedEventHandlersStarted = true;
-        this.matrixRoom.on(RoomEvent.Redaction, this.handleRoomRedaction);
         this.matrixRoom.on(RoomStateEvent.NewMember, this.handleNewMember);
     }
 
@@ -726,7 +763,7 @@ export class MatrixChatRoom
                         this.handleMessageDeletion(sourceEventId);
                         break;
                     case "m.reaction":
-                        this.handleReactionDeletion(redactionEvent, sourceEventId);
+                        this.handleReactionDeletion(redactionEvent, sourceEvent);
                         break;
                 }
             }
@@ -741,20 +778,21 @@ export class MatrixChatRoom
         }
     }
 
-    private handleReactionDeletion(redactionEvent: MatrixEvent, reactionEventId: string) {
+    private handleReactionDeletion(redactionEvent: MatrixEvent, reactionEvent: MatrixEvent) {
+        const reactionEventId = reactionEvent.getId();
+        if (reactionEventId === undefined) {
+            console.error("Reaction event id is undefined");
+            return;
+        }
         const reactionEventContent = this.inMemoryEventsContent.get(reactionEventId);
-        const sender = redactionEvent.getSender();
+        const sender = reactionEvent.getSender() ?? redactionEvent.getSender();
         if (sender === undefined) {
-            console.error("Redaction sender is undefined");
+            console.error("Reaction sender is undefined");
             return;
         }
 
-        if (reactionEventContent === undefined) {
-            console.error("No reaction event in memory to proceed deletion");
-            return;
-        }
-        const relation = reactionEventContent["m.relates_to"];
-        if (relation === undefined) {
+        const relation = reactionEventContent?.["m.relates_to"] ?? reactionEvent.getRelation();
+        if (relation === undefined || relation === null) {
             console.error("The event has no relation content,");
             return;
         }
@@ -1058,8 +1096,7 @@ export class MatrixChatRoom
     }
 
     destroy() {
-        this.dmMergerUsersByRoomUnsub?.();
-        this.dmMergerUsersByRoomUnsub = undefined;
+        this.stopVisibleProfileSync();
         this.currentUserRoomMember?.off(RoomMemberEvent.PowerLevel, this.handleCurrentUserRoomMemberPowerLevel);
         this.currentUserRoomMember = undefined;
         this.matrixRoom.currentState.off(RoomStateEvent.Members, this.handleRoomStateMembers);

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -18,6 +18,7 @@ import {
     PushRuleActionName,
     PushRuleKind,
     ReceiptType,
+    RoomMemberEvent,
     RoomEvent,
     RoomStateEvent,
     TimelineWindow,
@@ -29,8 +30,10 @@ import { derived, get, readable, readonly, writable } from "svelte/store";
 import type { MediaEventContent, MediaEventInfo } from "matrix-js-sdk/lib/@types/media";
 import { MapStore, SearchableArrayStore } from "@workadventure/store-utils";
 import type { RoomMessageEventContent } from "matrix-js-sdk/lib/@types/events";
+import Debug from "debug";
 import type {
     ChatRoom,
+    ChatRoomInitializationState,
     ChatRoomMember,
     ChatRoomMembership,
     ChatRoomMembershipManagement,
@@ -46,7 +49,6 @@ import { localUserStore } from "../../../Connection/LocalUserStore";
 import { MessageNotification } from "../../../Notification/MessageNotification";
 import { notificationManager } from "../../../Notification/NotificationManager";
 import type { LazyPictureStore, PictureStore } from "../../../Stores/PictureStore";
-import { isLazyPictureStore } from "../../../Stores/PictureStore";
 import { chatNotificationStore } from "../../../Stores/ProximityNotificationStore";
 import { chatVisibilityStore } from "../../../Stores/ChatStore";
 import type { UserProviderMerger } from "../../UserProviderMerger/UserProviderMerger";
@@ -56,10 +58,13 @@ import { matrixSecurity } from "./MatrixSecurity";
 import { hasValidViaEntries } from "./MatrixSpaceRelations";
 import { resolveChatUserColor } from "./services/WaMatrixProfileService";
 import { MatrixChatRoomMember } from "./MatrixChatRoomMember";
+import { matrixAvatarProfile } from "./services/MatrixAvatarProfile";
 
 type EventId = string;
 
 type ModerationAction = "ban" | "kick" | "invite" | "redact";
+
+const debug = Debug("MatrixChatRoom");
 
 export class MatrixChatRoom
     implements ChatRoom, ChatRoomMembershipManagement, ChatRoomModeration, ChatRoomNotificationControl
@@ -70,6 +75,8 @@ export class MatrixChatRoom
     readonly type: Readable<"multiple" | "direct">;
     readonly hasUnreadMessages: Writable<boolean>;
     readonly unreadNotificationCount: Writable<number>;
+    readonly initializationState: Writable<ChatRoomInitializationState> = writable("idle");
+    readonly initializationError: Writable<Error | undefined> = writable(undefined);
     pictureStore: LazyPictureStore;
     readonly avatarFallbackColor: Readable<string | undefined>;
     messages: SearchableArrayStore<string, MatrixChatMessage>;
@@ -85,7 +92,7 @@ export class MatrixChatRoom
     typingMembers: Readable<Array<{ id: string; name: string | null; pictureStore: PictureStore }>>;
     isRoomFolder = false;
     areNotificationsMuted = writable(false);
-    currentRoomMember: Readable<MatrixChatRoomMember>;
+    currentRoomMember: Readable<MatrixChatRoomMember | undefined>;
     readonly isCurrentUserRoomAdmin: Readable<boolean>;
     private notSentEvents: MapStore<string, MatrixEvent> = new MapStore<string, MatrixEvent>();
     shouldRetrySendingEvents = derived(this.notSentEvents, (notSentEvents) => notSentEvents.size > 0);
@@ -105,6 +112,17 @@ export class MatrixChatRoom
     private readonly userProviderMergerStore = writable<UserProviderMerger | undefined>(undefined);
     private dmMergerUsersByRoomUnsub: (() => void) | undefined;
     private dmMergerRoomTypeUnsub: (() => void) | undefined;
+    private initializationPromise: Promise<void> | undefined;
+    private membersInitializationPromise: Promise<void> | undefined;
+    private membersInitialized = false;
+    private initializedEventHandlersStarted = false;
+    private directRoomPeerAvatarStore: LazyPictureStore | undefined;
+    private directRoomPeerAvatarMember: RoomMember | undefined;
+    // Keep full MatrixChatRoomMember objects lazy. Space-level UI permissions still need the current user's
+    // power level before a room is opened, so we only observe the Matrix SDK RoomMember without avatar/profile work.
+    private currentUserRoomMember: RoomMember | undefined;
+    private currentUserPermissionLevel: Writable<ChatPermissionLevel | undefined> = writable(undefined);
+    private handleCurrentUserRoomMemberPowerLevel = this.onCurrentUserRoomMemberPowerLevel.bind(this);
 
     constructor(
         private matrixRoom: Room,
@@ -150,27 +168,34 @@ export class MatrixChatRoom
         this.messages = new SearchableArrayStore((item: MatrixChatMessage) => item.id);
         this.sendMessage = this.sendMessage.bind(this);
         this.myMembership = writable(matrixRoom.getMyMembership());
+        this.setCurrentUserRoomMember(matrixRoom.getMember(matrixRoom.client.getSafeUserId()) ?? undefined);
 
-        this.members = writable([
-            ...matrixRoom
-                .getMembers()
-                .map(
-                    (member) => new MatrixChatRoomMember(member, this.matrixRoom.client.baseUrl, this.matrixRoom.client)
-                ),
-        ]);
+        this.members = writable([]);
         this.membersForMessageAvatars = this.members;
+        this.directRoomPeerAvatarMember = this.getDirectRoomPeerRoomMember();
+        if (this.directRoomPeerAvatarMember) {
+            this.directRoomPeerAvatarStore = matrixAvatarProfile.createLazyAvatarStore(
+                this.directRoomPeerAvatarMember.userId,
+                () =>
+                    matrixAvatarProfile.resolveAvatarUrl(
+                        this.directRoomPeerAvatarMember!.userId,
+                        this.directRoomPeerAvatarMember!,
+                        this.matrixRoom.client.baseUrl,
+                        this.matrixRoom.client,
+                        get(this.userProviderMergerStore)
+                    )
+            );
+        }
 
         /** Channel: room avatar. DM: room avatar or peer Matrix avatar, with load delegated to the peer lazy store. */
         const roomPictureStore = derived(
-            [this.roomTypeStore, roomAvatarStore, this.members],
-            ([roomType, roomAvatar, members], set: (value: string | undefined) => void) => {
+            [this.roomTypeStore, roomAvatarStore],
+            ([roomType, roomAvatar], set: (value: string | undefined) => void) => {
                 if (roomType !== "direct") {
                     set(roomAvatar);
                     return;
                 }
-                const myUserId = this.matrixRoom.client.getUserId();
-                const other = members.find((m) => m.id !== myUserId);
-                if (!other) {
+                if (!this.directRoomPeerAvatarStore) {
                     set(roomAvatar);
                     return;
                 }
@@ -178,57 +203,50 @@ export class MatrixChatRoom
                     set(roomAvatar);
                     return;
                 }
-                return other.pictureStore.subscribe(set);
+                return this.directRoomPeerAvatarStore.subscribe(set);
             },
             undefined
         );
         this.pictureStore = {
             subscribe: roomPictureStore.subscribe,
             load: async () => {
-                const other = this.getDirectRoomPeerMember();
-                if (!get(roomAvatarStore) && isLazyPictureStore(other?.pictureStore)) {
-                    await other.pictureStore.load();
+                if (!get(roomAvatarStore) && this.directRoomPeerAvatarStore) {
+                    await this.directRoomPeerAvatarStore.load();
                 }
             },
             refresh: async () => {
-                const other = this.getDirectRoomPeerMember();
-                if (!get(roomAvatarStore) && isLazyPictureStore(other?.pictureStore)) {
-                    await other.pictureStore.refresh();
+                if (!get(roomAvatarStore) && this.directRoomPeerAvatarStore) {
+                    await this.directRoomPeerAvatarStore.refresh();
                 }
             },
             invalidate: () => {
-                const other = this.getDirectRoomPeerMember();
-                if (!get(roomAvatarStore) && isLazyPictureStore(other?.pictureStore)) {
-                    other.pictureStore.invalidate();
+                if (!get(roomAvatarStore) && this.directRoomPeerAvatarStore) {
+                    this.directRoomPeerAvatarStore.invalidate();
                 }
             },
         };
 
-        this.avatarFallbackColor = derived(
-            [this.roomTypeStore, this.members, this.userProviderMergerStore],
-            ([roomType, members, merger]) => {
-                if (roomType !== "direct") {
-                    return undefined;
-                }
-                const myUserId = this.matrixRoom.client.getUserId();
-                const other = members.find((m) => m.id !== myUserId);
-                if (!other) {
-                    return undefined;
-                }
-                let mergerColor: string | undefined;
-                if (merger) {
-                    const byRoom = get(merger.usersByRoomStore);
-                    for (const [, { users }] of byRoom) {
-                        const u = users.find((user) => user.chatId === other.id);
-                        if (u?.color) {
-                            mergerColor = u.color;
-                            break;
-                        }
+        this.avatarFallbackColor = derived([this.roomTypeStore, this.userProviderMergerStore], ([roomType, merger]) => {
+            if (roomType !== "direct") {
+                return undefined;
+            }
+            const other = this.directRoomPeerAvatarMember;
+            if (!other) {
+                return undefined;
+            }
+            let mergerColor: string | undefined;
+            if (merger) {
+                const byRoom = get(merger.usersByRoomStore);
+                for (const [, { users }] of byRoom) {
+                    const u = users.find((user) => user.chatId === other.userId);
+                    if (u?.color) {
+                        mergerColor = u.color;
+                        break;
                     }
                 }
-                return resolveChatUserColor(other.id, mergerColor, this.matrixRoom.client);
             }
-        );
+            return resolveChatUserColor(other.userId, mergerColor, this.matrixRoom.client);
+        });
 
         this.peerWaDisplayNameIfDifferent = derived(
             [this.roomTypeStore, this.members],
@@ -274,12 +292,24 @@ export class MatrixChatRoom
         this.isEncrypted = writable(matrixRoom.hasEncryptionStateEvent());
 
         this.typingMembers = derived(
-            get(this.members).map((member) => member.isTypingInformation),
-            (membersInformation) => {
-                return membersInformation.filter(
-                    (member) => member !== null && member.id !== this.matrixRoom.client.getUserId()
-                ) as memberTypingInformation[];
-            }
+            this.members,
+            (members, set: (value: memberTypingInformation[]) => void) => {
+                const typingByUser = new Map<string, memberTypingInformation>();
+                const sync = () => set(Array.from(typingByUser.values()));
+                const unsubscribers = members.map((member) =>
+                    member.isTypingInformation.subscribe((memberInformation) => {
+                        if (memberInformation && memberInformation.id !== this.matrixRoom.client.getUserId()) {
+                            typingByUser.set(memberInformation.id, memberInformation);
+                        } else {
+                            typingByUser.delete(member.id);
+                        }
+                        sync();
+                    })
+                );
+                sync();
+                return () => unsubscribers.forEach((unsubscribe) => unsubscribe());
+            },
+            []
         );
         this.isRoomFolder = matrixRoom.isSpaceRoom();
         this.inMemoryEventsContent = new Map<EventId, MatrixEvent>();
@@ -296,21 +326,7 @@ export class MatrixChatRoom
                 })
         );
 
-        (async () => {
-            await matrixSecurity.restoreRoomsMessages();
-        })()
-            .catch((error) => {
-                console.error("Failed to init client crypto configuration", error);
-            })
-            .then(async () => {
-                await this.initMatrixRoomMessagesAndReactions();
-            })
-            .catch((error) => {
-                console.error("Failed to init Matrix room messages:", error);
-            });
-
-        //Necessary to keep matrix event content for local event deletions after initialization
-        this.startHandlingChatRoomEvents();
+        this.startHandlingChatRoomShellEvents();
 
         gameManager
             .getCurrentGameScene()
@@ -325,6 +341,9 @@ export class MatrixChatRoom
                         return;
                     }
                     this.dmMergerUsersByRoomUnsub = merger.usersByRoomStore.subscribe(() => {
+                        this.directRoomPeerAvatarStore?.refresh().catch((error) => {
+                            console.warn("Failed to refresh Matrix direct room avatar", error);
+                        });
                         const myUserId = this.matrixRoom.client.getUserId();
                         get(this.members)
                             .filter((mem) => mem.id !== myUserId)
@@ -350,6 +369,83 @@ export class MatrixChatRoom
             });
     }
 
+    async ensureInitialized(): Promise<void> {
+        return this.ensureTimelineInitialized();
+    }
+
+    async ensureMembersInitialized(): Promise<void> {
+        if (this.membersInitialized) {
+            return;
+        }
+        if (this.membersInitializationPromise) {
+            return this.membersInitializationPromise;
+        }
+
+        this.debugInitialization("members");
+        this.membersInitializationPromise = Promise.resolve()
+            .then(() => {
+                this.initializeMembers();
+                this.startHandlingChatRoomInitializedEvents();
+                this.membersInitialized = true;
+            })
+            .catch((error: unknown) => {
+                this.membersInitializationPromise = undefined;
+                throw error;
+            });
+
+        return this.membersInitializationPromise;
+    }
+
+    async ensureTimelineInitialized(): Promise<void> {
+        if (get(this.initializationState) === "ready") {
+            return;
+        }
+        if (this.initializationPromise) {
+            return this.initializationPromise;
+        }
+
+        this.initializationState.set("loading");
+        this.initializationError.set(undefined);
+        this.debugInitialization("timeline");
+        this.initializationPromise = (async () => {
+            await this.ensureMembersInitialized();
+            await matrixSecurity.restoreRoomsMessages();
+            await this.initMatrixRoomMessagesAndReactions();
+            this.initializationState.set("ready");
+        })().catch((error: unknown) => {
+            const initializationError = error instanceof Error ? error : new Error(String(error));
+            this.initializationError.set(initializationError);
+            this.initializationState.set("error");
+            this.initializationPromise = undefined;
+            throw initializationError;
+        });
+
+        return this.initializationPromise;
+    }
+
+    private debugInitialization(type: "members" | "timeline"): void {
+        debug("init %s room=%s roomId=%s", type, get(this.name), this.id);
+    }
+
+    private initializeMembers(): void {
+        if (get(this.members).length > 0) {
+            return;
+        }
+        const merger = get(this.userProviderMergerStore);
+        const members = this.matrixRoom.getMembers().map((member) => {
+            const wrappedMember = new MatrixChatRoomMember(
+                member,
+                this.matrixRoom.client.baseUrl,
+                this.matrixRoom.client
+            );
+            if (merger) {
+                wrappedMember.setUserProviderMergerContext(merger);
+            }
+            return wrappedMember;
+        });
+        this.members.set(members);
+    }
+
     private async initMatrixRoomMessagesAndReactions() {
         if (this.matrixRoom.hasEncryptionStateEvent()) {
             await this.matrixRoom.decryptAllEvents();
@@ -369,12 +465,12 @@ export class MatrixChatRoom
         this.hasPreviousMessage.set(this.timelineWindow.canPaginate(Direction.Backward));
     }
 
-    private getDirectRoomPeerMember(): MatrixChatRoomMember | undefined {
+    private getDirectRoomPeerRoomMember(): RoomMember | undefined {
         if (get(this.roomTypeStore) !== "direct") {
             return undefined;
         }
         const myUserId = this.matrixRoom.client.getUserId();
-        return get(this.members).find((member) => member.id !== myUserId);
+        return this.getMembersForRoomTypeHeuristics().find((member) => member.userId !== myUserId);
     }
 
     private async readEventsToAddMessagesAndReactions(
@@ -397,15 +493,22 @@ export class MatrixChatRoom
         return undefined;
     }
 
-    private startHandlingChatRoomEvents() {
+    private startHandlingChatRoomShellEvents() {
         this.matrixRoom.on(RoomEvent.Timeline, this.handleRoomTimeline);
         this.matrixRoom.on(RoomEvent.Name, this.handleRoomName);
-        this.matrixRoom.on(RoomEvent.Redaction, this.handleRoomRedaction);
         this.matrixRoom.on(RoomStateEvent.Events, this.handleStateEvent);
         this.matrixRoom.on(RoomEvent.MyMembership, this.handleMyMembership);
-        this.matrixRoom.on(RoomStateEvent.NewMember, this.handleNewMember);
         this.matrixRoom.on(RoomEvent.UnreadNotifications, this.updateUnreadNotificationCount);
         this.matrixRoom.currentState.on(RoomStateEvent.Members, this.handleRoomStateMembers);
+    }
+
+    private startHandlingChatRoomInitializedEvents() {
+        if (this.initializedEventHandlersStarted) {
+            return;
+        }
+        this.initializedEventHandlersStarted = true;
+        this.matrixRoom.on(RoomEvent.Redaction, this.handleRoomRedaction);
+        this.matrixRoom.on(RoomStateEvent.NewMember, this.handleNewMember);
     }
 
     protected onRoomMyMembership(room: Room) {
@@ -431,7 +534,12 @@ export class MatrixChatRoom
         this.refreshRoomType();
         const myUserId = this.matrixRoom.client.getUserId();
         if (member.userId === myUserId) {
+            this.setCurrentUserRoomMember(member);
             return;
+        }
+        if (member.userId === this.directRoomPeerAvatarMember?.userId) {
+            this.directRoomPeerAvatarMember = member;
+            this.directRoomPeerAvatarStore?.invalidate();
         }
         get(this.members)
             .filter((m) => m.id === member.userId)
@@ -677,6 +785,7 @@ export class MatrixChatRoom
     }
 
     async loadMorePreviousMessages() {
+        await this.ensureTimelineInitialized();
         if (get(this.hasPreviousMessage)) {
             const existingEventsBeforePagination = this.timelineWindow.getEvents();
             await this.timelineWindow.paginate(Direction.Backward, 8);
@@ -951,6 +1060,8 @@ export class MatrixChatRoom
     destroy() {
         this.dmMergerUsersByRoomUnsub?.();
         this.dmMergerUsersByRoomUnsub = undefined;
+        this.currentUserRoomMember?.off(RoomMemberEvent.PowerLevel, this.handleCurrentUserRoomMemberPowerLevel);
+        this.currentUserRoomMember = undefined;
         this.matrixRoom.currentState.off(RoomStateEvent.Members, this.handleRoomStateMembers);
         this.matrixRoom.off(RoomEvent.Timeline, this.handleRoomTimeline);
         this.matrixRoom.off(RoomEvent.Name, this.handleRoomName);
@@ -984,9 +1095,28 @@ export class MatrixChatRoom
 
     public hasPermissionTo(action: ModerationAction, member?: ChatRoomMember): Readable<boolean> {
         const otherUserPermissionLevel = member ? member.permissionLevel : readable(ChatPermissionLevel.USER);
+        const currentRoomMember = get(this.currentRoomMember);
+        if (!currentRoomMember) {
+            return derived(
+                [this.currentUserPermissionLevel, otherUserPermissionLevel],
+                ([$currentUserPermission, $otherUserPermission]) => {
+                    if (!$currentUserPermission) return false;
+
+                    const currentUserPowerLevel = MatrixChatRoomMember.getPowerLevel($currentUserPermission);
+                    const otherUserPowerLevel = MatrixChatRoomMember.getPowerLevel($otherUserPermission);
+                    const hasSufficientPowerLevel =
+                        this.matrixRoom
+                            .getLiveTimeline()
+                            .getState(Direction.Backward)
+                            ?.hasSufficientPowerLevelFor(action, currentUserPowerLevel) ?? false;
+
+                    return hasSufficientPowerLevel && currentUserPowerLevel > otherUserPowerLevel;
+                }
+            );
+        }
 
         return derived(
-            [get(this.currentRoomMember).permissionLevel, otherUserPermissionLevel],
+            [currentRoomMember.permissionLevel, otherUserPermissionLevel],
             ([$currentRoomPermission, $otherUserPermission]) => {
                 if (!$currentRoomPermission) return false;
 
@@ -1005,7 +1135,7 @@ export class MatrixChatRoom
     }
 
     public hasPermissionForRoomStateEvent(eventType: keyof StateEvents): Readable<boolean> {
-        return derived([get(this.currentRoomMember).permissionLevel], () => {
+        return derived([this.currentUserPermissionLevel, this.myMembership], () => {
             return (
                 this.matrixRoom
                     .getLiveTimeline()
@@ -1013,6 +1143,30 @@ export class MatrixChatRoom
                     ?.maySendStateEvent(eventType, this.matrixRoom.client.getSafeUserId()) ?? false
             );
         });
+    }
+
+    private setCurrentUserRoomMember(member: RoomMember | undefined): void {
+        if (this.currentUserRoomMember === member) {
+            if (member) {
+                this.currentUserPermissionLevel.set(MatrixChatRoomMember.getPermissionLevel(member.powerLevelNorm));
+            }
+            return;
+        }
+
+        this.currentUserRoomMember?.off(RoomMemberEvent.PowerLevel, this.handleCurrentUserRoomMemberPowerLevel);
+        this.currentUserRoomMember = member;
+
+        if (!member) {
+            this.currentUserPermissionLevel.set(undefined);
+            return;
+        }
+
+        this.currentUserPermissionLevel.set(MatrixChatRoomMember.getPermissionLevel(member.powerLevelNorm));
+        member.on(RoomMemberEvent.PowerLevel, this.handleCurrentUserRoomMemberPowerLevel);
+    }
+
+    private onCurrentUserRoomMemberPowerLevel(_event: MatrixEvent, member: RoomMember): void {
+        this.currentUserPermissionLevel.set(MatrixChatRoomMember.getPermissionLevel(member.powerLevelNorm));
     }
 
     public async changePermissionLevelFor(member: ChatRoomMember, permissionLevel: ChatPermissionLevel): Promise<void> {
@@ -1047,7 +1201,11 @@ export class MatrixChatRoom
     public getAllowedRolesToAssign(): ChatPermissionLevel[] {
         const allowedRolesToAssign: ChatPermissionLevel[] = [];
 
-        const currentRoomMemberPermissionLevel = get(get(this.currentRoomMember).permissionLevel);
+        const currentRoomMember = get(this.currentRoomMember);
+        if (!currentRoomMember) {
+            return allowedRolesToAssign;
+        }
+        const currentRoomMemberPermissionLevel = get(currentRoomMember.permissionLevel);
 
         const currentRoomMemberPowerLevel = MatrixChatRoomMember.getPowerLevel(currentRoomMemberPermissionLevel);
 
@@ -1063,7 +1221,11 @@ export class MatrixChatRoom
     }
 
     public canModifyRoleOf(permissionLevel?: ChatPermissionLevel): boolean {
-        const currentRoomMemberPermissionLevel = get(get(this.currentRoomMember).permissionLevel);
+        const currentRoomMember = get(this.currentRoomMember);
+        if (!currentRoomMember) {
+            return false;
+        }
+        const currentRoomMemberPermissionLevel = get(currentRoomMember.permissionLevel);
         const currentRoomMemberPowerLevel = MatrixChatRoomMember.getPowerLevel(currentRoomMemberPermissionLevel);
         const memberPowerLevel = permissionLevel ? MatrixChatRoomMember.getPowerLevel(permissionLevel) : 0;
 

--- a/play/src/front/Chat/Connection/Matrix/MatrixClientWrapper.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixClientWrapper.ts
@@ -58,6 +58,7 @@ export class InvalidLoginTokenError extends Error {
 export class MatrixClientWrapper implements MatrixClientWrapperInterface {
     private client!: MatrixClient;
     private secretStorageKeys: Record<string, Uint8Array> = {};
+    private secretStorageKeyRequestPromise: Promise<[string, Uint8Array] | null> | undefined;
     private clientClosed = false;
 
     constructor(
@@ -269,7 +270,22 @@ export class MatrixClientWrapper implements MatrixClientWrapperInterface {
             return [keyId, this.secretStorageKeys[keyId]];
         }
 
-        const key = await new Promise<Uint8Array | null>((resolve, reject) => {
+        if (this.secretStorageKeyRequestPromise) {
+            return this.secretStorageKeyRequestPromise;
+        }
+
+        this.secretStorageKeyRequestPromise = this.openSecretStorageKeyDialog(keyId, keyInfo).finally(() => {
+            this.secretStorageKeyRequestPromise = undefined;
+        });
+
+        return this.secretStorageKeyRequestPromise;
+    }
+
+    private async openSecretStorageKeyDialog(
+        keyId: string,
+        keyInfo: SecretStorage.SecretStorageKeyDescription
+    ): Promise<[string, Uint8Array] | null> {
+        const key = await new Promise<Uint8Array | null>((resolve) => {
             if (!matrixSecurity.shouldDisplayModal) {
                 resolve(null);
                 return;

--- a/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
@@ -28,9 +28,13 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
     readonly allSuggestedRooms: Writable<{ name: string; id: string; avatarUrl: string }[]> = writable([]);
     readonly suggestedRooms: Readable<{ name: string; id: string; avatarUrl: string }[]>;
     readonly joinableRooms: Readable<{ name: string; id: string; avatarUrl: string }[]>;
+    readonly joinableRoomsLoading: Writable<boolean> = writable(false);
 
     private loadRoomsAndFolderPromise = new Deferred<void>();
     private joinRoomDeferred = new Deferred<void>();
+    private childrenLoaded = false;
+    private joinableRoomsLoaded = false;
+    private joinableRoomsLoadingPromise: Promise<void> | undefined;
 
     constructor(private room: Room) {
         super(room);
@@ -109,15 +113,6 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
 
     init() {
         try {
-            if (get(this.myMembership) === KnownMembership.Join) {
-                this.getChildren();
-                this.hasChildRoomsError.set(false);
-                this.refreshRooms().catch((error: Error) => {
-                    console.error("Failed to refresh rooms:", error);
-                    this.hasChildRoomsError.set(true);
-                    Sentry.captureException(error);
-                });
-            }
             this.loadRoomsAndFolderPromise.resolve();
         } catch (e) {
             this.loadRoomsAndFolderPromise.reject(e);
@@ -340,19 +335,52 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
         }
     }
 
+    async ensureJoinableRoomsLoaded(): Promise<void> {
+        if (this.joinableRoomsLoaded) {
+            return;
+        }
+        if (this.joinableRoomsLoadingPromise) {
+            return this.joinableRoomsLoadingPromise;
+        }
+
+        this.joinableRoomsLoading.set(true);
+        this.hasChildRoomsError.set(false);
+        this.joinableRoomsLoadingPromise = this.refreshRooms()
+            .then(() => {
+                this.joinableRoomsLoaded = true;
+            })
+            .catch((error: unknown) => {
+                this.hasChildRoomsError.set(true);
+                throw error;
+            })
+            .finally(() => {
+                this.joinableRoomsLoading.set(false);
+                this.joinableRoomsLoadingPromise = undefined;
+            });
+
+        return this.joinableRoomsLoadingPromise;
+    }
+
     protected override onRoomMyMembership(room: Room) {
         if (room.getMyMembership() === KnownMembership.Join) {
             this.joinRoomDeferred.resolve();
-            this.getChildren();
-            this.refreshRooms().catch((error: Error) => {
-                console.error("Failed to refresh rooms:", error);
-                Sentry.captureException(error);
-            });
         }
         super.onRoomMyMembership(room);
     }
 
+    public ensureChildrenLoaded(): void {
+        if (this.childrenLoaded) {
+            return;
+        }
+        this.getChildren();
+    }
+
+    public hasLoadedChildren(): boolean {
+        return this.childrenLoaded;
+    }
+
     public getChildren() {
+        this.childrenLoaded = true;
         const client = this.room.client;
         const room = this.room;
 

--- a/play/src/front/Chat/Connection/Matrix/MatrixSecurity.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixSecurity.ts
@@ -28,6 +28,7 @@ export class MatrixSecurity {
     isEncryptionRequiredAndNotSet = writable(false);
     private matrixClientStore: MatrixClient | null = null;
     private isVerifyingDevice = false;
+    private automaticDeviceVerificationPromptRequested = false;
     public shouldDisplayModal = false;
     constructor(
         private initializingEncryptionPromise: Promise<void> | undefined = undefined,
@@ -356,7 +357,20 @@ export class MatrixSecurity {
         });
     }
 
+    public openAutomaticChooseDeviceVerificationMethodModal(): Promise<void> {
+        if (this.automaticDeviceVerificationPromptRequested || this.isVerifyingDevice) {
+            return Promise.resolve();
+        }
+
+        this.automaticDeviceVerificationPromptRequested = true;
+        return this.openChooseDeviceVerificationMethodModal();
+    }
+
     public async openChooseDeviceVerificationMethodModal() {
+        if (this.isVerifyingDevice) {
+            return;
+        }
+
         try {
             this.isVerifyingDevice = true;
 

--- a/play/src/front/Chat/Connection/Matrix/services/MatrixAvatarProfile.ts
+++ b/play/src/front/Chat/Connection/Matrix/services/MatrixAvatarProfile.ts
@@ -19,32 +19,11 @@ type LazyAvatarStoreState = {
     hasLoaded: boolean;
 };
 
-function formatAvatarUrlForDebug(url: string | undefined): string | undefined {
-    if (url === undefined) {
-        return undefined;
-    }
-    if (url.startsWith("data:")) {
-        const mediaTypeEnd = url.indexOf(",");
-        const mediaType = mediaTypeEnd >= 0 ? url.slice(0, mediaTypeEnd) : "data:";
-        return `${mediaType},... (${url.length} chars)`;
-    }
-
-    try {
-        const parsedUrl = new URL(url, window.location.href);
-        parsedUrl.search = "";
-        parsedUrl.hash = "";
-        return parsedUrl.toString();
-    } catch {
-        return url;
-    }
-}
-
 export class MatrixAvatarProfile {
     private readonly avatarUrlCache = new Map<string, AvatarCacheEntry>();
     private readonly lazyAvatarStoresByUser = new Map<string, Set<LazyAvatarStoreState>>();
 
     createLazyAvatarStore(matrixUserId: string, resolveAvatarUrl: () => string | undefined): LazyPictureStore {
-        debug("Create lazy avatar store for %s", matrixUserId);
         const store = writable<string | undefined>(undefined);
         const state: LazyAvatarStoreState = {
             set: store.set,
@@ -56,10 +35,8 @@ export class MatrixAvatarProfile {
         this.lazyAvatarStoresByUser.set(matrixUserId, stores);
 
         const loadFromCache = async (forceRefresh = false): Promise<void> => {
-            debug("Load lazy avatar store for %s forceRefresh=%s", matrixUserId, forceRefresh);
             state.hasLoaded = true;
             const avatarUrl = await this.getCachedAvatarUrl(matrixUserId, state.resolveAvatarUrl, forceRefresh);
-            debug("Lazy avatar store loaded for %s => %s", matrixUserId, formatAvatarUrlForDebug(avatarUrl));
             state.set(avatarUrl);
         };
 
@@ -67,20 +44,16 @@ export class MatrixAvatarProfile {
             subscribe: store.subscribe,
             load: () => loadFromCache(false),
             refresh: () => {
-                debug("Refresh lazy avatar store for %s hasLoaded=%s", matrixUserId, state.hasLoaded);
                 this.markAvatarUrlStale(matrixUserId);
                 if (!state.hasLoaded) {
-                    debug("Skip refresh for %s because store has not been loaded yet", matrixUserId);
                     return Promise.resolve();
                 }
                 return loadFromCache(true);
             },
             invalidate: () => {
-                debug("Invalidate lazy avatar store for %s", matrixUserId);
                 this.invalidateAvatarUrl(matrixUserId);
             },
             destroy: () => {
-                debug("Destroy lazy avatar store for %s", matrixUserId);
                 stores.delete(state);
                 if (stores.size === 0) {
                     this.lazyAvatarStoresByUser.delete(matrixUserId);
@@ -103,29 +76,23 @@ export class MatrixAvatarProfile {
             matrixClient,
             mergerContext
         );
-        debug("Return avatar url for %s => %s", matrixUserId, formatAvatarUrlForDebug(avatarUrl));
         return avatarUrl;
     }
 
     resolveUserAvatarUrl(matrixUserId: string, matrixClient: MatrixClient): string | undefined {
         const avatarUrl = resolveDirectMessagePeerAvatarUrl(matrixUserId, undefined, matrixClient, undefined);
-        debug("Return user avatar url for %s => %s", matrixUserId, formatAvatarUrlForDebug(avatarUrl));
         return avatarUrl;
     }
 
     invalidateAvatarUrl(matrixUserId: string): void {
-        debug("Invalidate avatar URL cache for %s", matrixUserId);
         this.markAvatarUrlStale(matrixUserId);
         const stores = this.lazyAvatarStoresByUser.get(matrixUserId);
         stores?.forEach((store) => {
             if (!store.hasLoaded) {
-                debug("Skip invalidated store refresh for %s because store has not been loaded yet", matrixUserId);
                 return;
             }
-            debug("Refresh invalidated loaded store for %s", matrixUserId);
             this.getCachedAvatarUrl(matrixUserId, store.resolveAvatarUrl, true)
                 .then((avatarUrl) => {
-                    debug("Invalidated store refreshed for %s => %s", matrixUserId, formatAvatarUrlForDebug(avatarUrl));
                     store.set(avatarUrl);
                 })
                 .catch((error) => {
@@ -137,7 +104,6 @@ export class MatrixAvatarProfile {
 
     private markAvatarUrlStale(matrixUserId: string): void {
         const entry = this.avatarUrlCache.get(matrixUserId);
-        debug("Mark avatar URL cache stale for %s previousValid=%s", matrixUserId, entry?.valid ?? false);
         this.avatarUrlCache.set(matrixUserId, {
             value: entry?.value,
             valid: false,
@@ -151,20 +117,16 @@ export class MatrixAvatarProfile {
     ): Promise<string | undefined> {
         const entry = this.avatarUrlCache.get(matrixUserId);
         if (!forceRefresh && entry?.valid && entry.value !== undefined) {
-            debug("Return cached avatar url for %s => %s", matrixUserId, formatAvatarUrlForDebug(entry.value));
             return Promise.resolve(entry.value);
         }
         if (entry?.pending) {
-            debug("Return pending avatar URL promise for %s", matrixUserId);
             return entry.pending;
         }
 
-        debug("Resolve avatar URL for %s forceRefresh=%s previousValid=%s", matrixUserId, forceRefresh, !!entry?.valid);
         const pending = Promise.resolve()
             .then(resolveAvatarUrl)
             .then(
                 (avatarUrl) => {
-                    debug("Resolved avatar URL for %s => %s", matrixUserId, formatAvatarUrlForDebug(avatarUrl));
                     this.avatarUrlCache.set(matrixUserId, {
                         value: avatarUrl,
                         valid: true,

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -1218,11 +1218,11 @@ describe("MatrixChatConnection", () => {
             const addRoomToParentFolder = vi
                 .spyOn(
                     matrixChatConnection as unknown as {
-                        addRoomToParentFolder: (room: unknown, folder: MatrixRoomFolder) => Promise<void>;
+                        addRoomToParentFolder: (room: unknown, folder: MatrixRoomFolder) => void;
                     },
                     "addRoomToParentFolder"
                 )
-                .mockResolvedValue(undefined);
+                .mockImplementation(() => undefined);
 
             matrixChatConnection["onRoomEventMembership"](
                 { roomId: leftFolderId, name: "Left nested space" } as never,
@@ -1521,9 +1521,9 @@ describe("MatrixChatConnection", () => {
             );
             matrixChatConnection["roomFolders"].set(roomId, { id: roomId, destroy: vi.fn() } as never);
 
-            await matrixChatConnection["addRoomToParentFolder"](spaceRoom as never, parentFolder as never);
+            matrixChatConnection["addRoomToParentFolder"](spaceRoom as never, parentFolder as never);
 
-            expect(existingChildFolder.refreshRooms).toHaveBeenCalledOnce();
+            expect(existingChildFolder.refreshRooms).not.toHaveBeenCalled();
             expect(existingChildFolder.init).toHaveBeenCalledOnce();
         });
     });

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixClientWrapper.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixClientWrapper.test.ts
@@ -1,26 +1,37 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ICreateClientOpts } from "matrix-js-sdk";
+import type { SecretStorageKeyDescriptionAesV1 } from "matrix-js-sdk/lib/secret-storage";
+import { openModal } from "svelte-modals";
 import type { MatrixClientWrapperInterface, MatrixLocalUserStore } from "../MatrixClientWrapper";
 import { MatrixClientWrapper } from "../MatrixClientWrapper";
+import { matrixSecurity } from "../MatrixSecurity";
 
 // @vitest-environment jsdom
 vi.mock("../AccessSecretStorageDialog.svelte", () => {
-    return {};
+    return { default: {} };
 });
 
 vi.mock("../CreateRecoveryKeyDialog.svelte", () => {
-    return {};
+    return { default: {} };
 });
 vi.mock("../InteractiveAuthDialog.svelte", () => {
-    return {};
+    return { default: {} };
 });
 
 vi.mock("../../../Stores/ChatStore.ts", () => {
     return {};
 });
+
+vi.mock("svelte-modals", () => {
+    return {
+        openModal: vi.fn(),
+    };
+});
+
 describe("MatrixClientWrapper", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        matrixSecurity.shouldDisplayModal = false;
     });
     describe("initMatrixClient", () => {
         const basicMockClient = {
@@ -304,6 +315,88 @@ describe("MatrixClientWrapper", () => {
 
             expect(lastCreateClientArg.cryptoCallbacks?.getSecretStorageKey).toBeDefined();
             expect(lastCreateClientArg.cryptoCallbacks?.cacheSecretStorageKey).toBeDefined();
+        });
+
+        it("should deduplicate concurrent secret storage key requests", async () => {
+            matrixSecurity.shouldDisplayModal = true;
+
+            const userId = "Alice";
+            const accessToken = "accessToken";
+            const refreshToken = "refreshToken";
+            const deviceId = "deviceId";
+            const matrixBaseURL = "testUrl";
+            const secretStorageKeyId = "secretStorageKeyId";
+            const secretStorageKey = new Uint8Array([1, 2, 3]);
+
+            const mockClient = {
+                ...basicMockClient,
+                clearStores: vi.fn(),
+                secretStorage: {
+                    getDefaultKeyId: vi.fn().mockResolvedValue(secretStorageKeyId),
+                },
+            };
+
+            const createClient = vi.fn().mockReturnValue(mockClient);
+            const localUserStoreMock: MatrixLocalUserStore = {
+                ...basicLocalUserStoreMock,
+                getLocalUser: vi.fn().mockReturnValue({
+                    uuid: "myUuid",
+                    email: "",
+                    isMatrixRegistered: true,
+                    matrixUserId: userId,
+                }),
+                getMatrixAccessToken: vi.fn().mockReturnValue(accessToken),
+                getMatrixRefreshToken: vi.fn().mockReturnValue(refreshToken),
+                getMatrixUserId: vi.fn().mockReturnValue(userId),
+                getMatrixDeviceId: vi.fn().mockReturnValue(deviceId),
+                getMatrixLoginToken: vi.fn().mockReturnValue(null),
+            } as unknown as MatrixLocalUserStore;
+
+            // eslint-disable-next-line
+            vi.spyOn(MatrixClientWrapper.prototype as any, "matrixWebClientStore").mockReturnValue({});
+
+            const matrixClientWrapperInstance: MatrixClientWrapperInterface = new MatrixClientWrapper(
+                matrixBaseURL,
+                localUserStoreMock,
+                createClient
+            );
+
+            await matrixClientWrapperInstance.initMatrixClient();
+
+            const lastCreateClientArg: ICreateClientOpts = createClient.mock.calls[0][0] as ICreateClientOpts;
+            const getSecretStorageKey = lastCreateClientArg.cryptoCallbacks?.getSecretStorageKey;
+            if (!getSecretStorageKey) {
+                throw new Error("getSecretStorageKey callback is missing");
+            }
+
+            const keyRequest: { keys: Record<string, SecretStorageKeyDescriptionAesV1> } = {
+                keys: {
+                    [secretStorageKeyId]: {
+                        algorithm: "m.secret_storage.v1.aes-hmac-sha2",
+                        iv: "",
+                        mac: "",
+                        name: "",
+                        passphrase: {
+                            algorithm: "m.pbkdf2",
+                            iterations: 1,
+                            salt: "",
+                        },
+                    },
+                },
+            };
+
+            const firstRequest = getSecretStorageKey(keyRequest, "m.cross_signing.master");
+            const secondRequest = getSecretStorageKey(keyRequest, "m.cross_signing.master");
+
+            await vi.waitFor(() => expect(openModal).toHaveBeenCalledOnce());
+
+            const openModalProps = vi.mocked(openModal).mock.calls[0][1] as {
+                onClose: (key: Uint8Array | null) => void;
+            };
+            openModalProps.onClose(secretStorageKey);
+
+            await expect(firstRequest).resolves.toEqual([secretStorageKeyId, secretStorageKey]);
+            await expect(secondRequest).resolves.toEqual([secretStorageKeyId, secretStorageKey]);
         });
     });
 });

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixSecurity.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixSecurity.test.ts
@@ -29,7 +29,77 @@ vi.mock("../../../Stores/ChatStore.ts", () => {
         alreadyAskForInitCryptoConfiguration: writable(false),
     };
 });
+
+const createClientWithVerifiedOtherDevice = () => {
+    const otherDevice = {
+        deviceId: "OTHER",
+        getIdentityKey: vi.fn(() => "identity-key"),
+    };
+    const crypto = {
+        getUserDeviceInfo: vi
+            .fn()
+            .mockResolvedValue(new Map([["@me:example.test", new Map([["OTHER", otherDevice]])]])),
+        getDeviceVerificationStatus: vi.fn((_userId: string, deviceId: string) => {
+            return Promise.resolve({ signedByOwner: deviceId === "OTHER" });
+        }),
+    };
+    const mockMatrixClient = {
+        getCrypto: vi.fn(() => crypto),
+        getUserId: vi.fn(() => "@me:example.test"),
+        getDeviceId: vi.fn(() => "CURRENT"),
+        getKeyBackupVersion: vi.fn().mockResolvedValue(null),
+        isGuest: vi.fn(() => false),
+    } as unknown as MatrixClient;
+
+    return { mockMatrixClient, crypto };
+};
+
 describe("MatrixSecurity", () => {
+    describe("openAutomaticChooseDeviceVerificationMethodModal", () => {
+        it("opens the device verification chooser once for concurrent automatic requests", async () => {
+            const openModal = vi.fn();
+            const { mockMatrixClient } = createClientWithVerifiedOtherDevice();
+
+            const matrixSecurity = new MatrixSecurity(undefined, undefined, openModal);
+            matrixSecurity.updateMatrixClientStore(mockMatrixClient);
+
+            await Promise.all([
+                matrixSecurity.openAutomaticChooseDeviceVerificationMethodModal(),
+                matrixSecurity.openAutomaticChooseDeviceVerificationMethodModal(),
+            ]);
+
+            expect(openModal).toHaveBeenCalledOnce();
+        });
+
+        it("does not reopen the device verification chooser automatically after the first attempt", async () => {
+            const openModal = vi.fn();
+            const { mockMatrixClient } = createClientWithVerifiedOtherDevice();
+
+            const matrixSecurity = new MatrixSecurity(undefined, undefined, openModal);
+            matrixSecurity.updateMatrixClientStore(mockMatrixClient);
+
+            await matrixSecurity.openAutomaticChooseDeviceVerificationMethodModal();
+            await matrixSecurity.openAutomaticChooseDeviceVerificationMethodModal();
+
+            expect(openModal).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe("openChooseDeviceVerificationMethodModal", () => {
+        it("can reopen the device verification chooser explicitly after an automatic attempt", async () => {
+            const openModal = vi.fn();
+            const { mockMatrixClient } = createClientWithVerifiedOtherDevice();
+
+            const matrixSecurity = new MatrixSecurity(undefined, undefined, openModal);
+            matrixSecurity.updateMatrixClientStore(mockMatrixClient);
+
+            await matrixSecurity.openAutomaticChooseDeviceVerificationMethodModal();
+            await matrixSecurity.openChooseDeviceVerificationMethodModal();
+
+            expect(openModal).toHaveBeenCalledTimes(2);
+        });
+    });
+
     describe("initClientCryptoConfiguration", () => {
         const basicMockClient = {
             isGuest: vi.fn().mockReturnValue(null),

--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -100,6 +100,8 @@ export class ProximityChatRoom implements ChatRoom {
     hasUnreadMessages = writable(false);
     unreadMessagesCount = writable(0);
     unreadNotificationCount = writable(0);
+    initializationState = readable<"ready">("ready");
+    initializationError = readable<Error | undefined>(undefined);
     pictureStore = readable(undefined);
     avatarFallbackColor = readable(undefined);
     messages: SearchableArrayStore<string, ChatMessage> = new SearchableArrayStore((item) => item.id);
@@ -129,6 +131,16 @@ export class ProximityChatRoom implements ChatRoom {
     private _currentMeetingParticipantsStore = writable<MeetingParticipant[]>([]);
     public readonly currentMeetingParticipantsStore: Readable<MeetingParticipant[]> =
         this._currentMeetingParticipantsStore;
+
+    ensureInitialized(): Promise<void> {
+        return Promise.resolve();
+    }
+    ensureTimelineInitialized(): Promise<void> {
+        return Promise.resolve();
+    }
+    ensureMembersInitialized(): Promise<void> {
+        return Promise.resolve();
+    }
     currentMatrixRoom: ChatRoom | undefined;
     currentChatVisibility = false;
 

--- a/play/src/front/Chat/Stores/ChatStore.ts
+++ b/play/src/front/Chat/Stores/ChatStore.ts
@@ -81,7 +81,7 @@ export function initializeChatVisibilitySubscription() {
         const isEncrypted = get(selectedRoom.isEncrypted);
 
         if (visible && isEncrypted) {
-            matrixSecurity.openChooseDeviceVerificationMethodModal().catch((error) => {
+            matrixSecurity.openAutomaticChooseDeviceVerificationMethodModal().catch((error) => {
                 console.error(error);
             });
         }

--- a/play/src/front/Chat/Stores/SelectRoomStore.ts
+++ b/play/src/front/Chat/Stores/SelectRoomStore.ts
@@ -15,7 +15,7 @@ const createSelectedRoomStore = () => {
             if (currentValue !== value && value && get(value.isEncrypted) && !isOpen && get(chatVisibilityStore)) {
                 isOpen = true;
                 matrixSecurity
-                    .openChooseDeviceVerificationMethodModal()
+                    .openAutomaticChooseDeviceVerificationMethodModal()
                     .catch((error) => {
                         console.error(error);
                     })

--- a/play/src/front/Chat/Stores/SelectRoomStore.ts
+++ b/play/src/front/Chat/Stores/SelectRoomStore.ts
@@ -9,6 +9,9 @@ const createSelectedRoomStore = () => {
 
     const customSet = (value: ChatRoom | undefined) => {
         update((currentValue) => {
+            value?.ensureTimelineInitialized?.().catch((error) => {
+                console.error("Failed to initialize selected room", error);
+            });
             if (currentValue !== value && value && get(value.isEncrypted) && !isOpen && get(chatVisibilityStore)) {
                 isOpen = true;
                 matrixSecurity


### PR DESCRIPTION
## Problem

Matrix chat rooms were doing too much work during app startup: room construction eagerly created all room members, attached avatar-related stores/listeners, and loaded timelines/messages. In large Matrix accounts, this can slow down startup and amplify debug logging volume.

## Solution

Make Matrix chat rooms lightweight at construction time and move expensive work behind explicit lazy initialization when a room is selected/opened. Keep direct room avatars available in the room list through a lightweight peer avatar store, without initializing all room members.

## Changes

- Add room initialization state and `ensureInitialized()` to the chat room contract.
- Update Matrix rooms to defer member wrapper creation and timeline loading until room initialization.
- Keep unread counts, room names, membership state, and direct room avatars available before full initialization.
- Add loading/error UI handling in the room timeline while a room initializes.
- Reduce avatar debug logging to visible avatar load events and image load/error results.
- Remove debug metadata from `LazyPictureStore`.
- Add tests for avatar lazy loading, Matrix room lazy initialization, and direct room avatar loading from the room list.
