### PR TITLE
fix(play): keep local woka visible in meetings

### DIFF
--- a/play/src/front/Stores/StreamableCollectionRules.test.ts
+++ b/play/src/front/Stores/StreamableCollectionRules.test.ts
@@ -1,0 +1,55 @@
+import { AvailabilityStatus } from "@workadventure/messages";
+import { describe, expect, it } from "vitest";
+import { LOCAL_CAMERA_SMALL_SCREEN_WIDTH, shouldDisplayLocalCameraPeer } from "./StreamableCollectionRules";
+
+const defaultOptions = {
+    hasCameraDevice: true,
+    isCameraEnergySaving: false,
+    isSilent: false,
+    requestedCameraState: true,
+    windowWidth: 1024,
+    isMobile: false,
+    isInActiveConversation: false,
+    isListener: false,
+    listenerSharingCamera: false,
+    availabilityStatus: AvailabilityStatus.ONLINE,
+};
+
+describe("shouldDisplayLocalCameraPeer", () => {
+    it("hides the local camera on mobile while outside a conversation", () => {
+        expect(
+            shouldDisplayLocalCameraPeer({
+                ...defaultOptions,
+                isMobile: true,
+            })
+        ).toBe(false);
+    });
+
+    it("hides the local camera below the small screen width while outside a conversation", () => {
+        expect(
+            shouldDisplayLocalCameraPeer({
+                ...defaultOptions,
+                windowWidth: LOCAL_CAMERA_SMALL_SCREEN_WIDTH - 1,
+            })
+        ).toBe(false);
+    });
+
+    it("keeps the local camera peer in a conversation when the camera is disabled", () => {
+        expect(
+            shouldDisplayLocalCameraPeer({
+                ...defaultOptions,
+                requestedCameraState: false,
+                isInActiveConversation: true,
+            })
+        ).toBe(true);
+    });
+
+    it("hides the local camera peer outside a conversation when the camera is disabled", () => {
+        expect(
+            shouldDisplayLocalCameraPeer({
+                ...defaultOptions,
+                requestedCameraState: false,
+            })
+        ).toBe(false);
+    });
+});

--- a/play/src/front/Stores/StreamableCollectionRules.ts
+++ b/play/src/front/Stores/StreamableCollectionRules.ts
@@ -1,0 +1,58 @@
+import { AvailabilityStatus } from "@workadventure/messages";
+
+export const LOCAL_CAMERA_SMALL_SCREEN_WIDTH = 700;
+
+export type LocalCameraPeerDisplayOptions = {
+    hasCameraDevice: boolean;
+    isCameraEnergySaving: boolean;
+    isSilent: boolean;
+    requestedCameraState: boolean;
+    windowWidth: number;
+    isMobile: boolean;
+    isInActiveConversation: boolean;
+    isListener: boolean;
+    listenerSharingCamera: boolean;
+    availabilityStatus: AvailabilityStatus;
+};
+
+export function shouldDisplayLocalCameraPeer({
+    hasCameraDevice,
+    isCameraEnergySaving,
+    isSilent,
+    requestedCameraState,
+    windowWidth,
+    isMobile,
+    isInActiveConversation,
+    isListener,
+    listenerSharingCamera,
+    availabilityStatus,
+}: LocalCameraPeerDisplayOptions): boolean {
+    if (!hasCameraDevice || isCameraEnergySaving || isSilent) {
+        return false;
+    }
+
+    const isUnavailableStatus =
+        availabilityStatus === AvailabilityStatus.DENY_PROXIMITY_MEETING ||
+        availabilityStatus === AvailabilityStatus.SILENT ||
+        availabilityStatus === AvailabilityStatus.DO_NOT_DISTURB ||
+        availabilityStatus === AvailabilityStatus.BACK_IN_A_MOMENT ||
+        availabilityStatus === AvailabilityStatus.BUSY;
+
+    if (isUnavailableStatus) {
+        return false;
+    }
+
+    if (isListener && !listenerSharingCamera) {
+        return false;
+    }
+
+    if ((isMobile || windowWidth < LOCAL_CAMERA_SMALL_SCREEN_WIDTH) && !isInActiveConversation) {
+        return false;
+    }
+
+    if (!requestedCameraState && !isInActiveConversation) {
+        return false;
+    }
+
+    return true;
+}

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -1,4 +1,3 @@
-import { AvailabilityStatus } from "@workadventure/messages";
 import type { Readable } from "svelte/store";
 import { derived, get, writable } from "svelte/store";
 import ListenerBox from "../Components/Video/ListenerBox.svelte";
@@ -6,6 +5,7 @@ import { LayoutMode } from "../WebRtc/LayoutManager";
 import LL from "../../i18n/i18n-svelte";
 import { VideoBox } from "../Space/VideoBox";
 import type { Streamable } from "../Space/Streamable";
+import { touchScreenManager } from "../Touch/TouchScreenManager";
 import { screenSharingLocalVideoBox } from "./ScreenSharingStore";
 
 import { highlightedEmbedScreen } from "./HighlightedEmbedScreenStore";
@@ -33,6 +33,7 @@ import { muteMediaStreamStore } from "./MuteMediaStreamStore";
 import { isLiveStreamingStore } from "./IsStreamingStore";
 import { createDelayedUnsubscribeStore } from "./Utils/createDelayedUnsubscribeStore";
 import { currentPlayerGroupIdStore } from "./CurrentPlayerGroupStore";
+import { shouldDisplayLocalCameraPeer } from "./StreamableCollectionRules";
 
 export const LISTENER_BOX_UNIQUE_ID = "listener-box";
 export const LISTENER_BOX_PRIORITY = -4;
@@ -218,34 +219,21 @@ function createStreamableCollectionStore(): Readable<Map<string, VideoBox>> {
                 }
             };
 
-            const isUnavailableStatus =
-                $availabilityStatusStore === AvailabilityStatus.DENY_PROXIMITY_MEETING ||
-                $availabilityStatusStore === AvailabilityStatus.SILENT ||
-                $availabilityStatusStore === AvailabilityStatus.DO_NOT_DISTURB ||
-                $availabilityStatusStore === AvailabilityStatus.BACK_IN_A_MOMENT ||
-                $availabilityStatusStore === AvailabilityStatus.BUSY;
-
-            if ($myCameraStore && !$cameraEnergySavingStore && !$silentStore) {
-                let shouldAddMyCamera = true;
-
-                if (isUnavailableStatus) {
-                    shouldAddMyCamera = false;
-                }
-                if (!$requestedCameraState) {
-                    shouldAddMyCamera = false;
-                }
-                // On small screens, keep the local camera only while the user is actually in a conversation.
-                if ($windowSize.width < 768 && !$isInActiveConversationStore) {
-                    shouldAddMyCamera = false;
-                }
-                // Listeners can only show their camera if they have consented to share it (seeAttendees feature)
-                if ($isListenerStore && !$listenerSharingCameraStore) {
-                    shouldAddMyCamera = false;
-                }
-
-                if (shouldAddMyCamera) {
-                    addPeer($myCameraPeerStore);
-                }
+            if (
+                shouldDisplayLocalCameraPeer({
+                    hasCameraDevice: $myCameraStore,
+                    isCameraEnergySaving: $cameraEnergySavingStore,
+                    isSilent: $silentStore,
+                    requestedCameraState: $requestedCameraState,
+                    windowWidth: $windowSize.width,
+                    isMobile: touchScreenManager.primaryTouchDevice,
+                    isInActiveConversation: $isInActiveConversationStore,
+                    isListener: $isListenerStore,
+                    listenerSharingCamera: $listenerSharingCameraStore,
+                    availabilityStatus: $availabilityStatusStore,
+                })
+            ) {
+                addPeer($myCameraPeerStore);
             }
 
             $screenShareStreamElementsStore.forEach(addPeer);


### PR DESCRIPTION
## What changed

- Extracted the local camera peer visibility decision into a tested rule.
- Kept the local camera peer visible while the user is in an active conversation, even when their camera is disabled, so the local woka placeholder remains visible.
- Kept the local preview hidden on mobile or screens below 700px when the user is outside an active conversation.

## Root cause

The previous condition hid the local camera peer whenever `requestedCameraState` was false. That removed the whole local tile in desktop meetings, so the camera-off woka placeholder could not render.
