### PR TITLE
Fixing the x-forwarded-for mismatch in websockets

### DIFF
--- a/play/src/pusher/controllers/AuthenticateController.ts
+++ b/play/src/pusher/controllers/AuthenticateController.ts
@@ -181,8 +181,10 @@ export class AuthenticateController extends BaseHttpController {
          */
 
         this.app.get("/me", async (req, res) => {
-            debug(`AuthenticateController => [${req.method}] ${req.originalUrl} — IP: ${req.ip} — Time: ${Date.now()}`);
             const IPAddress = getClientIpFromXForwardedFor(req.header("x-forwarded-for"));
+            debug(
+                `AuthenticateController => [${req.method}] ${req.originalUrl} — IP: ${IPAddress} — Time: ${Date.now()}`
+            );
             const query = validateQuery(req, res, MeRequest);
             if (query === undefined) {
                 return;

--- a/play/src/pusher/services/PusherRoomSocketController.ts
+++ b/play/src/pusher/services/PusherRoomSocketController.ts
@@ -13,6 +13,7 @@ import type { UpgradeFailedData } from "../controllers/IoSocketController";
 import { PusherWebSocket } from "./PusherWebSocket";
 import type { RawSocket } from "./PusherWebSocket";
 import { validateWebsocketQuery } from "./QueryValidator";
+import { getClientIpFromXForwardedFor } from "./ClientIp";
 
 type UpgradeContext<TQuery> = {
     query: TQuery;
@@ -215,13 +216,13 @@ export class PusherRoomSocketController {
                         );
                         return;
                     }
-
+                    const ipAddress = getClientIpFromXForwardedFor(req.getHeader("x-forwarded-for"));
                     await config.upgrade({
                         query,
                         request: {
                             method: req.getMethod(),
                             url: req.getUrl(),
-                            ipAddress: req.getHeader("x-forwarded-for"),
+                            ipAddress,
                             locale: req.getHeader("accept-language"),
                             token: websocketProtocol,
                         },


### PR DESCRIPTION
- only keeping the first IP address in the x-forwarded-for header for websockets