### PR TITLE
fix: derive media request state from space

### DIFF
--- a/play/src/front/Components/Video/ActionMediaBox.svelte
+++ b/play/src/front/Components/Video/ActionMediaBox.svelte
@@ -8,7 +8,6 @@
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import type { SpaceUserExtended } from "../../Space/SpaceInterface";
     import { showReportScreenStore } from "../../Stores/ShowReportScreenStore";
-    import { isListenerStore } from "../../Stores/MediaStore";
     import RangeSlider from "../Input/RangeSlider.svelte";
     import type { StreamCategory } from "../../Space/Streamable";
     import { IconAlertTriangle, IconUser, IconMute, IconUnMute } from "@wa-icons";
@@ -23,6 +22,7 @@
 
     const isMicrophoneEnabled = spaceUser.reactiveUser.microphoneState;
     const isVideoEnabled = spaceUser.reactiveUser.cameraState;
+    const canAskToMuteAudioOrTurnOffVideo = spaceUser.space.canAskToMuteAudioOrTurnOffVideo;
 
     let moreActionOpened = false;
 
@@ -144,7 +144,7 @@
     </div>
 
     <!-- Mute audio user -->
-    {#if ($userIsAdminStore || !$isListenerStore) && !isScreenSharing}
+    {#if ($userIsAdminStore || $canAskToMuteAudioOrTurnOffVideo) && !isScreenSharing}
         <button
             class="action-button mute-audio-user flex gap-2 items-center hover:bg-white/10 m-0 p-2 w-full text-sm rounded leading-4 text-left text-white disabled:opacity-50"
             on:click|preventDefault|stopPropagation={() => muteAudio(spaceUser)}
@@ -171,7 +171,7 @@
     {/if}
 
     <!-- Mute video -->
-    {#if ($userIsAdminStore || !$isListenerStore) && !isScreenSharing}
+    {#if ($userIsAdminStore || $canAskToMuteAudioOrTurnOffVideo) && !isScreenSharing}
         <button
             id="mute-video-user"
             class="action-button flex gap-2 items-center hover:bg-white/10 m-0 p-2 w-full text-sm rounded leading-4 text-left text-white disabled:opacity-50"

--- a/play/src/front/Space/Space.ts
+++ b/play/src/front/Space/Space.ts
@@ -1165,6 +1165,10 @@ export class Space implements SpaceInterface {
         return this._isStreamingAudioStore;
     }
 
+    get canAskToMuteAudioOrTurnOffVideo(): Readable<boolean> {
+        return this._isStreamingAudioStore;
+    }
+
     private blockUser(spaceUserId: string): void {
         this._blockedUsersStore.update((blockedUsers) => {
             blockedUsers.add(spaceUserId);

--- a/play/src/front/Space/SpaceInterface.ts
+++ b/play/src/front/Space/SpaceInterface.ts
@@ -116,6 +116,7 @@ export interface SpaceInterface {
     readonly isStreamingStore: Readable<boolean>;
 
     readonly isStreamingAudioStore: Readable<boolean>;
+    readonly canAskToMuteAudioOrTurnOffVideo: Readable<boolean>;
     readonly shouldPublishScreenShareStore: Readable<boolean>;
 
     /**
@@ -159,6 +160,6 @@ export type ReactiveSpaceUser = {
 export type SpaceUserExtended = SpaceUser & {
     pictureStore: Readable<string | undefined>;
     emitPrivateEvent: (message: NonNullable<PrivateSpaceEvent["event"]>) => void;
-    space: Pick<SpaceInterface, "emitPublicMessage">;
+    space: Pick<SpaceInterface, "emitPublicMessage" | "canAskToMuteAudioOrTurnOffVideo">;
     reactiveUser: ReactiveSpaceUser;
 };

--- a/play/src/front/Space/localSpaceUser.ts
+++ b/play/src/front/Space/localSpaceUser.ts
@@ -44,6 +44,7 @@ export const localSpaceUser = (name?: string): SpaceUserExtended => {
             emitPublicMessage: (message: NonNullable<SpaceEvent["event"]>) => {
                 throw new Error("should not be called");
             },
+            canAskToMuteAudioOrTurnOffVideo: writable(false),
         },
         reactiveUser: {
             spaceUserId: "",


### PR DESCRIPTION
## Problem

The media action menu relied on a global listener state to decide whether a user could ask someone to mute their audio or turn off their video. This made the behavior depend on a broad global state instead of the actual state of the current space.

## Solution

Move the decision to a space-level state exposed through `SpaceInterface`, so the action menu reads the capability directly from the related space.

## Changes

- Add `canAskToMuteAudioOrTurnOffVideo` to `SpaceInterface`.
- Expose the new state from `Space` based on the space audio streaming state.
- Replace the global `isListenerStore` check in `ActionMediaBox.svelte`.
- Keep admin behavior unchanged for mute audio and turn off video actions.
