### PR TITLE
Fixing a bug when drawing a bubble in headless

### DIFF
--- a/play/src/front/Phaser/Entity/ConversationBubble.ts
+++ b/play/src/front/Phaser/Entity/ConversationBubble.ts
@@ -186,6 +186,11 @@ export class ConversationBubble extends Phaser.GameObjects.Sprite {
      * Build Catmull-Rom spline, create texture from it and apply to sprite.
      */
     private drawSpline(): void {
+        if (!this.scene.renderer) {
+            // In case we don't have a renderer at all (bots, etc...), no need to render the bubble.
+            return;
+        }
+
         // Convert polar samples to Cartesian points
         const pts: Phaser.Math.Vector2[] = [];
         for (let s = 0; s < this.segments; s++) {


### PR DESCRIPTION
With a headless renderer, drawing the spline of a bubble would crash Phaser. The spline drawing is now ignored.