### PR TITLE
Fix audio via scripting API in LiveKit (merged with microphone)

### DIFF
--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -44,11 +44,14 @@ type LivekitRoomCounter = {
 };
 
 export class LiveKitRoom implements LiveKitRoomInterface {
+    private static readonly SCRIPTING_AUDIO_TRACK_NAME = "workadventure-scripting-audio";
+
     private room: Room | undefined;
     private participants: MapStore<string, LiveKitParticipant> = new MapStore<string, LiveKitParticipant>();
     // Stores LiveKit participants that connected before their corresponding spaceUser was available
     private pendingParticipants: Map<string, RemoteParticipant> = new Map();
     private localParticipant: LocalParticipant | undefined;
+    private scriptingAudioTrack: MediaStreamTrack | undefined;
     private localScreenSharingVideoTrack: LocalVideoTrack | undefined;
     private localScreenSharingAudioTrack: LocalAudioTrack | undefined;
     private localCameraTrack: LocalVideoTrack | undefined;
@@ -618,9 +621,15 @@ export class LiveKitRoom implements LiveKitRoomInterface {
             return;
         }
 
+        if (this.scriptingAudioTrack && this.scriptingAudioTrack !== audioTrack) {
+            await this.localParticipant.unpublishTrack(this.scriptingAudioTrack, true);
+        }
+
         await this.localParticipant.publishTrack(audioTrack, {
+            name: LiveKitRoom.SCRIPTING_AUDIO_TRACK_NAME,
             source: Track.Source.Microphone,
         });
+        this.scriptingAudioTrack = audioTrack;
     }
 
     private handleParticipantConnected(participant: RemoteParticipant) {

--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -29,6 +29,7 @@ import { selectVideoPreset, type VideoQualitySetting } from "../WebRtc/VideoPres
 import { analyticsClient } from "../Administration/AnalyticsClient";
 import { LIVEKIT_PIXEL_DENSITY } from "../Enum/EnvironmentVariable";
 import { SCREEN_SHARE_STARTING_PRIORITY, VIDEO_STARTING_PRIORITY } from "../Space/VideoBoxPriorities";
+import { SCRIPTING_AUDIO_TRACK_NAME } from "./LivekitConstants";
 import { LiveKitParticipant } from "./LivekitParticipant";
 import type { LiveKitRoomInterface } from "./LiveKitRoomInterface";
 
@@ -44,8 +45,6 @@ type LivekitRoomCounter = {
 };
 
 export class LiveKitRoom implements LiveKitRoomInterface {
-    private static readonly SCRIPTING_AUDIO_TRACK_NAME = "workadventure-scripting-audio";
-
     private room: Room | undefined;
     private participants: MapStore<string, LiveKitParticipant> = new MapStore<string, LiveKitParticipant>();
     // Stores LiveKit participants that connected before their corresponding spaceUser was available
@@ -625,8 +624,12 @@ export class LiveKitRoom implements LiveKitRoomInterface {
             await this.localParticipant.unpublishTrack(this.scriptingAudioTrack, true);
         }
 
+        if (this.scriptingAudioTrack === audioTrack) {
+            return;
+        }
+
         await this.localParticipant.publishTrack(audioTrack, {
-            name: LiveKitRoom.SCRIPTING_AUDIO_TRACK_NAME,
+            name: SCRIPTING_AUDIO_TRACK_NAME,
             source: Track.Source.Microphone,
         });
         this.scriptingAudioTrack = audioTrack;

--- a/play/src/front/Livekit/LivekitConstants.ts
+++ b/play/src/front/Livekit/LivekitConstants.ts
@@ -1,0 +1,1 @@
+export const SCRIPTING_AUDIO_TRACK_NAME = "workadventure-scripting-audio";

--- a/play/src/front/Livekit/LivekitParticipant.test.ts
+++ b/play/src/front/Livekit/LivekitParticipant.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { Subject } from "rxjs";
-import { writable } from "svelte/store";
-import { ConnectionQuality, Track, type RemoteParticipant, type RemoteTrackPublication } from "livekit-client";
+import { get, writable } from "svelte/store";
+import {
+    ConnectionQuality,
+    Track,
+    type RemoteParticipant,
+    type RemoteTrack,
+    type RemoteTrackPublication,
+} from "livekit-client";
 import type { SpaceInterface, SpaceUserExtended } from "../Space/SpaceInterface";
 import type { StreamableSubjects } from "../Space/SpacePeerManager/SpacePeerManager";
 import type { LivekitStreamable, Streamable } from "../Space/Streamable";
+import { SCRIPTING_AUDIO_TRACK_NAME } from "./LivekitConstants";
 import { LiveKitParticipant } from "./LivekitParticipant";
 
 type MockRemoteTrackPublication = RemoteTrackPublication & {
@@ -120,6 +127,92 @@ describe("LiveKitParticipant", () => {
         expect(publication.setSubscribed).toHaveBeenCalledTimes(2);
         expect(publication.setSubscribed).toHaveBeenLastCalledWith(false);
     });
+
+    it("should merge microphone and scripting audio publications into the audio stream store", () => {
+        const participant = createParticipant({ publications: [] });
+        const media = participant.getStreamable().media as LivekitStreamable;
+        const microphonePublication = createMicrophonePublication();
+        const scriptingPublication = createScriptingAudioPublication();
+        const microphoneStream = createAudioMediaStream("microphone");
+        const scriptingStream = createAudioMediaStream("scripting");
+
+        participant["handleTrackPublished"](microphonePublication);
+        participant["handleTrackSubscribed"](createRemoteAudioTrack(microphoneStream), microphonePublication);
+        participant["handleTrackPublished"](scriptingPublication);
+        participant["handleTrackSubscribed"](createRemoteAudioTrack(scriptingStream), scriptingPublication);
+
+        const audioStream = get(media.streamStore);
+
+        expect(microphonePublication.setSubscribed).toHaveBeenCalledWith(true);
+        expect(scriptingPublication.setSubscribed).toHaveBeenCalledWith(true);
+        expect(audioStream).not.toBe(microphoneStream);
+        expect(audioStream).not.toBe(scriptingStream);
+        expect(audioStream?.getAudioTracks()).toEqual([
+            microphoneStream.getAudioTracks()[0],
+            scriptingStream.getAudioTracks()[0],
+        ]);
+        expect(get(participant.getStreamable().isMuted)).toBe(false);
+    });
+
+    it("should restart scripting audio without dropping microphone audio", () => {
+        const participant = createParticipant({ publications: [] });
+        const media = participant.getStreamable().media as LivekitStreamable;
+        const microphonePublication = createMicrophonePublication();
+        const firstScriptingPublication = createScriptingAudioPublication();
+        const secondScriptingPublication = createScriptingAudioPublication();
+        const microphoneStream = createAudioMediaStream("microphone");
+        const firstScriptingStream = createAudioMediaStream("scripting-1");
+        const secondScriptingStream = createAudioMediaStream("scripting-2");
+
+        participant["handleTrackPublished"](microphonePublication);
+        participant["handleTrackSubscribed"](createRemoteAudioTrack(microphoneStream), microphonePublication);
+        participant["handleTrackPublished"](firstScriptingPublication);
+        participant["handleTrackSubscribed"](createRemoteAudioTrack(firstScriptingStream), firstScriptingPublication);
+        participant["handleTrackPublished"](secondScriptingPublication);
+        participant["handleTrackSubscribed"](createRemoteAudioTrack(secondScriptingStream), secondScriptingPublication);
+
+        const audioStream = get(media.streamStore);
+
+        expect(firstScriptingPublication.setSubscribed).toHaveBeenLastCalledWith(false);
+        expect(audioStream?.getAudioTracks()).toEqual([
+            microphoneStream.getAudioTracks()[0],
+            secondScriptingStream.getAudioTracks()[0],
+        ]);
+        expect(get(participant.getStreamable().isMuted)).toBe(false);
+    });
+
+    it("should keep microphone audio when scripting audio is unpublished or unsubscribed", () => {
+        const participant = createParticipant({ publications: [] });
+        const media = participant.getStreamable().media as LivekitStreamable;
+        const microphonePublication = createMicrophonePublication();
+        const unpublishedScriptingPublication = createScriptingAudioPublication();
+        const unsubscribedScriptingPublication = createScriptingAudioPublication();
+        const microphoneStream = createAudioMediaStream("microphone");
+        const unpublishedScriptingStream = createAudioMediaStream("scripting-unpublished");
+        const unsubscribedScriptingStream = createAudioMediaStream("scripting-unsubscribed");
+
+        participant["handleTrackPublished"](microphonePublication);
+        participant["handleTrackSubscribed"](createRemoteAudioTrack(microphoneStream), microphonePublication);
+        participant["handleTrackPublished"](unpublishedScriptingPublication);
+        participant["handleTrackSubscribed"](
+            createRemoteAudioTrack(unpublishedScriptingStream),
+            unpublishedScriptingPublication
+        );
+
+        participant["handleTrackUnpublished"](unpublishedScriptingPublication);
+
+        expect(get(media.streamStore)).toBe(microphoneStream);
+        expect(get(participant.getStreamable().isMuted)).toBe(false);
+
+        participant["handleTrackPublished"](unsubscribedScriptingPublication);
+        const unsubscribedTrack = createRemoteAudioTrack(unsubscribedScriptingStream);
+        participant["handleTrackSubscribed"](unsubscribedTrack, unsubscribedScriptingPublication);
+
+        participant["handleTrackUnsubscribed"](unsubscribedTrack, unsubscribedScriptingPublication);
+
+        expect(get(media.streamStore)).toBe(microphoneStream);
+        expect(get(participant.getStreamable().isMuted)).toBe(false);
+    });
 });
 
 function createParticipant({ publications }: { publications: RemoteTrackPublication[] }): LiveKitParticipant {
@@ -164,9 +257,42 @@ function createCameraPublication(): MockRemoteTrackPublication {
     return {
         isLocal: false,
         isMuted: false,
+        kind: Track.Kind.Video,
         source: Track.Source.Camera,
+        trackName: "camera",
         track: undefined,
         setSubscribed: vi.fn(),
         setVideoQuality: vi.fn(),
     } as unknown as MockRemoteTrackPublication;
+}
+
+function createMicrophonePublication(): MockRemoteTrackPublication {
+    return createAudioPublication(Track.Source.Microphone, "microphone");
+}
+
+function createScriptingAudioPublication(): MockRemoteTrackPublication {
+    return createAudioPublication(Track.Source.Microphone, SCRIPTING_AUDIO_TRACK_NAME);
+}
+
+function createAudioPublication(source: Track.Source, trackName: string): MockRemoteTrackPublication {
+    return {
+        isLocal: false,
+        isMuted: false,
+        kind: Track.Kind.Audio,
+        source,
+        trackName,
+        track: undefined,
+        setSubscribed: vi.fn(),
+        setVideoQuality: vi.fn(),
+    } as unknown as MockRemoteTrackPublication;
+}
+
+function createRemoteAudioTrack(mediaStream: MediaStream): RemoteTrack {
+    return {
+        mediaStream,
+    } as unknown as RemoteTrack;
+}
+
+function createAudioMediaStream(id: string): MediaStream {
+    return new MediaStream([{ id, kind: "audio" } as MediaStreamTrack]);
 }

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -25,6 +25,7 @@ import type { LivekitStreamable, Streamable } from "../Space/Streamable";
 // Maximize/minimize can briefly mount 2 video components for the same participant.
 // Delaying the final unsubscribe avoids sending a false->true bounce to LiveKit during that handoff.
 const VIDEO_UNSUBSCRIBE_DELAY_MS = 75;
+const SCRIPTING_AUDIO_TRACK_NAME = "workadventure-scripting-audio";
 
 export class LiveKitParticipant {
     private _isSpeakingStore: Writable<boolean>;
@@ -65,8 +66,11 @@ export class LiveKitParticipant {
 
     private _cameraPublication: RemoteTrackPublication | undefined;
     private _microphonePublication: RemoteTrackPublication | undefined;
+    private _scriptingAudioPublication: RemoteTrackPublication | undefined;
     private _screenSharePublication: RemoteTrackPublication | undefined;
     private _screenShareAudioPublication: RemoteTrackPublication | undefined;
+    private _microphoneStream: MediaStream | undefined;
+    private _scriptingAudioStream: MediaStream | undefined;
 
     private boundHandleTrackPublished: (publication: RemoteTrackPublication) => void;
     private boundHandleTrackSubscribed: (track: RemoteTrack, publication: RemoteTrackPublication) => void;
@@ -230,6 +234,38 @@ export class LiveKitParticipant {
         this._screenSharePublication?.setSubscribed(this._screenShareVideoSubscribed);
     }
 
+    private isScriptingAudioPublication(publication: TrackPublication): boolean {
+        return (
+            publication.source === Track.Source.Microphone &&
+            publication.kind === Track.Kind.Audio &&
+            publication.trackName === SCRIPTING_AUDIO_TRACK_NAME
+        );
+    }
+
+    private refreshLivekitAudioStreamStore() {
+        const audioTracks = [
+            ...(this._microphoneStream?.getAudioTracks() ?? []),
+            ...(this._scriptingAudioStream?.getAudioTracks() ?? []),
+        ];
+
+        if (audioTracks.length === 0) {
+            this._audioStreamStore.set(undefined);
+            return;
+        }
+
+        if (this._microphoneStream && audioTracks.length === this._microphoneStream.getAudioTracks().length) {
+            this._audioStreamStore.set(this._microphoneStream);
+            return;
+        }
+
+        if (this._scriptingAudioStream && audioTracks.length === this._scriptingAudioStream.getAudioTracks().length) {
+            this._audioStreamStore.set(this._scriptingAudioStream);
+            return;
+        }
+
+        this._audioStreamStore.set(new MediaStream(audioTracks));
+    }
+
     private handleTrackPublished(publication: RemoteTrackPublication) {
         if (this.abortSignal.aborted) {
             return;
@@ -277,6 +313,19 @@ export class LiveKitParticipant {
             this._hasScreenShareAudio.set(true);
             this._isScreenShareAudioMuted.set(publication.isMuted);
             this.refreshLivekitScreenShareStreamStore();
+        } else if (this.isScriptingAudioPublication(publication)) {
+            if (this._scriptingAudioPublication && this._scriptingAudioPublication !== publication) {
+                console.warn(
+                    "Scripting audio track received on a publication that is not the one we expected. This should not happen."
+                );
+                Sentry.captureMessage(
+                    "Scripting audio track received on a publication that is not the one we expected. This should not happen."
+                );
+                this._scriptingAudioPublication.setSubscribed(false);
+            }
+            publication.setSubscribed(true);
+            this._scriptingAudioPublication = publication;
+            this._hasAudio.set(true);
         } else if (publication.source === Track.Source.Microphone) {
             if (this._microphonePublication && this._microphonePublication !== publication) {
                 console.warn(
@@ -318,8 +367,12 @@ export class LiveKitParticipant {
             }
         } else if (publication.source === Track.Source.ScreenShareAudio) {
             this._audioScreenShareStreamStore.set(track.mediaStream);
+        } else if (this.isScriptingAudioPublication(publication)) {
+            this._scriptingAudioStream = track.mediaStream;
+            this.refreshLivekitAudioStreamStore();
         } else if (publication.source === Track.Source.Microphone) {
-            this._audioStreamStore.set(track.mediaStream);
+            this._microphoneStream = track.mediaStream;
+            this.refreshLivekitAudioStreamStore();
         }
     }
 
@@ -348,12 +401,20 @@ export class LiveKitParticipant {
             this._hasScreenShareAudio.set(false);
             this._isScreenShareAudioMuted.set(true);
             this.refreshLivekitScreenShareStreamStore();
+        } else if (this.isScriptingAudioPublication(publication)) {
+            publication.setSubscribed(false);
+            if (this._scriptingAudioPublication === publication) {
+                this._scriptingAudioPublication = undefined;
+                this._scriptingAudioStream = undefined;
+                this.refreshLivekitAudioStreamStore();
+            }
         } else if (publication.source === Track.Source.Microphone) {
             publication.setSubscribed(false);
             if (this._microphonePublication === publication) {
                 this._microphonePublication = undefined;
+                this._microphoneStream = undefined;
+                this.refreshLivekitAudioStreamStore();
             }
-            this._audioStreamStore.set(undefined);
             this._isMuted.set(true);
         }
     }
@@ -369,8 +430,16 @@ export class LiveKitParticipant {
             }
         } else if (publication.source === Track.Source.ScreenShareAudio) {
             this._audioScreenShareStreamStore.set(undefined);
+        } else if (this.isScriptingAudioPublication(publication)) {
+            if (this._scriptingAudioPublication === publication) {
+                this._scriptingAudioStream = undefined;
+                this.refreshLivekitAudioStreamStore();
+            }
         } else if (publication.source === Track.Source.Microphone) {
-            this._audioStreamStore.set(undefined);
+            if (this._microphonePublication === publication) {
+                this._microphoneStream = undefined;
+                this.refreshLivekitAudioStreamStore();
+            }
         }
     }
 
@@ -587,6 +656,7 @@ export class LiveKitParticipant {
         this._screenShareVideoSubscribed = false;
         this._cameraPublication?.setSubscribed(false);
         this._microphonePublication?.setSubscribed(false);
+        this._scriptingAudioPublication?.setSubscribed(false);
         this._screenSharePublication?.setSubscribed(false);
         this._screenShareAudioPublication?.setSubscribed(false);
 

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -21,11 +21,11 @@ import { screenShareQualityStore } from "../Stores/ScreenSharingStore";
 import { subscribeToVideoQualityAnalytics } from "../WebRtc/VideoQualityAnalytics";
 import { createLivekitWebRtcStats } from "../WebRtc/WebRtcStatsFactory";
 import type { LivekitStreamable, Streamable } from "../Space/Streamable";
+import { SCRIPTING_AUDIO_TRACK_NAME } from "./LivekitConstants";
 
 // Maximize/minimize can briefly mount 2 video components for the same participant.
 // Delaying the final unsubscribe avoids sending a false->true bounce to LiveKit during that handoff.
 const VIDEO_UNSUBSCRIBE_DELAY_MS = 75;
-const SCRIPTING_AUDIO_TRACK_NAME = "workadventure-scripting-audio";
 
 export class LiveKitParticipant {
     private _isSpeakingStore: Writable<boolean>;

--- a/play/tests/setup/vitest.setup.ts
+++ b/play/tests/setup/vitest.setup.ts
@@ -3,18 +3,27 @@ import type { FrontConfigurationInterface } from "../../src/common/FrontConfigur
 // Vitest setup: provide a minimal MediaStream polyfill for Node test environment
 
 class MediaStreamPolyfill {
-    constructor(_tracks?: unknown[]) {}
+    private tracks: unknown[];
+
+    constructor(tracks: unknown[] = []) {
+        this.tracks = tracks;
+    }
+
     getTracks(): unknown[] {
-        return [];
+        return this.tracks;
     }
     getAudioTracks(): unknown[] {
-        return [];
+        return this.tracks.filter((track) => (track as MediaStreamTrack).kind === "audio");
     }
     getVideoTracks(): unknown[] {
-        return [];
+        return this.tracks.filter((track) => (track as MediaStreamTrack).kind === "video");
     }
-    addTrack(_track: unknown): void {}
-    removeTrack(_track: unknown): void {}
+    addTrack(track: unknown): void {
+        this.tracks.push(track);
+    }
+    removeTrack(track: unknown): void {
+        this.tracks = this.tracks.filter((currentTrack) => currentTrack !== track);
+    }
 }
 
 if (typeof globalThis.MediaStream === "undefined") {

--- a/tests/tests/scripting_spaces.spec.ts
+++ b/tests/tests/scripting_spaces.spec.ts
@@ -306,7 +306,7 @@ test.describe("Scripting space-related functions @nowebkit", () => {
                 }
                 return null;
             }),
-        ).toContain("type mismatch");
+        ).toMatch(/[Ff]ilter type mismatch/);
 
         await bob.close();
         await bob.context().close();


### PR DESCRIPTION
## What changed

- Tag scripting audio publications with a dedicated LiveKit track name while keeping the allowed microphone source.
- Track scripting audio separately from the real microphone publication on remote participants.
- Unpublish the previous scripting audio track before publishing a replacement, so restarting a scripting stream does not leave stale LiveKit publications behind.
- Make the scripting spaces filter mismatch assertion tolerate the local and backend-wrapped error messages.

## Why

The scripting audio stream test was failing after a LiveKit transition/restart because scripted audio was handled like a normal microphone publication. That let a restarted scripted stream collide with the participant microphone bookkeeping and could drop the audio stream that listeners consume.

## Validation

- `npx eslint src/front/Livekit/LiveKitRoom.ts src/front/Livekit/LivekitParticipant.ts` from `play/`
- `npx eslint tests/scripting_spaces.spec.ts` from `tests/`
- `npm run test-headed-chrome -- tests/scripting_audio_stream.spec.ts`
- `npm run test-headed-chrome -- tests/scripting_spaces.spec.ts -g "cannot join a space with a different filter in 2 browsers"`