### PR TITLE
Temporarily disabling "allow talking" feature

### DIFF
--- a/play/src/front/Components/MapEditor/PropertyEditor/ListenerMegaphonePropertyEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/ListenerMegaphonePropertyEditor.svelte
@@ -110,13 +110,13 @@
                 onChange={onValueChange}
             />
         </div>
-        <div class="value-switch">
+        <!--<div class="value-switch">
             <InputSwitch
                 id="allowTalking"
                 label={$LL.mapEditor.properties.allowTalking()}
                 bind:value={property.allowTalking}
                 onChange={onValueChange}
             />
-        </div>
+        </div>-->
     </span>
 </PropertyEditorBase>


### PR DESCRIPTION
The "allow talking" feature in the audience zone was merged too quickly. It does not work yet because there cannot yet be 2 proximity chat rooms at a same time.

We are simply commenting out the code that displays the toggle button while we work on a fix.