### PR TITLE
Fixing zoom when zooming slowly on trackpad

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -4182,7 +4182,7 @@ ${escapedMessage}
             return;
         }
 
-        const time = zoomFactor > 1 ? (zoomFactor - 1) * 250 : (1 / zoomFactor - 1) * 250;
+        const time = zoomFactor > 1 ? zoomFactor * 250 : (1 / zoomFactor) * 250;
         this.cameraManager.zoomByFactor(zoomFactor, smooth ? time : 0);
     }
 


### PR DESCRIPTION
When zooming really slowly, we could have a nasty quick zoom in/out effect due to an error in the calculation of the animation time that was triggering a divide by 0 error.