### PR TITLE
Center back view on Woka when moving

### DIFF
--- a/play/src/front/Components/ActionsMenu/WokaMenu.svelte
+++ b/play/src/front/Components/ActionsMenu/WokaMenu.svelte
@@ -69,11 +69,11 @@
     };
 
     onMount(() => {
-        gameManager.getCurrentGameScene().CurrentPlayer.on(startMovingEventName, onStartMoving);
+        gameManager.getCurrentGameScene().CurrentPlayer?.on(startMovingEventName, onStartMoving);
     });
 
     onDestroy(() => {
-        gameManager.getCurrentGameScene().CurrentPlayer.off(startMovingEventName, onStartMoving);
+        gameManager.getCurrentGameScene().CurrentPlayer?.off(startMovingEventName, onStartMoving);
         if (wokaMenuStoreUnsubscriber) {
             wokaMenuStoreUnsubscriber();
         }

--- a/play/src/front/Components/ActionsMenu/WokaMenu.svelte
+++ b/play/src/front/Components/ActionsMenu/WokaMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { Unsubscriber } from "svelte/store";
     import type { AvailabilityStatus } from "@workadventure/messages";
-    import { onDestroy } from "svelte";
+    import { onDestroy, onMount } from "svelte";
     import { wokaMenuStore, wokaMenuProgressStore } from "../../Stores/WokaMenuStore";
     import ButtonClose from "../Input/ButtonClose.svelte";
     import VisitCard from "../VisitCard/VisitCard.svelte";
@@ -11,6 +11,7 @@
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { getColorHexOfStatus, getStatusLabel } from "../../Utils/AvailabilityStatus";
     import type { WokaMenuAction, WokaMenuData } from "../../Stores/WokaMenuStore";
+    import { startMovingEventName } from "../../Phaser/Player/Player";
 
     let wokaMenuData: WokaMenuData | undefined;
     let sortedActions: WokaMenuAction[] | undefined;
@@ -63,7 +64,16 @@
         }
     });
 
+    const onStartMoving = () => {
+        wokaMenuStore.clear();
+    };
+
+    onMount(() => {
+        gameManager.getCurrentGameScene().CurrentPlayer.on(startMovingEventName, onStartMoving);
+    });
+
     onDestroy(() => {
+        gameManager.getCurrentGameScene().CurrentPlayer.off(startMovingEventName, onStartMoving);
         if (wokaMenuStoreUnsubscriber) {
             wokaMenuStoreUnsubscriber();
         }

--- a/play/src/front/Phaser/Player/Player.ts
+++ b/play/src/front/Phaser/Player/Player.ts
@@ -92,11 +92,15 @@ export class Player extends Character {
         path: { x: number; y: number }[],
         speed?: number
     ): Promise<{ x: number; y: number; cancelled: boolean }> {
-        this.emit(startMovingEventName, { direction: this._lastDirection, x: this.x, y: this.y });
+        if (!this.isMoving) {
+            this.isMoving = true;
+            this.emit(startMovingEventName, { direction: this._lastDirection, x: this.x, y: this.y });
+        }
 
         this.getBody().setDirectControl(true);
-        return super.setPathToFollow(path, speed);
-    }
+        return super.setPathToFollow(path, speed).finally(() => {
+            this.isMoving = false;
+        });
 
     public getCurrentPathDestinationPoint(): { x: number; y: number } | undefined {
         if (!this.pathToFollow) {

--- a/play/src/front/Phaser/Player/Player.ts
+++ b/play/src/front/Phaser/Player/Player.ts
@@ -15,10 +15,12 @@ import { passStatusToOnline } from "../../Rules/StatusRules/statusChangerFunctio
 import { localUserStore } from "../../Connection/LocalUserStore";
 
 export const hasMovedEventName = "hasMoved";
+export const startMovingEventName = "startMoving";
 export const requestEmoteEventName = "requestEmote";
 
 export class Player extends Character {
     private readonly unsubscribeVisibilityStore: Unsubscriber;
+    private isMoving = false;
 
     constructor(
         Scene: GameScene,
@@ -90,6 +92,8 @@ export class Player extends Character {
         path: { x: number; y: number }[],
         speed?: number
     ): Promise<{ x: number; y: number; cancelled: boolean }> {
+        this.emit(startMovingEventName, { direction: this._lastDirection, x: this.x, y: this.y });
+
         this.getBody().setDirectControl(true);
         return super.setPathToFollow(path, speed);
     }
@@ -143,9 +147,16 @@ export class Player extends Character {
         // Send movement events
         const emit = () => this.emit(hasMovedEventName, { moving, direction, x: this.x, y: this.y });
         if (moving) {
+            if (!this.isMoving) {
+                this.isMoving = true;
+                this.emit(startMovingEventName, { direction, x: this.x, y: this.y });
+            }
             this.moveBy(x, y);
             emit();
         } else if (get(userMovingStore)) {
+            if (this.isMoving) {
+                this.isMoving = false;
+            }
             this.stop();
             emit();
         }


### PR DESCRIPTION
If the view is centered on another Woka (because we clicked on this other Woka) and we start moving, we are now closing the remote Woka contextural menu automatically so that the camera centers back on our Woka.