### PR TITLE
fix: keep long lines in chat code blocks from breaking the layout

### DIFF
--- a/play/src/front/Chat/Components/Room/Message.svelte
+++ b/play/src/front/Chat/Components/Room/Message.svelte
@@ -134,7 +134,7 @@
 >
     <div
         style={replyDepth === 0 ? "max-width: calc( 100% - 50px );" : "padding-left: 0"}
-        class="flex gap-2 justify-start overflow-visible relative {replyDepth === 0
+        class="flex min-w-0 gap-2 justify-start overflow-visible relative {replyDepth === 0
             ? 'max-w-[calc(100% - 100px)]'
             : ''} {!$isDeleted ? 'group-hover/message:pb-4' : ''} {isMyMessage
             ? 'justify-end grid-container-inverted pr-4'
@@ -151,7 +151,7 @@
             </div>
         {/if}
 
-        <div class="flex flex-col justify-end max-w-full {replyDepth === 0 && !showHeader ? 'ml-12' : ''}">
+        <div class="flex min-w-0 flex-col justify-end max-w-full {replyDepth === 0 && !showHeader ? 'ml-12' : ''}">
             {#if replyDepth <= 0 && showHeader}
                 <div
                     class="w-full h-fit text-xs px-2 flex justify-between items-end gap-2 overflow-x-hidden"
@@ -174,7 +174,7 @@
                 </div>
             {/if}
             <div
-                class="message rounded-md
+                class="message max-w-full rounded-md
                     {$isDeleted && !isMyMessage && !messageFromSystem && replyDepth === 0 ? 'bg-white/10' : ''}
                     {$isDeleted && isMyMessage && !messageFromSystem && replyDepth === 0 ? 'bg-white/10' : ''}
                     {!isMyMessage && !messageFromSystem && !$isDeleted && replyDepth === 0

--- a/play/src/front/Chat/Components/Room/Message/MessageText.svelte
+++ b/play/src/front/Chat/Components/Room/Message/MessageText.svelte
@@ -83,4 +83,26 @@
 </div>
 
 <style>
+    .message-bubble {
+        max-width: 100%;
+        min-width: 0;
+        overflow-wrap: anywhere;
+    }
+
+    .message-bubble :global(pre) {
+        max-width: 100%;
+        overflow-x: auto;
+        white-space: pre;
+    }
+
+    .message-bubble :global(code) {
+        max-width: 100%;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+    }
+
+    .message-bubble :global(pre code) {
+        overflow-wrap: normal;
+        word-break: normal;
+    }
 </style>


### PR DESCRIPTION
## Summary
Long lines inside chat code blocks now wrap/scroll within the message instead of stretching the chat layout.

## Why this matters
Reported in #5688: a code block containing a long unbroken line widened the whole chat panel, pushing the layout out of shape. Constraining the code block's width keeps long lines contained.

## Changes
- Constrain the code block container in `MessageText.svelte` so long lines stay within the message bounds.
- Minor `Message.svelte` adjustment to support the contained layout.

## Testing
Verified a chat message with a long single-line code block no longer expands the chat panel.

Fixes #5688

AI was used for assistance.
