### PR TITLE
Fix megaphone attendee screen share publishing

### DIFF
--- a/play/src/front/Livekit/LiveKitRoom.test.ts
+++ b/play/src/front/Livekit/LiveKitRoom.test.ts
@@ -1,0 +1,138 @@
+import { Subject } from "rxjs";
+import { writable } from "svelte/store";
+import { describe, expect, it, vi } from "vitest";
+import type { Readable } from "svelte/store";
+import type { LocalStreamStoreValue } from "../Stores/MediaStore";
+import type { SpaceInterface } from "../Space/SpaceInterface";
+import type { Streamable } from "../Space/Streamable";
+import type { StreamableSubjects } from "../Space/SpacePeerManager/SpacePeerManager";
+import { LiveKitRoom } from "./LiveKitRoom";
+
+vi.mock("../Stores/ScreenSharingStore", async () => {
+    const { writable } = await import("svelte/store");
+    const requestedScreenSharingState = writable(false);
+    return {
+        requestedScreenSharingState,
+        screenSharingLocalStreamStore: writable({ type: "success", stream: undefined }),
+        screenShareQualityStore: writable("recommended"),
+    };
+});
+
+vi.mock("../Stores/MegaphoneStore", async () => {
+    const { writable } = await import("svelte/store");
+    return {
+        liveStreamingEnabledStore: writable(false),
+        requestedMegaphoneStore: writable(false),
+        megaphoneSpaceStore: writable(undefined),
+        megaphoneCanBeUsedStore: writable(false),
+    };
+});
+
+vi.mock("../WebRtc/MediaManager", () => ({
+    mediaManager: {},
+    MediaManager: vi.fn(),
+}));
+
+vi.mock("../Stores/NoMicrophoneSoundWarningVisibleStore", async () => {
+    const { writable } = await import("svelte/store");
+    return {
+        noMicrophoneSoundWarningVisibleStore: writable(false),
+    };
+});
+
+vi.mock("../Stores/OrderedStreamableCollectionStore", async () => {
+    const { writable } = await import("svelte/store");
+    return {
+        triggerReorderStore: writable(0),
+    };
+});
+
+vi.mock("../Stores/StreamableCollectionStore", async () => {
+    const { writable } = await import("svelte/store");
+    return {
+        streamableCollectionStore: writable([]),
+    };
+});
+
+vi.mock("../Space/SpacePeerManager/SpacePeerManager", () => ({}));
+
+describe("LiveKitRoom", () => {
+    it("should not forward screen share updates when the space forbids screen share publication", () => {
+        const shouldPublishScreenShareStore = writable(false);
+        const screenShareStream = createScreenShareStream();
+        const room = createLiveKitRoom({
+            screenSharingLocalStreamStore: writable(screenShareStream),
+            shouldPublishScreenShareStore,
+        });
+        const queueScreenShareUpdate = vi.fn();
+        room["queueScreenShareUpdate"] = queueScreenShareUpdate;
+
+        room["synchronizeMediaState"]();
+
+        expect(queueScreenShareUpdate).toHaveBeenLastCalledWith(undefined);
+    });
+
+    it("should stop forwarding screen share updates when the space stops allowing screen share publication", () => {
+        const shouldPublishScreenShareStore = writable(true);
+        const screenShareStream = createScreenShareStream();
+        const room = createLiveKitRoom({
+            screenSharingLocalStreamStore: writable(screenShareStream),
+            shouldPublishScreenShareStore,
+        });
+        const queueScreenShareUpdate = vi.fn();
+        room["queueScreenShareUpdate"] = queueScreenShareUpdate;
+
+        room["synchronizeMediaState"]();
+        shouldPublishScreenShareStore.set(false);
+
+        expect(queueScreenShareUpdate).toHaveBeenLastCalledWith(undefined);
+    });
+});
+
+function createLiveKitRoom({
+    screenSharingLocalStreamStore,
+    shouldPublishScreenShareStore,
+}: {
+    screenSharingLocalStreamStore: Readable<LocalStreamStoreValue | undefined>;
+    shouldPublishScreenShareStore: Readable<boolean>;
+}): LiveKitRoom {
+    return new LiveKitRoom(
+        "wss://livekit.example.com",
+        "token",
+        createSpace(shouldPublishScreenShareStore),
+        createStreamableSubjects(),
+        writable(new Set<string>()),
+        new AbortController().signal,
+        screenSharingLocalStreamStore,
+        writable(undefined),
+        {
+            increment: vi.fn(),
+            decrement: vi.fn(),
+        },
+        writable({ type: "success", stream: undefined })
+    );
+}
+
+function createSpace(shouldPublishScreenShareStore: Readable<boolean>): SpaceInterface {
+    return {
+        isStreamingVideoStore: writable(false),
+        isStreamingAudioStore: writable(false),
+        shouldPublishScreenShareStore,
+    } as unknown as SpaceInterface;
+}
+
+function createStreamableSubjects(): StreamableSubjects {
+    return {
+        videoPeerAdded: new Subject<Streamable>(),
+        videoPeerRemoved: new Subject<Streamable>(),
+        screenSharingPeerAdded: new Subject<Streamable>(),
+        screenSharingPeerRemoved: new Subject<Streamable>(),
+    };
+}
+
+function createScreenShareStream(): LocalStreamStoreValue {
+    return {
+        type: "success",
+        stream: { id: "screen-share-stream" } as unknown as MediaStream,
+    };
+}

--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -328,9 +328,11 @@ export class LiveKitRoom implements LiveKitRoomInterface {
         );
 
         this.unsubscribers.push(
-            this.screenSharingLocalStreamStore.subscribe((stream) => {
-                this.queueScreenShareUpdate(stream);
-            })
+            deriveSwitchStore(this.screenSharingLocalStreamStore, this.space.shouldPublishScreenShareStore).subscribe(
+                (stream) => {
+                    this.queueScreenShareUpdate(stream);
+                }
+            )
         );
 
         this.unsubscribers.push(

--- a/tests/tests/map_editor/map_editor_megaphone_speaker_zone.spec.ts
+++ b/tests/tests/map_editor/map_editor_megaphone_speaker_zone.spec.ts
@@ -574,6 +574,13 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
             });
         }
 
+        // A listener may keep their local screen share active, but it must not be published to the megaphone speaker.
+        await pageListener1.getByTestId("screenShareButton").click();
+        await Menu.expectButtonState(pageListener1, "screenShareButton", "active");
+        await expect(pageSpeaker.locator("#highlighted-media").getByText("Admin2", { exact: true })).toBeHidden({
+            timeout: 20_000,
+        });
+
         // Verify listeners cannot see each other (only the speaker)
         // Admin2 (listener1) should NOT see Alice, Bob, and John
         await expect(


### PR DESCRIPTION
## Summary
- Prevent LiveKit from publishing a listener/attendee screen share into a megaphone space when screen sharing is not allowed by the space.
- Reuse `space.shouldPublishScreenShareStore` for LiveKit screen share updates, matching the existing WebRTC behavior.
- Add a regression unit test and an E2E assertion for attendee screen share visibility in megaphone auditorium mode.

## Root cause
WebRTC already gated the local screen share stream through `space.shouldPublishScreenShareStore`, but LiveKit subscribed directly to `screenSharingLocalStreamStore`. In megaphone see-attendees mode, that allowed an attendee's local screen share to be forwarded to LiveKit even though only speakers should publish screen shares.
