### PR TITLE
fix: Improve mobile action bar and explorer menu layout

### DIFF
--- a/play/src/front/Components/ActionBar/ActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ActionBar.svelte
@@ -80,7 +80,9 @@
 
                         {#if smallArrowVisible}
                             <div
-                                class="absolute h-3 mobile:h-6 w-7 rounded-b mobile:rounded-t bg-contrast/80 backdrop-blur start-[2.86rem] m-auto p-1 z-10 transition-all -bottom-3 hidden opacity-0 sm:block mobile:-top-12 mobile:block mobile:opacity-100
+                                class="absolute h-3 mobile:h-6 w-7 rounded-b mobile:rounded-t bg-contrast/80 backdrop-blur start-[2.86rem] m-auto p-1 z-10 transition-all -bottom-3 hidden opacity-0 sm:block mobile:-top-12 mobile:block {$inExternalServiceStore
+                                    ? ''
+                                    : 'mobile:opacity-100'}
                                 {$mediaSettingsOpenStore ? 'opacity-100' : 'group-hover/hardware:opacity-100'}"
                             >
                                 <!-- svelte-ignore a11y-click-events-have-key-events -->

--- a/play/src/front/Components/ActionsMenu/ExplorerMenu.svelte
+++ b/play/src/front/Components/ActionsMenu/ExplorerMenu.svelte
@@ -111,7 +111,7 @@
 <svelte:window on:blur={stopZoom} />
 
 <div
-    class="fixed bottom-2 bg-contrast/80 rounded pointer-events-auto p-1 backdrop-blur hover:bg-contrast/100"
+    class="fixed bottom-2 mobile:bottom-24 bg-contrast/80 rounded pointer-events-auto p-1 backdrop-blur hover:bg-contrast/100"
     style:right={`calc(${mapEditorRightOffset}px + 0.5rem)`}
     data-testid="actions-explorer"
 >


### PR DESCRIPTION
## Problem

Two mobile UI elements could overlap or appear when they should not:

- The small media settings arrow in the action bar stayed visible in external service mode on mobile.
- The Explorer menu stayed too close to the bottom of the screen on mobile, where it could be covered by the bottom action bar.

## Solution

Adjust the mobile action bar UI so controls stay accessible and do not display extra affordances in external service mode.

## Changes

- Hide the action bar small arrow on mobile when the user is in external service mode.
- Move the Explorer menu higher on mobile so it stays usable above the bottom action bar.
.