### PR TITLE
Fix area access collision warning

### DIFF
--- a/play/src/front/Phaser/Entity/Area.ts
+++ b/play/src/front/Phaser/Entity/Area.ts
@@ -96,8 +96,12 @@ export class Area extends Phaser.GameObjects.Rectangle {
             this.areaCollider = this.scene.physics.add.collider(this.scene.CurrentPlayer, this, () =>
                 this.onCollideAction()
             );
-            // If the user is already colliding with the area when the collider is applied, we need to mark it so we don't trigger the collide action until they leave and re-enter the area.
-            if (!this.userHasCollideWithArea && this.scene.physics.overlap(this.scene.CurrentPlayer, this)) {
+            // If the user is already inside the area when the collider is applied, we need to mark it so we don't
+            // trigger the collide action until they leave and re-enter the area.
+            const isCurrentPlayerAlreadyInArea =
+                this.areasManager?.isCurrentPlayerInArea(this.areaData.id) ??
+                this.scene.physics.overlap(this.scene.CurrentPlayer, this);
+            if (!this.userHasCollideWithArea && isCurrentPlayerAlreadyInArea) {
                 this.userHasCollideWithArea = true;
             }
         }


### PR DESCRIPTION
## What changed

- Use the area manager's coordinate-based `isCurrentPlayerInArea` check before marking a blocked area as already collided when its Phaser collider is installed.
- Keep the raw physics overlap fallback for cases where an area manager is not available.

## Why

The flaky `map_editor_area_rights.spec.ts` failure was missing `Sorry, you don't have access to this area`. A restricted area is created near the spawn point, and the existing physics overlap check could mark the player as already colliding at the area boundary before the player actually tried to enter. That suppresses the first blocked-entry warning.

## Validation

- `npm run typecheck --workspace=workadventure-play`
- `npx eslint src/front/Phaser/Entity/Area.ts` from `play/`
- Tried the targeted Firefox E2E test, but the local run failed earlier while creating `User1` at the microphone-button state check, before reaching the area access assertion.