### PR TITLE
feat : added allow talking and forming bubbles in audience zone - by …

### DIFF
--- a/libs/map-editor/src/types.ts
+++ b/libs/map-editor/src/types.ts
@@ -143,6 +143,7 @@ export const ListenerMegaphonePropertyData = PropertyBase.extend({
     type: z.literal("listenerMegaphone"),
     speakerZoneName: z.string(),
     chatEnabled: z.boolean().default(false),
+    allowTalking: z.boolean().default(false),
     waitingLink: z.string().optional(),
 });
 

--- a/libs/map-editor/src/types.ts
+++ b/libs/map-editor/src/types.ts
@@ -143,7 +143,7 @@ export const ListenerMegaphonePropertyData = PropertyBase.extend({
     type: z.literal("listenerMegaphone"),
     speakerZoneName: z.string(),
     chatEnabled: z.boolean().default(false),
-    allowTalking: z.boolean().default(false),
+    allowTalking: z.boolean().optional().default(false),
     waitingLink: z.string().optional(),
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4204,6 +4204,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -4246,6 +4247,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4267,6 +4269,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4288,6 +4291,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4309,6 +4313,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4330,6 +4335,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4351,6 +4357,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4372,6 +4379,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4393,6 +4401,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4414,6 +4423,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4435,6 +4445,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4456,6 +4467,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4477,6 +4489,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4498,6 +4511,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -18207,7 +18221,8 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-datachannel": {
       "version": "0.32.2",
@@ -25516,6 +25531,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
@@ -30848,23 +30880,6 @@
       },
       "bin": {
         "which": "bin/which"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/play/src/front/Components/MapEditor/AreaEditor/AreaPropertiesEditor.svelte
+++ b/play/src/front/Components/MapEditor/AreaEditor/AreaPropertiesEditor.svelte
@@ -318,6 +318,7 @@
                     type,
                     speakerZoneName: areasName.size == 1 ? [...areasName.keys()][0] : "",
                     chatEnabled: false,
+                    allowTalking: false,
                 };
             }
             case "exit":

--- a/play/src/front/Components/MapEditor/PropertyEditor/ListenerMegaphonePropertyEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/ListenerMegaphonePropertyEditor.svelte
@@ -110,5 +110,13 @@
                 onChange={onValueChange}
             />
         </div>
+        <div class="value-switch">
+            <InputSwitch
+                id="allowTalking"
+                label={$LL.mapEditor.properties.allowTalking()}
+                bind:value={property.allowTalking}
+                onChange={onValueChange}
+            />
+        </div>
     </span>
 </PropertyEditorBase>

--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -1572,9 +1572,7 @@ export class AreasPropertiesListener {
                         Sentry.captureException(error);
                     }
                     isSpeakerStore.set(false);
-                    if (!remainingListenerZone.allowTalking) {
-                        isListenerStore.set(true);
-                    }
+                    isListenerStore.set(!this.shouldAllowTalkingInSpace(uniqRoomName));
                     listenerWaitingMediaStore.set(remainingListenerZone.waitingLink);
 
                     // Restore listener-specific state
@@ -1619,9 +1617,6 @@ export class AreasPropertiesListener {
                 const proximityRoom = this.scene.proximityChatRoom;
                 const currentSpaceName = proximityRoom.getCurrentSpaceName();
 
-                if (!property.allowTalking) {
-                    isListenerStore.set(true);
-                }
                 // If already in this space (as speaker or listener), just update tracking
                 if (currentSpaceName === uniqRoomName) {
                     // Check if we're already as speaker - speaker has priority, don't change role
@@ -1650,6 +1645,8 @@ export class AreasPropertiesListener {
                         allowTalking: property.allowTalking,
                         waitingLink: property.waitingLink,
                     });
+                    // Update mute state based on all active listener zones
+                    isListenerStore.set(!this.shouldAllowTalkingInSpace(uniqRoomName));
                     return;
                 }
 
@@ -1683,6 +1680,7 @@ export class AreasPropertiesListener {
                     allowTalking: property.allowTalking,
                     waitingLink: property.waitingLink,
                 });
+                isListenerStore.set(!property.allowTalking);
             }
         }
     }
@@ -1709,7 +1707,8 @@ export class AreasPropertiesListener {
                 // Check if still in another listener zone for the same space
                 const remainingListenerZone = this.findActiveListenerZoneForSpace(uniqRoomName);
                 if (remainingListenerZone) {
-                    // Still in another listener zone, don't leave the space
+                    // Still in another listener zone, update mute state based on remaining zones
+                    isListenerStore.set(!this.shouldAllowTalkingInSpace(uniqRoomName));
                     return;
                 }
 
@@ -1737,6 +1736,20 @@ export class AreasPropertiesListener {
             }
         }
         return undefined;
+    }
+
+    /**
+     * Checks if talking should be allowed in a space by examining all active listener zones.
+     * Returns true only if all active listener zones for the space have allowTalking=true.
+     * If any zone has allowTalking=false, the user should be muted.
+     */
+    private shouldAllowTalkingInSpace(spaceName: string): boolean {
+        for (const zone of this.activeMegaphoneZones.values()) {
+            if (zone.spaceName === spaceName && zone.role === "listener" && !zone.allowTalking) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
+++ b/play/src/front/Phaser/Game/MapEditor/AreasPropertiesListener.ts
@@ -103,6 +103,7 @@ interface MegaphoneZoneState {
     propertyId: string;
     seeAttendees: boolean;
     chatEnabled: boolean;
+    allowTalking: boolean;
     waitingLink: string | undefined;
 }
 
@@ -1506,6 +1507,7 @@ export class AreasPropertiesListener {
                             propertyId: property.id,
                             seeAttendees: property.seeAttendees,
                             chatEnabled: property.chatEnabled,
+                            allowTalking: false,
                             waitingLink: undefined,
                         });
                         return;
@@ -1535,6 +1537,7 @@ export class AreasPropertiesListener {
                     propertyId: property.id,
                     seeAttendees: property.seeAttendees,
                     chatEnabled: property.chatEnabled,
+                    allowTalking: false,
                     waitingLink: undefined,
                 });
             } catch (e) {
@@ -1569,7 +1572,9 @@ export class AreasPropertiesListener {
                         Sentry.captureException(error);
                     }
                     isSpeakerStore.set(false);
-                    isListenerStore.set(true);
+                    if (!remainingListenerZone.allowTalking) {
+                        isListenerStore.set(true);
+                    }
                     listenerWaitingMediaStore.set(remainingListenerZone.waitingLink);
 
                     // Restore listener-specific state
@@ -1614,7 +1619,9 @@ export class AreasPropertiesListener {
                 const proximityRoom = this.scene.proximityChatRoom;
                 const currentSpaceName = proximityRoom.getCurrentSpaceName();
 
-                isListenerStore.set(true);
+                if (!property.allowTalking) {
+                    isListenerStore.set(true);
+                }
                 // If already in this space (as speaker or listener), just update tracking
                 if (currentSpaceName === uniqRoomName) {
                     // Check if we're already as speaker - speaker has priority, don't change role
@@ -1627,6 +1634,7 @@ export class AreasPropertiesListener {
                             propertyId: property.id,
                             seeAttendees,
                             chatEnabled: property.chatEnabled,
+                            allowTalking: property.allowTalking,
                             waitingLink: property.waitingLink,
                         });
                         return;
@@ -1639,6 +1647,7 @@ export class AreasPropertiesListener {
                         propertyId: property.id,
                         seeAttendees,
                         chatEnabled: property.chatEnabled,
+                        allowTalking: property.allowTalking,
                         waitingLink: property.waitingLink,
                     });
                     return;
@@ -1671,6 +1680,7 @@ export class AreasPropertiesListener {
                     propertyId: property.id,
                     seeAttendees,
                     chatEnabled: property.chatEnabled,
+                    allowTalking: property.allowTalking,
                     waitingLink: property.waitingLink,
                 });
             }

--- a/play/src/i18n/ar-SA/mapEditor.ts
+++ b/play/src/i18n/ar-SA/mapEditor.ts
@@ -139,6 +139,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             actionButtonLabel: "الانضمام إلى الجمهور",
         },
         chatEnabled: "ربط قناة دردشة مخصصة",
+        allowTalking: "السماح بالتحدث وتشكيل الفقاعات",
         seeAttendees: "عرض الحضور",
         start: {
             label: "منطقة البداية",

--- a/play/src/i18n/ca-ES/mapEditor.ts
+++ b/play/src/i18n/ca-ES/mapEditor.ts
@@ -329,6 +329,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         },
         advancedOptions: "Opcions avançades",
         chatEnabled: "Associar un canal de xat dedicat",
+        allowTalking: "Permetre parlar i formar bombolles",
         noProperties: "No s'han definit propietats",
     },
     areaEditor: {

--- a/play/src/i18n/de-DE/mapEditor.ts
+++ b/play/src/i18n/de-DE/mapEditor.ts
@@ -142,6 +142,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         },
 
         chatEnabled: "Chat aktiviert",
+        allowTalking: "Sprechen und Blasenbildung erlauben",
         seeAttendees: "Teilnehmer anzeigen",
         start: {
             label: "Startbereich",

--- a/play/src/i18n/dsb-DE/mapEditor.ts
+++ b/play/src/i18n/dsb-DE/mapEditor.ts
@@ -141,6 +141,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             actionButtonLabel: "K publikumoju pśipowjazaś",
         },
         chatEnabled: "Chat jo aktiwěrowany",
+        allowTalking: "Powědanje a twórjenje pucherow dowóliś",
         seeAttendees: "Wobźělnikow pokazaś",
         start: {
             label: "Startowy wobceŕk",

--- a/play/src/i18n/en-US/mapEditor.ts
+++ b/play/src/i18n/en-US/mapEditor.ts
@@ -325,6 +325,7 @@ const mapEditor: BaseTranslation = {
         },
         advancedOptions: "Advanced Options",
         chatEnabled: "Associate a dedicated chat channel",
+        allowTalking: "Allow talking and forming bubbles",
         noProperties: "No properties defined",
     },
     areaEditor: {

--- a/play/src/i18n/es-ES/mapEditor.ts
+++ b/play/src/i18n/es-ES/mapEditor.ts
@@ -317,6 +317,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         },
         advancedOptions: "Opciones avanzadas",
         chatEnabled: "Asociar un canal de chat dedicado",
+        allowTalking: "Permitir hablar y formar burbujas",
         maxUsersInAreaPropertyData: {
             label: "Número máximo de usuarios",
             description: "Establecer el número máximo de usuarios en la zona.",

--- a/play/src/i18n/fr-FR/mapEditor.ts
+++ b/play/src/i18n/fr-FR/mapEditor.ts
@@ -142,6 +142,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             actionButtonLabel: "Rejoindre l'audience",
         },
         chatEnabled: "Chat activé",
+        allowTalking: "Autoriser la parole et la formation de bulles",
         seeAttendees: "Voir les participants",
         start: {
             label: "Zone de départ",

--- a/play/src/i18n/hsb-DE/mapEditor.ts
+++ b/play/src/i18n/hsb-DE/mapEditor.ts
@@ -140,6 +140,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             actionButtonLabel: "K publikumjej připojować",
         },
         chatEnabled: "Chat aktiwizowany",
+        allowTalking: "Rěčenje a tworjenje pucherjow dowolić",
         seeAttendees: "Wobdźělnikow pokazać",
         start: {
             label: "startowy wobłuk",

--- a/play/src/i18n/it-IT/mapEditor.ts
+++ b/play/src/i18n/it-IT/mapEditor.ts
@@ -142,6 +142,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             actionButtonLabel: "Unisciti al pubblico",
         },
         chatEnabled: "Associa un canale di chat dedicato",
+        allowTalking: "Consentire di parlare e formare bolle",
         seeAttendees: "Vedi partecipanti",
         start: {
             label: "Area di Partenza",

--- a/play/src/i18n/ja-JP/mapEditor.ts
+++ b/play/src/i18n/ja-JP/mapEditor.ts
@@ -141,6 +141,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         },
 
         chatEnabled: "専用チャットチャンネルを開設",
+        allowTalking: "会話とバブルの形成を許可する",
         seeAttendees: "参加者を表示",
         start: {
             label: "入口エリア",

--- a/play/src/i18n/ko-KR/mapEditor.ts
+++ b/play/src/i18n/ko-KR/mapEditor.ts
@@ -139,6 +139,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
             actionButtonLabel: "청중 참가",
         },
         chatEnabled: "전용 채팅 채널 연결",
+        allowTalking: "대화 및 버블 형성 허용",
         seeAttendees: "참석자 보기",
         start: {
             label: "시작 영역",

--- a/play/src/i18n/nl-NL/mapEditor.ts
+++ b/play/src/i18n/nl-NL/mapEditor.ts
@@ -143,6 +143,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         },
 
         chatEnabled: "Koppel een speciale chatkanaal",
+        allowTalking: "Praten en bubbels vormen toestaan",
         seeAttendees: "Deelnemers zien",
         start: {
             label: "Startgebied",

--- a/play/src/i18n/pt-BR/mapEditor.ts
+++ b/play/src/i18n/pt-BR/mapEditor.ts
@@ -142,6 +142,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         },
 
         chatEnabled: "Associar um canal de chat dedicado",
+        allowTalking: "Permitir falar e formar bolhas",
         seeAttendees: "Ver participantes",
         start: {
             label: "Área inicial",

--- a/play/src/i18n/zh-CN/mapEditor.ts
+++ b/play/src/i18n/zh-CN/mapEditor.ts
@@ -322,6 +322,7 @@ const mapEditor: DeepPartial<Translation["mapEditor"]> = {
         },
         advancedOptions: "高级选项",
         chatEnabled: "关联专用聊天频道",
+        allowTalking: "允许交谈和形成气泡",
         noProperties: "未定义属性",
     },
     areaEditor: {


### PR DESCRIPTION
Adds an **"Allow talking and forming bubbles"** toggle to the Listener Megaphone area property in the map editor.

---

### Changes

* Added `allowTalking` boolean field (default: `false`) to `ListenerMegaphonePropertyData` schema
* Added a toggle switch in `ListenerMegaphonePropertyEditor.svelte` for the new property
* Updated `AreasPropertiesListener.ts` to conditionally set `isListenerStore`:

  * When `allowTalking` is `true`, users in the audience zone can still talk and form proximity chat bubbles instead of being muted as listeners
* Added i18n translation key for the new label

---

### Behavior

* **Default (`false`)**:
  Audience zone works as before — users are set as listeners (muted)

* **Enabled (`true`)**:
  Users in the audience zone can talk to each other and form bubbles while still receiving the megaphone broadcast
<img width="3024" height="1696" alt="image" src="https://github.com/user-attachments/assets/7b33964d-e1ec-4710-b82c-44083c872184" />
<img width="3020" height="1708" alt="image" src="https://github.com/user-attachments/assets/4f7ea675-e9d4-4da1-a89d-f78c287908d6" />
