### PR TITLE
Fixing bad name zoom level on Woka creation

### DIFF
--- a/play/src/front/Phaser/Components/UsernameDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameDisplay.ts
@@ -65,7 +65,6 @@ export class UsernameDisplay {
         this.updateUsernameBackgroundColor(outlineColor);
 
         this.gameScene.usernameDomLayer.addUsername(this.element);
-        this.element.style.setProperty("--username-dom-scale", this.displayScale.toString());
 
         this.scene.game.events.on(WaScaleManagerEvent.ZoomChanged, this.onZoomChanged);
     }


### PR DESCRIPTION
Fixes:
<img width="655" height="459" alt="image" src="https://github.com/user-attachments/assets/bbb255eb-50e8-4617-8e63-d34e19f3dc89" />
