### PR TITLE
Fix waitForStoreValue synchronous resolution

### DIFF
--- a/play/src/front/Stores/Utils/waitForStoreValue.ts
+++ b/play/src/front/Stores/Utils/waitForStoreValue.ts
@@ -2,11 +2,19 @@ import type { Readable } from "svelte/store";
 
 export function waitForStoreValue<T>(store: Readable<T | undefined | null>): Promise<T> {
     return new Promise((resolve) => {
-        const unsubscribe = store.subscribe((value) => {
-            if (value) {
+        let unsubscribe: (() => void) | undefined = undefined;
+        let resolved = false;
+
+        unsubscribe = store.subscribe((value) => {
+            if (value !== undefined && value !== null) {
+                resolved = true;
                 resolve(value);
-                unsubscribe();
+                unsubscribe?.();
             }
         });
+
+        if (resolved) {
+            unsubscribe?.();
+        }
     });
 }

--- a/play/tests/front/Stores/Utils/waitForStoreValue.test.ts
+++ b/play/tests/front/Stores/Utils/waitForStoreValue.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { readable, writable } from "svelte/store";
+import { waitForStoreValue } from "../../../../src/front/Stores/Utils/waitForStoreValue";
+
+describe("waitForStoreValue", () => {
+    it("should resolve when the store already has a value", async () => {
+        let unsubscribeCount = 0;
+        const store = readable("ready", () => {
+            return () => {
+                unsubscribeCount++;
+            };
+        });
+
+        await expect(waitForStoreValue(store)).resolves.toBe("ready");
+        expect(unsubscribeCount).toBe(1);
+    });
+
+    it("should resolve when the store receives a value later", async () => {
+        const store = writable<string | undefined>(undefined);
+        const promise = waitForStoreValue(store);
+
+        store.set("ready");
+
+        await expect(promise).resolves.toBe("ready");
+    });
+});


### PR DESCRIPTION
## What changed

- Updated `waitForStoreValue` so it can resolve safely when a Svelte store already has a value at subscription time.
- Added a focused Vitest covering both an already-present value and a value that arrives later.

## Why

Svelte store subscribers are called synchronously when subscribing. The previous implementation referenced `unsubscribe` inside that callback before the `const unsubscribe = store.subscribe(...)` assignment had completed, which could throw `ReferenceError: Cannot access 'e' before initialization` during `gameSceneStore.set(this)` after connecting to pusher.

## Validation

- `npm test -- tests/front/Stores/Utils/waitForStoreValue.test.ts`
- `npx eslint src/front/Stores/Utils/waitForStoreValue.ts tests/front/Stores/Utils/waitForStoreValue.test.ts`
- `git diff --check -- play/src/front/Stores/Utils/waitForStoreValue.ts play/tests/front/Stores/Utils/waitForStoreValue.test.ts`