### PR TITLE
feat: configurable Room API bind host for dual-stack deployments

### DIFF
--- a/docs/others/self-hosting/env-variables.md
+++ b/docs/others/self-hosting/env-variables.md
@@ -97,7 +97,7 @@ Environment variables for the Play service (frontend and pusher).
 | `SENTRY_RELEASE` | No | Sentry release version identifier for error tracking |
 | `SENTRY_ENVIRONMENT` | No | Sentry environment name (e.g., 'production', 'staging', 'development') |
 | `SENTRY_TRACES_SAMPLE_RATE` | No | The sampling rate for Sentry traces. Only used if SENTRY_DSN is configured. Defaults to 0.1 |
-| `ROOM_API_BIND_HOST` | No | Bind host for the Room API gRPC server. Defaults to 0.0.0.0. Use `[::]` for dual-stack IPv6 deployments. |
+| `ROOM_API_BIND_HOST` | No | Bind host for the Room API gRPC server. Defaults to `[::]`. |
 | `ROOM_API_PORT` | No | Port for the Room API gRPC server. Defaults to 50051 |
 | `ROOM_API_SECRET_KEY` | No | Secret key for Room API authentication |
 | `ENABLE_MAP_EDITOR` | No | Enable the built-in map editor. Defaults to false |

--- a/docs/others/self-hosting/env-variables.md
+++ b/docs/others/self-hosting/env-variables.md
@@ -97,6 +97,7 @@ Environment variables for the Play service (frontend and pusher).
 | `SENTRY_RELEASE` | No | Sentry release version identifier for error tracking |
 | `SENTRY_ENVIRONMENT` | No | Sentry environment name (e.g., 'production', 'staging', 'development') |
 | `SENTRY_TRACES_SAMPLE_RATE` | No | The sampling rate for Sentry traces. Only used if SENTRY_DSN is configured. Defaults to 0.1 |
+| `ROOM_API_BIND_HOST` | No | Bind host for the Room API gRPC server. Defaults to 0.0.0.0. Use `[::]` for dual-stack IPv6 deployments. |
 | `ROOM_API_PORT` | No | Port for the Room API gRPC server. Defaults to 50051 |
 | `ROOM_API_SECRET_KEY` | No | Secret key for Room API authentication |
 | `ENABLE_MAP_EDITOR` | No | Enable the built-in map editor. Defaults to false |

--- a/play/src/pusher/enums/EnvironmentVariable.ts
+++ b/play/src/pusher/enums/EnvironmentVariable.ts
@@ -130,7 +130,7 @@ export const TURN_STATIC_AUTH_SECRET: string | undefined = env.TURN_STATIC_AUTH_
 export const TURN_CREDENTIALS_RENEWAL_TIME: number = env.TURN_CREDENTIALS_RENEWAL_TIME;
 
 // RoomAPI
-export const ROOM_API_BIND_HOST = env.ROOM_API_BIND_HOST ?? "0.0.0.0";
+export const ROOM_API_BIND_HOST = env.ROOM_API_BIND_HOST ?? "[::]";
 export const ROOM_API_PORT = env.ROOM_API_PORT;
 export const ROOM_API_SECRET_KEY = env.ROOM_API_SECRET_KEY;
 

--- a/play/src/pusher/enums/EnvironmentVariable.ts
+++ b/play/src/pusher/enums/EnvironmentVariable.ts
@@ -130,6 +130,7 @@ export const TURN_STATIC_AUTH_SECRET: string | undefined = env.TURN_STATIC_AUTH_
 export const TURN_CREDENTIALS_RENEWAL_TIME: number = env.TURN_CREDENTIALS_RENEWAL_TIME;
 
 // RoomAPI
+export const ROOM_API_BIND_HOST = env.ROOM_API_BIND_HOST ?? "0.0.0.0";
 export const ROOM_API_PORT = env.ROOM_API_PORT;
 export const ROOM_API_SECRET_KEY = env.ROOM_API_SECRET_KEY;
 

--- a/play/src/pusher/enums/EnvironmentVariableValidator.ts
+++ b/play/src/pusher/enums/EnvironmentVariableValidator.ts
@@ -383,10 +383,7 @@ export const EnvironmentVariables = z.object({
         .describe("The sampling rate for Sentry traces. Only used if SENTRY_DSN is configured. Defaults to 0.1"),
 
     // RoomAPI related environment variables
-    ROOM_API_BIND_HOST: z
-        .string()
-        .optional()
-        .describe("Bind host for the Room API gRPC server. Defaults to `[::]`."),
+    ROOM_API_BIND_HOST: z.string().optional().describe("Bind host for the Room API gRPC server. Defaults to `[::]`."),
     ROOM_API_PORT: PositiveIntAsString.optional()
         .transform((val) => toNumber(val, 50051))
         .describe("Port for the Room API gRPC server. Defaults to 50051"),

--- a/play/src/pusher/enums/EnvironmentVariableValidator.ts
+++ b/play/src/pusher/enums/EnvironmentVariableValidator.ts
@@ -383,6 +383,10 @@ export const EnvironmentVariables = z.object({
         .describe("The sampling rate for Sentry traces. Only used if SENTRY_DSN is configured. Defaults to 0.1"),
 
     // RoomAPI related environment variables
+    ROOM_API_BIND_HOST: z
+        .string()
+        .optional()
+        .describe("Bind host for the Room API gRPC server. Defaults to 0.0.0.0. Use `[::]` for dual-stack IPv6 deployments."),
     ROOM_API_PORT: PositiveIntAsString.optional()
         .transform((val) => toNumber(val, 50051))
         .describe("Port for the Room API gRPC server. Defaults to 50051"),

--- a/play/src/pusher/enums/EnvironmentVariableValidator.ts
+++ b/play/src/pusher/enums/EnvironmentVariableValidator.ts
@@ -386,7 +386,7 @@ export const EnvironmentVariables = z.object({
     ROOM_API_BIND_HOST: z
         .string()
         .optional()
-        .describe("Bind host for the Room API gRPC server. Defaults to 0.0.0.0. Use `[::]` for dual-stack IPv6 deployments."),
+        .describe("Bind host for the Room API gRPC server. Defaults to `[::]`."),
     ROOM_API_PORT: PositiveIntAsString.optional()
         .transform((val) => toNumber(val, 50051))
         .describe("Port for the Room API gRPC server. Defaults to 50051"),

--- a/play/src/server.ts
+++ b/play/src/server.ts
@@ -8,6 +8,7 @@ import app from "./pusher/app";
 import {
     PUSHER_HTTP_PORT,
     ADMIN_API_URL,
+    ROOM_API_BIND_HOST,
     ROOM_API_PORT,
     ROOM_API_SECRET_KEY,
     SENTRY_DSN,
@@ -72,7 +73,7 @@ if (!ADMIN_API_URL && !ROOM_API_SECRET_KEY) {
 
     RoomAPI.addService(RoomApiService, RoomApiServer);
 
-    RoomAPI.bindAsync(`0.0.0.0:${ROOM_API_PORT}`, ServerCredentials.createInsecure(), (err, port) => {
+    RoomAPI.bindAsync(`${ROOM_API_BIND_HOST}:${ROOM_API_PORT}`, ServerCredentials.createInsecure(), (err, port) => {
         if (err) {
             throw err;
         }


### PR DESCRIPTION
## Summary
The Room API server's bind host is now configurable via an environment variable, instead of being hardcoded.

## Why this matters
Requested in #5871: the Room API gRPC server bound to a fixed host, which prevents dual-stack and non-default-interface deployments. A `ROOM_API_BIND_HOST` (validated) environment variable lets operators choose the bind address; the default is unchanged.

## Changes
- Add the bind-host environment variable to the pusher env enum and validator.
- Use it when starting the Room API server, defaulting to the previous value.
- Document it in the self-hosting env-variables reference.

## Testing
The variable is validated through the existing env-variable validator; default behavior is unchanged when it is unset.

Fixes #5871

AI was used for assistance.
