### PR TITLE
Fixing nonce inavertently reused

### DIFF
--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -529,7 +529,7 @@ class ConnectionManager {
 
                 this.reconnectingTimeout = setTimeout(() => {
                     console.info(
-                        "[ConnectionManager] connectToRoomSocket => catch => ew Promise[OnConnectInterface] reconnectingTimeout => setTimeout",
+                        "[ConnectionManager] connectToRoomSocket => catch => new Promise[OnConnectInterface] reconnectingTimeout => setTimeout",
                         roomUrl,
                         name,
                         characterTextureIds,

--- a/play/src/pusher/services/PusherRoomSocketController.ts
+++ b/play/src/pusher/services/PusherRoomSocketController.ts
@@ -227,11 +227,9 @@ export class PusherRoomSocketController {
                         },
                         isAborted: () => upgradeAborted.aborted,
                         upgrade: (data) => {
-                            if (clientLastReceivedNonce !== undefined) {
-                                const tabContext = this.contextByTabKey.get(query.tabId) ?? {};
-                                tabContext.clientLastReceivedNonce = clientLastReceivedNonce;
-                                this.contextByTabKey.set(query.tabId, tabContext);
-                            }
+                            const tabContext = this.contextByTabKey.get(query.tabId) ?? {};
+                            tabContext.clientLastReceivedNonce = clientLastReceivedNonce;
+                            this.contextByTabKey.set(query.tabId, tabContext);
 
                             this.upgradeSocket(
                                 upgradeAborted.aborted,


### PR DESCRIPTION
If a retry was attempted once, the clientLastReceivedNonce would get stored in the context on the pusher side and would be reused for future connection attempts sharing the same tabId, even if we were trying to connect WITHOUT a clientLastReceivedNonce. Now, the clientLastReceivedNonce is always applied to the pusher websocket context, without any condition.