### PR TITLE
fix: prevent woka menu overlap with map editor sidebar

### DIFF
--- a/play/src/front/Components/ActionsMenu/ExplorerMenu.svelte
+++ b/play/src/front/Components/ActionsMenu/ExplorerMenu.svelte
@@ -1,25 +1,92 @@
 <script lang="ts">
+    import { onDestroy } from "svelte";
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import { mapEditorModeStore, mapExplorationModeStore } from "../../Stores/MapEditorStore";
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { EditorToolName } from "../../Phaser/Game/MapEditor/MapEditorModeManager";
+    import { BUTTON_ZOOM_FACTOR_PER_SECOND, BUTTON_ZOOM_STEP_FACTOR } from "../../Phaser/Game/CameraZoomUtils";
     import LL from "../../../i18n/i18n-svelte";
     import { IconFocusCentered, IconMapSearch, IconMinus, IconPlus } from "@wa-icons";
 
     export let mapEditorRightOffset = 0;
 
-    function zoomIn() {
-        analyticsClient.clickToZoomIn();
+    // Keep click and long-press as the same gesture: a press always starts with one smooth zoom step,
+    // then turns into continuous zoom if the user keeps the pointer down.
+    const ZOOM_HOLD_DELAY = 180;
 
-        const cameraManager = gameManager.getCurrentGameScene().getCameraManager();
-        cameraManager.zoomByFactor(1.2, 500);
+    // Track one active pointer so a second finger/button cannot start a competing zoom loop.
+    let zoomHoldTimeout: ReturnType<typeof setTimeout> | undefined;
+    let activeZoomPointerId: number | undefined;
+
+    function getCameraManager() {
+        return gameManager.getCurrentGameScene().getCameraManager();
     }
 
-    function zoomOut() {
-        analyticsClient.clickToZoomOut();
+    function clearZoomHoldTimeout() {
+        if (zoomHoldTimeout === undefined) {
+            return;
+        }
 
+        clearTimeout(zoomHoldTimeout);
+        zoomHoldTimeout = undefined;
+    }
+
+    function isPointerEvent(event?: Event): event is PointerEvent {
+        return event !== undefined && "pointerId" in event;
+    }
+
+    /**
+     * Starts the zoom gesture for mouse, touch, and stylus.
+     * Analytics is emitted once here so a long press does not create one event per animation frame.
+     */
+    function startZoom(direction: "in" | "out", event: PointerEvent) {
+        if (event.pointerType === "mouse" && event.button !== 0) {
+            return;
+        }
+
+        event.preventDefault();
+
+        if (activeZoomPointerId !== undefined) {
+            return;
+        }
+
+        activeZoomPointerId = event.pointerId;
         const cameraManager = gameManager.getCurrentGameScene().getCameraManager();
-        cameraManager.zoomByFactor(1 / 1.2, 500);
+        const zoomFactor = direction === "in" ? BUTTON_ZOOM_STEP_FACTOR : 1 / BUTTON_ZOOM_STEP_FACTOR;
+        const continuousZoomFactor =
+            direction === "in" ? BUTTON_ZOOM_FACTOR_PER_SECOND : 1 / BUTTON_ZOOM_FACTOR_PER_SECOND;
+
+        if (direction === "in") {
+            analyticsClient.clickToZoomIn();
+        } else {
+            analyticsClient.clickToZoomOut();
+        }
+
+        cameraManager.smoothZoomByFactor(zoomFactor);
+
+        // If the pointer is still down after the delay, the same gesture becomes continuous zoom.
+        clearZoomHoldTimeout();
+        zoomHoldTimeout = setTimeout(() => {
+            if (activeZoomPointerId === event.pointerId) {
+                getCameraManager().startContinuousZoom(continuousZoomFactor);
+            }
+        }, ZOOM_HOLD_DELAY);
+    }
+
+    /**
+     * Stops the gesture from all exit paths: release, cancel, leaving the button, window blur, or component destroy.
+     */
+    function stopZoom(event?: Event) {
+        if (isPointerEvent(event) && activeZoomPointerId !== undefined && activeZoomPointerId !== event.pointerId) {
+            return;
+        }
+
+        const hadActiveZoom = activeZoomPointerId !== undefined || zoomHoldTimeout !== undefined;
+        clearZoomHoldTimeout();
+        activeZoomPointerId = undefined;
+        if (hadActiveZoom) {
+            getCameraManager().stopContinuousZoom();
+        }
     }
 
     function openMapExplorer() {
@@ -35,7 +102,13 @@
         mapEditorModeStore.switchMode(false);
         gameManager.getCurrentGameScene().getMapEditorModeManager().equipTool(EditorToolName.CloseMapEditor);
     }
+
+    onDestroy(() => {
+        stopZoom();
+    });
 </script>
+
+<svelte:window on:blur={stopZoom} />
 
 <div
     class="fixed bottom-2 bg-contrast/80 rounded pointer-events-auto p-1 backdrop-blur hover:bg-contrast/100"
@@ -48,7 +121,10 @@
             <!-- svelte-ignore a11y-no-static-element-interactions -->
             <div
                 class="group flex justify-center items-center p-1 rounded hover:bg-white/30 cursor-pointer"
-                on:click={zoomIn}
+                on:pointerdown={(event) => startZoom("in", event)}
+                on:pointerup={stopZoom}
+                on:pointercancel={stopZoom}
+                on:pointerleave={stopZoom}
             >
                 <IconPlus />
                 <div
@@ -61,7 +137,10 @@
             <!-- svelte-ignore a11y-no-static-element-interactions -->
             <div
                 class="group flex justify-center items-center p-1 rounded hover:bg-white/30 cursor-pointer"
-                on:click={zoomOut}
+                on:pointerdown={(event) => startZoom("out", event)}
+                on:pointerup={stopZoom}
+                on:pointercancel={stopZoom}
+                on:pointerleave={stopZoom}
             >
                 <IconMinus />
                 <div

--- a/play/src/front/Components/ActionsMenu/ExplorerMenu.svelte
+++ b/play/src/front/Components/ActionsMenu/ExplorerMenu.svelte
@@ -6,6 +6,8 @@
     import LL from "../../../i18n/i18n-svelte";
     import { IconFocusCentered, IconMapSearch, IconMinus, IconPlus } from "@wa-icons";
 
+    export let mapEditorRightOffset = 0;
+
     function zoomIn() {
         analyticsClient.clickToZoomIn();
 
@@ -36,7 +38,8 @@
 </script>
 
 <div
-    class="absolute bottom-2 right-2 bg-contrast/80 rounded pointer-events-auto p-1 backdrop-blur hover:bg-contrast/100"
+    class="fixed bottom-2 bg-contrast/80 rounded pointer-events-auto p-1 backdrop-blur hover:bg-contrast/100"
+    style:right={`calc(${mapEditorRightOffset}px + 0.5rem)`}
     data-testid="actions-explorer"
 >
     <div class="flex flex-col justify-center gap-2">

--- a/play/src/front/Components/MainLayout.svelte
+++ b/play/src/front/Components/MainLayout.svelte
@@ -15,12 +15,13 @@
     import { wokaMenuStore } from "../Stores/WokaMenuStore";
     import { showDesktopCapturerSourcePicker } from "../Stores/ScreenSharingStore";
     import { uiWebsitesStore } from "../Stores/UIWebsiteStore";
-    import { coWebsites } from "../Stores/CoWebsiteStore";
+    import { coWebsites, windowSize } from "../Stores/CoWebsiteStore";
     import { proximityMeetingStore } from "../Stores/MyMediaStore";
     import { notificationPlayingStore } from "../Stores/NotificationStore";
     import { popupStore } from "../Stores/PopupStore";
     import {
         mapEditorAskToClaimPersonalAreaStore,
+        mapEditorModeStore,
         mapEditorSelectedToolStore,
         mapEditorVisibilityStore,
         mapExplorationObjectSelectedStore,
@@ -84,6 +85,9 @@
     let highlightParticipantCamerasListOpen = true;
 
     const HIGHLIGHT_FULLSCREEN_PARTICIPANT_LIST_AUTO_HIDE_MS = 5000;
+    const MAP_EDITOR_TOOLBAR_WIDTH = 64;
+    const MAP_EDITOR_TOOLBAR_GAP = 16;
+    const MAP_EDITOR_TOOLBAR_RESERVED_WIDTH = MAP_EDITOR_TOOLBAR_WIDTH + MAP_EDITOR_TOOLBAR_GAP;
 
     let participantListAutoHideTimer: ReturnType<typeof setTimeout> | undefined;
     let wasHighlightFullscreenActive = false;
@@ -139,6 +143,27 @@
         }
     };
 
+    function getMapEditorRightReservedSpace({
+        isMapEditorActive,
+        isMapEditorPanelVisible,
+        isMapEditorToolbarVisible,
+        mapEditorPanelWidth,
+    }: {
+        isMapEditorActive: boolean;
+        isMapEditorPanelVisible: boolean;
+        isMapEditorToolbarVisible: boolean;
+        mapEditorPanelWidth: number;
+    }): number {
+        if (!isMapEditorActive) {
+            return 0;
+        }
+
+        return (
+            (isMapEditorPanelVisible ? mapEditorPanelWidth : 0) +
+            (isMapEditorToolbarVisible ? MAP_EDITOR_TOOLBAR_RESERVED_WIDTH : 0)
+        );
+    }
+
     onMount(() => {
         document.addEventListener("focusin", handleFocusInEvent);
         document.addEventListener("focusout", handleFocusOutEvent);
@@ -154,10 +179,15 @@
     });
 
     $: marginLeft = $chatVisibilityStore ? $chatSidebarWidthStore : 0;
-    $: marginRight =
-        $mapEditorVisibilityStore && $mapEditorSelectedToolStore !== EditorToolName.WAMSettingsEditor
-            ? $mapEditorSideBarWidthStore
-            : 0;
+    $: mapEditorPanelVisible =
+        $mapEditorVisibilityStore && $mapEditorSelectedToolStore !== EditorToolName.WAMSettingsEditor;
+    $: mapEditorToolbarVisible = $windowSize.width >= 768 || !$mapEditorVisibilityStore;
+    $: marginRight = getMapEditorRightReservedSpace({
+        isMapEditorActive: $mapEditorModeStore,
+        isMapEditorPanelVisible: mapEditorPanelVisible,
+        isMapEditorToolbarVisible: mapEditorToolbarVisible,
+        mapEditorPanelWidth: $mapEditorSideBarWidthStore,
+    });
 
     function onHighlightFullscreenSendMessage() {
         if (get(chatVisibilityStore) && get(navChat).key === "chat") {

--- a/play/src/front/Components/MainLayout.svelte
+++ b/play/src/front/Components/MainLayout.svelte
@@ -451,7 +451,7 @@
             {/if}
             <ExternalComponents zone="centeredPopup" />
 
-            <ExplorerMenu />
+            <ExplorerMenu mapEditorRightOffset={mapEditorPanelVisible ? $mapEditorSideBarWidthStore : 0} />
         </section>
         <div class="">
             <!--<ActionBar />-->

--- a/play/src/front/Phaser/Game/CameraManager.ts
+++ b/play/src/front/Phaser/Game/CameraManager.ts
@@ -9,6 +9,13 @@ import { WaScaleManagerEvent } from "../Services/WaScaleManager";
 import type { ActiveEventList } from "../UserInput/UserInputManager";
 import { UserInputEvent } from "../UserInput/UserInputManager";
 import type { RemotePlayer } from "../Entity/RemotePlayer";
+import {
+    SMOOTH_BUTTON_ZOOM_DURATION,
+    SMOOTH_BUTTON_ZOOM_TARGET_EPSILON,
+    getContinuousButtonZoomFactor,
+    getRetargetedButtonZoomModifier,
+    getSmoothButtonZoomModifier,
+} from "./CameraZoomUtils";
 import type { GameScene } from "./GameScene";
 import Clamp = Phaser.Math.Clamp;
 
@@ -56,6 +63,14 @@ export class CameraManager extends Phaser.Events.EventEmitter {
 
     private cameraAnimation: CameraAnimation | undefined;
     private zoomAnimation: ZoomAnimation | undefined;
+
+    // Button zoom is kept separate from the regular tween-based zoom so repeated clicks can retarget
+    // the current destination without recreating a Phaser tween on every press.
+    private buttonZoomAnimation: ZoomAnimation | undefined;
+    private smoothButtonZoomStartModifier: number | undefined;
+    private smoothButtonZoomTargetModifier: number | undefined;
+    private smoothButtonZoomElapsedMs = 0;
+    private continuousButtonZoomFactorPerSecond: number | undefined;
 
     private playerToFollow?: Player | RemotePlayer;
     private zoomLocked: boolean;
@@ -130,6 +145,8 @@ export class CameraManager extends Phaser.Events.EventEmitter {
 
     public destroy(): void {
         this.cancelOffsetTween();
+        this.zoomAnimation?.onInterrupt();
+        this.zoomAnimation = undefined;
         this.scene.game.events.off(WaScaleManagerEvent.ZoomChanged, this.onZoomChanged);
 
         this.scene.game.events.off(WaScaleManagerEvent.RefreshFocusOnTarget);
@@ -519,6 +536,64 @@ export class CameraManager extends Phaser.Events.EventEmitter {
         this.animateToZoomLevel(this.waScaleManager.zoomModifier * zoomFactor, duration, callback);
     }
 
+    /**
+     * Applies one Explorer menu click step.
+     * If another click arrives while the previous step is still animating, the target is moved again
+     * and the animation restarts from the current zoom, which avoids the visible "restart" effect.
+     */
+    public smoothZoomByFactor(zoomFactor: number): void {
+        if (this.isZoomLocked()) {
+            return;
+        }
+
+        this.smoothButtonZoomTargetModifier = getRetargetedButtonZoomModifier(
+            this.waScaleManager.zoomModifier,
+            zoomFactor,
+            this.smoothButtonZoomTargetModifier
+        );
+        this.smoothButtonZoomStartModifier = this.waScaleManager.zoomModifier;
+        this.smoothButtonZoomElapsedMs = 0;
+        this.continuousButtonZoomFactorPerSecond = undefined;
+
+        if (!this.buttonZoomAnimation) {
+            this.zoomAnimation?.onInterrupt();
+            this.startButtonZoomAnimation();
+        }
+    }
+
+    /**
+     * Starts long-press zoom. The caller passes a per-second factor so the update loop can remain frame-rate independent.
+     */
+    public startContinuousZoom(zoomFactorPerSecond: number): void {
+        if (this.isZoomLocked()) {
+            return;
+        }
+
+        this.smoothButtonZoomTargetModifier = undefined;
+        this.smoothButtonZoomStartModifier = undefined;
+        this.smoothButtonZoomElapsedMs = 0;
+        this.continuousButtonZoomFactorPerSecond = zoomFactorPerSecond;
+
+        if (!this.buttonZoomAnimation) {
+            this.zoomAnimation?.onInterrupt();
+            this.startButtonZoomAnimation();
+        }
+    }
+
+    /**
+     * Ends long-press zoom and asks WaScaleManager to settle outside animation mode.
+     * This lets its existing zoom bounds and canvas resize logic finish cleanly.
+     */
+    public stopContinuousZoom(): void {
+        if (this.continuousButtonZoomFactorPerSecond === undefined) {
+            return;
+        }
+
+        this.waScaleManager.setZoomModifier(this.waScaleManager.zoomModifier, this.camera, false);
+        this.emit(CameraManagerEvent.CameraUpdate, this.getCameraUpdateEventData());
+        this.stopButtonZoomAnimation();
+    }
+
     private animateToZoomLevel(targetZoomModifier: number, duration: number, callback?: () => void): void {
         this.zoomAnimation?.onInterrupt();
         const startZoomModifier = this.waScaleManager.zoomModifier;
@@ -566,6 +641,98 @@ export class CameraManager extends Phaser.Events.EventEmitter {
             },
         };
     }
+
+    private startButtonZoomAnimation(): void {
+        // We drive the button zoom from the scene update event because it handles both click easing
+        // and continuous hold zoom with the same cleanup path.
+        this.scene.events.on(Phaser.Scenes.Events.UPDATE, this.animateButtonZoom);
+
+        const buttonZoomAnimation: ZoomAnimation = {
+            onInterrupt: () => {
+                this.scene.events.off(Phaser.Scenes.Events.UPDATE, this.animateButtonZoom);
+                this.smoothButtonZoomStartModifier = undefined;
+                this.smoothButtonZoomTargetModifier = undefined;
+                this.smoothButtonZoomElapsedMs = 0;
+                this.continuousButtonZoomFactorPerSecond = undefined;
+                this.buttonZoomAnimation = undefined;
+                if (this.zoomAnimation === buttonZoomAnimation) {
+                    this.zoomAnimation = undefined;
+                }
+            },
+        };
+
+        this.buttonZoomAnimation = buttonZoomAnimation;
+        this.zoomAnimation = buttonZoomAnimation;
+    }
+
+    private stopButtonZoomAnimation(): void {
+        this.buttonZoomAnimation?.onInterrupt();
+    }
+
+    private updateButtonZoomModifier(targetZoomModifier: number, animating: boolean): void {
+        this.waScaleManager.setZoomModifier(targetZoomModifier, this.camera, animating);
+        this.emit(CameraManagerEvent.CameraUpdate, this.getCameraUpdateEventData());
+    }
+
+    private isButtonZoomLimitReached(previousZoomModifier: number, requestedZoomModifier: number): boolean {
+        // WaScaleManager clamps by mutating its internal zoom modifier when bounds are reached.
+        // Comparing the requested direction with the exposed bound flags tells us when to stop the loop.
+        if (requestedZoomModifier > previousZoomModifier && this.waScaleManager.isMaximumZoomInReached) {
+            return true;
+        }
+
+        if (requestedZoomModifier < previousZoomModifier && this.waScaleManager.isMaximumZoomOutReached) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private readonly animateButtonZoom = (_time: number, delta: number): void => {
+        if (this.continuousButtonZoomFactorPerSecond !== undefined) {
+            // Long press zoom is multiplicative and frame-rate independent.
+            const currentZoomModifier = this.waScaleManager.zoomModifier;
+            const targetZoomModifier =
+                currentZoomModifier * getContinuousButtonZoomFactor(this.continuousButtonZoomFactorPerSecond, delta);
+
+            this.updateButtonZoomModifier(targetZoomModifier, true);
+
+            if (this.isButtonZoomLimitReached(currentZoomModifier, targetZoomModifier)) {
+                this.stopContinuousZoom();
+            }
+            return;
+        }
+
+        // Click zoom uses elapsed time from the last click target change, not only the frame delta.
+        // This keeps the easing curve stable even if the browser drops frames.
+        const startZoomModifier = this.smoothButtonZoomStartModifier;
+        const targetZoomModifier = this.smoothButtonZoomTargetModifier;
+        if (startZoomModifier === undefined || targetZoomModifier === undefined) {
+            this.stopButtonZoomAnimation();
+            return;
+        }
+
+        const currentZoomModifier = this.waScaleManager.zoomModifier;
+        this.smoothButtonZoomElapsedMs += delta;
+        const nextZoomModifier = getSmoothButtonZoomModifier(
+            startZoomModifier,
+            targetZoomModifier,
+            this.smoothButtonZoomElapsedMs,
+            SMOOTH_BUTTON_ZOOM_DURATION
+        );
+
+        this.updateButtonZoomModifier(nextZoomModifier, true);
+
+        if (
+            this.smoothButtonZoomElapsedMs >= SMOOTH_BUTTON_ZOOM_DURATION ||
+            Math.abs(this.waScaleManager.zoomModifier - targetZoomModifier) <= SMOOTH_BUTTON_ZOOM_TARGET_EPSILON ||
+            this.isButtonZoomLimitReached(currentZoomModifier, targetZoomModifier)
+        ) {
+            this.updateButtonZoomModifier(this.waScaleManager.zoomModifier, false);
+            this.stopButtonZoomAnimation();
+        }
+    };
+
     private animate = (time: number, delta: number): void => {
         const cameraSpeed = this.cameraAnimation;
         if (cameraSpeed?.type !== "speed") {

--- a/play/src/front/Phaser/Game/CameraZoomUtils.test.ts
+++ b/play/src/front/Phaser/Game/CameraZoomUtils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+    BUTTON_ZOOM_FACTOR_PER_SECOND,
+    CONTINUOUS_BUTTON_ZOOM_STEP_DURATION,
+    SMOOTH_BUTTON_ZOOM_DURATION,
+    getContinuousButtonZoomFactor,
+    getRetargetedButtonZoomModifier,
+    getSmoothButtonZoomModifier,
+} from "./CameraZoomUtils";
+
+describe("CameraZoomUtils", () => {
+    it("retargets repeated button zooms from the existing target", () => {
+        expect(getRetargetedButtonZoomModifier(1, 1.2, undefined)).toBeCloseTo(1.2);
+        expect(getRetargetedButtonZoomModifier(1.05, 1.2, 1.2)).toBeCloseTo(1.44);
+    });
+
+    it("moves smoothly toward the target without overshooting", () => {
+        const currentZoomModifier = 1;
+        const targetZoomModifier = 1.2;
+
+        const nextZoomModifier = getSmoothButtonZoomModifier(
+            currentZoomModifier,
+            targetZoomModifier,
+            SMOOTH_BUTTON_ZOOM_DURATION / 2
+        );
+
+        expect(nextZoomModifier).toBeGreaterThan(currentZoomModifier);
+        expect(nextZoomModifier).toBeLessThan(targetZoomModifier);
+    });
+
+    it("does not jump aggressively on the first animation frame", () => {
+        expect(getSmoothButtonZoomModifier(1, 1.2, 16)).toBeLessThan(1.03);
+    });
+
+    it("keeps a moderate continuous zoom speed", () => {
+        expect(
+            getContinuousButtonZoomFactor(BUTTON_ZOOM_FACTOR_PER_SECOND, CONTINUOUS_BUTTON_ZOOM_STEP_DURATION)
+        ).toBeCloseTo(1.2);
+    });
+});

--- a/play/src/front/Phaser/Game/CameraZoomUtils.ts
+++ b/play/src/front/Phaser/Game/CameraZoomUtils.ts
@@ -1,0 +1,56 @@
+// Explorer menu zoom buttons need a different feel from wheel/pinch zoom:
+// clicks should animate to a clear step, while long presses should keep moving at a steady pace.
+export const BUTTON_ZOOM_STEP_FACTOR = 1.2;
+
+// A click uses a longer ease-in-out animation so the first frame does not feel like a jump.
+export const SMOOTH_BUTTON_ZOOM_DURATION = 520;
+
+// Long press keeps the previous rhythm: roughly one x1.2 zoom step every 375ms.
+export const CONTINUOUS_BUTTON_ZOOM_STEP_DURATION = 375;
+export const SMOOTH_BUTTON_ZOOM_TARGET_EPSILON = 0.001;
+export const BUTTON_ZOOM_FACTOR_PER_SECOND = Math.pow(
+    BUTTON_ZOOM_STEP_FACTOR,
+    1000 / CONTINUOUS_BUTTON_ZOOM_STEP_DURATION
+);
+
+/**
+ * Retargets quick repeated clicks from the previous destination, not from the current in-flight zoom.
+ * This avoids restarting from a partially animated value and makes repeated clicks feel like one continuous motion.
+ */
+export function getRetargetedButtonZoomModifier(
+    currentZoomModifier: number,
+    zoomFactor: number,
+    targetZoomModifier: number | undefined
+): number {
+    return (targetZoomModifier ?? currentZoomModifier) * zoomFactor;
+}
+
+/**
+ * Computes the click animation position using elapsed time from the beginning of the current click animation.
+ * CameraManager resets the start value and elapsed time every time the click target is retargeted.
+ */
+export function getSmoothButtonZoomModifier(
+    currentZoomModifier: number,
+    targetZoomModifier: number,
+    deltaMs: number,
+    durationMs = SMOOTH_BUTTON_ZOOM_DURATION
+): number {
+    if (durationMs <= 0) {
+        return targetZoomModifier;
+    }
+
+    if (deltaMs >= durationMs) {
+        return targetZoomModifier;
+    }
+
+    const progress = deltaMs / durationMs;
+    const easedProgress = -(Math.cos(Math.PI * progress) - 1) / 2;
+    return currentZoomModifier + (targetZoomModifier - currentZoomModifier) * easedProgress;
+}
+
+/**
+ * Converts a per-second zoom factor to the factor that should be applied during one Phaser update frame.
+ */
+export function getContinuousButtonZoomFactor(zoomFactorPerSecond: number, deltaMs: number): number {
+    return Math.pow(zoomFactorPerSecond, deltaMs / 1000);
+}


### PR DESCRIPTION
before : 
<img width="1123" height="1281" alt="Capture d’écran 2026-05-19 à 15 58 44" src="https://github.com/user-attachments/assets/75ac68ec-c98c-451d-a8e0-e16dde4a3ecd" />

after : 
<img width="1123" height="1281" alt="Capture d’écran 2026-05-19 à 15 49 27" src="https://github.com/user-attachments/assets/8fcbc911-af0d-46cb-8657-555dbb760e5b" />

