### PR TITLE
Prevent selecting video boxes

### DIFF
--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -220,7 +220,7 @@
 </script>
 
 <div
-    class="group/screenshare relative flex justify-center mx-auto h-full w-full @container/videomediabox screen-blocker z-20"
+    class="group/screenshare relative flex justify-center mx-auto h-full w-full @container/videomediabox screen-blocker z-20 select-none"
 >
     <div
         class={"w-full transition-all bg-center bg-no-repeat " +

--- a/play/src/front/Components/Video/WebRtcStatsBox.svelte
+++ b/play/src/front/Components/Video/WebRtcStatsBox.svelte
@@ -14,7 +14,7 @@
 
 {#if webRtcStats}
     <div
-        class={`absolute bottom-0 right-0 p-2 text-[0.6rem] @[20rem]/videomediabox:text-[0.75rem] rounded-br-md rounded-tl-md ${statsColorClass}`}
+        class={`absolute bottom-0 right-0 p-2 text-[0.6rem] @[20rem]/videomediabox:text-[0.75rem] rounded-br-md rounded-tl-md select-text ${statsColorClass}`}
     >
         <table class="m-0 p-0 border-hidden">
             <tr>


### PR DESCRIPTION
Disables the ability to select a video with a mouse (by dragging text from the stats box for instance)

Fixes:
<img width="1918" height="1078" alt="2026-05-15_Blue screen" src="https://github.com/user-attachments/assets/9c980a5e-8277-4710-9658-4cccec9dc328" />
