### PR TITLE
fix: preserve matrix message order after notification click

### DIFF
--- a/play/src/front/Chat/Components/Room/RoomTimeline.svelte
+++ b/play/src/front/Chat/Components/Room/RoomTimeline.svelte
@@ -53,6 +53,7 @@
     let shouldDisplayLoader = false;
     let messageInputBarRef: MessageInputBar;
     let lastTimelineFocusSequence = 0;
+    let initialMessagesLoaded = false;
 
     const gameScene = gameManager.getCurrentGameScene();
     const chatRoomsEnableInAdmin = gameScene.room.isChatEnabled;
@@ -79,7 +80,7 @@
         showRoomSidePanelToggle,
         roomSidePanelToggleIsOpen
     );
-    $: if ($roomTimelineFocusStore) {
+    $: if (initialMessagesLoaded && $roomTimelineFocusStore) {
         focusTimelineEvent($roomTimelineFocusStore).catch((error) => console.error(error));
     }
 
@@ -184,6 +185,7 @@
 
     async function initMessages() {
         if (!messageListRef) return;
+        initialMessagesLoaded = false;
 
         const loadMessages = async () => {
             try {
@@ -205,6 +207,7 @@
         try {
             await loadMessages();
             setFirstListItem();
+            initialMessagesLoaded = true;
         } catch (error) {
             console.error(`Failed to load messages: ${error}`);
         }

--- a/play/src/front/Chat/Components/RoomList.svelte
+++ b/play/src/front/Chat/Components/RoomList.svelte
@@ -414,7 +414,9 @@
             {#if showRoomSidePanelInTimelineColumn && selectedRoomWithSidePanel}
                 <RoomSidePanel room={selectedRoomWithSidePanel} showCloseButton closeOnTimelineFocus />
             {:else if shouldShowRoomTimeline(roomSidePanelPlacement)}
-                <RoomTimeline room={$selectedRoomStore} {showRoomSidePanelToggle} />
+                {#key $selectedRoomStore.id}
+                    <RoomTimeline room={$selectedRoomStore} {showRoomSidePanelToggle} />
+                {/key}
             {/if}
         </div>
     {:else if $selectedRoomStore === undefined && sideBarWidth >= CHAT_LAYOUT_LIMIT}

--- a/play/src/front/Components/ProximityNotification/NotificationRoomFocus.ts
+++ b/play/src/front/Components/ProximityNotification/NotificationRoomFocus.ts
@@ -1,0 +1,10 @@
+import type { ChatRoom } from "../../Chat/Connection/ChatConnection";
+import { roomSidePanelStore } from "../../Chat/Stores/RoomSidePanelStore";
+
+export function focusNotificationMessage(room: ChatRoom, messageId: string | undefined): void {
+    if (!messageId) {
+        return;
+    }
+
+    roomSidePanelStore.focusTimelineEvent(room.id, messageId);
+}

--- a/play/src/front/Components/ProximityNotification/ProximityNotification.svelte
+++ b/play/src/front/Components/ProximityNotification/ProximityNotification.svelte
@@ -7,6 +7,7 @@
     import { selectedRoomStore } from "../../Chat/Stores/SelectRoomStore";
     import { navChat } from "../../Chat/Stores/ChatStore";
     import LL from "../../../i18n/i18n-svelte";
+    import { focusNotificationMessage } from "./NotificationRoomFocus";
 
     export let notification: ProximityNotification;
 
@@ -35,38 +36,11 @@
             const room = notification.room;
             room.setTimelineAsRead();
             selectedRoomStore.set(room);
-
-            const messageId = notification.messageId;
-            if (messageId) {
-                setTimeout(() => {
-                    scrollToMessage(messageId);
-                }, 300);
-            }
+            focusNotificationMessage(room, notification.messageId);
         } else {
             // Open the chat on the main chat panel
             selectedRoomStore.set(undefined);
         }
-    }
-
-    function scrollToMessage(messageId: string) {
-        let attempts = 0;
-        const maxAttempts = 10;
-
-        const tryScroll = () => {
-            const messageElement = document.querySelector(`li[data-event-id="${messageId}"]`);
-            if (messageElement) {
-                messageElement.scrollIntoView({ behavior: "smooth", block: "center" });
-                messageElement.classList.add("highlight-message");
-                setTimeout(() => {
-                    messageElement.classList.remove("highlight-message");
-                }, 2000);
-            } else if (attempts < maxAttempts) {
-                attempts++;
-                setTimeout(tryScroll, 200);
-            }
-        };
-
-        tryScroll();
     }
 </script>
 


### PR DESCRIPTION
## Problem

Clicking an in-app notification for a Matrix conversation that had not been opened yet could display the clicked recent message in the wrong position.

The timeline could focus the notified message before the room had finished loading its initial history, making the newest clicked message appear above older messages instead of keeping the chronological order visible around it.

## Solution

Defer notification message focus until the Matrix room timeline has completed its initial load and pagination.

The notification click now delegates focus to the room timeline instead of scrolling the DOM directly from the notification component.

## Changes

- Replaced direct notification DOM scrolling with a timeline focus request.
- Wait for the room timeline initial messages to load before applying focus.
- Recreate the timeline when switching rooms to avoid carrying scroll/loading state between conversations.
- Added test coverage for notification message focus requests.
