### PR TITLE
fix: prevent feedback attendees from connecting peer-to-peer

### DIFF
--- a/back/src/Model/Interfaces/ICommunicationSpace.ts
+++ b/back/src/Model/Interfaces/ICommunicationSpace.ts
@@ -9,6 +9,7 @@ export type ICommunicationSpace = Pick<
     | "dispatchPrivateEvent"
     | "dispatchPublicEvent"
     | "getSpaceName"
+    | "filterType"
     | "getPropertiesToSync"
     | "publishMetadata"
     | "stopRecordingByServer"

--- a/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
@@ -79,22 +79,19 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
             return Promise.resolve();
         }
 
-        const freshNewUser = this.getFreshUser(newUser);
-
         for (const existingUser of this.usersToNotify.values()) {
             if (existingUser.spaceUserId === newUser.spaceUserId) {
                 continue;
             }
-            const freshExistingUser = this.getFreshUser(existingUser);
             try {
-                if (this.shouldEstablishConnection(freshNewUser, freshExistingUser)) {
-                    this.establishConnection(freshNewUser, freshExistingUser);
+                if (this.shouldEstablishConnection(newUser, existingUser)) {
+                    this.establishConnection(newUser, existingUser);
                 }
             } catch (error) {
                 console.error(
                     "An error occurred while adding a new user to WebRTC discussion",
-                    freshNewUser,
-                    freshExistingUser,
+                    newUser,
+                    existingUser,
                     error,
                 );
                 Sentry.captureException(error);
@@ -128,22 +125,19 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     }
 
     public async addUserToNotify(user: SpaceUser): Promise<void> {
-        const freshUser = this.getFreshUser(user);
-
         for (const userInFilter of this.users.values()) {
             if (userInFilter.spaceUserId === user.spaceUserId) {
                 continue;
             }
-            const freshUserInFilter = this.getFreshUser(userInFilter);
             try {
-                if (this.shouldEstablishConnection(freshUser, freshUserInFilter)) {
-                    this.establishConnection(freshUser, freshUserInFilter);
+                if (this.shouldEstablishConnection(user, userInFilter)) {
+                    this.establishConnection(user, userInFilter);
                 }
             } catch (error) {
                 console.error(
                     "An error occurred while adding a user to notify in WebRTCCommunicationStrategy",
-                    freshUser,
-                    freshUserInFilter,
+                    user,
+                    userInFilter,
                     error,
                 );
                 Sentry.captureException(error);
@@ -211,19 +205,20 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
             return true;
         }
 
+        // The user objects we hold (especially in usersToNotify) can be stale copies: read the roles
+        // from the canonical, up-to-date objects.
+        const freshUser1 = this.getFreshUser(user1);
+        const freshUser2 = this.getFreshUser(user2);
+
+        // P2P is only allowed between feedback participants when one of them is a speaker
         return (
-            this.hasFeedbackStreamingRole(user1) &&
-            this.hasFeedbackStreamingRole(user2) &&
-            this.hasSpeaker(user1, user2)
+            (freshUser1.megaphoneState && this.hasFeedbackStreamingRole(freshUser2)) ||
+            (freshUser2.megaphoneState && this.hasFeedbackStreamingRole(freshUser1))
         );
     }
 
     private hasFeedbackStreamingRole(user: SpaceUser): boolean {
         return user.megaphoneState || user.attendeesState;
-    }
-
-    private hasSpeaker(user1: SpaceUser, user2: SpaceUser): boolean {
-        return user1.megaphoneState || user2.megaphoneState;
     }
 
     private establishConnection(user1: SpaceUser, user2: SpaceUser): void {
@@ -251,7 +246,7 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     private getOtherKnownUsers(userId: string): SpaceUser[] {
         const knownUsers = new Map<string, SpaceUser>([...this.usersToNotify, ...this.users]);
         knownUsers.delete(userId);
-        return Array.from(knownUsers.values(), (user) => this.getFreshUser(user));
+        return Array.from(knownUsers.values());
     }
 
     private getKnownUser(userId: string): SpaceUser | undefined {
@@ -259,7 +254,7 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     }
 
     private getFreshUser(user: SpaceUser): SpaceUser {
-        return this.users.get(user.spaceUserId) ?? this._space.getUser(user.spaceUserId) ?? user;
+        return this.getKnownUser(user.spaceUserId) ?? user;
     }
 
     private sendWebRTCStart(senderId: string, receiverId: string, isInitiator: boolean, connectionId: string): void {
@@ -307,18 +302,16 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
                 if (user1.spaceUserId === user2.spaceUserId) {
                     return;
                 }
-                const freshUser1 = this.getFreshUser(user1);
-                const freshUser2 = this.getFreshUser(user2);
                 try {
-                    if (this.shouldEstablishConnection(freshUser1, freshUser2)) {
-                        this.establishConnection(freshUser1, freshUser2);
+                    if (this.shouldEstablishConnection(user1, user2)) {
+                        this.establishConnection(user1, user2);
                         return;
                     }
                 } catch (error) {
                     console.error(
                         "An error occurred while initializing WebRTCCommunicationStrategy",
-                        freshUser1,
-                        freshUser2,
+                        user1,
+                        user2,
                         error,
                     );
                     Sentry.captureException(error);

--- a/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
@@ -104,6 +104,17 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     public deleteUser(user: SpaceUser): void {
         if (!this.usersToNotify.has(user.spaceUserId)) {
             this.shutdownAllConnections(user);
+        } else {
+            // The user left the filter but is still watching the space (e.g. an attendee that lost
+            // their role): shut down the connections their new state no longer allows.
+            for (const peer of this.getOtherKnownUsers(user.spaceUserId)) {
+                if (
+                    this.hasAnyExistingConnection(user.spaceUserId, peer.spaceUserId) &&
+                    !this.canEstablishConnection(user, peer)
+                ) {
+                    this.shutdownConnection(user.spaceUserId, peer.spaceUserId);
+                }
+            }
         }
 
         for (const userToNotify of this.usersToNotify.values()) {

--- a/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
@@ -1,4 +1,4 @@
-import type { SpaceUser, MeetingConnectionRestartMessage } from "@workadventure/messages";
+import { FilterType, type SpaceUser, type MeetingConnectionRestartMessage } from "@workadventure/messages";
 import * as Sentry from "@sentry/node";
 import { v4 as uuidv4 } from "uuid";
 import type { ICommunicationStrategy } from "../Interfaces/ICommunicationStrategy";
@@ -158,8 +158,16 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     }
 
     public updateUser(user: SpaceUser): void {
-        // TODO: remove the handleUserMediaUpdate function after testing
-        //this.handleUserMediaUpdate(user);
+        for (const peer of this.getOtherKnownUsers(user.spaceUserId)) {
+            const hasExistingConnection = this.hasAnyExistingConnection(user.spaceUserId, peer.spaceUserId);
+            if (hasExistingConnection && !this.canEstablishConnection(user, peer)) {
+                this.shutdownConnection(user.spaceUserId, peer.spaceUserId);
+                continue;
+            }
+            if (!hasExistingConnection && this.shouldEstablishConnection(user, peer)) {
+                this.establishConnection(user, peer);
+            }
+        }
     }
     private shutdownConnection(user: string, otherUser: string): void {
         try {
@@ -187,9 +195,29 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     }
 
     private shouldEstablishConnection(user1: SpaceUser, user2: SpaceUser): boolean {
-        const hasExisting = this.hasExistingConnection(user1.spaceUserId, user2.spaceUserId);
+        const hasExisting = this.hasAnyExistingConnection(user1.spaceUserId, user2.spaceUserId);
         // Only establish if we need media connection AND don't already have one
-        return !hasExisting;
+        return !hasExisting && this.canEstablishConnection(user1, user2);
+    }
+
+    private canEstablishConnection(user1: SpaceUser, user2: SpaceUser): boolean {
+        if (this._space.filterType !== FilterType.LIVE_STREAMING_USERS_WITH_FEEDBACK) {
+            return true;
+        }
+
+        return (
+            this.hasFeedbackStreamingRole(user1) &&
+            this.hasFeedbackStreamingRole(user2) &&
+            this.hasSpeaker(user1, user2)
+        );
+    }
+
+    private hasFeedbackStreamingRole(user: SpaceUser): boolean {
+        return user.megaphoneState || user.attendeesState;
+    }
+
+    private hasSpeaker(user1: SpaceUser, user2: SpaceUser): boolean {
+        return user1.megaphoneState || user2.megaphoneState;
     }
 
     private establishConnection(user1: SpaceUser, user2: SpaceUser): void {
@@ -208,6 +236,20 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
 
     private hasExistingConnection(userId1: string, userId2: string): boolean {
         return this._connections.hasConnection(userId1, userId2);
+    }
+
+    private hasAnyExistingConnection(userId1: string, userId2: string): boolean {
+        return this.hasExistingConnection(userId1, userId2) || this.hasExistingConnection(userId2, userId1);
+    }
+
+    private getOtherKnownUsers(userId: string): SpaceUser[] {
+        const knownUsers = new Map<string, SpaceUser>([...this.users, ...this.usersToNotify]);
+        knownUsers.delete(userId);
+        return Array.from(knownUsers.values());
+    }
+
+    private getKnownUser(userId: string): SpaceUser | undefined {
+        return this.users.get(userId) ?? this.usersToNotify.get(userId) ?? this._space.getUser(userId);
     }
 
     private sendWebRTCStart(senderId: string, receiverId: string, isInitiator: boolean, connectionId: string): void {
@@ -248,13 +290,15 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     }
 
     initialize(users: ReadonlyMap<string, SpaceUser>, usersToNotify: ReadonlyMap<string, SpaceUser>): Promise<void> {
+        this.users = users;
+        this.usersToNotify = usersToNotify;
         users.forEach((user1) => {
             usersToNotify.forEach((user2) => {
                 if (user1.spaceUserId === user2.spaceUserId) {
                     return;
                 }
                 try {
-                    if (!this.hasExistingConnection(user1.spaceUserId, user2.spaceUserId)) {
+                    if (this.shouldEstablishConnection(user1, user2)) {
                         this.establishConnection(user1, user2);
                         return;
                     }
@@ -298,6 +342,15 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
             meetingConnectionRestartMessage.connectionId !== undefined &&
             meetingConnectionRestartMessage.connectionId !== existingConnectionId
         ) {
+            return;
+        }
+
+        // The peers may no longer be allowed to talk P2P (e.g. a feedback attendee lost their
+        // role): tear the connection down instead of restarting it.
+        const sender = this.getKnownUser(senderUserId);
+        const receiver = this.getKnownUser(receiverId);
+        if (!sender || !receiver || !this.canEstablishConnection(sender, receiver)) {
+            this.shutdownConnection(senderUserId, receiverId);
             return;
         }
 

--- a/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
@@ -79,19 +79,22 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
             return Promise.resolve();
         }
 
+        const freshNewUser = this.getFreshUser(newUser);
+
         for (const existingUser of this.usersToNotify.values()) {
             if (existingUser.spaceUserId === newUser.spaceUserId) {
                 continue;
             }
+            const freshExistingUser = this.getFreshUser(existingUser);
             try {
-                if (this.shouldEstablishConnection(newUser, existingUser)) {
-                    this.establishConnection(newUser, existingUser);
+                if (this.shouldEstablishConnection(freshNewUser, freshExistingUser)) {
+                    this.establishConnection(freshNewUser, freshExistingUser);
                 }
             } catch (error) {
                 console.error(
                     "An error occurred while adding a new user to WebRTC discussion",
-                    newUser,
-                    existingUser,
+                    freshNewUser,
+                    freshExistingUser,
                     error,
                 );
                 Sentry.captureException(error);
@@ -125,19 +128,22 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     }
 
     public async addUserToNotify(user: SpaceUser): Promise<void> {
+        const freshUser = this.getFreshUser(user);
+
         for (const userInFilter of this.users.values()) {
             if (userInFilter.spaceUserId === user.spaceUserId) {
                 continue;
             }
+            const freshUserInFilter = this.getFreshUser(userInFilter);
             try {
-                if (this.shouldEstablishConnection(user, userInFilter)) {
-                    this.establishConnection(user, userInFilter);
+                if (this.shouldEstablishConnection(freshUser, freshUserInFilter)) {
+                    this.establishConnection(freshUser, freshUserInFilter);
                 }
             } catch (error) {
                 console.error(
                     "An error occurred while adding a user to notify in WebRTCCommunicationStrategy",
-                    user,
-                    userInFilter,
+                    freshUser,
+                    freshUserInFilter,
                     error,
                 );
                 Sentry.captureException(error);
@@ -243,13 +249,17 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     }
 
     private getOtherKnownUsers(userId: string): SpaceUser[] {
-        const knownUsers = new Map<string, SpaceUser>([...this.users, ...this.usersToNotify]);
+        const knownUsers = new Map<string, SpaceUser>([...this.usersToNotify, ...this.users]);
         knownUsers.delete(userId);
-        return Array.from(knownUsers.values());
+        return Array.from(knownUsers.values(), (user) => this.getFreshUser(user));
     }
 
     private getKnownUser(userId: string): SpaceUser | undefined {
-        return this.users.get(userId) ?? this.usersToNotify.get(userId) ?? this._space.getUser(userId);
+        return this.users.get(userId) ?? this._space.getUser(userId) ?? this.usersToNotify.get(userId);
+    }
+
+    private getFreshUser(user: SpaceUser): SpaceUser {
+        return this.users.get(user.spaceUserId) ?? this._space.getUser(user.spaceUserId) ?? user;
     }
 
     private sendWebRTCStart(senderId: string, receiverId: string, isInitiator: boolean, connectionId: string): void {
@@ -297,16 +307,18 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
                 if (user1.spaceUserId === user2.spaceUserId) {
                     return;
                 }
+                const freshUser1 = this.getFreshUser(user1);
+                const freshUser2 = this.getFreshUser(user2);
                 try {
-                    if (this.shouldEstablishConnection(user1, user2)) {
-                        this.establishConnection(user1, user2);
+                    if (this.shouldEstablishConnection(freshUser1, freshUser2)) {
+                        this.establishConnection(freshUser1, freshUser2);
                         return;
                     }
                 } catch (error) {
                     console.error(
                         "An error occurred while initializing WebRTCCommunicationStrategy",
-                        user1,
-                        user2,
+                        freshUser1,
+                        freshUser2,
                         error,
                     );
                     Sentry.captureException(error);

--- a/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
+++ b/back/src/Model/Strategies/WebRTCCommunicationStrategy.ts
@@ -169,13 +169,22 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
     }
 
     public updateUser(user: SpaceUser): void {
+        // The connection topology only depends on a field (role) in the feedback filter. Everywhere
+        // else it is driven solely by add/delete, so an update never has to touch it.
+        if (this._space.filterType !== FilterType.LIVE_STREAMING_USERS_WITH_FEEDBACK) {
+            return;
+        }
         for (const peer of this.getOtherKnownUsers(user.spaceUserId)) {
             const hasExistingConnection = this.hasAnyExistingConnection(user.spaceUserId, peer.spaceUserId);
             if (hasExistingConnection && !this.canEstablishConnection(user, peer)) {
                 this.shutdownConnection(user.spaceUserId, peer.spaceUserId);
                 continue;
             }
-            if (!hasExistingConnection && this.shouldEstablishConnection(user, peer)) {
+            if (
+                !hasExistingConnection &&
+                this.isPairInConnectionMatrix(user.spaceUserId, peer.spaceUserId) &&
+                this.canEstablishConnection(user, peer)
+            ) {
                 this.establishConnection(user, peer);
             }
         }
@@ -230,6 +239,16 @@ export class WebRTCCommunicationStrategy implements ICommunicationStrategy {
 
     private hasFeedbackStreamingRole(user: SpaceUser): boolean {
         return user.megaphoneState || user.attendeesState;
+    }
+
+    /**
+     * Connections are only ever created between a user in the filter and a user watching the space.
+     */
+    private isPairInConnectionMatrix(userId1: string, userId2: string): boolean {
+        return (
+            (this.users.has(userId1) && this.usersToNotify.has(userId2)) ||
+            (this.usersToNotify.has(userId1) && this.users.has(userId2))
+        );
     }
 
     private establishConnection(user1: SpaceUser, user2: SpaceUser): void {

--- a/back/tests/CommunicationManager.test.ts
+++ b/back/tests/CommunicationManager.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
     HandleLivekitWebhookRequest,
     HandleRecordingWebhookRequest,
+    FilterType,
     RecordingWebhookPhase,
     SpaceUser,
 } from "@workadventure/messages";
@@ -64,6 +65,7 @@ describe("CommunicationManager", () => {
 
     // Real space implementation (no complex mock)
     const createSpace = (users: SpaceUser[] = []): ICommunicationSpace => ({
+        filterType: FilterType.ALL_USERS,
         getAllUsers: () => users,
         getUsersInFilter: () => users,
         getUsersToNotify: () => [],

--- a/back/tests/LivekitCommunicationStrategy.test.ts
+++ b/back/tests/LivekitCommunicationStrategy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { SpaceUser } from "@workadventure/messages";
+import { FilterType, SpaceUser } from "@workadventure/messages";
 import { LivekitCommunicationStrategy } from "../src/Model/Strategies/LivekitCommunicationStrategy";
 import type { ICommunicationSpace } from "../src/Model/Interfaces/ICommunicationSpace";
 
@@ -12,11 +12,12 @@ function createUser(spaceUserId: string): SpaceUser {
 }
 
 describe("LivekitCommunicationStrategy", () => {
-    it("stops recording through the server path when the last streaming user leaves",async () => {
+    it("stops recording through the server path when the last streaming user leaves", async () => {
         const dispatchPrivateEvent = vi.fn();
         const stopRecordingByServer = vi.fn().mockResolvedValue(undefined);
 
         const space: ICommunicationSpace = {
+            filterType: FilterType.ALL_USERS,
             getAllUsers: () => [],
             getUsersInFilter: () => [],
             getUsersToNotify: () => [],
@@ -61,6 +62,7 @@ describe("LivekitCommunicationStrategy", () => {
 
     it("keeps recording running while another streaming user remains", async () => {
         const space: ICommunicationSpace = {
+            filterType: FilterType.ALL_USERS,
             getAllUsers: () => [],
             getUsersInFilter: () => [],
             getUsersToNotify: () => [],

--- a/back/tests/RecordingManager.test.ts
+++ b/back/tests/RecordingManager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { SpaceUser } from "@workadventure/messages";
+import { FilterType, SpaceUser } from "@workadventure/messages";
 import { RecordingManager } from "../src/Model/RecordingManager";
 import type { ICommunicationSpace } from "../src/Model/Interfaces/ICommunicationSpace";
 import type { IRecordableState } from "../src/Model/Interfaces/ICommunicationState";
@@ -50,6 +50,7 @@ function createRecordableState() {
 function createDependencies(state: IRecordableState<IRecordableStrategy>) {
     const publishMetadata = vi.fn();
     const space: ICommunicationSpace = {
+        filterType: FilterType.ALL_USERS,
         getAllUsers: () => [],
         getUsersInFilter: () => [],
         getUsersToNotify: () => [],

--- a/back/tests/WebRTCCommunicationStrategy.test.ts
+++ b/back/tests/WebRTCCommunicationStrategy.test.ts
@@ -128,9 +128,9 @@ describe("WebRTCCommunicationStrategy", () => {
     });
 
     it("should create missing WebRTC connections when an attendee becomes a speaker", async () => {
-        const speaker = createUser("speaker", "attendee");
+        const otherAttendee = createUser("speaker", "attendee");
         const changingUser = createUser("changing-user", "attendee");
-        const users = [speaker, changingUser];
+        const users = [otherAttendee, changingUser];
         const usersMap = createUsersMap(users);
         const { space, privateEvents } = createSpace(users);
         const strategy = new WebRTCCommunicationStrategy(space, usersMap, usersMap);

--- a/back/tests/WebRTCCommunicationStrategy.test.ts
+++ b/back/tests/WebRTCCommunicationStrategy.test.ts
@@ -1,44 +1,24 @@
 import { describe, expect, it, vi } from "vitest";
-import type { PrivateEvent, SpaceUser } from "@workadventure/messages";
+import { FilterType, SpaceUser, type PrivateEvent } from "@workadventure/messages";
 import { WebRTCCommunicationStrategy } from "../src/Model/Strategies/WebRTCCommunicationStrategy";
 import type { ICommunicationSpace } from "../src/Model/Interfaces/ICommunicationSpace";
 
-vi.mock("@workadventure/messages", () => ({
-    FilterType: {
-        ALL_USERS: 0,
-        LIVE_STREAMING_USERS: 1,
-        LIVE_STREAMING_USERS_WITH_FEEDBACK: 2,
-    },
-}));
-
-const allUsersFilter = 0;
-const feedbackFilter = 2;
-
 function createUser(spaceUserId: string, role: "attendee" | "speaker" | "none"): SpaceUser {
-    return {
+    return SpaceUser.fromPartial({
         spaceUserId,
         uuid: `uuid-${spaceUserId}`,
         name: `User ${spaceUserId}`,
         playUri: "https://play.test",
-        color: "",
-        characterTextures: [],
-        isLogged: false,
-        availabilityStatus: 0,
-        roomName: undefined,
-        visitCardUrl: undefined,
-        tags: [],
-        cameraState: false,
-        microphoneState: false,
-        screenSharingState: false,
         attendeesState: role === "attendee",
         megaphoneState: role === "speaker",
-        jitsiParticipantId: undefined,
-        chatID: undefined,
         showVoiceIndicator: true,
-    };
+    });
 }
 
-function createSpace(users: SpaceUser[], filterType = feedbackFilter) {
+function createSpace(
+    users: SpaceUser[],
+    filterType: Exclude<FilterType, FilterType.UNRECOGNIZED> = FilterType.LIVE_STREAMING_USERS_WITH_FEEDBACK,
+) {
     const privateEvents: PrivateEvent[] = [];
     const space: ICommunicationSpace = {
         filterType,
@@ -97,7 +77,7 @@ describe("WebRTCCommunicationStrategy", () => {
         expect(
             webRtcStartEvents(privateEvents)
                 .map((event) => event.receiverUserId)
-                .sort()
+                .sort(),
         ).toEqual(["attendee", "speaker"]);
     });
 
@@ -135,7 +115,7 @@ describe("WebRTCCommunicationStrategy", () => {
         expect(
             webRtcStartEvents(privateEvents)
                 .map((event) => event.receiverUserId)
-                .sort()
+                .sort(),
         ).toEqual(["listener", "speaker"]);
     });
 
@@ -195,7 +175,7 @@ describe("WebRTCCommunicationStrategy", () => {
 
     it("should keep existing WebRTC behavior outside feedback live streaming", async () => {
         const attendees = [createUser("attendee-1", "attendee"), createUser("attendee-2", "attendee")];
-        const { space, privateEvents } = createSpace(attendees, allUsersFilter);
+        const { space, privateEvents } = createSpace(attendees, FilterType.ALL_USERS);
         const strategy = new WebRTCCommunicationStrategy(space, createUsersMap(attendees), createUsersMap(attendees));
 
         await strategy.initialize(createUsersMap(attendees), createUsersMap(attendees));

--- a/back/tests/WebRTCCommunicationStrategy.test.ts
+++ b/back/tests/WebRTCCommunicationStrategy.test.ts
@@ -121,6 +121,24 @@ describe("WebRTCCommunicationStrategy", () => {
         expect(webRtcStartEvents(privateEvents)).toHaveLength(0);
     });
 
+    it("should use the active user role when a watcher copy is stale", async () => {
+        const speaker = createUser("speaker", "speaker");
+        const activeListener = createUser("listener", "attendee");
+        const staleListenerWatcherCopy = createUser("listener", "none");
+        const users = [speaker, activeListener];
+        const { space, privateEvents } = createSpace(users);
+        const strategy = new WebRTCCommunicationStrategy(space, createUsersMap(users), new Map());
+
+        await strategy.addUserToNotify(staleListenerWatcherCopy);
+
+        expect(webRtcStartEvents(privateEvents)).toHaveLength(2);
+        expect(
+            webRtcStartEvents(privateEvents)
+                .map((event) => event.receiverUserId)
+                .sort()
+        ).toEqual(["listener", "speaker"]);
+    });
+
     it("should create missing WebRTC connections when an attendee becomes a speaker", async () => {
         const speaker = createUser("speaker", "attendee");
         const changingUser = createUser("changing-user", "attendee");

--- a/back/tests/WebRTCCommunicationStrategy.test.ts
+++ b/back/tests/WebRTCCommunicationStrategy.test.ts
@@ -55,6 +55,14 @@ function webRtcDisconnectEvents(events: PrivateEvent[]): PrivateEvent[] {
     return events.filter((event) => event.spaceEvent?.event?.$case === "webRtcDisconnectMessage");
 }
 
+function hasWebRtcDisconnectBetween(events: PrivateEvent[], userId1: string, userId2: string): boolean {
+    return webRtcDisconnectEvents(events).some(
+        (event) =>
+            (event.senderUserId === userId1 && event.receiverUserId === userId2) ||
+            (event.senderUserId === userId2 && event.receiverUserId === userId1),
+    );
+}
+
 describe("WebRTCCommunicationStrategy", () => {
     it("should not start WebRTC when both feedback users are attendees", async () => {
         const attendees = [createUser("attendee-1", "attendee"), createUser("attendee-2", "attendee")];
@@ -181,5 +189,25 @@ describe("WebRTCCommunicationStrategy", () => {
         await strategy.initialize(createUsersMap(attendees), createUsersMap(attendees));
 
         expect(webRtcStartEvents(privateEvents)).toHaveLength(2);
+    });
+
+    it("should close the P2P connection when a watching attendee loses their role", async () => {
+        const speaker = createUser("speaker", "speaker");
+        const attendee = createUser("attendee", "attendee");
+        const users = new Map<string, SpaceUser>([speaker, attendee].map((user) => [user.spaceUserId, user]));
+        const usersToNotify = new Map<string, SpaceUser>([speaker, attendee].map((user) => [user.spaceUserId, user]));
+        const { space, privateEvents } = createSpace([speaker, attendee]);
+        const strategy = new WebRTCCommunicationStrategy(space, users, usersToNotify);
+
+        await strategy.initialize(users, usersToNotify);
+        privateEvents.length = 0;
+
+        // The attendee loses their role while still watching the space. In the real flow the registry
+        // removes them from the filtered `users` set before deleteUser runs.
+        attendee.attendeesState = false;
+        users.delete(attendee.spaceUserId);
+        strategy.deleteUser(attendee);
+
+        expect(hasWebRtcDisconnectBetween(privateEvents, "speaker", "attendee")).toBe(true);
     });
 });

--- a/back/tests/WebRTCCommunicationStrategy.test.ts
+++ b/back/tests/WebRTCCommunicationStrategy.test.ts
@@ -1,145 +1,187 @@
 import { describe, expect, it, vi } from "vitest";
-import { MeetingConnectionRestartMessage, SpaceUser } from "@workadventure/messages";
+import type { PrivateEvent, SpaceUser } from "@workadventure/messages";
 import { WebRTCCommunicationStrategy } from "../src/Model/Strategies/WebRTCCommunicationStrategy";
 import type { ICommunicationSpace } from "../src/Model/Interfaces/ICommunicationSpace";
 
-interface WebRtcStartDispatch {
-    receiverUserId: string;
-    senderUserId: string;
-    spaceEvent: {
-        event: {
-            $case: string;
-            webRtcStartMessage?: { userId: string; initiator: boolean; connectionId: string };
-        };
+vi.mock("@workadventure/messages", () => ({
+    FilterType: {
+        ALL_USERS: 0,
+        LIVE_STREAMING_USERS: 1,
+        LIVE_STREAMING_USERS_WITH_FEEDBACK: 2,
+    },
+}));
+
+const allUsersFilter = 0;
+const feedbackFilter = 2;
+
+function createUser(spaceUserId: string, role: "attendee" | "speaker" | "none"): SpaceUser {
+    return {
+        spaceUserId,
+        uuid: `uuid-${spaceUserId}`,
+        name: `User ${spaceUserId}`,
+        playUri: "https://play.test",
+        color: "",
+        characterTextures: [],
+        isLogged: false,
+        availabilityStatus: 0,
+        roomName: undefined,
+        visitCardUrl: undefined,
+        tags: [],
+        cameraState: false,
+        microphoneState: false,
+        screenSharingState: false,
+        attendeesState: role === "attendee",
+        megaphoneState: role === "speaker",
+        jitsiParticipantId: undefined,
+        chatID: undefined,
+        showVoiceIndicator: true,
     };
 }
 
-function createUser(spaceUserId: string): SpaceUser {
-    return SpaceUser.fromPartial({
-        spaceUserId,
-        uuid: `uuid-${spaceUserId}`,
-        name: spaceUserId,
-    });
-}
-
-function createSpace(dispatchPrivateEvent = vi.fn()): ICommunicationSpace {
-    return {
-        getAllUsers: () => [],
-        getUsersInFilter: () => [],
+function createSpace(users: SpaceUser[], filterType = feedbackFilter) {
+    const privateEvents: PrivateEvent[] = [];
+    const space: ICommunicationSpace = {
+        filterType,
+        getAllUsers: () => users,
+        getUsersInFilter: () => users,
         getUsersToNotify: () => [],
-        getRecordingState: () => ({ isRecording: false }),
-        dispatchPrivateEvent,
-        dispatchPublicEvent: vi.fn(),
+        getRecordingState: () => ({ isRecording: false, recorder: null, status: "idle" }),
+        dispatchPrivateEvent: (event: PrivateEvent) => {
+            privateEvents.push(event);
+        },
+        dispatchPublicEvent: vi.fn().mockResolvedValue(undefined),
         getSpaceName: () => "test-space",
-        getPropertiesToSync: () => [],
+        getPropertiesToSync: () => ["cameraState", "microphoneState"],
         publishMetadata: vi.fn(),
         stopRecordingByServer: vi.fn().mockResolvedValue(undefined),
-        getUser: vi.fn(),
-    } as unknown as ICommunicationSpace;
+        getUser: (spaceUserId: string) => users.find((user) => user.spaceUserId === spaceUserId),
+    };
+
+    return {
+        privateEvents,
+        space,
+    };
 }
 
-function webRtcStartDispatches(dispatchPrivateEvent: ReturnType<typeof vi.fn>): WebRtcStartDispatch[] {
-    return dispatchPrivateEvent.mock.calls
-        .map((call) => call[0] as WebRtcStartDispatch)
-        .filter((event) => event.spaceEvent.event.$case === "webRtcStartMessage");
+function createUsersMap(users: SpaceUser[]): ReadonlyMap<string, SpaceUser> {
+    return new Map(users.map((user) => [user.spaceUserId, user]));
 }
 
-/**
- * Establishes a single WebRTC connection between user-a and user-b and returns the strategy,
- * the dispatch mock (cleared) and the real connectionId the strategy generated for that connection.
- */
-async function setupStrategyWithConnection() {
-    const dispatchPrivateEvent = vi.fn();
-    const space = createSpace(dispatchPrivateEvent);
-    const userA = createUser("user-a");
-    const userB = createUser("user-b");
-    const users = new Map([
-        [userA.spaceUserId, userA],
-        [userB.spaceUserId, userB],
-    ]);
-
-    const strategy = new WebRTCCommunicationStrategy(space, users, users);
-    await strategy.initialize(users, users);
-
-    const starts = webRtcStartDispatches(dispatchPrivateEvent);
-    const connectionId = starts[0]?.spaceEvent.event.webRtcStartMessage?.connectionId;
-    if (!connectionId) {
-        throw new Error("Test setup failed: no WebRTC connection was established");
-    }
-
-    dispatchPrivateEvent.mockClear();
-
-    return { strategy, dispatchPrivateEvent, connectionId };
+function webRtcStartEvents(events: PrivateEvent[]): PrivateEvent[] {
+    return events.filter((event) => event.spaceEvent?.event?.$case === "webRtcStartMessage");
 }
 
-describe("WebRTCCommunicationStrategy.handleMeetingConnectionRestartMessage", () => {
-    it("establishes exactly one bidirectional connection on initialize", async () => {
-        const { connectionId } = await setupStrategyWithConnection();
-        expect(connectionId).toBeTruthy();
+function webRtcDisconnectEvents(events: PrivateEvent[]): PrivateEvent[] {
+    return events.filter((event) => event.spaceEvent?.event?.$case === "webRtcDisconnectMessage");
+}
+
+describe("WebRTCCommunicationStrategy", () => {
+    it("should not start WebRTC when both feedback users are attendees", async () => {
+        const attendees = [createUser("attendee-1", "attendee"), createUser("attendee-2", "attendee")];
+        const { space, privateEvents } = createSpace(attendees);
+        const strategy = new WebRTCCommunicationStrategy(space, createUsersMap(attendees), createUsersMap(attendees));
+
+        await strategy.initialize(createUsersMap(attendees), createUsersMap(attendees));
+
+        expect(webRtcStartEvents(privateEvents)).toHaveLength(0);
     });
 
-    it("regenerates a fresh connection when the restart references the current connection", async () => {
-        const { strategy, dispatchPrivateEvent, connectionId } = await setupStrategyWithConnection();
+    it("should start WebRTC when a feedback speaker connects with an attendee", async () => {
+        const users = [createUser("speaker", "speaker"), createUser("attendee", "attendee")];
+        const { space, privateEvents } = createSpace(users);
+        const strategy = new WebRTCCommunicationStrategy(space, createUsersMap(users), createUsersMap(users));
 
-        strategy.handleMeetingConnectionRestartMessage(
-            MeetingConnectionRestartMessage.fromPartial({ userId: "user-b", connectionId }),
-            "user-a",
-        );
+        await strategy.initialize(createUsersMap(users), createUsersMap(users));
 
-        const starts = webRtcStartDispatches(dispatchPrivateEvent);
-        expect(starts).toHaveLength(2);
-
-        const newIds = starts.map((start) => start.spaceEvent.event.webRtcStartMessage?.connectionId);
-        // Both starts share a single new id, different from the superseded one.
-        expect(new Set(newIds).size).toBe(1);
-        expect(newIds[0]).not.toBe(connectionId);
-
-        // One peer is the initiator, the other is not.
-        const initiators = starts.map((start) => start.spaceEvent.event.webRtcStartMessage?.initiator);
-        expect(initiators).toContain(true);
-        expect(initiators).toContain(false);
+        expect(webRtcStartEvents(privateEvents)).toHaveLength(2);
+        expect(
+            webRtcStartEvents(privateEvents)
+                .map((event) => event.receiverUserId)
+                .sort()
+        ).toEqual(["attendee", "speaker"]);
     });
 
-    it("ignores a stale restart that references a superseded connection", async () => {
-        const { strategy, dispatchPrivateEvent } = await setupStrategyWithConnection();
+    it("should start WebRTC when two feedback speakers connect", async () => {
+        const users = [createUser("speaker-1", "speaker"), createUser("speaker-2", "speaker")];
+        const { space, privateEvents } = createSpace(users);
+        const strategy = new WebRTCCommunicationStrategy(space, createUsersMap(users), createUsersMap(users));
 
-        strategy.handleMeetingConnectionRestartMessage(
-            MeetingConnectionRestartMessage.fromPartial({ userId: "user-b", connectionId: "stale-connection-id" }),
-            "user-a",
-        );
+        await strategy.initialize(createUsersMap(users), createUsersMap(users));
 
-        expect(dispatchPrivateEvent).not.toHaveBeenCalled();
+        expect(webRtcStartEvents(privateEvents)).toHaveLength(2);
     });
 
-    it("regenerates when the restart omits the connectionId (backward compatibility)", async () => {
-        const { strategy, dispatchPrivateEvent } = await setupStrategyWithConnection();
+    it("should not start WebRTC when a feedback user has no streaming role", async () => {
+        const users = [createUser("speaker", "speaker"), createUser("none", "none")];
+        const { space, privateEvents } = createSpace(users);
+        const strategy = new WebRTCCommunicationStrategy(space, createUsersMap(users), createUsersMap(users));
 
-        strategy.handleMeetingConnectionRestartMessage(
-            MeetingConnectionRestartMessage.fromPartial({ userId: "user-b" }),
-            "user-a",
-        );
+        await strategy.initialize(createUsersMap(users), createUsersMap(users));
 
-        expect(webRtcStartDispatches(dispatchPrivateEvent)).toHaveLength(2);
+        expect(webRtcStartEvents(privateEvents)).toHaveLength(0);
     });
 
-    it("ignores a restart when no connection exists between the peers", async () => {
-        const dispatchPrivateEvent = vi.fn();
-        const space = createSpace(dispatchPrivateEvent);
-        const strategy = new WebRTCCommunicationStrategy(space, new Map(), new Map());
+    it("should create missing WebRTC connections when an attendee becomes a speaker", async () => {
+        const speaker = createUser("speaker", "attendee");
+        const changingUser = createUser("changing-user", "attendee");
+        const users = [speaker, changingUser];
+        const usersMap = createUsersMap(users);
+        const { space, privateEvents } = createSpace(users);
+        const strategy = new WebRTCCommunicationStrategy(space, usersMap, usersMap);
 
-        strategy.handleMeetingConnectionRestartMessage(
-            MeetingConnectionRestartMessage.fromPartial({ userId: "user-b", connectionId: "any-connection-id" }),
-            "user-a",
-        );
+        await strategy.initialize(usersMap, usersMap);
+        privateEvents.length = 0;
+        changingUser.megaphoneState = true;
+        changingUser.attendeesState = false;
 
-        expect(dispatchPrivateEvent).not.toHaveBeenCalled();
+        strategy.updateUser(changingUser);
+
+        expect(webRtcStartEvents(privateEvents)).toHaveLength(2);
     });
 
-    it("ignores a restart without a target userId", async () => {
-        const { strategy, dispatchPrivateEvent } = await setupStrategyWithConnection();
+    it("should close invalid WebRTC connections when a speaker becomes an attendee", async () => {
+        const attendee = createUser("attendee", "attendee");
+        const changingUser = createUser("changing-user", "speaker");
+        const users = [attendee, changingUser];
+        const usersMap = createUsersMap(users);
+        const { space, privateEvents } = createSpace(users);
+        const strategy = new WebRTCCommunicationStrategy(space, usersMap, usersMap);
 
-        strategy.handleMeetingConnectionRestartMessage(MeetingConnectionRestartMessage.fromPartial({}), "user-a");
+        await strategy.initialize(usersMap, usersMap);
+        privateEvents.length = 0;
+        changingUser.megaphoneState = false;
+        changingUser.attendeesState = true;
 
-        expect(dispatchPrivateEvent).not.toHaveBeenCalled();
+        strategy.updateUser(changingUser);
+
+        expect(webRtcDisconnectEvents(privateEvents)).toHaveLength(2);
+    });
+
+    it("should close invalid WebRTC connections instead of restarting them", async () => {
+        const attendee = createUser("attendee", "attendee");
+        const changingUser = createUser("changing-user", "speaker");
+        const users = [attendee, changingUser];
+        const usersMap = createUsersMap(users);
+        const { space, privateEvents } = createSpace(users);
+        const strategy = new WebRTCCommunicationStrategy(space, usersMap, usersMap);
+
+        await strategy.initialize(usersMap, usersMap);
+        privateEvents.length = 0;
+        changingUser.megaphoneState = false;
+        changingUser.attendeesState = true;
+        strategy.handleMeetingConnectionRestartMessage({ userId: attendee.spaceUserId }, changingUser.spaceUserId);
+
+        expect(webRtcStartEvents(privateEvents)).toHaveLength(0);
+        expect(webRtcDisconnectEvents(privateEvents)).toHaveLength(2);
+    });
+
+    it("should keep existing WebRTC behavior outside feedback live streaming", async () => {
+        const attendees = [createUser("attendee-1", "attendee"), createUser("attendee-2", "attendee")];
+        const { space, privateEvents } = createSpace(attendees, allUsersFilter);
+        const strategy = new WebRTCCommunicationStrategy(space, createUsersMap(attendees), createUsersMap(attendees));
+
+        await strategy.initialize(createUsersMap(attendees), createUsersMap(attendees));
+
+        expect(webRtcStartEvents(privateEvents)).toHaveLength(2);
     });
 });

--- a/back/tests/WebRTCCommunicationStrategy.test.ts
+++ b/back/tests/WebRTCCommunicationStrategy.test.ts
@@ -236,3 +236,93 @@ describe("WebRTCCommunicationStrategy", () => {
         expect(webRtcStartEvents(privateEvents)).toHaveLength(0);
     });
 });
+
+function webRtcStartPayload(event: PrivateEvent): { initiator: boolean; connectionId: string } | undefined {
+    const inner = event.spaceEvent?.event;
+    return inner?.$case === "webRtcStartMessage" ? inner.webRtcStartMessage : undefined;
+}
+
+describe("WebRTCCommunicationStrategy.handleMeetingConnectionRestartMessage", () => {
+    // Outside the feedback filter, a connection is always allowed, so these tests isolate the
+    // restart/stale-connection bookkeeping from the feedback-role rules.
+    async function setupStrategyWithConnection() {
+        const userA = createUser("user-a", "none");
+        const userB = createUser("user-b", "none");
+        const usersMap = createUsersMap([userA, userB]);
+        const { space, privateEvents } = createSpace([userA, userB], FilterType.ALL_USERS);
+
+        const strategy = new WebRTCCommunicationStrategy(space, usersMap, usersMap);
+        await strategy.initialize(usersMap, usersMap);
+
+        const connectionId = webRtcStartPayload(webRtcStartEvents(privateEvents)[0])?.connectionId;
+        if (!connectionId) {
+            throw new Error("Test setup failed: no WebRTC connection was established");
+        }
+
+        privateEvents.length = 0;
+        return { strategy, privateEvents, connectionId };
+    }
+
+    it("establishes exactly one bidirectional connection on initialize", async () => {
+        const { connectionId } = await setupStrategyWithConnection();
+        expect(connectionId).toBeTruthy();
+    });
+
+    it("regenerates a fresh connection when the restart references the current connection", async () => {
+        const { strategy, privateEvents, connectionId } = await setupStrategyWithConnection();
+
+        strategy.handleMeetingConnectionRestartMessage({ userId: "user-b", connectionId }, "user-a");
+
+        const starts = webRtcStartEvents(privateEvents);
+        expect(starts).toHaveLength(2);
+
+        // Both starts share a single new id, different from the superseded one.
+        const newIds = starts.map((event) => webRtcStartPayload(event)?.connectionId);
+        expect(new Set(newIds).size).toBe(1);
+        expect(newIds[0]).not.toBe(connectionId);
+
+        // One peer is the initiator, the other is not.
+        const initiators = starts.map((event) => webRtcStartPayload(event)?.initiator);
+        expect(initiators).toContain(true);
+        expect(initiators).toContain(false);
+    });
+
+    it("ignores a stale restart that references a superseded connection", async () => {
+        const { strategy, privateEvents } = await setupStrategyWithConnection();
+
+        strategy.handleMeetingConnectionRestartMessage(
+            { userId: "user-b", connectionId: "stale-connection-id" },
+            "user-a",
+        );
+
+        expect(privateEvents).toHaveLength(0);
+    });
+
+    it("regenerates when the restart omits the connectionId (backward compatibility)", async () => {
+        const { strategy, privateEvents } = await setupStrategyWithConnection();
+
+        strategy.handleMeetingConnectionRestartMessage({ userId: "user-b" }, "user-a");
+
+        expect(webRtcStartEvents(privateEvents)).toHaveLength(2);
+    });
+
+    it("ignores a restart when no connection exists between the peers", () => {
+        const { space, privateEvents } = createSpace([], FilterType.ALL_USERS);
+        const strategy = new WebRTCCommunicationStrategy(space, new Map(), new Map());
+
+        strategy.handleMeetingConnectionRestartMessage(
+            { userId: "user-b", connectionId: "any-connection-id" },
+            "user-a",
+        );
+
+        expect(privateEvents).toHaveLength(0);
+    });
+
+    it("ignores a restart without a target userId", async () => {
+        const { strategy, privateEvents } = await setupStrategyWithConnection();
+
+        strategy.handleMeetingConnectionRestartMessage({}, "user-a");
+
+        expect(privateEvents).toHaveLength(0);
+    });
+});

--- a/back/tests/WebRTCCommunicationStrategy.test.ts
+++ b/back/tests/WebRTCCommunicationStrategy.test.ts
@@ -210,4 +210,29 @@ describe("WebRTCCommunicationStrategy", () => {
 
         expect(hasWebRtcDisconnectBetween(privateEvents, "speaker", "attendee")).toBe(true);
     });
+
+    it("should not touch the topology on update outside the feedback filter", () => {
+        const user1 = createUser("user-1", "none");
+        const user2 = createUser("user-2", "none");
+        const { space, privateEvents } = createSpace([user1, user2], FilterType.ALL_USERS);
+        // Outside feedback, connections are driven only by add/delete: an update must be a no-op.
+        const strategy = new WebRTCCommunicationStrategy(space, createUsersMap([user1, user2]), new Map());
+
+        strategy.updateUser(user1);
+
+        expect(webRtcStartEvents(privateEvents)).toHaveLength(0);
+    });
+
+    it("should not connect two feedback users that are not watching on update", () => {
+        const speaker = createUser("speaker", "speaker");
+        const attendee = createUser("attendee", "attendee");
+        const { space, privateEvents } = createSpace([speaker, attendee]);
+        // Both are in the filter but nobody is watching yet (empty usersToNotify), so no P2P pair
+        // exists in the connection matrix.
+        const strategy = new WebRTCCommunicationStrategy(space, createUsersMap([speaker, attendee]), new Map());
+
+        strategy.updateUser(speaker);
+
+        expect(webRtcStartEvents(privateEvents)).toHaveLength(0);
+    });
 });


### PR DESCRIPTION
## Problem
In `LIVE_STREAMING_USERS_WITH_FEEDBACK`, attendees could receive unnecessary WebRTC P2P connections with other attendees, allowing media to leak through attendee-attendee peers.

## Solution
Make the backend WebRTC strategy role-aware for feedback live streaming and only allow P2P connections when at least one peer is a speaker.

## Changes
- Restrict feedback WebRTC pairs to speaker-attendee or speaker-speaker.
- Reconcile WebRTC connections when users change speaker/attendee roles.
- Prevent invalid WebRTC restart messages from recreating attendee-attendee connections.
- Add targeted backend tests for feedback role connection rules.