### PR TITLE
fix(play): restore local camera breakpoint

### DIFF
--- a/play/src/front/Stores/StreamableCollectionRules.ts
+++ b/play/src/front/Stores/StreamableCollectionRules.ts
@@ -1,6 +1,6 @@
 import { AvailabilityStatus } from "@workadventure/messages";
 
-export const LOCAL_CAMERA_SMALL_SCREEN_WIDTH = 700;
+export const LOCAL_CAMERA_SMALL_SCREEN_WIDTH = 768;
 
 export type LocalCameraPeerDisplayOptions = {
     hasCameraDevice: boolean;


### PR DESCRIPTION
## What changed

- Restores the local camera small-screen breakpoint from `700px` to the previous `768px` value.

## Why

The merged local woka visibility fix introduced `700px`, but the previous behavior used `768px`. This PR keeps the new visibility rule while preserving the original breakpoint width.

## Validation

- `npm run test -- StreamableCollectionRules.test.ts --run`
- precommit hook: `eslint --fix`, `prettier --write`, `npm run i18n:check`, env docs generation