### PR TITLE
fix: show local camera preview on mobile

### DIFF
--- a/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
+++ b/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
@@ -34,8 +34,7 @@
 -->
 <script lang="ts">
     import { onDestroy, onMount, setContext } from "svelte";
-    import type { Writable } from "svelte/store";
-    import { myCameraPeerStore, type MyLocalStreamable } from "../../Stores/StreamableCollectionStore";
+    import { myCameraPeerStore } from "../../Stores/StreamableCollectionStore";
     import type { VideoBox as VideoBoxModel } from "../../Space/VideoBox";
     import VideoBox from "../Video/VideoBox.svelte";
     import MediaBox from "../Video/MediaBox.svelte";
@@ -93,24 +92,16 @@
 
     const gameScene = gameManager.getCurrentGameScene();
 
-    $: myCameraStreamable = $myCameraPeerStore.streamable as Writable<MyLocalStreamable | undefined>;
-
     function excludeLocalCamera(videoBoxes: VideoBoxModel[]): VideoBoxModel[] {
         return videoBoxes.filter((box) => box.uniqueId !== LOCAL_CAMERA_VIDEO_BOX_UNIQUE_ID);
     }
 
     $: isPictureInPictureGridMode = $activePictureInPictureStore && oneLineMode === "vertical";
-    /** Plus de 8 participants en grille PiP : la cam locale sort de la grille (vignette fixe). */
     $: pipDockLocalCamera =
         isPictureInPictureGridMode &&
         $oneLineStreamableCollectionStore.length > PIP_GRID_MAX_VIDEOS &&
         $oneLineStreamableCollectionStore.some((box) => box.uniqueId === LOCAL_CAMERA_VIDEO_BOX_UNIQUE_ID);
     $: pipRemoteParticipantCount = excludeLocalCamera($oneLineStreamableCollectionStore).length;
-
-    $: {
-        const inPipWithHighlight = $activePictureInPictureStore && $highlightedEmbedScreen != undefined;
-        $myCameraStreamable?.setDisplayInPictureInPictureMode(inPipWithHighlight && !pipDockLocalCamera);
-    }
 
     // Single IntersectionObserver shared across all VideoBox components
     let intersectionObserver: IntersectionObserver | undefined;
@@ -526,7 +517,11 @@
                     {videoWidth}
                     {videoHeight}
                     intersectionObserver={isPictureInPictureGridMode ? undefined : intersectionObserver}
-                    forceDisplay={isPictureInPictureGridMode}
+                    forceDisplay={isPictureInPictureGridMode ||
+                        (videoBox.uniqueId === LOCAL_CAMERA_VIDEO_BOX_UNIQUE_ID &&
+                            isOnOneLine &&
+                            oneLineMode === "vertical" &&
+                            !pipDockLocalCamera)}
                     fitContainer={isPictureInPictureGridMode}
                 />
             </div>

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -27,6 +27,7 @@ import { inExternalServiceStore, myCameraStore, myMicrophoneStore, proximityMeet
 import { userMovingStore } from "./GameStore";
 import { hideHelpCameraSettings } from "./HelpSettingsStore";
 import { isLiveStreamingStore } from "./IsStreamingStore";
+import { currentPlayerGroupIdStore } from "./CurrentPlayerGroupStore";
 
 import { backgroundConfigStore, backgroundProcessingEnabledStore } from "./BackgroundTransformStore";
 
@@ -220,6 +221,17 @@ export const mouseIsHoveringCameraButton = writable(false);
 export const cameraNoEnergySavingStore = writable<boolean>(false);
 
 export const streamingMegaphoneStore = writable<boolean>(false);
+export const inJitsiStore = writable(false);
+export const inBbbStore = writable(false);
+export const isSpeakerStore = writable(false);
+export const inLivekitStore = writable(false);
+export const isListenerStore = writable(false);
+export const listenerWaitingMediaStore = writable<string | undefined>(undefined);
+/**
+ * When true, the listener has consented to share their camera with the speaker (seeAttendees feature).
+ * This store is set to true when the listener accepts the camera sharing popup.
+ */
+export const listenerSharingCameraStore = writable(false);
 
 export const requestedCameraDeviceIdStore: Writable<string | undefined> = writable(
     localUserStore.getPreferredVideoInputDevice() ? localUserStore.getPreferredVideoInputDevice() : undefined
@@ -304,6 +316,8 @@ export const cameraEnergySavingStore = derived(
         cameraNoEnergySavingStore,
         devicesNotLoaded,
         isLiveStreamingStore,
+        currentPlayerGroupIdStore,
+        inLivekitStore,
         displayedMegaphoneScreenStore,
     ],
     ([
@@ -314,6 +328,8 @@ export const cameraEnergySavingStore = derived(
         $cameraNoEnergySavingStore,
         $devicesNotLoaded,
         $isLiveStreamingStore,
+        $currentPlayerGroupIdStore,
+        $inLivekitStore,
         $displayedMegaphoneScreenStore,
     ]) => {
         return (
@@ -324,22 +340,12 @@ export const cameraEnergySavingStore = derived(
             !$cameraNoEnergySavingStore &&
             !$devicesNotLoaded &&
             !$isLiveStreamingStore &&
+            $currentPlayerGroupIdStore === undefined &&
+            !$inLivekitStore &&
             !$displayedMegaphoneScreenStore
         );
     }
 );
-
-export const inJitsiStore = writable(false);
-export const inBbbStore = writable(false);
-export const isSpeakerStore = writable(false);
-export const inLivekitStore = writable(false);
-export const isListenerStore = writable(false);
-export const listenerWaitingMediaStore = writable<string | undefined>(undefined);
-/**
- * When true, the listener has consented to share their camera with the speaker (seeAttendees feature).
- * This store is set to true when the listener accepts the camera sharing popup.
- */
-export const listenerSharingCameraStore = writable(false);
 
 export const requestedStatusStore: Writable<RequestedStatus | null> = writable(localUserStore.getRequestedStatus());
 

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -16,6 +16,7 @@ import { myCameraStore } from "./MyMediaStore";
 import {
     availabilityStatusStore,
     cameraEnergySavingStore,
+    inLivekitStore,
     isListenerStore,
     listenerSharingCameraStore,
     localStreamStore,
@@ -32,14 +33,7 @@ import { muteMediaStreamStore } from "./MuteMediaStreamStore";
 import { isLiveStreamingStore } from "./IsStreamingStore";
 import { createDelayedUnsubscribeStore } from "./Utils/createDelayedUnsubscribeStore";
 import { cameraPermissionStateStore } from "./MediaStatusStore";
-
-// MyLocalStreamable is a streamable that is the local camera streamable
-// It is used to display the local camera stream in the picture in picture mode when the user have an highlighted embed screen
-export interface MyLocalStreamable extends Streamable {
-    // No readonly because it is used to update the displayInPictureInPictureMode of the local camera streamable
-    displayInPictureInPictureMode: boolean;
-    setDisplayInPictureInPictureMode: (displayInPictureInPictureMode: boolean) => void;
-}
+import { currentPlayerGroupIdStore } from "./CurrentPlayerGroupStore";
 
 export const LISTENER_BOX_UNIQUE_ID = "listener-box";
 export const LISTENER_BOX_PRIORITY = -4;
@@ -58,7 +52,7 @@ const localstreamStoreValue = derived(localStreamStore, (myLocalStream) => {
 const mutedLocalStream = muteMediaStreamStore(localstreamStoreValue);
 
 export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL], set) => {
-    const streamable: MyLocalStreamable = {
+    const streamable: Streamable = {
         uniqueId: "-1",
         media: {
             type: "webrtc" as const,
@@ -94,9 +88,6 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL], set) 
         canCloseStreamable: () => false,
         volume: writable(1),
         videoType: "video",
-        setDisplayInPictureInPictureMode: (displayInPictureInPictureMode: boolean) => {
-            streamable.displayInPictureInPictureMode = displayInPictureInPictureMode;
-        },
         webrtcStats: undefined,
     };
     const videoBox = VideoBox.fromLocalStreamable(streamable, -2);
@@ -152,6 +143,8 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
             requestedCameraState,
             windowSize,
             isLiveStreamingStore,
+            currentPlayerGroupIdStore,
+            inLivekitStore,
             isListenerStore,
             listenerSharingCameraStore,
             availabilityStatusStore,
@@ -169,6 +162,8 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
                 $requestedCameraState,
                 $windowSize,
                 $isLiveStreamingStore,
+                $currentPlayerGroupIdStore,
+                $inLivekitStore,
                 $isListenerStore,
                 $listenerSharingCameraStore,
                 $availabilityStatusStore,
@@ -194,12 +189,22 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
 
             if ($myCameraStore && !$cameraEnergySavingStore && !$silentStore) {
                 let shouldAddMyCamera = true;
+                const isInActiveConversation =
+                    $currentPlayerGroupIdStore !== undefined ||
+                    $inLivekitStore ||
+                    $isLiveStreamingStore ||
+                    $videoStreamElementsStore.length > 0 ||
+                    $screenShareStreamElementsStore.length > 0 ||
+                    $scriptingVideoStore.size > 0;
+
                 if (isUnavailableStatus) {
                     shouldAddMyCamera = false;
                 }
-                // Are we the only one to display video AND are we not publishing a video stream? If so, let's hide the video.
-                // Are we the only one to display video AND we are on a small screen? If so, let's hide the video (because the webcam takes space and makes iPhones laggy when it starts)
-                if (!$isLiveStreamingStore && (!$requestedCameraState || $windowSize.width < 768)) {
+                if (!$requestedCameraState) {
+                    shouldAddMyCamera = false;
+                }
+                // On small screens, keep the local camera only while the user is actually in a conversation.
+                if ($windowSize.width < 768 && !isInActiveConversation) {
                     shouldAddMyCamera = false;
                 }
                 // Listeners can only show their camera if they have consented to share it (seeAttendees feature)

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -32,7 +32,6 @@ import { windowSize } from "./CoWebsiteStore";
 import { muteMediaStreamStore } from "./MuteMediaStreamStore";
 import { isLiveStreamingStore } from "./IsStreamingStore";
 import { createDelayedUnsubscribeStore } from "./Utils/createDelayedUnsubscribeStore";
-import { cameraPermissionStateStore } from "./MediaStatusStore";
 import { currentPlayerGroupIdStore } from "./CurrentPlayerGroupStore";
 
 export const LISTENER_BOX_UNIQUE_ID = "listener-box";
@@ -63,15 +62,13 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL], set) 
             },
         },
         volumeStore: localVolumeStore,
-        hasVideo: derived(
-            [mediaStreamConstraintsStore, cameraPermissionStateStore],
-            ([mediaStreamConstraintsStore, cameraPermissionStateStore]) => {
-                return (
-                    mediaStreamConstraintsStore.video !== false &&
-                    (cameraPermissionStateStore === "granted" || cameraPermissionStateStore === null)
-                );
-            }
-        ),
+        hasVideo: derived([mediaStreamConstraintsStore, mutedLocalStream], ([mediaStreamConstraintsStore, stream]) => {
+            return (
+                mediaStreamConstraintsStore.video !== false &&
+                stream !== undefined &&
+                stream.getVideoTracks().length > 0
+            );
+        }),
         // hasAudio = true because the webcam has a microphone attached and could potentially play sound
         hasAudio: writable(true),
         isMuted: derived(requestedMicrophoneState, (micState) => !micState),
@@ -126,6 +123,51 @@ const listenerBoxStreamable: Streamable = {
 
 const listenerBoxVideoBox: VideoBox = VideoBox.fromLocalStreamable(listenerBoxStreamable, LISTENER_BOX_PRIORITY);
 
+// Store to track if we are in a conversation with someone else
+export const isInRemoteConversation = derived(
+    [videoStreamElementsStore, screenShareStreamElementsStore, scriptingVideoStore, silentStore, isLiveStreamingStore],
+    ([
+        $videoStreamElementsStore,
+        $screenShareStreamElementsStore,
+        $scriptingVideoStore,
+        $silentStore,
+        $isLiveStreamingStore,
+    ]) => {
+        // If we are live streaming, we are in a conversation
+        if ($isLiveStreamingStore) {
+            return true;
+        }
+
+        // If we are silent, we are not in a conversation
+        if ($silentStore) {
+            return false;
+        }
+
+        // Check if we have any peers
+        if ($videoStreamElementsStore.length > 0) {
+            return true;
+        }
+
+        // Check if we have any screen sharing streams
+        if ($screenShareStreamElementsStore.length > 0) {
+            return true;
+        }
+
+        // Check if we have any scripting videos
+        if ($scriptingVideoStore.size > 0) {
+            return true;
+        }
+
+        return false;
+    }
+);
+
+const isInActiveConversationStore = derived(
+    [isInRemoteConversation, currentPlayerGroupIdStore, inLivekitStore],
+    ([$isInRemoteConversation, $currentPlayerGroupIdStore, $inLivekitStore]) =>
+        $isInRemoteConversation || $currentPlayerGroupIdStore !== undefined || $inLivekitStore
+);
+
 /**
  * A store that contains everything that can produce a stream (so the peers + the local screen sharing stream)
  */
@@ -142,9 +184,7 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
             silentStore,
             requestedCameraState,
             windowSize,
-            isLiveStreamingStore,
-            currentPlayerGroupIdStore,
-            inLivekitStore,
+            isInActiveConversationStore,
             isListenerStore,
             listenerSharingCameraStore,
             availabilityStatusStore,
@@ -161,9 +201,7 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
                 $silentStore,
                 $requestedCameraState,
                 $windowSize,
-                $isLiveStreamingStore,
-                $currentPlayerGroupIdStore,
-                $inLivekitStore,
+                $isInActiveConversationStore,
                 $isListenerStore,
                 $listenerSharingCameraStore,
                 $availabilityStatusStore,
@@ -189,13 +227,6 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
 
             if ($myCameraStore && !$cameraEnergySavingStore && !$silentStore) {
                 let shouldAddMyCamera = true;
-                const isInActiveConversation =
-                    $currentPlayerGroupIdStore !== undefined ||
-                    $inLivekitStore ||
-                    $isLiveStreamingStore ||
-                    $videoStreamElementsStore.length > 0 ||
-                    $screenShareStreamElementsStore.length > 0 ||
-                    $scriptingVideoStore.size > 0;
 
                 if (isUnavailableStatus) {
                     shouldAddMyCamera = false;
@@ -204,7 +235,7 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
                     shouldAddMyCamera = false;
                 }
                 // On small screens, keep the local camera only while the user is actually in a conversation.
-                if ($windowSize.width < 768 && !isInActiveConversation) {
+                if ($windowSize.width < 768 && !$isInActiveConversationStore) {
                     shouldAddMyCamera = false;
                 }
                 // Listeners can only show their camera if they have consented to share it (seeAttendees feature)
@@ -242,45 +273,6 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
 }
 
 export const streamableCollectionStore = createStreamableCollectionStore();
-
-// Store to track if we are in a conversation with someone else
-export const isInRemoteConversation = derived(
-    [videoStreamElementsStore, screenShareStreamElementsStore, scriptingVideoStore, silentStore, isLiveStreamingStore],
-    ([
-        $screenSharingStreamStore,
-        $videoStreamElementsStore,
-        $scriptingVideoStore,
-        $silentStore,
-        $isLiveStreamingStore,
-    ]) => {
-        // If we are live streaming, we are in a conversation
-        if ($isLiveStreamingStore) {
-            return true;
-        }
-
-        // If we are silent, we are not in a conversation
-        if ($silentStore) {
-            return false;
-        }
-
-        // Check if we have any peers
-        if ($videoStreamElementsStore.length > 0) {
-            return true;
-        }
-
-        // Check if we have any screen sharing streams
-        if ($screenSharingStreamStore.length > 0) {
-            return true;
-        }
-
-        // Check if we have any scripting videos
-        if ($scriptingVideoStore.size > 0) {
-            return true;
-        }
-
-        return false;
-    }
-);
 
 // No need to unsubscribe, the store is global
 // eslint-disable-next-line svelte/no-ignored-unsubscribe


### PR DESCRIPTION
## Summary

Fixes the missing local camera preview on iPhone/mobile when joining a meeting or proximity bubble.

## What changed

- Keep the local camera available in meetings on mobile instead of filtering it out because of the small screen width.
- Prevent camera energy saving from disabling the camera while the user is in an active meeting/bubble.
- Force the local camera tile to render in the vertical mobile camera layout.
- Update local camera `hasVideo` detection to use the actual local video stream instead of the browser permission state.

## Why `hasVideo` changed

The local camera was published correctly to other participants, but the local preview could still appear as disabled.

The issue was that `hasVideo` depended on `cameraPermissionStateStore`. On iPhone/Safari, the Permissions API can stay in `prompt` even after `getUserMedia` successfully returns a video track. In that case, WorkAdventure was receiving and publishing the local camera stream, but the UI still considered the local camera disabled and did not mount the local `<video>` preview.

`hasVideo` now checks the real local stream (`mutedLocalStream`) and confirms that a video track exists. This matches the actual media state and avoids relying on inconsistent browser permission reporting.