### PR TITLE
Removing "Close" button from action message

### DIFF
--- a/play/src/front/Api/Iframe/Ui/ActionMessage.ts
+++ b/play/src/front/Api/Iframe/Ui/ActionMessage.ts
@@ -24,7 +24,7 @@ export class ActionMessage {
         this.uuid = uuidv4();
         this.message = actionMessageOptions.message;
         this.type = actionMessageOptions.type ?? "message";
-        this.callback = actionMessageOptions.callback;
+        this.callback = actionMessageOptions.callback ?? (() => {});
         this.create().catch((e) => console.error(e));
     }
 

--- a/play/src/front/Components/PopUp/PopUpContainer.svelte
+++ b/play/src/front/Components/PopUp/PopUpContainer.svelte
@@ -5,11 +5,15 @@
     export let reduceOnSmallScreen = false;
     /** When false, the buttons wrapper is hidden even if slot "buttons" has content. Default true. */
     export let showButtons = true;
+    export let onclick = () => {};
 </script>
 
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
     class="popup-container bg-contrast/80 flex flex-col backdrop-blur-md text-white min-w-60 min-h-20 rounded-lg overflow-hidden transition-all animation responsive z-20 {extraClasses}"
     class:responsive={reduceOnSmallScreen}
+    on:click={onclick}
 >
     <div class="flex items-center p-4 px-10 pointer-events-auto justify-center grow">
         <div class="text-center leading-6 responsive-message {fullContent ? 'w-full' : ''}">

--- a/play/src/front/Components/PopUp/PopUpTriggerActionMessage.svelte
+++ b/play/src/front/Components/PopUp/PopUpTriggerActionMessage.svelte
@@ -16,9 +16,6 @@
     });
 </script>
 
-<PopUpContainer reduceOnSmallScreen={true}>
+<PopUpContainer reduceOnSmallScreen={true} onclick={click}>
     {message}
-    <svelte:fragment slot="buttons">
-        <button class="btn btn-secondary btn-sm w-full max-w-96 justify-center" on:click={click}> Close </button>
-    </svelte:fragment>
 </PopUpContainer>

--- a/tests/tests/areas.spec.ts
+++ b/tests/tests/areas.spec.ts
@@ -136,11 +136,11 @@ test.describe("Areas @nomobile", () => {
 
         // Let's first check the onEnter is triggered when we are already in the area when we subscribe.
         await expect(page.getByText("Welcome to MyNewArea")).toBeVisible();
-        await page.getByRole("button", { name: "Close" }).first().click();
+        await page.getByText("Welcome to MyNewArea").click();
         // Let's move out
         await Map.teleportToPosition(page, 9 * 32, 9 * 32);
         await expect(page.getByText("Goodbye MyNewArea")).toBeVisible();
-        await page.getByRole("button", { name: "Close" }).click();
+        await page.getByText("Goodbye MyNewArea").click();
         await expect(page.locator("span.characterTriggerAction")).toBeHidden();
 
         // Let's move back in

--- a/tests/tests/scripting_area.spec.ts
+++ b/tests/tests/scripting_area.spec.ts
@@ -57,11 +57,11 @@ test.describe("Scripting for Map editor @oidc @nomobile @nowebkit", () => {
 
         // Let's first check the onEnter is triggered when we are already in the area when we subscribe.
         await expect(page.getByText("Welcome to MyZone")).toBeVisible();
-        await page.getByRole("button", { name: "Close" }).first().click();
+        await page.getByText("Welcome to MyZone").click();
         // Let's move out
         await Map.teleportToPosition(page, 9 * 32, 9 * 32);
         await expect(page.getByText("Goodbye to MyZone")).toBeVisible();
-        await page.getByRole("button", { name: "Close" }).click();
+        await page.getByText("Goodbye to MyZone").click();
         await expect(page.locator("span.characterTriggerAction")).toBeHidden();
 
         // Let's move back in

--- a/tests/tests/scripting_enter_leave_layer.spec.ts
+++ b/tests/tests/scripting_enter_leave_layer.spec.ts
@@ -33,18 +33,18 @@ test.describe("Scripting for enter / leave layer event", () => {
 
         // The subscription should automatically trigger on start because we are already in the start zone.
         await expect(page.getByText("Welcome to start initial")).toBeVisible();
-        await page.getByRole("button", { name: "Close" }).first().click();
+        await page.getByText("Welcome to start initial").click();
 
         await Map.teleportToPosition(page, 2 * 32, 8 * 32);
 
         await expect(page.getByText("Goodbye start move")).toBeVisible();
-        await page.getByRole("button", { name: "Close" }).first().click();
+        await page.getByText("Goodbye start move").click();
 
         // Let's go back to start
         await Map.teleportToPosition(page, 0.5 * 32, 4.5 * 32);
 
         await expect(page.getByText("Welcome to start move")).toBeVisible();
-        await page.getByRole("button", { name: "Close" }).first().click();
+        await page.getByText("Welcome to start move").first().click();
 
         // Let's subscribe to the "start" event again.
         // The subscribe should be fired again.


### PR DESCRIPTION
This "Close" was hard coded in English and definitely counter intuitive as it was triggering the action of the action message anyway.

Replaced by a proper "click" on the whole action message popup (plus the classic "space" key handler)

Closes #6175 