### PR TITLE
Fixing audio muted for speaker

### DIFF
--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -326,19 +326,13 @@ export class LiveKitRoom implements LiveKitRoomInterface {
 
     private synchronizeMediaState() {
         this.unsubscribers.push(
-            deriveSwitchStore(this._localStreamStore, this.space.isStreamingStore).subscribe((localStream) => {
+            deriveSwitchStore(this._localStreamStore, this.space.isStreamingVideoStore).subscribe((localStream) => {
                 this.handleCameraTrack(localStream);
+            })
+        );
 
-                if (
-                    this.space.filterType === FilterType.LIVE_STREAMING_USERS_WITH_FEEDBACK &&
-                    !this.space.getSpaceUserBySpaceUserId(this.space.mySpaceUserId)?.megaphoneState
-                ) {
-                    this.unpublishMicrophoneTrack().catch((err) => {
-                        console.error("An error occurred while unpublishing microphone track", err);
-                        Sentry.captureException(err);
-                    });
-                    return;
-                }
+        this.unsubscribers.push(
+            deriveSwitchStore(this._localStreamStore, this.space.isStreamingAudioStore).subscribe((localStream) => {
                 this.handleMicrophoneTrack(localStream);
             })
         );

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1931,7 +1931,7 @@ export class GameScene extends DirtyScene {
                     })
                     .catch((e) => {
                         const errorMessage = "Failed to get chatConnection from gameManager : " + e;
-                        console.error(errorMessage);
+                        console.error(errorMessage, e);
                     });
 
                 this.initExtensionModule();

--- a/play/src/front/Space/Space.ts
+++ b/play/src/front/Space/Space.ts
@@ -98,7 +98,7 @@ export class Space implements SpaceInterface {
     private readonly _isSpeakerStreamingStore: Writable<boolean>;
     private readonly _isListenerStreamingStore: Writable<boolean>;
     // Derived store that is true if either speaker or listener streaming is active, or if ALL_USERS filter with video properties
-    private readonly _isStreamingStore: Readable<boolean>;
+    private readonly _isStreamingVideoStore: Readable<boolean>;
     private readonly _isStreamingAudioStore: Readable<boolean>;
     private readonly _canRecordStore: Writable<boolean>;
     private readonly _isRecordingStore: Writable<boolean> = writable(false);
@@ -292,13 +292,14 @@ export class Space implements SpaceInterface {
                 this._propertiesToSync.includes("screenSharingState"));
 
         // Derived store: true if speaker OR listener streaming is active, or if ALL_USERS video space
-        this._isStreamingStore = derived(
+        this._isStreamingVideoStore = derived(
             [this._isSpeakerStreamingStore, this._isListenerStreamingStore],
             ([$isSpeakerStreaming, $isListenerStreaming]) => {
                 return isAllUsersVideoSpace || $isSpeakerStreaming || $isListenerStreaming;
             }
         );
 
+        // Derived store: true if speaker is active, or if ALL_USERS video space
         this._isStreamingAudioStore = derived([this._isSpeakerStreamingStore], ([$isSpeakerStreaming]) => {
             return isAllUsersVideoSpace || $isSpeakerStreaming;
         });
@@ -313,7 +314,7 @@ export class Space implements SpaceInterface {
         // One can record if we are streaming or if there is at least one video or screen sharing peer and if we are authorized to record
         this.shouldDisplayRecordButton = derived(
             [
-                this.isStreamingStore,
+                this.isStreamingVideoStore,
                 this.videoStreamStore,
                 this.screenShareStreamStore,
                 this._canRecordStore,
@@ -1133,8 +1134,8 @@ export class Space implements SpaceInterface {
         this._isListenerStreamingStore.set(false);
     }
 
-    get isStreamingStore(): Readable<boolean> {
-        return this._isStreamingStore;
+    get isStreamingVideoStore(): Readable<boolean> {
+        return this._isStreamingVideoStore;
     }
 
     get isStreamingAudioStore(): Readable<boolean> {

--- a/play/src/front/Space/SpaceInterface.ts
+++ b/play/src/front/Space/SpaceInterface.ts
@@ -104,13 +104,19 @@ export interface SpaceInterface {
     stopListenerStreaming(): void;
 
     /**
-     * This store returns true if the local user is currently streaming their camera and microphone to other users in the space.
-     * In a ALL_USERS space, this store will always return true.
+     * This store returns true if the local user is currently streaming their camera to other users in the space.
+     * In a ALL_USERS space that syncs video/audio-related properties, this store will always return true.
+     * In a LIVE_STREAMING_USERS, this store will return true when the startStreaming() method has been called, and false when the stopStreaming() method has been called.
+     * In a LIVE_STREAMING_USERS_WITH_FEEDBACK, this store will return true when the startStreaming()/startListenerStreaming() method has been called, and false when the stopStreaming()/stopListenerStreaming() method has been called.
+     */
+    readonly isStreamingVideoStore: Readable<boolean>;
+
+    /**
+     * This store returns true if the local user is currently streaming their microphone to other users in the space.
+     * In a ALL_USERS space that syncs video/audio-related properties, this store will always return true.
      * In a LIVE_STREAMING_USERS, this store will return true when the startStreaming() method has been called, and false when the stopStreaming() method has been called.
      * In a LIVE_STREAMING_USERS_WITH_FEEDBACK, this store will return true when the startStreaming() method has been called, and false when the stopStreaming() method has been called.
      */
-    readonly isStreamingStore: Readable<boolean>;
-
     readonly isStreamingAudioStore: Readable<boolean>;
 
     /**

--- a/play/src/front/Space/SpaceRegistry/SpaceRegistry.ts
+++ b/play/src/front/Space/SpaceRegistry/SpaceRegistry.ts
@@ -116,7 +116,7 @@ export class SpaceRegistry implements SpaceRegistryInterface {
             return () => {};
         }
 
-        const stores = Array.from($spaces.values(), (space) => space.isStreamingStore);
+        const stores = Array.from($spaces.values(), (space) => space.isStreamingVideoStore);
         return derived(stores, (list) => list.some(Boolean)).subscribe(set);
 
         /*const spaceStores = Array.from($spaces.values()).map((space) => space.isStreamingStore);

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -433,7 +433,7 @@ export class RemotePeer extends Peer implements Streamable {
 
         this.localStreamStoreSubscribe = deriveSwitchStore(
             this.localStreamStore,
-            this.space.isStreamingStore
+            this.space.isStreamingVideoStore
         ).subscribe((streamValue) => {
             if (streamValue === undefined) {
                 if (this.localStream) {


### PR DESCRIPTION
When the "See attendees" option is enabled, a nasty race condition could mute the audio for the speaker in addition of muting the audio of the attendence (because the speaker is not considered part of the space for the local user for some reason) We are fixing this by refactoring the way we track who is supposed to stream video and audio. We do that locally without going through spaces and the pusher.