### PR TITLE
Add permissions to BBBCoWebsite

### DIFF
--- a/play/src/front/WebRtc/BBBFactory.ts
+++ b/play/src/front/WebRtc/BBBFactory.ts
@@ -13,7 +13,7 @@ class BBBFactory {
         const coWebsite = new BBBCoWebsite(
             new URL(clientURL),
             false,
-            "microphone *; camera *; display-capture *; clipboard-read *; clipboard-write *; screen-wake-lock *;"
+            "microphone *; camera *; display-capture *; clipboard-read *; clipboard-write *; screen-wake-lock *;  fullscreen *; geolocation *;"
         );
         coWebsites.add(coWebsite);
     }


### PR DESCRIPTION
This pull request makes a small update to the permissions requested by the `BBBCoWebsite` instance in the `BBBFactory` class. The change expands the list of allow policies to include support for fullscreen and geolocation features.

* `fullscreen` to allow BBB meetings going into fullscreen mode;
* `geolocation` to allow the Geolocation BBB plugin to obtain an approximate location of the participants (with their approval) and show them in a map.