### PR TITLE
update: UX rule with right click

### DIFF
--- a/play/src/front/Components/ActionBar/MenuIcons/ProfileMenu.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/ProfileMenu.svelte
@@ -120,16 +120,19 @@
             onFormOpen: () => {
                 // Disable the user inputs
                 gameManager.getCurrentGameScene().userInputManager.disableControls("store");
+                gameManager.getCurrentGameScene().userInputManager.disableRightClick();
                 // Close the menu
                 openedMenuStore.close("profileMenu");
             },
             onFormClose: () => {
                 gameManager.getCurrentGameScene().userInputManager.restoreControls("store");
+                gameManager.getCurrentGameScene().userInputManager.restoreRightClick();
                 // Remove the actor buttom from the DOM
                 form?.close();
             },
             onSubmitSuccess: () => {
                 gameManager.getCurrentGameScene().userInputManager.restoreControls("store");
+                gameManager.getCurrentGameScene().userInputManager.restoreRightClick();
                 // Remove the actor buttom from the DOM
                 form?.close();
             },

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -2896,9 +2896,10 @@ ${escapedMessage}
             iframeListener.disablePlayerControlStream.subscribe((messageEventSource) => {
                 if (messageEventSource) {
                     this.userInputManager.disableControls(messageEventSource);
-
+                    this.userInputManager.disableRightClick();
                     iframeListener.onIframeCloseEvent(messageEventSource, () => {
                         this.userInputManager.restoreControls(messageEventSource);
+                        this.userInputManager.restoreRightClick();
                     });
                 }
             })
@@ -2908,6 +2909,7 @@ ${escapedMessage}
             iframeListener.enablePlayerControlStream.subscribe((messageEventSource) => {
                 if (messageEventSource) {
                     this.userInputManager.restoreControls(messageEventSource);
+                    this.userInputManager.restoreRightClick();
                 }
             })
         );
@@ -4118,6 +4120,7 @@ ${escapedMessage}
         this.cleanupClosingScene();
 
         this.userInputManager.disableControls("errorScreen");
+        this.userInputManager.disableRightClick();
     }
 
     //todo: put this into an 'orchestrator' scene (EntryScene?)
@@ -4127,6 +4130,7 @@ ${escapedMessage}
         this.scene.stop(ReconnectingSceneName);
         this.scene.remove(ReconnectingSceneName);
         this.userInputManager.disableControls("errorScreen");
+        this.userInputManager.disableRightClick();
         //FIX ME to use status code
         if (message == undefined) {
             this.scene.start(ErrorSceneName, {

--- a/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
+++ b/play/src/front/Phaser/Game/MapEditor/Tools/ExplorerTool.ts
@@ -160,6 +160,7 @@ export class ExplorerTool implements MapEditorTool {
 
         // Restore controls of the scene
         this.scene.userInputManager.restoreControls("explorerTool");
+        this.scene.userInputManager.restoreRightClick();
 
         // Remove all controls for the exploration mode
         this.scene.input.keyboard?.off("keydown", this.keyDownHandler);
@@ -249,7 +250,7 @@ export class ExplorerTool implements MapEditorTool {
 
         // Disable controls of the scene
         this.scene.userInputManager.disableControls("explorerTool");
-
+        this.scene.userInputManager.disableRightClick();
         // Implement all controls for the exploration mode
         this.scene.input.setTopOnly(false);
         this.scene.input.keyboard?.on("keydown", this.keyDownHandler);

--- a/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
+++ b/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
@@ -121,7 +121,7 @@ export class GameSceneUserInputHandler implements UserInputHandlerInterface {
             return;
         }
 
-        if (!this.gameScene.userInputManager.isControlsEnabled) {
+        if (!this.gameScene.userInputManager.isControlsEnabled && !this.gameScene.userInputManager.isRightClickEnabled) {
             return;
         }
 

--- a/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
+++ b/play/src/front/Phaser/UserInput/GameSceneUserInputHandler.ts
@@ -121,7 +121,10 @@ export class GameSceneUserInputHandler implements UserInputHandlerInterface {
             return;
         }
 
-        if (!this.gameScene.userInputManager.isControlsEnabled && !this.gameScene.userInputManager.isRightClickEnabled) {
+        if (
+            !this.gameScene.userInputManager.isControlsEnabled &&
+            !this.gameScene.userInputManager.isRightClickEnabled
+        ) {
             return;
         }
 


### PR DESCRIPTION
When the user is in an input, the right click on the map is disabled. Fix it to permit a right click and move WOKA only when the user is in input.