### PR TITLE
fix: restore exploration mode after closing woka menu

### DIFF
--- a/play/src/front/Phaser/Game/LocateManager.ts
+++ b/play/src/front/Phaser/Game/LocateManager.ts
@@ -48,7 +48,9 @@ export class LocateManager {
         // Subscribe to woka menu store to stop following the remote player when the woka menu is closed.
         this.wokaMenuStoreUnsubscriber = wokaMenuStore.subscribe((value) => {
             if (value === undefined && previouslyFollowedRemotePlayer !== undefined) {
-                this.cameraManager.stopFollowRemotePlayer();
+                if (!this.scene.getMapEditorModeManager().returnToLastMode()) {
+                    this.cameraManager.stopFollowRemotePlayer();
+                }
                 previouslyFollowedRemotePlayer = undefined;
             } else if (
                 value !== undefined &&

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -408,9 +408,6 @@ export class MapEditorModeManager {
         if (this.activeTool === tool) {
             return;
         }
-        if (this.activeTool !== undefined && this.activeTool !== EditorToolName.CloseMapEditor) {
-            this.lastlyUsedTool = this.activeTool;
-        }
         this.clearToNeutralState();
         this.activeTool = tool;
 
@@ -425,18 +422,15 @@ export class MapEditorModeManager {
             return false;
         }
 
+        // Only restore exploration when it is the currently active tool. Relying on the
+        // last used tool could switch the active editor tool (Area/Floor/Entity...) to
+        // exploration mode when the Woka menu is closed, which is not desired.
         if (this.activeTool === EditorToolName.ExploreTheRoom) {
             this.scene.getCameraManager().setExplorationMode();
             return true;
         }
 
-        if (this.lastlyUsedTool !== EditorToolName.ExploreTheRoom) {
-            return false;
-        }
-
-        this.equipTool(EditorToolName.ExploreTheRoom);
-
-        return true;
+        return false;
     }
 
     private emitMapEditorUpdate(command: FrontCommandInterface, delay = 0): void {

--- a/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
+++ b/play/src/front/Phaser/Game/MapEditor/MapEditorModeManager.ts
@@ -408,6 +408,9 @@ export class MapEditorModeManager {
         if (this.activeTool === tool) {
             return;
         }
+        if (this.activeTool !== undefined && this.activeTool !== EditorToolName.CloseMapEditor) {
+            this.lastlyUsedTool = this.activeTool;
+        }
         this.clearToNeutralState();
         this.activeTool = tool;
 
@@ -415,6 +418,25 @@ export class MapEditorModeManager {
             this.activateTool();
         }
         mapEditorSelectedToolStore.set(tool);
+    }
+
+    public returnToLastMode(): boolean {
+        if (!this.active) {
+            return false;
+        }
+
+        if (this.activeTool === EditorToolName.ExploreTheRoom) {
+            this.scene.getCameraManager().setExplorationMode();
+            return true;
+        }
+
+        if (this.lastlyUsedTool !== EditorToolName.ExploreTheRoom) {
+            return false;
+        }
+
+        this.equipTool(EditorToolName.ExploreTheRoom);
+
+        return true;
     }
 
     private emitMapEditorUpdate(command: FrontCommandInterface, delay = 0): void {


### PR DESCRIPTION
## Problem
Closing the Woka menu always made the camera follow the current player again. When the user opened the Woka menu while using map exploration mode, this caused the view to recenter instead of returning to the previous exploration state.

## Solution
Keep track of the last relevant map editor tool and let the Woka menu close flow restore exploration mode when applicable. If no exploration mode can be restored, the existing recenter behavior is preserved.

## Changes
- Track the previously active map editor tool in `MapEditorModeManager`.
- Add `returnToLastMode()` to restore `ExploreTheRoom` when possible.
- Use this restoration path in `LocateManager` before falling back to `stopFollowRemotePlayer()`.