### PR TITLE
Fixing error messages sent on Websocket

### DIFF
--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -1082,9 +1082,6 @@ message RefreshRoomMessage{
 message DeleteMapMessage{
 }
 
-message WorldFullMessage{
-}
-
 message TokenExpiredMessage{
 }
 
@@ -1345,7 +1342,6 @@ message ServerToClientMessage {
     BanUserMessage banUserMessage = 13;
     //AdminRoomMessage adminRoomMessage = 14;
     WorldFullWarningMessage worldFullWarningMessage = 15;
-    WorldFullMessage worldFullMessage = 16;
     RefreshRoomMessage refreshRoomMessage = 17;
     WorldConnectionMessage worldConnectionMessage = 18;
     //EmoteEventMessage emoteEventMessage = 19;

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -75,6 +75,7 @@ import type { LazyPictureStore, PictureStore } from "../../../Stores/PictureStor
 import { chatNotificationStore } from "../../../Stores/ProximityNotificationStore";
 import { chatVisibilityStore } from "../../../Stores/ChatStore";
 import type { UserProviderMerger } from "../../UserProviderMerger/UserProviderMerger";
+import { waitForGameSceneStore } from "../../../Stores/GameSceneStore";
 import { MatrixChatMessage } from "./MatrixChatMessage";
 import { MatrixChatLightPoll } from "./MatrixChatLightPoll";
 import { MatrixChatPoll } from "./MatrixChatPoll";
@@ -436,14 +437,16 @@ export class MatrixChatRoom
         this.startHandlingChatRoomShellEvents();
         this.refreshJoinedMemberCount();
 
-        this.userProviderMergerPromise = gameManager
-            .getCurrentGameScene()
-            .userProviderMerger.then((merger) => {
-                this.userProviderMergerStore.set(merger);
-                get(this.members).forEach((m) => m.setUserProviderMergerContext(merger));
-                return merger;
+        this.userProviderMergerPromise = waitForGameSceneStore()
+            .then((gameScene) => {
+                return gameScene.userProviderMerger.then((merger) => {
+                    this.userProviderMergerStore.set(merger);
+                    get(this.members).forEach((m) => m.setUserProviderMergerContext(merger));
+                    return merger;
+                });
             })
-            .catch(() => {
+            .catch((e) => {
+                console.error(e);
                 /* chat list can work without merger */
                 return undefined;
             });

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -67,7 +67,7 @@ import type {
 import { ChatPermissionLevel } from "../ChatConnection";
 import { isAChatRoomIsVisible, navChat, selectedChatMessageToReply, botsChatIds } from "../../Stores/ChatStore";
 import { selectedRoomStore } from "../../Stores/SelectRoomStore";
-import { gameManager } from "../../../Phaser/Game/GameManager";
+import { gameManager, GameSceneNotFoundError } from "../../../Phaser/Game/GameManager";
 import { localUserStore } from "../../../Connection/LocalUserStore";
 import { MessageNotification } from "../../../Notification/MessageNotification";
 import { notificationManager } from "../../../Notification/NotificationManager";
@@ -190,7 +190,15 @@ export class MatrixChatRoom
             const isRoomIsDisplayed = get(selectedRoomStore)?.id === this.id && get(chatVisibilityStore);
             const isNotificationIsMuted = get(this.areNotificationsMuted);
             if (canPlaySound && !isRoomIsDisplayed && !isNotificationIsMuted) {
-                gameManager.getCurrentGameScene().playSound("new-message");
+                try {
+                    gameManager.getCurrentGameScene().playSound("new-message");
+                } catch (e) {
+                    // If the game scene is not found, it means the message is received before the room is loaded.
+                    // It's ok to skip playing notifications in this case.
+                    if (!(e instanceof GameSceneNotFoundError)) {
+                        throw e;
+                    }
+                }
             }
 
             if (isNotificationIsMuted || isRoomIsDisplayed) {

--- a/play/src/front/Connection/RoomConnection.ts
+++ b/play/src/front/Connection/RoomConnection.ts
@@ -592,11 +592,6 @@ export class RoomConnection implements RoomConnection {
 
                     break;
                 }
-                case "worldFullMessage": {
-                    this._worldFullMessageStream.next(null);
-                    this.closeConnection();
-                    break;
-                }
                 case "invalidCharacterTextureMessage": {
                     console.warn(
                         "One of your Woka textures is invalid for this world, you will be redirect to the Woka selection screen"

--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -11,7 +11,6 @@ import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import type { FetchMemberDataByUuidResponse } from "../services/AdminApi";
 import type { AdminSocketTokenData } from "../services/JWTTokenManager";
 import { jwtTokenManager, tokenInvalidException } from "../services/JWTTokenManager";
-import type { SocketUpgradeFailed } from "../services/SocketManager";
 import { socketManager } from "../services/SocketManager";
 import {
     ADMIN_SOCKETS_TOKEN,
@@ -481,8 +480,7 @@ export class IoSocketController {
                 }
             },
             /* Handlers */
-            rejectedOpen: (socket: SocketUpgradeFailed): void => {
-                const socketData = socket.getUserData();
+            rejectedOpen: (socketData: UpgradeFailedData) => {
                 debug("Rejected WebSocket connection established");
 
                 if ("roomId" in socketData) {
@@ -490,20 +488,18 @@ export class IoSocketController {
                 }
 
                 if (socketData.reason === tokenInvalidException) {
-                    socketManager.emitTokenExpiredMessage(socket);
+                    return socketManager.getTokenExpiredMessage();
                 } else if (socketData.reason === "error") {
-                    socketManager.emitErrorScreenMessage(socket, socketData.error);
+                    return socketManager.toErrorScreenMessage(socketData.error);
                 } else if (socketData.reason === "invalidTexture") {
                     if (socketData.entityType === "character") {
-                        socketManager.emitInvalidCharacterTextureMessage(socket);
+                        return socketManager.getInvalidCharacterTextureMessage();
                     } else {
-                        socketManager.emitInvalidCompanionTextureMessage(socket);
+                        return socketManager.getInvalidCompanionTextureMessage();
                     }
                 } else {
-                    socketManager.emitConnectionErrorMessage(socket, socketData.message.toString());
+                    return socketManager.toConnectionErrorMessage(socketData.message.toString());
                 }
-
-                socket.end(1000, "Error message sent");
             },
             open: async (socket) => {
                 const socketData = socket.getUserData();

--- a/play/src/pusher/services/PusherRoomSocketController.ts
+++ b/play/src/pusher/services/PusherRoomSocketController.ts
@@ -1,12 +1,15 @@
 import type { TemplatedApp, HttpResponse, HttpRequest, us_socket_context_t } from "uWebSockets.js";
-import type { ClientToServerMessage } from "@workadventure/messages";
+import {
+    type ClientToServerMessage,
+    PusherToFrontWebSocketMessage,
+    type ServerToClientMessage,
+} from "@workadventure/messages";
 import type { ZodObject, ZodRawShape, ZodTypeAny } from "zod";
 import * as Sentry from "@sentry/node";
 import { asError } from "catch-unknown";
 import { CLIENT_DISCONNECTION_RETENTION_MS } from "../enums/EnvironmentVariable";
 import type { ConnectingSocketData } from "../models/Websocket/SocketData";
 import type { UpgradeFailedData } from "../controllers/IoSocketController";
-import type { SocketUpgradeFailed } from "./SocketManager";
 import { PusherWebSocket } from "./PusherWebSocket";
 import type { RawSocket } from "./PusherWebSocket";
 import { validateWebsocketQuery } from "./QueryValidator";
@@ -27,7 +30,8 @@ type UpgradeContext<TQuery> = {
 
 type UpgradeHandler<TQuery> = (context: UpgradeContext<TQuery>) => void | Promise<void>;
 type OpenHandler = (socket: PusherWebSocket) => void | Promise<void>;
-type RejectedOpenHandler = (socket: SocketUpgradeFailed) => void | Promise<void>;
+// The rejected open handler should return the unique error message that will be sent over the websocket before closing it.
+type RejectedOpenHandler = (socketData: UpgradeFailedData) => ServerToClientMessage | Promise<ServerToClientMessage>;
 type MessageHandler = (socket: PusherWebSocket, message: ClientToServerMessage) => void | Promise<void>;
 type CloseHandler = (socket: PusherWebSocket, code: number, reason: string) => void | Promise<void>;
 
@@ -260,8 +264,17 @@ export class PusherRoomSocketController {
             open: (ws) => {
                 (async () => {
                     const socketData = ws.getUserData();
+
                     if (socketData.rejected === true) {
-                        await config.rejectedOpen(ws as SocketUpgradeFailed);
+                        const errorMessage = await config.rejectedOpen(socketData);
+                        ws.send(
+                            PusherToFrontWebSocketMessage.encode({
+                                nonce: 1,
+                                message: errorMessage,
+                            }).finish(),
+                            true
+                        );
+                        ws.end(1000, "Error message sent");
                         return;
                     }
 

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -45,8 +45,9 @@ import type {
     BackEventFrontToPusherMessage,
     ConnectToRoomMessage,
     JoinRoomFrontMessage,
+    ServerToClientMessage,
 } from "@workadventure/messages";
-import { noUndefined, ServerToClientMessage } from "@workadventure/messages";
+import { noUndefined } from "@workadventure/messages";
 import * as Sentry from "@sentry/node";
 import type { AxiosResponse } from "axios";
 import axios, { isAxiosError } from "axios";
@@ -943,72 +944,49 @@ export class SocketManager implements ZoneEventListener {
         });
     }
 
-    public emitWorldFullMessage(client: PusherWebSocket): void {
-        if (!client.isDisconnecting()) {
-            client.send({
-                message: {
-                    $case: "worldFullMessage",
-                    worldFullMessage: {},
-                },
-            });
-        }
+    public getTokenExpiredMessage(): ServerToClientMessage {
+        return {
+            message: {
+                $case: "tokenExpiredMessage",
+                tokenExpiredMessage: {},
+            },
+        };
     }
 
-    public emitTokenExpiredMessage(client: SocketUpgradeFailed): void {
-        client.send(
-            ServerToClientMessage.encode({
-                message: {
-                    $case: "tokenExpiredMessage",
-                    tokenExpiredMessage: {},
+    public getInvalidCharacterTextureMessage(): ServerToClientMessage {
+        return {
+            message: {
+                $case: "invalidCharacterTextureMessage",
+                invalidCharacterTextureMessage: {
+                    message: "Invalid character textures",
                 },
-            }).finish(),
-            true
-        );
+            },
+        };
     }
 
-    public emitInvalidCharacterTextureMessage(client: SocketUpgradeFailed): void {
-        client.send(
-            ServerToClientMessage.encode({
-                message: {
-                    $case: "invalidCharacterTextureMessage",
-                    invalidCharacterTextureMessage: {
-                        message: "Invalid character textures",
-                    },
+    public getInvalidCompanionTextureMessage(): ServerToClientMessage {
+        return {
+            message: {
+                $case: "invalidCompanionTextureMessage",
+                invalidCompanionTextureMessage: {
+                    message: "Invalid companion texture",
                 },
-            }).finish(),
-            true
-        );
+            },
+        };
     }
 
-    public emitInvalidCompanionTextureMessage(client: SocketUpgradeFailed): void {
-        client.send(
-            ServerToClientMessage.encode({
-                message: {
-                    $case: "invalidCompanionTextureMessage",
-                    invalidCompanionTextureMessage: {
-                        message: "Invalid companion texture",
-                    },
+    public toConnectionErrorMessage(message: string): ServerToClientMessage {
+        return {
+            message: {
+                $case: "worldConnectionMessage",
+                worldConnectionMessage: {
+                    message,
                 },
-            }).finish(),
-            true
-        );
+            },
+        };
     }
 
-    public emitConnectionErrorMessage(client: SocketUpgradeFailed, message: string): void {
-        client.send(
-            ServerToClientMessage.encode({
-                message: {
-                    $case: "worldConnectionMessage",
-                    worldConnectionMessage: {
-                        message,
-                    },
-                },
-            }).finish(),
-            true
-        );
-    }
-
-    public emitErrorScreenMessage(client: SocketUpgradeFailed, errorApi: ErrorApiData): void {
+    public toErrorScreenMessage(errorApi: ErrorApiData): ServerToClientMessage {
         // FIXME: improve typing of ErrorScreenMessage
         const errorScreenMessage: ErrorScreenMessage = {
             type: errorApi.type,
@@ -1046,17 +1024,12 @@ export class SocketManager implements ZoneEventListener {
             errorScreenMessage.urlToRedirect = errorApi.urlToRedirect;
         }
 
-        //if (!client.disconnecting) {
-        client.send(
-            ServerToClientMessage.encode({
-                message: {
-                    $case: "errorScreenMessage",
-                    errorScreenMessage,
-                },
-            }).finish(),
-            true
-        );
-        //}
+        return {
+            message: {
+                $case: "errorScreenMessage",
+                errorScreenMessage,
+            },
+        };
     }
 
     private refreshRoomData(roomId: string, versionNumber: number): void {


### PR DESCRIPTION
Following the adding of a reconnect nonce in a wrapper, we introduced a bug for all error messages sent to WorkAdventure. This commit fixes the error messages and also wraps them into the nonce container.