### PR TITLE
fix(pusher): silent OIDC refresh token on access token expiry

### DIFF
--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -243,16 +243,12 @@ export class AuthenticateController extends BaseHttpController {
                     } satisfies MeResponse);
                 } catch (err) {
                     // The OIDC access token has likely expired. If we have a refresh token stored
-                    // in the WA auth JWT, attempt a silent exchange before giving up and forcing
-                    // the user through the full login flow.
+                    // in the WA auth JWT, attempt a silent exchange before giving up.
                     if (authTokenData.refreshToken) {
                         try {
                             const refreshed = await openIDClient.refreshAccessToken(authTokenData.refreshToken);
-                            // Re-verify with the fresh access token to get up-to-date user claims.
                             const resCheckTokenAuth = await openIDClient.checkTokenAuth(refreshed.access_token);
-                            // Issue a new WA JWT containing the rotated tokens.
-                            // If the provider returned a new refresh_token we store it;
-                            // otherwise carry the existing one forward.
+                            // Issue a new WA JWT with rotated tokens so the client continues seamlessly.
                             const newAuthToken = await jwtTokenManager.createAuthToken(
                                 authTokenData.identifier,
                                 refreshed.access_token,

--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -1,18 +1,21 @@
 import fs from "fs";
 import { v4 } from "uuid";
-import { MeRequest, MeResponse, RegisterData } from "@workadventure/messages";
+import type { MeResponse, RegisterData } from "@workadventure/messages";
+import { MeRequest } from "@workadventure/messages";
 import { z } from "zod";
-import { JsonWebTokenError } from "jsonwebtoken";
+import { errors } from "jose";
 import Mustache from "mustache";
-import { Application } from "express";
+import type { Application } from "express";
 import Debug from "debug";
-import { AuthTokenData, jwtTokenManager } from "../services/JWTTokenManager";
+import type { AuthTokenData } from "../services/JWTTokenManager";
+import { jwtTokenManager } from "../services/JWTTokenManager";
 import { openIDClient } from "../services/OpenIDClient";
 import { DISABLE_ANONYMOUS, FRONT_URL, MATRIX_PUBLIC_URI, PUSHER_URL } from "../enums/EnvironmentVariable";
 import { adminService } from "../services/AdminService";
 import { validateQuery } from "../services/QueryValidator";
 import { VerifyDomainService } from "../services/verifyDomain/VerifyDomainService";
 import { matrixProvider } from "../services/MatrixProvider";
+import { getClientIpFromXForwardedFor } from "../services/ClientIp";
 import { BaseHttpController } from "./BaseHttpController";
 
 const debug = Debug("pusher:requests");
@@ -179,7 +182,7 @@ export class AuthenticateController extends BaseHttpController {
 
         this.app.get("/me", async (req, res) => {
             debug(`AuthenticateController => [${req.method}] ${req.originalUrl} — IP: ${req.ip} — Time: ${Date.now()}`);
-            const IPAddress = req.header("x-forwarded-for") ?? "";
+            const IPAddress = getClientIpFromXForwardedFor(req.header("x-forwarded-for"));
             const query = validateQuery(req, res, MeRequest);
             if (query === undefined) {
                 return;
@@ -190,7 +193,7 @@ export class AuthenticateController extends BaseHttpController {
                 localStorageCharacterTextureIds = [localStorageCharacterTextureIds];
             }
             try {
-                const authTokenData: AuthTokenData = jwtTokenManager.verifyJWTToken(token, false);
+                const authTokenData: AuthTokenData = await jwtTokenManager.verifyJWTToken(token, false);
 
                 //Get user data from Admin Back Office
                 //This is very important to create User Local in LocalStorage in WorkAdventure
@@ -239,12 +242,49 @@ export class AuthenticateController extends BaseHttpController {
                         ...resCheckTokenAuth,
                     } satisfies MeResponse);
                 } catch (err) {
+                    // The OIDC access token has likely expired. If we have a refresh token stored
+                    // in the WA auth JWT, attempt a silent exchange before giving up and forcing
+                    // the user through the full login flow.
+                    if (authTokenData.refreshToken) {
+                        try {
+                            const refreshed = await openIDClient.refreshAccessToken(authTokenData.refreshToken);
+                            // Re-verify with the fresh access token to get up-to-date user claims.
+                            const resCheckTokenAuth = await openIDClient.checkTokenAuth(refreshed.access_token);
+                            // Issue a new WA JWT containing the rotated tokens.
+                            // If the provider returned a new refresh_token we store it;
+                            // otherwise carry the existing one forward.
+                            const newAuthToken = await jwtTokenManager.createAuthToken(
+                                authTokenData.identifier,
+                                refreshed.access_token,
+                                refreshed.refresh_token ?? authTokenData.refreshToken,
+                                authTokenData.username,
+                                authTokenData.locale,
+                                authTokenData.tags,
+                                authTokenData.matrixUserId
+                            );
+                            res.json({
+                                username: authTokenData?.username,
+                                authToken: newAuthToken,
+                                locale: authTokenData?.locale,
+                                matrixUserId: authTokenData?.matrixUserId,
+                                matrixServerUrl:
+                                    (resCheckTokenAuth.matrix_url as string | undefined) ?? MATRIX_PUBLIC_URI,
+                                // TODO: replace ... with each property
+                                ...resUserData,
+                                ...resCheckTokenAuth,
+                            } satisfies MeResponse);
+                            return;
+                        } catch (refreshErr) {
+                            // Refresh token is also expired or revoked — fall through to 401.
+                            console.warn("OIDC silent refresh failed, forcing re-login", refreshErr);
+                        }
+                    }
                     console.warn("Error while checking token auth", err);
-                    throw new JsonWebTokenError("Invalid token");
+                    throw new errors.JWTInvalid("Invalid token");
                 }
                 return;
             } catch (err) {
-                if (err instanceof JsonWebTokenError) {
+                if (err instanceof errors.JWTInvalid || err instanceof errors.JWTExpired) {
                     res.status(401);
                     res.send("Invalid token");
                     return;
@@ -309,9 +349,10 @@ export class AuthenticateController extends BaseHttpController {
             if (!email) {
                 throw new Error("No email in the response");
             }
-            const authToken = jwtTokenManager.createAuthToken(
+            const authToken = await jwtTokenManager.createAuthToken(
                 email,
                 userInfo?.access_token,
+                userInfo?.refresh_token,
                 userInfo?.username,
                 userInfo?.locale,
                 userInfo?.tags,
@@ -472,8 +513,9 @@ export class AuthenticateController extends BaseHttpController {
             const mapUrlStart = data.mapUrlStart;
             const matrixUserId = email ? matrixProvider.getBareMatrixIdFromEmail(email) : undefined;
 
-            const authToken = jwtTokenManager.createAuthToken(
+            const authToken = await jwtTokenManager.createAuthToken(
                 email || userUuid,
+                undefined,
                 undefined,
                 undefined,
                 undefined,
@@ -515,14 +557,15 @@ export class AuthenticateController extends BaseHttpController {
      *         description: Anonymous login is disabled at the configuration level (environment variable DISABLE_ANONYMOUS = true)
      */
     private anonymLogin(): void {
-        this.app.post("/anonymLogin", (req, res) => {
+        this.app.post("/anonymLogin", async (req, res) => {
             debug(`AuthenticateController => [${req.method}] ${req.originalUrl} — IP: ${req.ip} — Time: ${Date.now()}`);
+            // We refuse the anonymous login if the anonymous mode is disabled AND that the default woka name is not set
             if (DISABLE_ANONYMOUS) {
                 res.status(403).send("");
                 return;
             } else {
                 const userUuid = v4();
-                const authToken = jwtTokenManager.createAuthToken(userUuid);
+                const authToken = await jwtTokenManager.createAuthToken(userUuid);
                 res.json({
                     authToken,
                     userUuid,
@@ -567,7 +610,7 @@ export class AuthenticateController extends BaseHttpController {
                 return;
             }
             const { token, playUri } = query;
-            const authTokenData: AuthTokenData = jwtTokenManager.verifyJWTToken(token, false);
+            const authTokenData: AuthTokenData = await jwtTokenManager.verifyJWTToken(token, false);
             if (authTokenData.accessToken == undefined) {
                 throw Error("Token cannot be checked on OpenID connect provider");
             }
@@ -648,7 +691,7 @@ export class AuthenticateController extends BaseHttpController {
                 return;
             }
 
-            const authTokenData: AuthTokenData = jwtTokenManager.verifyJWTToken(query.token, false);
+            const authTokenData: AuthTokenData = await jwtTokenManager.verifyJWTToken(query.token, false);
             if (authTokenData.accessToken == undefined) {
                 throw Error("Cannot log out, no access token found.");
             }

--- a/play/src/pusher/services/JWTTokenManager.ts
+++ b/play/src/pusher/services/JWTTokenManager.ts
@@ -1,19 +1,42 @@
-import Jwt from "jsonwebtoken";
+import { jwtVerify, SignJWT, errors } from "jose";
 import z from "zod";
 import { ADMIN_SOCKETS_TOKEN, SECRET_KEY } from "../enums/EnvironmentVariable";
 
 export const AuthTokenData = z.object({
     identifier: z.string(), //will be a email if logged in or an uuid if anonymous
     accessToken: z.string().optional(),
+    refreshToken: z.string().optional(),
     username: z.string().optional(),
     locale: z.string().optional(),
-    tags: z.string().array().optional(),
+    tags: z
+        .preprocess((val) => {
+            if (typeof val === "string") {
+                try {
+                    return JSON.parse(val);
+                } catch {
+                    return [val];
+                }
+            }
+            return val;
+        }, z.string().array())
+        .optional(),
     matrixUserId: z.string().optional(),
 });
 export type AuthTokenData = z.infer<typeof AuthTokenData>;
 
 export const AccessTokenData = z.object({
-    tags: z.string().array().optional(),
+    tags: z
+        .preprocess((val) => {
+            if (typeof val === "string") {
+                try {
+                    return JSON.parse(val);
+                } catch {
+                    return [val];
+                }
+            }
+            return val;
+        }, z.string().array())
+        .optional(),
 });
 export type AccessTokenData = z.infer<typeof AccessTokenData>;
 
@@ -23,32 +46,44 @@ export const AdminSocketTokenData = z.object({
 export type AdminSocketTokenData = z.infer<typeof AdminSocketTokenData>;
 export const tokenInvalidException = "tokenInvalid";
 
+const secret = new TextEncoder().encode(SECRET_KEY ?? "");
+const adminSocketsSecret = new TextEncoder().encode(ADMIN_SOCKETS_TOKEN ?? "");
+
 export class JWTTokenManager {
-    public verifyAdminSocketToken(token: string): AdminSocketTokenData {
+    public async verifyAdminSocketToken(token: string): Promise<AdminSocketTokenData> {
         if (!ADMIN_SOCKETS_TOKEN) {
             throw new Error("Missing environment variable ADMIN_SOCKETS_TOKEN");
         }
 
-        const verifiedToken = Jwt.verify(token, ADMIN_SOCKETS_TOKEN);
+        const verifiedToken = (await jwtVerify(token, adminSocketsSecret)).payload;
 
         return AdminSocketTokenData.parse(verifiedToken);
     }
 
-    public createAuthToken(
+    public async createAuthToken(
         identifier: string,
         accessToken?: string,
+        refreshToken?: string,
         username?: string,
         locale?: string,
         tags?: string[],
         matrixUserId?: string
-    ): string {
-        return Jwt.sign({ identifier, accessToken, username, locale, tags, matrixUserId }, SECRET_KEY, {
-            expiresIn: "30d",
-        });
+    ): Promise<string> {
+        return new SignJWT({ identifier, accessToken, refreshToken, username, locale, tags, matrixUserId })
+            .setExpirationTime("30d")
+            .setProtectedHeader({ alg: "HS256" })
+            .sign(secret);
     }
 
-    public verifyJWTToken(token: string, ignoreExpiration = false): AuthTokenData {
-        return AuthTokenData.parse(Jwt.verify(token, SECRET_KEY, { ignoreExpiration }));
+    public async verifyJWTToken(token: string, ignoreExpiration = false): Promise<AuthTokenData> {
+        try {
+            return AuthTokenData.parse((await jwtVerify(token, secret)).payload);
+        } catch (error) {
+            if (ignoreExpiration && error instanceof errors.JWTExpired) {
+                return AuthTokenData.parse(error.payload);
+            }
+            throw new errors.JWTInvalid("Token is invalid");
+        }
     }
 }
 

--- a/play/src/pusher/services/OpenIDClient.ts
+++ b/play/src/pusher/services/OpenIDClient.ts
@@ -196,9 +196,6 @@ class OpenIDClient {
     /**
      * Exchange a refresh token for a new access token (and optionally a rotated refresh token).
      * Uses openid-client's built-in client.refresh() — no new dependencies required.
-     *
-     * Most OIDC providers issue a refresh_token by default with the authorization_code flow.
-     * Providers that require it explicitly should add `offline_access` to OPID_SCOPE.
      */
     public async refreshAccessToken(refreshToken: string): Promise<{
         access_token: string;

--- a/play/src/pusher/services/OpenIDClient.ts
+++ b/play/src/pusher/services/OpenIDClient.ts
@@ -123,6 +123,7 @@ class OpenIDClient {
         email: string;
         sub: string;
         access_token: string;
+        refresh_token: string | undefined;
         username: string;
         locale: string;
         matrix_url: string | undefined;
@@ -165,6 +166,7 @@ class OpenIDClient {
                             email: res.email ?? "",
                             sub: res.sub,
                             access_token: tokenSet.access_token ?? "",
+                            refresh_token: tokenSet.refresh_token,
                             username: res[OPID_USERNAME_CLAIM] as string,
                             locale: res[OPID_LOCALE_CLAIM] as string,
                             tags: res[OPID_TAGS_CLAIM] as string[],
@@ -189,6 +191,28 @@ class OpenIDClient {
         return this.initClient().then((client) => {
             return client.userinfo(token);
         });
+    }
+
+    /**
+     * Exchange a refresh token for a new access token (and optionally a rotated refresh token).
+     * Uses openid-client's built-in client.refresh() — no new dependencies required.
+     *
+     * Most OIDC providers issue a refresh_token by default with the authorization_code flow.
+     * Providers that require it explicitly should add `offline_access` to OPID_SCOPE.
+     */
+    public async refreshAccessToken(refreshToken: string): Promise<{
+        access_token: string;
+        refresh_token: string | undefined;
+    }> {
+        const client = await this.initClient();
+        const tokenSet = await client.refresh(refreshToken);
+        if (!tokenSet.access_token) {
+            throw new Error("No access_token returned from token refresh endpoint");
+        }
+        return {
+            access_token: tokenSet.access_token,
+            refresh_token: tokenSet.refresh_token,
+        };
     }
 
     private encrypt(text: string): string {


### PR DESCRIPTION
## Problem

When a user's OIDC access token expires (e.g. Authentik/Keycloak default ~5 min), the next `/me` call returns a 401 and forces a full re-login — even though a valid `refresh_token` was available.

Root cause: the `refresh_token` from the OIDC `tokenSet` inside `getUserInfo()` was silently discarded and never stored in the WA auth JWT.

## Changes

### `OpenIDClient.ts`
- Expose `refresh_token` in the return type & value of `getUserInfo()`
- Add `refreshAccessToken(refreshToken)` — calls `client.refresh()` (built-in openid-client, no new deps) and returns the new `access_token` + optionally rotated `refresh_token`

### `JWTTokenManager.ts`
- Add `refreshToken?: string` to the `AuthTokenData` Zod schema
- Thread it through `createAuthToken()` so it is embedded in the WA JWT

### `AuthenticateController.ts`
- `/openid-callback`: pass `userInfo.refresh_token` to `createAuthToken()` so fresh logins always persist the refresh token
- `/me`: when `checkTokenAuth()` fails, check whether `authTokenData.refreshToken` exists; if so, call `refreshAccessToken()`, re-verify with the new access token, issue a **new** WA JWT with the rotated tokens, and return it — the client continues seamlessly without a redirect
- If the refresh also fails (revoked/expired), fall through to the existing 401

## Behaviour

| Scenario | Before | After |
|---|---|---|  
| Access token valid | ✅ normal | ✅ unchanged |
| Access token expired, refresh token present | ❌ 401, full re-login | ✅ silent refresh, new authToken returned |
| Access token expired, no refresh token | ❌ 401 | ❌ 401 (expected) |
| Refresh token also expired/revoked | ❌ 401 | ❌ 401 (expected, with console.warn) |

## Notes
- No new npm dependencies — uses `client.refresh()` already provided by `openid-client`
- Providers that require `offline_access` scope to issue a refresh token should add it to `OPID_SCOPE`
- The WA JWT TTL remains 30 days; only the embedded OIDC tokens rotate