### PR TITLE
Add multi-meeting scripting API

### DIFF
--- a/docs/developer/map-scripting/references/api-deprecated.md
+++ b/docs/developer/map-scripting/references/api-deprecated.md
@@ -24,3 +24,10 @@ The list of functions below is **deprecated**. You should not use those but. use
 - Method `WA.ui.registerMenuCommand` parameter `callback` is deprecated. Use [`WA.ui.registerMenuCommand(commandDescriptor: string, options: MenuOptions)`](api-ui.md#add-custom-menu).
 - Method `WA.room.onEnterZone` is deprecated. Use instead [`WA.room.onEnterLayer`](api-room.md#detecting-when-the-user-entersleaves-a-layer).
 - Method `WA.room.onLeaveZone` is deprecated. Use instead [`WA.room.onLeaveLayer`](api-room.md#detecting-when-the-user-entersleaves-a-layer).
+- Method `WA.player.proximityMeeting.onJoin` is deprecated. Use [`WA.player.meetings.onJoin`](api-player.md#detecting-when-the-user-entersleaves-a-meeting).
+- Method `WA.player.proximityMeeting.onLeave` is deprecated. Use `Meeting.onLeave` from [`WA.player.meetings.onJoin`](api-player.md#detecting-when-the-user-entersleaves-a-meeting).
+- Method `WA.player.proximityMeeting.onParticipantJoin` is deprecated. Use [`Meeting.onParticipantJoin`](api-player.md#detecting-when-a-participant-entersleaves-the-current-meeting).
+- Method `WA.player.proximityMeeting.onParticipantLeave` is deprecated. Use [`Meeting.onParticipantLeave`](api-player.md#detecting-when-a-participant-entersleaves-the-current-meeting).
+- Method `WA.player.proximityMeeting.playSound` is deprecated. Use [`Meeting.playSound`](api-player.md#playing-a-sound-to-players-in-the-same-meeting).
+- Method `WA.player.proximityMeeting.startAudioStream` is deprecated. Use [`Meeting.startAudioStream`](api-player.md#streaming-sound-to-players-in-the-same-meeting).
+- Method `WA.player.proximityMeeting.listenToAudioStream` is deprecated. Use [`Meeting.listenToAudioStream`](api-player.md#listening-to-the-microphone-of-the-players-in-the-same-meeting).

--- a/docs/developer/map-scripting/references/api-player.md
+++ b/docs/developer/map-scripting/references/api-player.md
@@ -520,29 +520,45 @@ WA.player.setStatus("BACK_IN_A_MOMENT");
 ## Detecting when the user enters/leaves a meeting
 
 ```ts
-WA.player.proximityMeeting.onJoin(): Subscription<RemotePlayerInterface[]>
-WA.player.proximityMeeting.onLeave(): Subscription<RemotePlayerInterface[]>
+WA.player.meetings.onJoin(): Subscription<Meeting>
+
+interface Meeting {
+  id: string;
+  name: string;
+  kind: "default" | "proximity" | "meeting" | "listener" | "speaker" | "area";
+  participants: RemotePlayerInterface[];
+  onParticipantJoin(): Subscription<RemotePlayerInterface>;
+  onParticipantLeave(): Subscription<RemotePlayerInterface>;
+  onLeave(): Subscription<void>;
+  playSound(url: string): Promise<void>;
+  startAudioStream(sampleRate: number): Promise<AudioStream>;
+  listenToAudioStream(sampleRate: number): Observable<Float32Array>;
+}
 ```
 
-The event is triggered when the user enters or leaves a proximity meeting.
+The event is triggered when the user enters a proximity meeting. A proximity meeting can be a bubble, a meeting room,
+or another proximity-backed area. The returned `Meeting` object is scoped to that specific meeting.
 
 Example:
 
 ```ts
-WA.player.proximityMeeting.onJoin().subscribe(async (players: RemotePlayerInterface[]) => {
+WA.player.meetings.onJoin().subscribe(async (meeting: Meeting) => {
     WA.chat.sendChatMessage("You joined a proximity chat", "System");
-});
 
-WA.player.proximityMeeting.onLeave().subscribe(async () => {
-    WA.chat.sendChatMessage("You left the proximity chat", "System");
+    meeting.onLeave().subscribe(async () => {
+        WA.chat.sendChatMessage("You left the proximity chat", "System");
+    });
 });
 ```
+
+`WA.player.proximityMeeting.onJoin()` and `WA.player.proximityMeeting.onLeave()` are deprecated single-meeting methods.
+They only target the default proximity bubble. Use `WA.player.meetings.onJoin()` for new scripts.
 
 ## Detecting when a participant enters/leaves the current meeting
 
 ```ts
-WA.player.proximityMeeting.onParticipantJoin(): Subscription<RemotePlayerInterface>
-WA.player.proximityMeeting.onParticipantLeave(): Subscription<RemotePlayerInterface>
+Meeting.onParticipantJoin(): Subscription<RemotePlayerInterface>
+Meeting.onParticipantLeave(): Subscription<RemotePlayerInterface>
 ```
 
 The event is triggered when a user enters or leaves a proximity meeting.
@@ -550,14 +566,19 @@ The event is triggered when a user enters or leaves a proximity meeting.
 Example:
 
 ```ts
-WA.player.proximityMeeting.onParticipantJoin().subscribe(async (player: RemotePlayerInterface) => {
-    WA.chat.sendChatMessage("A participant joined the proximity chat", { scope: 'local', author: 'System' });
-});
+WA.player.meetings.onJoin().subscribe((meeting: Meeting) => {
+    meeting.onParticipantJoin().subscribe(async (player: RemotePlayerInterface) => {
+        WA.chat.sendChatMessage("A participant joined the proximity chat", { scope: 'local', author: 'System' });
+    });
 
-WA.player.proximityMeeting.onParticipantLeave().subscribe(async (player: RemotePlayerInterface) => {
-    WA.chat.sendChatMessage("A participant left the proximity chat", { scope: 'local', author: 'System' });
+    meeting.onParticipantLeave().subscribe(async (player: RemotePlayerInterface) => {
+        WA.chat.sendChatMessage("A participant left the proximity chat", { scope: 'local', author: 'System' });
+    });
 });
 ```
+
+`WA.player.proximityMeeting.onParticipantJoin()` and `WA.player.proximityMeeting.onParticipantLeave()` are deprecated
+single-meeting methods. They only target the default proximity bubble.
 
 ## Playing a sound to players in the same meeting
 
@@ -566,7 +587,7 @@ This feature is experimental. The signature of the function might change in the 
 :::
 
 ```ts
-WA.player.proximityMeeting.playSound(url: string): Promise<void>
+Meeting.playSound(url: string): Promise<void>
 ```
 
 The `playSound` function plays a sound to all the players in the same bubble.
@@ -575,10 +596,14 @@ The sound will appear to come from the microphone of the player who called the f
 Example:
 
 ```ts
-await WA.player.proximityMeeting.playSound("https://example.com/my_sound.mp3");
+WA.player.meetings.onJoin().subscribe(async (meeting: Meeting) => {
+    await meeting.playSound("https://example.com/my_sound.mp3");
+});
 ```
 
 The method returns a promise that resolves when the sound has been played.
+
+`WA.player.proximityMeeting.playSound()` is deprecated and only targets the default proximity bubble.
 
 ## Streaming sound to players in the same meeting
 
@@ -590,7 +615,7 @@ You can send a stream of audio to all the players in the same bubble. A typical 
 voice chat in WorkAdventure. The sound can be generated on a server and streamed to the players in the bubble.
 
 ```ts
-WA.player.proximityMeeting.startAudioStream(sampleRate: number): Promise<AudioStream>;
+Meeting.startAudioStream(sampleRate: number): Promise<AudioStream>;
 
 interface AudioStream {
   appendAudioData(data: Float32Array): Promise<void>;
@@ -637,7 +662,7 @@ Then it stops the stream and waits for 5 seconds before closing the stream.
 ```ts
 const sampleRate = 24000;
 
-const audioStream = await WA.player.proximityMeeting.startAudioStream(sampleRate);
+const audioStream = await meeting.startAudioStream(sampleRate);
 
 // Generate a sine wave
     
@@ -665,6 +690,8 @@ await new Promise((resolve) => setTimeout(resolve, 5000));
 await audioStream.close();
 ```
 
+`WA.player.proximityMeeting.startAudioStream()` is deprecated and only targets the default proximity bubble.
+
 ## Listening to the microphone of the players in the same meeting
 
 :::warning
@@ -672,7 +699,7 @@ This feature is experimental. The signature of the function might change in the 
 :::
 
 ```ts
-WA.player.proximityMeeting.listenToAudioStream(sampleRate: number): Observable<Float32Array>
+Meeting.listenToAudioStream(sampleRate: number): Observable<Float32Array>
 ```
 
 The `listenToAudioStream` function listens to the microphone of all the players in the same bubble. The `sampleRate` parameter
@@ -690,7 +717,7 @@ Example:
 ```ts
 const sampleRate = 24000;
 
-const subscription = WA.player.proximityMeeting.listenToAudioStream(sampleRate).subscribe((data: Float32Array) => {
+const subscription = meeting.listenToAudioStream(sampleRate).subscribe((data: Float32Array) => {
     // Process the audio data
     console.log(data);
 });
@@ -698,6 +725,8 @@ const subscription = WA.player.proximityMeeting.listenToAudioStream(sampleRate).
 // When you are done listening to the audio stream, you can unsubscribe from the observable.
 subscription.unsubscribe();
 ```
+
+`WA.player.proximityMeeting.listenToAudioStream()` is deprecated and only targets the default proximity bubble.
 
 ## Asking users to follow you
 

--- a/play/src/front/Api/Events/IframeEvent.ts
+++ b/play/src/front/Api/Events/IframeEvent.ts
@@ -66,6 +66,14 @@ import { isReceiveEventEvent } from "./ReceiveEventEvent";
 import { isPlaySoundInBubbleEvent } from "./ProximityMeeting/PlaySoundInBubbleEvent";
 import { isStartStreamInBubbleEvent } from "./ProximityMeeting/StartStreamInBubbleEvent";
 import { isAppendPCMDataEvent } from "./ProximityMeeting/AppendPCMDataEvent";
+import {
+    isAppendPCMDataToMeetingEvent,
+    isJoinMeetingEvent,
+    isMeetingIdEvent,
+    isParticipantMeetingEvent,
+    isPlaySoundInMeetingEvent,
+    isStartStreamInMeetingEvent,
+} from "./ProximityMeeting/MeetingEvent";
 import { isWamMapDataEvent } from "./WamMapDataEvent";
 import { isPlayVideoEvent } from "./Ui/PlayVideoEvent";
 import { isSetStatusEvent } from "./SetStatusEvent";
@@ -360,6 +368,14 @@ export const isIframeEventWrapper = z.union([
         data: z.undefined(),
     }),
     z.object({
+        type: z.literal("startListeningToStreamInMeeting"),
+        data: isStartStreamInMeetingEvent,
+    }),
+    z.object({
+        type: z.literal("stopListeningToStreamInMeeting"),
+        data: isMeetingIdEvent,
+    }),
+    z.object({
         type: z.literal("setStatus"),
         data: isSetStatusEvent,
     }),
@@ -387,6 +403,22 @@ export const isIframeResponseEvent = z.union([
     z.object({
         type: z.literal("leaveProximityMeetingEvent"),
         data: z.undefined(),
+    }),
+    z.object({
+        type: z.literal("joinMeetingEvent"),
+        data: isJoinMeetingEvent,
+    }),
+    z.object({
+        type: z.literal("participantJoinMeetingEvent"),
+        data: isParticipantMeetingEvent,
+    }),
+    z.object({
+        type: z.literal("participantLeaveMeetingEvent"),
+        data: isParticipantMeetingEvent,
+    }),
+    z.object({
+        type: z.literal("leaveMeetingEvent"),
+        data: isMeetingIdEvent,
     }),
     z.object({
         type: z.literal("onFollowed"),
@@ -513,6 +545,10 @@ export const isIframeResponseEvent = z.union([
     z.object({
         type: z.literal("appendPCMData"),
         data: isAppendPCMDataEvent,
+    }),
+    z.object({
+        type: z.literal("appendMeetingPCMData"),
+        data: isAppendPCMDataToMeetingEvent,
     }),
 ]);
 export type IframeResponseEvent = z.infer<typeof isIframeResponseEvent>;
@@ -664,20 +700,40 @@ export const iframeQueryMapTypeGuards = {
         query: isPlaySoundInBubbleEvent,
         answer: z.undefined(),
     },
+    playSoundInMeeting: {
+        query: isPlaySoundInMeetingEvent,
+        answer: z.undefined(),
+    },
     startStreamInBubble: {
         query: isStartStreamInBubbleEvent,
+        answer: z.undefined(),
+    },
+    startStreamInMeeting: {
+        query: isStartStreamInMeetingEvent,
         answer: z.undefined(),
     },
     stopStreamInBubble: {
         query: z.undefined(),
         answer: z.undefined(),
     },
+    stopStreamInMeeting: {
+        query: isMeetingIdEvent,
+        answer: z.undefined(),
+    },
     appendPCMData: {
         query: isAppendPCMDataEvent,
         answer: z.undefined(),
     },
+    appendPCMDataToMeeting: {
+        query: isAppendPCMDataToMeetingEvent,
+        answer: z.undefined(),
+    },
     resetAudioBuffer: {
         query: z.undefined(),
+        answer: z.undefined(),
+    },
+    resetMeetingAudioBuffer: {
+        query: isMeetingIdEvent,
         answer: z.undefined(),
     },
     followMe: {

--- a/play/src/front/Api/Events/ProximityMeeting/MeetingEvent.ts
+++ b/play/src/front/Api/Events/ProximityMeeting/MeetingEvent.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { isAddPlayerEvent } from "../AddPlayerEvent";
+import { isAppendPCMDataEvent } from "./AppendPCMDataEvent";
+import { isPlaySoundInBubbleEvent } from "./PlaySoundInBubbleEvent";
+import { isStartStreamInBubbleEvent } from "./StartStreamInBubbleEvent";
+
+export const isMeetingKind = z.enum(["default", "proximity", "meeting", "listener", "speaker", "area"]);
+
+export const isMeetingIdEvent = z.object({
+    meetingId: z.string(),
+});
+
+export const isJoinMeetingEvent = isMeetingIdEvent.extend({
+    name: z.string(),
+    kind: isMeetingKind,
+    users: isAddPlayerEvent.array(),
+});
+
+export const isParticipantMeetingEvent = isMeetingIdEvent.extend({
+    user: isAddPlayerEvent,
+});
+
+export const isPlaySoundInMeetingEvent = isPlaySoundInBubbleEvent.extend({
+    meetingId: z.string(),
+});
+
+export const isStartStreamInMeetingEvent = isStartStreamInBubbleEvent.extend({
+    meetingId: z.string(),
+});
+
+export const isAppendPCMDataToMeetingEvent = isAppendPCMDataEvent.extend({
+    meetingId: z.string(),
+});
+
+export type MeetingKind = z.infer<typeof isMeetingKind>;
+export type MeetingIdEvent = z.infer<typeof isMeetingIdEvent>;
+export type JoinMeetingEvent = z.infer<typeof isJoinMeetingEvent>;
+export type ParticipantMeetingEvent = z.infer<typeof isParticipantMeetingEvent>;
+export type PlaySoundInMeetingEvent = z.infer<typeof isPlaySoundInMeetingEvent>;
+export type StartStreamInMeetingEvent = z.infer<typeof isStartStreamInMeetingEvent>;
+export type AppendPCMDataToMeetingEvent = z.infer<typeof isAppendPCMDataToMeetingEvent>;

--- a/play/src/front/Api/Iframe/Player/AudioStream.ts
+++ b/play/src/front/Api/Iframe/Player/AudioStream.ts
@@ -1,12 +1,30 @@
 import { queryWorkadventure } from "../IframeApiContribution";
 
 export class AudioStream {
+    public constructor(private readonly meetingId?: string) {}
+
     /**
      * Append raw PCM audio data to the audio stream.
      * The promise resolves when the sound is played. If the audio buffer is reset with resetAudioBuffer before
      * the data was played, the promise will reject.
      */
     public appendAudioData(float32Array: Float32Array): Promise<void> {
+        if (this.meetingId !== undefined) {
+            return queryWorkadventure(
+                {
+                    type: "appendPCMDataToMeeting",
+                    data: {
+                        meetingId: this.meetingId,
+                        data: float32Array as Float32Array<ArrayBuffer>,
+                    },
+                },
+                {
+                    transfer: [float32Array.buffer],
+                    timeout: null,
+                }
+            );
+        }
+
         return queryWorkadventure(
             {
                 type: "appendPCMData",
@@ -22,6 +40,16 @@ export class AudioStream {
     }
 
     public async resetAudioBuffer(): Promise<void> {
+        if (this.meetingId !== undefined) {
+            await queryWorkadventure({
+                type: "resetMeetingAudioBuffer",
+                data: {
+                    meetingId: this.meetingId,
+                },
+            });
+            return;
+        }
+
         await queryWorkadventure({
             type: "resetAudioBuffer",
             data: undefined,
@@ -29,6 +57,15 @@ export class AudioStream {
     }
 
     public close(): Promise<void> {
+        if (this.meetingId !== undefined) {
+            return queryWorkadventure({
+                type: "stopStreamInMeeting",
+                data: {
+                    meetingId: this.meetingId,
+                },
+            });
+        }
+
         return queryWorkadventure({
             type: "stopStreamInBubble",
             data: undefined,

--- a/play/src/front/Api/Iframe/Player/ProximityMeeting.ts
+++ b/play/src/front/Api/Iframe/Player/ProximityMeeting.ts
@@ -1,12 +1,180 @@
 import { Observable, Subject } from "rxjs";
 import type { JoinProximityMeetingEvent } from "../../Events/ProximityMeeting/JoinProximityMeetingEvent";
 import type { ParticipantProximityMeetingEvent } from "../../Events/ProximityMeeting/ParticipantProximityMeetingEvent";
+import type {
+    JoinMeetingEvent,
+    MeetingKind,
+    ParticipantMeetingEvent,
+} from "../../Events/ProximityMeeting/MeetingEvent";
 
 import { IframeApiContribution, queryWorkadventure, sendToWorkadventure } from "../IframeApiContribution";
 import { RemotePlayer } from "../Players/RemotePlayer";
 import { apiCallback } from "../registeredCallbacks";
 import type { AppendPCMDataEvent } from "../../Events/ProximityMeeting/AppendPCMDataEvent";
 import { AudioStream } from "./AudioStream";
+
+export class Meeting {
+    private participantJoinStream: Subject<RemotePlayer> | undefined;
+    private participantLeaveStream: Subject<RemotePlayer> | undefined;
+    private leaveStream: Subject<void> | undefined;
+    private pcmDataStream: Subject<Float32Array> = new Subject();
+
+    public constructor(
+        public readonly id: string,
+        public readonly name: string,
+        public readonly kind: MeetingKind,
+        public participants: RemotePlayer[]
+    ) {}
+
+    onParticipantJoin(): Subject<RemotePlayer> {
+        if (this.participantJoinStream === undefined) {
+            this.participantJoinStream = new Subject<RemotePlayer>();
+        }
+        return this.participantJoinStream;
+    }
+
+    onParticipantLeave(): Subject<RemotePlayer> {
+        if (this.participantLeaveStream === undefined) {
+            this.participantLeaveStream = new Subject<RemotePlayer>();
+        }
+        return this.participantLeaveStream;
+    }
+
+    onLeave(): Subject<void> {
+        if (this.leaveStream === undefined) {
+            this.leaveStream = new Subject<void>();
+        }
+        return this.leaveStream;
+    }
+
+    async playSound(url: string): Promise<void> {
+        await queryWorkadventure(
+            {
+                type: "playSoundInMeeting",
+                data: {
+                    meetingId: this.id,
+                    url,
+                },
+            },
+            {
+                timeout: null,
+            }
+        );
+    }
+
+    async startAudioStream(sampleRate: number): Promise<AudioStream> {
+        await queryWorkadventure({
+            type: "startStreamInMeeting",
+            data: {
+                meetingId: this.id,
+                sampleRate,
+            },
+        });
+        return new AudioStream(this.id);
+    }
+
+    listenToAudioStream(sampleRate: number): Observable<Float32Array> {
+        return new Observable<Float32Array>((subscriber) => {
+            sendToWorkadventure({
+                type: "startListeningToStreamInMeeting",
+                data: {
+                    meetingId: this.id,
+                    sampleRate,
+                },
+            });
+
+            const subscription = this.pcmDataStream.subscribe(subscriber);
+
+            return () => {
+                subscription.unsubscribe();
+                sendToWorkadventure({
+                    type: "stopListeningToStreamInMeeting",
+                    data: {
+                        meetingId: this.id,
+                    },
+                });
+            };
+        });
+    }
+
+    updateParticipants(participants: RemotePlayer[]): void {
+        this.participants = participants;
+    }
+
+    participantJoined(player: RemotePlayer): void {
+        this.participants = this.participants.filter((participant) => participant.playerId !== player.playerId);
+        this.participants.push(player);
+        this.participantJoinStream?.next(player);
+    }
+
+    participantLeft(player: RemotePlayer): void {
+        this.participants = this.participants.filter((participant) => participant.playerId !== player.playerId);
+        this.participantLeaveStream?.next(player);
+    }
+
+    leave(): void {
+        this.leaveStream?.next();
+    }
+
+    appendPCMData(data: Float32Array): void {
+        this.pcmDataStream.next(data);
+    }
+}
+
+export class WorkadventureMeetingsCommands extends IframeApiContribution<WorkadventureMeetingsCommands> {
+    private joinStream: Subject<Meeting> | undefined;
+    private meetings = new Map<string, Meeting>();
+
+    callbacks = [
+        apiCallback({
+            type: "joinMeetingEvent",
+            callback: (payloadData: JoinMeetingEvent) => {
+                const participants = payloadData.users.map((user) => new RemotePlayer(user));
+                let meeting = this.meetings.get(payloadData.meetingId);
+                if (meeting === undefined) {
+                    meeting = new Meeting(payloadData.meetingId, payloadData.name, payloadData.kind, participants);
+                    this.meetings.set(payloadData.meetingId, meeting);
+                } else {
+                    meeting.updateParticipants(participants);
+                }
+                this.joinStream?.next(meeting);
+            },
+        }),
+        apiCallback({
+            type: "participantJoinMeetingEvent",
+            callback: (payloadData: ParticipantMeetingEvent) => {
+                this.meetings.get(payloadData.meetingId)?.participantJoined(new RemotePlayer(payloadData.user));
+            },
+        }),
+        apiCallback({
+            type: "participantLeaveMeetingEvent",
+            callback: (payloadData: ParticipantMeetingEvent) => {
+                this.meetings.get(payloadData.meetingId)?.participantLeft(new RemotePlayer(payloadData.user));
+            },
+        }),
+        apiCallback({
+            type: "leaveMeetingEvent",
+            callback: (payloadData) => {
+                const meeting = this.meetings.get(payloadData.meetingId);
+                meeting?.leave();
+                this.meetings.delete(payloadData.meetingId);
+            },
+        }),
+        apiCallback({
+            type: "appendMeetingPCMData",
+            callback: (payloadData) => {
+                this.meetings.get(payloadData.meetingId)?.appendPCMData(payloadData.data);
+            },
+        }),
+    ];
+
+    onJoin(): Subject<Meeting> {
+        if (this.joinStream === undefined) {
+            this.joinStream = new Subject<Meeting>();
+        }
+        return this.joinStream;
+    }
+}
 
 export class WorkadventureProximityMeetingCommands extends IframeApiContribution<WorkadventureProximityMeetingCommands> {
     private joinStream: Subject<RemotePlayer[]> | undefined;
@@ -65,6 +233,7 @@ export class WorkadventureProximityMeetingCommands extends IframeApiContribution
     /**
      * Detecting when the user enter on a meeting.
      * {@link https://docs.workadventu.re/map-building/api-player.md#detecting-when-the-user-entersleaves-a-meeting | Website documentation}
+     * @deprecated Use WA.player.meetings.onJoin() instead.
      *
      * @returns {Subject<RemotePlayer[]>} Observable who return the joined users
      */
@@ -78,6 +247,7 @@ export class WorkadventureProximityMeetingCommands extends IframeApiContribution
     /**
      * Detecting when a participant joined on the current meeting.
      * {@link https://docs.workadventu.re/map-building/api-player.md#detecting-when-a-participant-entersleaves-the-current-meeting | Website documentation}
+     * @deprecated Use Meeting.onParticipantJoin() from WA.player.meetings.onJoin() instead.
      *
      * @returns {Subject<RemotePlayer>} Observable who return the joined user
      */
@@ -91,6 +261,7 @@ export class WorkadventureProximityMeetingCommands extends IframeApiContribution
     /**
      * Detecting when a participant left on the current meeting.
      * {@link https://docs.workadventu.re/map-building/api-player.md#detecting-when-a-participant-entersleaves-the-current-meeting | Website documentation}
+     * @deprecated Use Meeting.onParticipantLeave() from WA.player.meetings.onJoin() instead.
      *
      * @returns {Subject<RemotePlayer>} Observable who return the left user
      */
@@ -104,6 +275,7 @@ export class WorkadventureProximityMeetingCommands extends IframeApiContribution
     /**
      * Detecting when the user leave on a meeting.
      * {@link https://docs.workadventu.re/developer/map-scripting/references/api-player/#detecting-when-the-user-entersleaves-a-meeting | Website documentation}
+     * @deprecated Use Meeting.onLeave() from WA.player.meetings.onJoin() instead.
      */
     onLeave(): Subject<void> {
         if (this.leaveStream === undefined) {
@@ -115,6 +287,7 @@ export class WorkadventureProximityMeetingCommands extends IframeApiContribution
     /**
      * Play a sound to all players in the current meeting.
      * {@link https://docs.workadventu.re/developer/map-scripting/references/api-player/#playing-a-sound-to-players-in-the-same-meeting | Website documentation}
+     * @deprecated Use Meeting.playSound() from WA.player.meetings.onJoin() instead.
      */
     async playSound(url: string): Promise<void> {
         await queryWorkadventure(
@@ -133,6 +306,7 @@ export class WorkadventureProximityMeetingCommands extends IframeApiContribution
     /**
      * Starts an audio stream played to all players in the current meeting.
      * {@link https://docs.workadventu.re/developer/map-scripting/references/api-player/#audio-streams | Website documentation}
+     * @deprecated Use Meeting.startAudioStream() from WA.player.meetings.onJoin() instead.
      * @param {number} sampleRate - The sample rate of the audio stream expressed in Hertz.
      */
     async startAudioStream(sampleRate: number): Promise<AudioStream> {
@@ -149,6 +323,7 @@ export class WorkadventureProximityMeetingCommands extends IframeApiContribution
     /**
      * Listen to the audio stream played sent by all players.
      * The voice of all players in the bubble is merged in a single stream that is regularly sent to the callback.
+     * @deprecated Use Meeting.listenToAudioStream() from WA.player.meetings.onJoin() instead.
      * @param {number} sampleRate - The sample rate of the audio stream expressed in Hertz.
      */
     listenToAudioStream(sampleRate: number): Observable<Float32Array> {

--- a/play/src/front/Api/Iframe/Player/ProximityMeeting.ts
+++ b/play/src/front/Api/Iframe/Player/ProximityMeeting.ts
@@ -18,6 +18,10 @@ export class Meeting {
     private participantLeaveStream: Subject<RemotePlayer> | undefined;
     private leaveStream: Subject<void> | undefined;
     private pcmDataStream: Subject<Float32Array> = new Subject();
+    private audioStreamListeners = new Map<
+        number,
+        { observable: Observable<Float32Array>; subscriptionsCount: number }
+    >();
 
     public constructor(
         public readonly id: string,
@@ -74,27 +78,65 @@ export class Meeting {
     }
 
     listenToAudioStream(sampleRate: number): Observable<Float32Array> {
-        return new Observable<Float32Array>((subscriber) => {
-            sendToWorkadventure({
-                type: "startListeningToStreamInMeeting",
-                data: {
-                    meetingId: this.id,
-                    sampleRate,
-                },
-            });
+        const existingListener = this.audioStreamListeners.get(sampleRate);
+        if (existingListener !== undefined) {
+            return existingListener.observable;
+        }
 
-            const subscription = this.pcmDataStream.subscribe(subscriber);
+        const listener = {
+            subscriptionsCount: 0,
+            observable: new Observable<Float32Array>((subscriber) => {
+                if (listener.subscriptionsCount === 0) {
+                    sendToWorkadventure({
+                        type: "startListeningToStreamInMeeting",
+                        data: {
+                            meetingId: this.id,
+                            sampleRate,
+                        },
+                    });
+                }
 
-            return () => {
-                subscription.unsubscribe();
+                listener.subscriptionsCount++;
+                const subscription = this.pcmDataStream.subscribe(subscriber);
+
+                return () => {
+                    subscription.unsubscribe();
+                    if (listener.subscriptionsCount === 0) {
+                        return;
+                    }
+
+                    listener.subscriptionsCount--;
+                    if (listener.subscriptionsCount > 0) {
+                        return;
+                    }
+
+                    sendToWorkadventure({
+                        type: "stopListeningToStreamInMeeting",
+                        data: {
+                            meetingId: this.id,
+                        },
+                    });
+                };
+            }),
+        };
+
+        this.audioStreamListeners.set(sampleRate, listener);
+        return listener.observable;
+    }
+
+    stopListeningToAudioStreams(): void {
+        for (const listener of this.audioStreamListeners.values()) {
+            if (listener.subscriptionsCount > 0) {
+                listener.subscriptionsCount = 0;
                 sendToWorkadventure({
                     type: "stopListeningToStreamInMeeting",
                     data: {
                         meetingId: this.id,
                     },
                 });
-            };
-        });
+            }
+        }
+        this.audioStreamListeners.clear();
     }
 
     updateParticipants(participants: RemotePlayer[]): void {
@@ -113,6 +155,7 @@ export class Meeting {
     }
 
     leave(): void {
+        this.stopListeningToAudioStreams();
         this.leaveStream?.next();
     }
 

--- a/play/src/front/Api/Iframe/player.ts
+++ b/play/src/front/Api/Iframe/player.ts
@@ -4,7 +4,7 @@ import type { HasPlayerMovedEvent, HasPlayerMovedEventCallback } from "../Events
 import { IframeApiContribution, queryWorkadventure, sendToWorkadventure } from "./IframeApiContribution";
 import { apiCallback } from "./registeredCallbacks";
 import { playerState } from "./playerState";
-import { WorkadventureProximityMeetingCommands } from "./Player/ProximityMeeting";
+import { WorkadventureMeetingsCommands, WorkadventureProximityMeetingCommands } from "./Player/ProximityMeeting";
 
 const moveStream = new Subject<HasPlayerMovedEvent>();
 
@@ -53,6 +53,7 @@ export const setIsLogged = (_isLogged: boolean | undefined) => {
 export class WorkadventurePlayerCommands extends IframeApiContribution<WorkadventurePlayerCommands> {
     readonly state = playerState;
     private _proximityMeeting: WorkadventureProximityMeetingCommands = new WorkadventureProximityMeetingCommands();
+    private _meetings: WorkadventureMeetingsCommands = new WorkadventureMeetingsCommands();
 
     callbacks = [
         apiCallback({
@@ -272,6 +273,10 @@ export class WorkadventurePlayerCommands extends IframeApiContribution<Workadven
 
     get proximityMeeting(): WorkadventureProximityMeetingCommands {
         return this._proximityMeeting;
+    }
+
+    get meetings(): WorkadventureMeetingsCommands {
+        return this._meetings;
     }
 
     /**

--- a/play/src/front/Api/IframeListener.ts
+++ b/play/src/front/Api/IframeListener.ts
@@ -52,6 +52,12 @@ import type { SetSharedPlayerVariableEvent } from "./Events/SetSharedPlayerVaria
 import type { HasPlayerMovedInterface } from "./Events/HasPlayerMovedInterface";
 import type { JoinProximityMeetingEvent } from "./Events/ProximityMeeting/JoinProximityMeetingEvent";
 import type { ParticipantProximityMeetingEvent } from "./Events/ProximityMeeting/ParticipantProximityMeetingEvent";
+import type {
+    JoinMeetingEvent,
+    MeetingIdEvent,
+    ParticipantMeetingEvent,
+    StartStreamInMeetingEvent,
+} from "./Events/ProximityMeeting/MeetingEvent";
 import type { AddPlayerEvent } from "./Events/AddPlayerEvent";
 import type { ModalEvent } from "./Events/ModalEvent";
 import type { ReceiveEventEvent } from "./Events/ReceiveEventEvent";
@@ -228,6 +234,12 @@ class IframeListener {
 
     private readonly _stopListeningToStreamInBubbleStream: Subject<void> = new Subject();
     public readonly stopListeningToStreamInBubbleStream = this._stopListeningToStreamInBubbleStream.asObservable();
+
+    private readonly _startListeningToStreamInMeetingStream: Subject<StartStreamInMeetingEvent> = new Subject();
+    public readonly startListeningToStreamInMeetingStream = this._startListeningToStreamInMeetingStream.asObservable();
+
+    private readonly _stopListeningToStreamInMeetingStream: Subject<MeetingIdEvent> = new Subject();
+    public readonly stopListeningToStreamInMeetingStream = this._stopListeningToStreamInMeetingStream.asObservable();
 
     private readonly _addButtonActionBarStream: Subject<AddButtonActionBarEvent> = new Subject();
     public readonly addButtonActionBarStream = this._addButtonActionBarStream.asObservable();
@@ -473,6 +485,10 @@ class IframeListener {
                             this._startListeningToStreamInBubbleStream.next(iframeEvent.data);
                         } else if (iframeEvent.type === "stopListeningToStreamInBubble") {
                             this._stopListeningToStreamInBubbleStream.next();
+                        } else if (iframeEvent.type === "startListeningToStreamInMeeting") {
+                            this._startListeningToStreamInMeetingStream.next(iframeEvent.data);
+                        } else if (iframeEvent.type === "stopListeningToStreamInMeeting") {
+                            this._stopListeningToStreamInMeetingStream.next(iframeEvent.data);
                         } else if (iframeEvent.type === "openChat") {
                             this._openChatStream.next(iframeEvent.data);
                         } else if (iframeEvent.type === "closeChat") {
@@ -868,6 +884,30 @@ class IframeListener {
         });
     }
 
+    sendJoinMeetingEvent(meetingId: string, name: string, kind: JoinMeetingEvent["kind"], users: MessageUserJoined[]) {
+        const formattedUsers: AddPlayerEvent[] = users.map((user) => {
+            return {
+                playerId: user.userId,
+                name: user.name,
+                userUuid: user.userUuid,
+                outlineColor: user.outlineColor,
+                availabilityStatus: availabilityStatusToJSON(user.availabilityStatus),
+                position: user.position,
+                variables: user.variables,
+            };
+        });
+
+        this.postMessage({
+            type: "joinMeetingEvent",
+            data: {
+                meetingId,
+                name,
+                kind,
+                users: formattedUsers,
+            } as JoinMeetingEvent,
+        });
+    }
+
     sendParticipantJoinProximityMeetingEvent(user: MessageUserJoined) {
         this.postMessage({
             type: "participantJoinProximityMeetingEvent",
@@ -882,6 +922,24 @@ class IframeListener {
                     variables: user.variables,
                 },
             } as ParticipantProximityMeetingEvent,
+        });
+    }
+
+    sendParticipantJoinMeetingEvent(meetingId: string, user: MessageUserJoined) {
+        this.postMessage({
+            type: "participantJoinMeetingEvent",
+            data: {
+                meetingId,
+                user: {
+                    playerId: user.userId,
+                    name: user.name,
+                    userUuid: user.userUuid,
+                    outlineColor: user.outlineColor,
+                    availabilityStatus: availabilityStatusToJSON(user.availabilityStatus),
+                    position: user.position,
+                    variables: user.variables,
+                },
+            } as ParticipantMeetingEvent,
         });
     }
 
@@ -902,10 +960,37 @@ class IframeListener {
         });
     }
 
+    sendParticipantLeaveMeetingEvent(meetingId: string, user: MessageUserJoined) {
+        this.postMessage({
+            type: "participantLeaveMeetingEvent",
+            data: {
+                meetingId,
+                user: {
+                    playerId: user.userId,
+                    name: user.name,
+                    userUuid: user.userUuid,
+                    outlineColor: user.outlineColor,
+                    availabilityStatus: availabilityStatusToJSON(user.availabilityStatus),
+                    position: user.position,
+                    variables: user.variables,
+                },
+            } as ParticipantMeetingEvent,
+        });
+    }
+
     sendLeaveProximityMeetingEvent() {
         this.postMessage({
             type: "leaveProximityMeetingEvent",
             data: undefined,
+        });
+    }
+
+    sendLeaveMeetingEvent(meetingId: string) {
+        this.postMessage({
+            type: "leaveMeetingEvent",
+            data: {
+                meetingId,
+            },
         });
     }
 

--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoom.ts
@@ -167,8 +167,6 @@ export class ProximityChatRoom implements ChatRoom {
 
     private scriptingOutputAudioStreamManager: ScriptingOutputAudioStreamManager | undefined;
     private scriptingInputAudioStreamManager: ScriptingInputAudioStreamManager | undefined;
-    private startListeningToStreamInBubbleStreamUnsubscriber: Subscription | undefined;
-    private stopListeningToStreamInBubbleStreamUnsubscriber: Subscription | undefined;
     private screenWakeRelease: undefined | (() => Promise<void>);
 
     constructor(
@@ -209,31 +207,6 @@ export class ProximityChatRoom implements ChatRoom {
         this.name = writable(displayName);
         this.kind = writable(kind);
         this.typingMembers = writable([]);
-
-        if (this.isDefaultProximityRoom()) {
-            this.startListeningToStreamInBubbleStreamUnsubscriber =
-                iframeListener.startListeningToStreamInBubbleStream.subscribe((message) => {
-                    if (!this.scriptingInputAudioStreamManager) {
-                        console.error(
-                            "Trying to start listening to stream in bubble but no bubble has been joined yet"
-                        );
-                        return;
-                    }
-                    this.scriptingInputAudioStreamManager.startListeningToAudioStream(message.sampleRate).catch((e) => {
-                        console.error("Error while starting listening to streams", e);
-                        Sentry.captureException(e);
-                    });
-                });
-
-            this.stopListeningToStreamInBubbleStreamUnsubscriber =
-                iframeListener.stopListeningToStreamInBubbleStream.subscribe(() => {
-                    if (!this.scriptingInputAudioStreamManager) {
-                        console.error("Trying to stop listening to stream in bubble but no bubble has been joined yet");
-                        return;
-                    }
-                    this.scriptingInputAudioStreamManager.stopListeningToAudioStream();
-                });
-        }
     }
 
     sendMessage(message: string, action: ChatMessageType = "proximity", broadcast = true): void {
@@ -562,12 +535,6 @@ export class ProximityChatRoom implements ChatRoom {
         this.intentionallyClosed.set(false);
         this.isJoined.set(true);
 
-        if (this.isDefaultProximityRoom()) {
-            // TODO: we need to move that elsewhere.
-            // Set up manager of audio streams received by the scripting API (useful for bots)
-            this.scriptingOutputAudioStreamManager = new ScriptingOutputAudioStreamManager(this._space);
-            this.scriptingInputAudioStreamManager = new ScriptingInputAudioStreamManager(this._space);
-        }
         await this.throwIfAborted(joinSignal, spaceForThisJoin);
 
         let hasUserInProximityChat = false;
@@ -685,14 +652,7 @@ export class ProximityChatRoom implements ChatRoom {
             }
             await this.throwIfAborted(joinSignal, spaceForThisJoin);
 
-            const playersInSpace: MessageUserJoined[] = [];
-
-            for (const spaceUser of users.values()) {
-                const player = this.getRemotePlayerFromSpaceUserId(spaceUser.spaceUserId);
-                if (player) {
-                    playersInSpace.push(player);
-                }
-            }
+            const playersInSpace = this.mapSpaceUsersToRemotePlayers(users);
             if (this.isDefaultProximityRoom()) {
                 iframeListener.sendJoinProximityMeetingEvent(playersInSpace);
             }
@@ -739,6 +699,7 @@ export class ProximityChatRoom implements ChatRoom {
         this.observeUserJoinedSubscription = this._space.observeUserJoined.subscribe((spaceUser) => {
             const player = this.getRemotePlayerFromSpaceUserId(spaceUser.spaceUserId);
             if (player) {
+                iframeListener.sendParticipantJoinMeetingEvent(spaceName, player);
                 if (this.isDefaultProximityRoom()) {
                     iframeListener.sendParticipantJoinProximityMeetingEvent(player);
                 }
@@ -758,6 +719,7 @@ export class ProximityChatRoom implements ChatRoom {
         this.observeUserLeftSubscription = this._space.observeUserLeft.subscribe((spaceUser) => {
             const player = this.getRemotePlayerFromSpaceUserId(spaceUser.spaceUserId);
             if (player) {
+                iframeListener.sendParticipantLeaveMeetingEvent(spaceName, player);
                 if (this.isDefaultProximityRoom()) {
                     iframeListener.sendParticipantLeaveProximityMeetingEvent(player);
                 }
@@ -775,6 +737,9 @@ export class ProximityChatRoom implements ChatRoom {
             this.removeTypingUserbyID(spaceUser.spaceUserId);
         });
         await this.throwIfAborted(joinSignal, spaceForThisJoin);
+
+        const playersInMeeting = this.mapSpaceUsersToRemotePlayers(Array.from((this.users ?? new Map()).values()));
+        iframeListener.sendJoinMeetingEvent(spaceName, get(this.name), get(this.kind), playersInMeeting);
 
         this.joinSpaceAbortController = undefined;
         return this._space;
@@ -897,6 +862,19 @@ export class ProximityChatRoom implements ChatRoom {
         return this.remotePlayersRepository.getPlayers().get(userId);
     }
 
+    private mapSpaceUsersToRemotePlayers(spaceUsers: SpaceUserExtended[]): MessageUserJoined[] {
+        const playersInSpace: MessageUserJoined[] = [];
+
+        for (const spaceUser of spaceUsers.values()) {
+            const player = this.getRemotePlayerFromSpaceUserId(spaceUser.spaceUserId);
+            if (player) {
+                playersInSpace.push(player);
+            }
+        }
+
+        return playersInSpace;
+    }
+
     private extractUserIdAndRoomUrlFromSpaceId(spaceId: string): { roomUrl: string; userId: number } {
         const lastUnderscoreIndex = spaceId.lastIndexOf("_");
         if (lastUnderscoreIndex === -1) {
@@ -945,6 +923,7 @@ export class ProximityChatRoom implements ChatRoom {
         this._currentMeetingParticipantsStore.set([]);
 
         hideBubbleConfirmationModal();
+        iframeListener.sendLeaveMeetingEvent(spaceName);
         if (this.isDefaultProximityRoom()) {
             iframeListener.sendLeaveProximityMeetingEvent();
         }
@@ -1041,6 +1020,50 @@ export class ProximityChatRoom implements ChatRoom {
         return this._space.dispatchSound(url);
     }
 
+    public async startScriptingAudioStream(sampleRate: number): Promise<void> {
+        await this.getOrCreateScriptingOutputAudioStreamManager().startStream(sampleRate);
+    }
+
+    public async appendScriptingAudioData(float32Array: Float32Array): Promise<void> {
+        await this.getOrCreateScriptingOutputAudioStreamManager().appendPCMData(float32Array);
+    }
+
+    public stopScriptingAudioStream(): void {
+        this.scriptingOutputAudioStreamManager?.stopStream();
+    }
+
+    public async resetScriptingAudioBuffer(): Promise<void> {
+        await this.getOrCreateScriptingOutputAudioStreamManager().resetAudioBuffer();
+    }
+
+    public async startListeningToScriptingAudioStream(sampleRate: number, meetingId?: string): Promise<void> {
+        await this.getOrCreateScriptingInputAudioStreamManager().startListeningToAudioStream(sampleRate, meetingId);
+    }
+
+    public stopListeningToScriptingAudioStream(): void {
+        this.scriptingInputAudioStreamManager?.stopListeningToAudioStream();
+    }
+
+    private getOrCreateScriptingOutputAudioStreamManager(): ScriptingOutputAudioStreamManager {
+        if (!this._space) {
+            throw new Error("Trying to start a scripting audio stream in a space that is not joined");
+        }
+        if (!this.scriptingOutputAudioStreamManager) {
+            this.scriptingOutputAudioStreamManager = new ScriptingOutputAudioStreamManager(this._space);
+        }
+        return this.scriptingOutputAudioStreamManager;
+    }
+
+    private getOrCreateScriptingInputAudioStreamManager(): ScriptingInputAudioStreamManager {
+        if (!this._space) {
+            throw new Error("Trying to listen to scripting audio streams in a space that is not joined");
+        }
+        if (!this.scriptingInputAudioStreamManager) {
+            this.scriptingInputAudioStreamManager = new ScriptingInputAudioStreamManager(this._space);
+        }
+        return this.scriptingInputAudioStreamManager;
+    }
+
     /**
      * Returns the name of the currently joined space, or undefined if not in any space.
      */
@@ -1056,8 +1079,6 @@ export class ProximityChatRoom implements ChatRoom {
     }
 
     public destroy(): void {
-        this.startListeningToStreamInBubbleStreamUnsubscriber?.unsubscribe();
-        this.stopListeningToStreamInBubbleStreamUnsubscriber?.unsubscribe();
         this.spaceMessageSubscription?.unsubscribe();
         this.spaceIsTypingSubscription?.unsubscribe();
 

--- a/play/src/front/Chat/Connection/Proximity/ProximityChatRoomManager.ts
+++ b/play/src/front/Chat/Connection/Proximity/ProximityChatRoomManager.ts
@@ -189,6 +189,21 @@ export class ProximityChatRoomManager {
         return this.rooms.get(roomId.substring("proximity:".length));
     }
 
+    public getRoomByMeetingId(meetingId: string): ProximityChatRoom | undefined {
+        const room = this.rooms.get(meetingId);
+        if (room && get(room.isJoined)) {
+            return room;
+        }
+
+        for (const room of this.rooms.values()) {
+            if (get(room.isJoined) && room.getCurrentSpaceName() === meetingId) {
+                return room;
+            }
+        }
+
+        return undefined;
+    }
+
     public getDefaultRoom(): ProximityChatRoom | undefined {
         return this.rooms.get(DEFAULT_PROXIMITY_SPACE_NAME);
     }

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1252,6 +1252,15 @@ export class GameScene extends DirtyScene {
         iframeListener.unregisterAnswerer("getWoka");
         iframeListener.unregisterAnswerer("goToLogin");
         iframeListener.unregisterAnswerer("playSoundInBubble");
+        iframeListener.unregisterAnswerer("playSoundInMeeting");
+        iframeListener.unregisterAnswerer("startStreamInBubble");
+        iframeListener.unregisterAnswerer("startStreamInMeeting");
+        iframeListener.unregisterAnswerer("appendPCMData");
+        iframeListener.unregisterAnswerer("appendPCMDataToMeeting");
+        iframeListener.unregisterAnswerer("resetAudioBuffer");
+        iframeListener.unregisterAnswerer("resetMeetingAudioBuffer");
+        iframeListener.unregisterAnswerer("stopStreamInBubble");
+        iframeListener.unregisterAnswerer("stopStreamInMeeting");
         this.sharedVariablesManager?.close();
         this.playerVariablesManager?.close();
         this.areaPropertyVariablesManager?.destroy();
@@ -3596,14 +3605,83 @@ ${escapedMessage}
         iframeListener.registerAnswerer("playSoundInBubble", async (message) => {
             const soundUrl = new URL(message.url, this.mapUrlFile);
             try {
-                const proximityChatRoomManager = await this._proximityChatRoomManagerDeferred.promise;
-                const proximityChatRoom =
-                    proximityChatRoomManager.getDefaultRoom() ?? this.getDefaultProximityChatRoom();
-                await proximityChatRoom.dispatchSound(soundUrl);
+                await this.getDefaultProximityChatRoom().dispatchSound(soundUrl);
             } catch (error) {
                 console.error("Error playing sound in bubble:", error);
             }
         });
+
+        iframeListener.registerAnswerer("playSoundInMeeting", async (message) => {
+            const soundUrl = new URL(message.url, this.mapUrlFile);
+            await this.getMeetingProximityChatRoom(message.meetingId).dispatchSound(soundUrl);
+        });
+
+        iframeListener.registerAnswerer("startStreamInBubble", async (message) => {
+            await this.getDefaultProximityChatRoom().startScriptingAudioStream(message.sampleRate);
+        });
+
+        iframeListener.registerAnswerer("startStreamInMeeting", async (message) => {
+            await this.getMeetingProximityChatRoom(message.meetingId).startScriptingAudioStream(message.sampleRate);
+        });
+
+        iframeListener.registerAnswerer("appendPCMData", async (message) => {
+            await this.getDefaultProximityChatRoom().appendScriptingAudioData(message.data);
+        });
+
+        iframeListener.registerAnswerer("appendPCMDataToMeeting", async (message) => {
+            await this.getMeetingProximityChatRoom(message.meetingId).appendScriptingAudioData(message.data);
+        });
+
+        iframeListener.registerAnswerer("resetAudioBuffer", async () => {
+            await this.getDefaultProximityChatRoom().resetScriptingAudioBuffer();
+        });
+
+        iframeListener.registerAnswerer("resetMeetingAudioBuffer", async (message) => {
+            await this.getMeetingProximityChatRoom(message.meetingId).resetScriptingAudioBuffer();
+        });
+
+        iframeListener.registerAnswerer("stopStreamInBubble", () => {
+            this.getDefaultProximityChatRoom().stopScriptingAudioStream();
+        });
+
+        iframeListener.registerAnswerer("stopStreamInMeeting", (message) => {
+            this.getMeetingProximityChatRoom(message.meetingId).stopScriptingAudioStream();
+        });
+
+        const startListeningToStreamInBubbleSubscription =
+            iframeListener.startListeningToStreamInBubbleStream.subscribe((message) => {
+                this.getDefaultProximityChatRoom()
+                    .startListeningToScriptingAudioStream(message.sampleRate)
+                    .catch((error) => {
+                        console.error("Error while starting listening to streams", error);
+                        Sentry.captureException(error);
+                    });
+            });
+        this.unsubscribers.push(() => startListeningToStreamInBubbleSubscription.unsubscribe());
+
+        const stopListeningToStreamInBubbleSubscription = iframeListener.stopListeningToStreamInBubbleStream.subscribe(
+            () => {
+                this.getDefaultProximityChatRoom().stopListeningToScriptingAudioStream();
+            }
+        );
+        this.unsubscribers.push(() => stopListeningToStreamInBubbleSubscription.unsubscribe());
+
+        const startListeningToStreamInMeetingSubscription =
+            iframeListener.startListeningToStreamInMeetingStream.subscribe((message) => {
+                this.getMeetingProximityChatRoom(message.meetingId)
+                    .startListeningToScriptingAudioStream(message.sampleRate, message.meetingId)
+                    .catch((error) => {
+                        console.error("Error while starting listening to meeting streams", error);
+                        Sentry.captureException(error);
+                    });
+            });
+        this.unsubscribers.push(() => startListeningToStreamInMeetingSubscription.unsubscribe());
+
+        const stopListeningToStreamInMeetingSubscription =
+            iframeListener.stopListeningToStreamInMeetingStream.subscribe((message) => {
+                this.getMeetingProximityChatRoom(message.meetingId).stopListeningToScriptingAudioStream();
+            });
+        this.unsubscribers.push(() => stopListeningToStreamInMeetingSubscription.unsubscribe());
     }
 
     private setPropertyLayer(
@@ -4350,6 +4428,14 @@ ${escapedMessage}
             throw new Error("_proximityChatRoom not yet initialized");
         }
         return defaultRoom;
+    }
+
+    private getMeetingProximityChatRoom(meetingId: string): ProximityChatRoom {
+        const room = this._proximityChatRoomManager?.getRoomByMeetingId(meetingId);
+        if (!room) {
+            throw new Error(`Proximity meeting "${meetingId}" is not joined`);
+        }
+        return room;
     }
 
     get applicationManager(): ApplicationManager {

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -3668,18 +3668,28 @@ ${escapedMessage}
 
         const startListeningToStreamInMeetingSubscription =
             iframeListener.startListeningToStreamInMeetingStream.subscribe((message) => {
-                this.getMeetingProximityChatRoom(message.meetingId)
-                    .startListeningToScriptingAudioStream(message.sampleRate, message.meetingId)
-                    .catch((error) => {
-                        console.error("Error while starting listening to meeting streams", error);
-                        Sentry.captureException(error);
-                    });
+                try {
+                    this.getMeetingProximityChatRoom(message.meetingId)
+                        .startListeningToScriptingAudioStream(message.sampleRate, message.meetingId)
+                        .catch((error) => {
+                            console.error("Error while starting listening to meeting streams", error);
+                            Sentry.captureException(error);
+                        });
+                } catch (error) {
+                    console.error("Error while starting listening to meeting streams", error);
+                    Sentry.captureException(error);
+                }
             });
         this.unsubscribers.push(() => startListeningToStreamInMeetingSubscription.unsubscribe());
 
         const stopListeningToStreamInMeetingSubscription =
             iframeListener.stopListeningToStreamInMeetingStream.subscribe((message) => {
-                this.getMeetingProximityChatRoom(message.meetingId).stopListeningToScriptingAudioStream();
+                try {
+                    this.getMeetingProximityChatRoom(message.meetingId).stopListeningToScriptingAudioStream();
+                } catch (error) {
+                    console.error("Error while stopping listening to meeting streams", error);
+                    Sentry.captureException(error);
+                }
             });
         this.unsubscribers.push(() => stopListeningToStreamInMeetingSubscription.unsubscribe());
     }

--- a/play/src/front/WebRtc/AudioStream/ScriptingInputAudioStreamManager.ts
+++ b/play/src/front/WebRtc/AudioStream/ScriptingInputAudioStreamManager.ts
@@ -16,6 +16,7 @@ export class ScriptingInputAudioStreamManager {
     private pcmStreamerResolved = false;
     private pcmStreamerResolving = false;
     private isListening = false;
+    private currentMeetingId: string | undefined;
     private streams: Map<Readable<MediaStream | undefined>, Unsubscriber> = new Map();
     private videoPeerAddedUnsubscriber: Subscription;
     private videoPeerRemovedUnsubscriber: Subscription;
@@ -38,12 +39,13 @@ export class ScriptingInputAudioStreamManager {
         });
     }
 
-    public async startListeningToAudioStream(sampleRate: number): Promise<void> {
+    public async startListeningToAudioStream(sampleRate: number, meetingId?: string): Promise<void> {
         if (this.isListening) {
             throw new Error("Already listening");
         }
 
         this.isListening = true;
+        this.currentMeetingId = meetingId;
 
         // Start listening to the stream
         if (this.pcmStreamerResolved || this.pcmStreamerResolving) {
@@ -57,13 +59,23 @@ export class ScriptingInputAudioStreamManager {
         this.pcmStreamerDeferred.resolve(pcmStreamer);
 
         this.appendPCMDataStreamUnsubscriber = pcmStreamer.pcmDataStream.subscribe((data) => {
-            iframeListener.postMessage(
-                {
-                    type: "appendPCMData",
-                    data: { data: data as Float32Array<ArrayBuffer> },
-                },
-                undefined /*, [data.buffer]*/
-            );
+            if (this.currentMeetingId !== undefined) {
+                iframeListener.postMessage(
+                    {
+                        type: "appendMeetingPCMData",
+                        data: { meetingId: this.currentMeetingId, data: data as Float32Array<ArrayBuffer> },
+                    },
+                    undefined /*, [data.buffer]*/
+                );
+            } else {
+                iframeListener.postMessage(
+                    {
+                        type: "appendPCMData",
+                        data: { data: data as Float32Array<ArrayBuffer> },
+                    },
+                    undefined /*, [data.buffer]*/
+                );
+            }
             // Note: if we try to transfer the buffer, we get the following error:
             //      ArrayBuffer already detached.
             // It looks like a bug in the browser to me (the ArrayBuffer was detached from the worklet process
@@ -81,6 +93,7 @@ export class ScriptingInputAudioStreamManager {
 
     public stopListeningToAudioStream(): void {
         this.isListening = false;
+        this.currentMeetingId = undefined;
 
         this.appendPCMDataStreamUnsubscriber?.unsubscribe();
         this.appendPCMDataStreamUnsubscriber = undefined;

--- a/play/src/front/WebRtc/AudioStream/ScriptingOutputAudioStreamManager.ts
+++ b/play/src/front/WebRtc/AudioStream/ScriptingOutputAudioStreamManager.ts
@@ -1,5 +1,4 @@
 import { Deferred } from "@workadventure/shared-utils";
-import { iframeListener } from "../../Api/IframeListener";
 import { customWebRTCLogger } from "../CustomWebRTCLogger";
 import type { SpaceInterface } from "../../Space/SpaceInterface";
 import { OutputPCMStreamer } from "./OutputPCMStreamer";
@@ -12,55 +11,53 @@ export class ScriptingOutputAudioStreamManager {
     private pcmStreamerResolved = false;
     private pcmStreamerResolving = false;
 
-    constructor(space: SpaceInterface) {
-        iframeListener.registerAnswerer("startStreamInBubble", async (message) => {
-            if (this.pcmStreamerResolved || this.pcmStreamerResolving) {
-                throw new Error("A stream is already running");
-            }
-            const pcmStreamer = new OutputPCMStreamer(message.sampleRate);
-            this.pcmStreamerResolving = true;
+    constructor(private readonly space: SpaceInterface) {}
+
+    public async startStream(sampleRate: number): Promise<void> {
+        if (this.pcmStreamerResolved || this.pcmStreamerResolving) {
+            throw new Error("A stream is already running");
+        }
+        const pcmStreamer = new OutputPCMStreamer(sampleRate);
+        this.pcmStreamerResolving = true;
+        try {
             await pcmStreamer.initWorklet();
             this.pcmStreamerResolved = true;
-            this.pcmStreamerResolving = false;
             this.pcmStreamerDeferred.resolve(pcmStreamer);
-            space.spacePeerManager.dispatchStream(pcmStreamer.getMediaStream());
-        });
-
-        iframeListener.registerAnswerer("appendPCMData", async (message) => {
-            const pcmStreamer = await this.pcmStreamerDeferred.promise;
-            await pcmStreamer.appendPCMData(message.data);
-        });
-
-        iframeListener.registerAnswerer("stopStreamInBubble", () => {
-            if (this.pcmStreamerResolved || this.pcmStreamerResolving) {
-                this.pcmStreamerDeferred.promise
-                    .then((pcmStreamer) => {
-                        pcmStreamer.close();
-                    })
-                    .catch((e) => {
-                        console.error("Error while stopping stream", e);
-                    });
-            } else {
-                console.error("stopStreamInBubble called while no stream is running");
-            }
-            this.pcmStreamerResolved = false;
+            this.space.spacePeerManager.dispatchStream(pcmStreamer.getMediaStream());
+        } finally {
             this.pcmStreamerResolving = false;
-            this.pcmStreamerDeferred = new Deferred<OutputPCMStreamer>();
-        });
+        }
+    }
 
-        iframeListener.registerAnswerer("resetAudioBuffer", async () => {
-            customWebRTCLogger.info("Resetting audio buffer");
-            const pcmStreamer = await this.pcmStreamerDeferred.promise;
-            pcmStreamer.resetAudioBuffer();
-        });
+    public async appendPCMData(float32Array: Float32Array): Promise<void> {
+        const pcmStreamer = await this.pcmStreamerDeferred.promise;
+        await pcmStreamer.appendPCMData(float32Array);
+    }
+
+    public stopStream(): void {
+        if (this.pcmStreamerResolved || this.pcmStreamerResolving) {
+            this.pcmStreamerDeferred.promise
+                .then((pcmStreamer) => {
+                    pcmStreamer.close();
+                })
+                .catch((e) => {
+                    console.error("Error while stopping stream", e);
+                });
+        } else {
+            console.error("stopStreamInBubble called while no stream is running");
+        }
+        this.pcmStreamerResolved = false;
+        this.pcmStreamerResolving = false;
+        this.pcmStreamerDeferred = new Deferred<OutputPCMStreamer>();
+    }
+
+    public async resetAudioBuffer(): Promise<void> {
+        customWebRTCLogger.info("Resetting audio buffer");
+        const pcmStreamer = await this.pcmStreamerDeferred.promise;
+        pcmStreamer.resetAudioBuffer();
     }
 
     public close(): void {
-        iframeListener.unregisterAnswerer("startStreamInBubble");
-        iframeListener.unregisterAnswerer("stopStreamInBubble");
-        iframeListener.unregisterAnswerer("resetAudioBuffer");
-        iframeListener.unregisterAnswerer("appendPCMData");
-
         if (this.pcmStreamerResolved || this.pcmStreamerResolving) {
             this.pcmStreamerDeferred.promise
                 .then((pcmStreamer) => {

--- a/play/src/front/WebRtc/AudioStream/ScriptingOutputAudioStreamManager.ts
+++ b/play/src/front/WebRtc/AudioStream/ScriptingOutputAudioStreamManager.ts
@@ -44,7 +44,7 @@ export class ScriptingOutputAudioStreamManager {
                     console.error("Error while stopping stream", e);
                 });
         } else {
-            console.error("stopStreamInBubble called while no stream is running");
+            console.error("stopStream called while no stream is running");
         }
         this.pcmStreamerResolved = false;
         this.pcmStreamerResolving = false;

--- a/tests/tests/scripting_audio_stream.spec.ts
+++ b/tests/tests/scripting_audio_stream.spec.ts
@@ -147,7 +147,9 @@ test.describe("Scripting audio streams @nomobile @nofirefox @nowebkit", () => {
             publicTestMapUrl("tests/E2E/empty.json", "scripting_audio_stream"),
         );
         await Menu.turnOffMicrophone(alice2);
+        const alice2ProximityChatPromise = waitForJoinProximityChat(alice2);
         await Map.teleportToPosition(alice2, 32, 32);
+        await alice2ProximityChatPromise;
         await using eve = await getPage(
             browser,
             "Eve",

--- a/tests/tests/scripting_audio_stream.spec.ts
+++ b/tests/tests/scripting_audio_stream.spec.ts
@@ -18,8 +18,12 @@ async function playAudioStream(page: Page, frequency: number) {
         page,
         async ({ frequency }) => {
             const sampleRate = 24000;
+            const meeting = window.meeting;
+            if (!meeting) {
+                throw new Error("No meeting joined");
+            }
 
-            const audioStream = await WA.player.proximityMeeting.startAudioStream(sampleRate);
+            const audioStream = await meeting.startAudioStream(sampleRate);
 
             // Generate a sine wave
             const amplitude = 1;
@@ -30,7 +34,9 @@ async function playAudioStream(page: Page, frequency: number) {
                 samples[i] = amplitude * Math.sin((2 * Math.PI * frequency * i) / sampleRate);
             }
 
+            // eslint-disable-next-line require-atomic-updates
             window.streamInterrupted = false;
+            // eslint-disable-next-line require-atomic-updates
             window.audioStream = audioStream;
             audioStream.appendAudioData(samples).catch((e) => {
                 window.streamInterrupted = true;
@@ -46,6 +52,10 @@ async function hasAudioStream(page: Page, volume = 0.7): Promise<void> {
         page,
         async ({ volume }) => {
             const sampleRate = 24000;
+            const meeting = window.meeting;
+            if (!meeting) {
+                throw new Error("No meeting joined");
+            }
 
             return new Promise<void>((resolve, reject) => {
                 const timeout = setTimeout(() => {
@@ -54,16 +64,14 @@ async function hasAudioStream(page: Page, volume = 0.7): Promise<void> {
                     subscription.unsubscribe();
                 }, 20000);
 
-                const subscription = WA.player.proximityMeeting
-                    .listenToAudioStream(sampleRate)
-                    .subscribe((data: Float32Array) => {
-                        // At some point, the volume of the sound should be high enough to be noticed in the sample
-                        if (data.some((sample) => Math.abs(sample) > volume)) {
-                            resolve();
-                            subscription.unsubscribe();
-                            clearTimeout(timeout);
-                        }
-                    });
+                const subscription = meeting.listenToAudioStream(sampleRate).subscribe((data: Float32Array) => {
+                    // At some point, the volume of the sound should be high enough to be noticed in the sample
+                    if (data.some((sample) => Math.abs(sample) > volume)) {
+                        resolve();
+                        subscription.unsubscribe();
+                        clearTimeout(timeout);
+                    }
+                });
             });
         },
         { volume },
@@ -73,7 +81,8 @@ async function hasAudioStream(page: Page, volume = 0.7): Promise<void> {
 async function waitForJoinProximityChat(page: Page): Promise<void> {
     await evaluateScript(page, async () => {
         return new Promise<void>((resolve) => {
-            const joinSubscription = WA.player.proximityMeeting.onJoin().subscribe(() => {
+            const joinSubscription = WA.player.meetings.onJoin().subscribe((meeting) => {
+                window.meeting = meeting;
                 resolve();
                 joinSubscription.unsubscribe();
             });
@@ -210,15 +219,19 @@ test.describe("Scripting audio streams @nomobile @nofirefox @nowebkit", () => {
         await Menu.turnOffMicrophone(alice);
 
         // Move alice to the same position as bob
+        const aliceProximityChatPromise = waitForJoinProximityChat(alice);
+        const bobProximityChatPromise = waitForJoinProximityChat(bob);
         await Map.teleportToPosition(alice, 32, 32);
+        await aliceProximityChatPromise;
+        await bobProximityChatPromise;
 
         await expect(alice.getByTestId("screenShareButton")).toBeVisible({ timeout: 120_000 }); // Wait for the audio stream to be ready
 
         // Test play sound scripting
         await evaluateScript(bob, async () => {
-            WA.player.proximityMeeting
-                .playSound("http://maps.workadventure.localhost/tests/Audience.mp3")
-                .catch((err) => console.error(err));
+            window.meeting?.playSound("http://maps.workadventure.localhost/tests/Audience.mp3").catch((err) => {
+                console.error(err);
+            });
         });
 
         // Test listen to sound scripting

--- a/tests/tests/scripting_chat.spec.ts
+++ b/tests/tests/scripting_chat.spec.ts
@@ -75,8 +75,8 @@ test.describe("#Scripting chat functions @nowebkit @nomobile", () => {
         //await oidcMatrixUserLogin(bob, false);
         // test to send bubble message when entering proximity meeting
         await evaluateScript(bob, async () => {
-            WA.player.proximityMeeting.onJoin().subscribe((user) => {
-                console.log("Entering proximity meeting with", user);
+            WA.player.meetings.onJoin().subscribe((meeting) => {
+                console.log("Entering proximity meeting with", meeting.participants);
                 // Let's wait a bit to be sure the "bob entered the meeting" message is sent first
                 setTimeout(() => {
                     WA.chat.sendChatMessage("Test message sent", {


### PR DESCRIPTION
## Summary

Adds a new multi-meeting scripting API for proximity chat rooms while keeping the existing follow API on `WA.player.proximityMeeting`.

- Add `WA.player.meetings.onJoin()` and scoped `Meeting` objects for lifecycle, participant, sound, and audio stream APIs.
- Keep legacy `WA.player.proximityMeeting` default-bubble behavior, but mark its single-meeting lifecycle/audio methods as deprecated.
- Route meeting-scoped iframe events and commands by meeting id through the proximity chat room manager.
- Update scripting audio/chat tests and API documentation, including the deprecated methods page.

## Validation

- `npm run typecheck --workspace play`
- Focused ESLint on touched `play` files
- `npm run lint --workspace tests` (passes with existing warnings only)
- `git diff --check`