### PR TITLE
Fixing user name display in chat audience

### DIFF
--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -310,7 +310,7 @@ export class ProximityChatRoom implements ChatRoom {
         };
 
         const spaceUser = this.users?.get(senderUserId);
-        let chatUser: AnyKindOfUser = this.unknownUser;
+        let chatUser: AnyKindOfUser = { ...this.unknownUser, spaceUserId: senderUserId };
         if (spaceUser) {
             chatUser = mapExtendedSpaceUserToChatUser(spaceUser);
         }


### PR DESCRIPTION
When users are in an audience zone, they are not part of the space. They get a 0 ID associated with their messages. Because 2 users share the same ID, it was causing the system to believe they were different users (but they are not!) We solve this by putting their real spaceUserId in the message instead of 0.