### PR TITLE
Fine tuning zoom

### DIFF
--- a/play/src/front/Phaser/Game/CameraManager.ts
+++ b/play/src/front/Phaser/Game/CameraManager.ts
@@ -524,13 +524,19 @@ export class CameraManager extends Phaser.Events.EventEmitter {
         const startZoomModifier = this.waScaleManager.zoomModifier;
         const startDate = Date.now();
 
+        const easeAlgo = Easing.QuintEaseOut;
+
         const zoomTween = this.scene.tweens.addCounter({
             from: startZoomModifier,
             to: targetZoomModifier,
             duration,
-            ease: Easing.SineEaseOut,
+            ease: easeAlgo,
             onUpdate: (tween: Phaser.Tweens.Tween) => {
-                this.waScaleManager.setZoomModifier(tween.getValue() ?? 0, this.camera, true);
+                const value = tween.getValue();
+                if (value === undefined) {
+                    return;
+                }
+                this.waScaleManager.setZoomModifier(value, this.camera, true);
                 this.emit(CameraManagerEvent.CameraUpdate, this.getCameraUpdateEventData());
             },
             onComplete: () => {
@@ -545,15 +551,19 @@ export class CameraManager extends Phaser.Events.EventEmitter {
 
                 let elapsedTime = Date.now() - startDate;
                 if (elapsedTime > duration) {
-                    elapsedTime = 1;
+                    elapsedTime = duration;
                 }
+
+                const easeFunction = Phaser.Tweens.Builders.GetEaseFunction(easeAlgo);
+
                 let value;
                 if (duration !== 0) {
-                    value = (elapsedTime / duration) * (targetZoomModifier - startZoomModifier) + startZoomModifier;
+                    value =
+                        easeFunction(elapsedTime / duration) * (targetZoomModifier - startZoomModifier) +
+                        startZoomModifier;
                 } else {
                     value = targetZoomModifier;
                 }
-
                 this.waScaleManager.setZoomModifier(value, this.camera, true);
                 this.emit(CameraManagerEvent.CameraUpdate, this.getCameraUpdateEventData());
             },

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -244,7 +244,7 @@ import SpriteSheetFile = Phaser.Loader.FileTypes.SpriteSheetFile;
 import FILE_LOAD_ERROR = Phaser.Loader.Events.FILE_LOAD_ERROR;
 import Clamp = Phaser.Math.Clamp;
 
-const MOUSE_WHEEL_ZOOM_RATE = 0.25;
+const MOUSE_WHEEL_ZOOM_RATE = 0.5;
 
 export interface GameSceneInitInterface {
     reconnecting: boolean;
@@ -4169,7 +4169,7 @@ ${escapedMessage}
 
         // Sometimes, deltaY can be really high (this happens when the browser is lagging for 1 second or so)
         // Let's clamp the value to avoid zooming too much
-        zoomFactor = Clamp(zoomFactor, 0.5, 2);
+        zoomFactor = Clamp(zoomFactor, 0.1, 10);
 
         debugZoom("DeltaY: ", deltaY, "Zoom factor", zoomFactor);
 


### PR DESCRIPTION
Making the zoom wheel more sensitive and fixing a glitch where we would stop not at the exact position of the tween (because the tween is using an easing algo and we were not in the stop() function)