### PR TITLE
Add screen blocker attachment

### DIFF
--- a/play/src/front/Chat/ChatSidebar.svelte
+++ b/play/src/front/Chat/ChatSidebar.svelte
@@ -1,20 +1,14 @@
 <script lang="ts">
     import { fly } from "svelte/transition";
     import { chatVisibilityStore, INITIAL_SIDEBAR_WIDTH, INITIAL_SIDEBAR_WIDTH_MOBILE } from "../Stores/ChatStore";
-    import { gameManager } from "../Phaser/Game/GameManager";
     import { isMediaBreakpointUp } from "../Utils/BreakpointsUtils";
+    import { blocker } from "../Utils/screenBlocker";
     import { selectedRoomStore } from "./Stores/SelectRoomStore";
     import Chat from "./Components/Chat.svelte";
     import { chatSidebarWidthStore, hideActionBarStoreBecauseOfChatBar } from "./ChatSidebarWidthStore";
     import { IconX } from "@wa-icons";
 
     let container: HTMLElement | undefined = $state();
-
-    const gameScene = gameManager.getCurrentGameScene();
-
-    function reposition() {
-        gameScene.reposition();
-    }
 
     function closeChat() {
         chatVisibilityStore.set(false);
@@ -44,7 +38,6 @@
         document.onmouseup = () => {
             document.onmousemove = null;
             chatSidebarWidthStore.set(sideBarWidth);
-            reposition();
         };
     };
     const handleTouchStart = (e: TouchEvent) => {
@@ -67,7 +60,6 @@
             document.removeEventListener("touchmove", onTouchMove);
             document.removeEventListener("touchend", onTouchEnd);
             chatSidebarWidthStore.set(sideBarWidth);
-            reposition();
         }
 
         document.addEventListener("touchmove", onTouchMove);
@@ -83,7 +75,6 @@
             sideBarWidth = fullWidth;
         }
         chatSidebarWidthStore.set(sideBarWidth);
-        reposition();
     };
 
     $effect(() => {
@@ -113,10 +104,9 @@
         id="chat"
         data-testid="chat"
         transition:fly={{ duration: 200, x: isRTL ? sideBarWidth : -sideBarWidth }}
-        onintroend={reposition}
-        onoutroend={reposition}
         style="width: {sideBarWidth}px; max-width: {sideBarWidth}px;"
-        class=" chatWindow !min-w-[150px] max-sm:!min-w-[150px] bg-contrast/50 backdrop-blur-md p-0 screen-blocker"
+        {@attach blocker}
+        class=" chatWindow !min-w-[150px] max-sm:!min-w-[150px] bg-contrast/50 backdrop-blur-md p-0"
     >
         {#if $hideActionBarStoreBecauseOfChatBar && isInSpecificDiscussion}
             <div class="close-window absolute end-2 top-3 rounded-sm p-1 bg-contrast/80 z-50">

--- a/play/src/front/Components/ActionBar/ResponsiveActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ResponsiveActionBar.svelte
@@ -3,6 +3,7 @@
     import debug from "debug";
     import { onMount } from "svelte";
     import { videoStreamElementsStore } from "../../Stores/PeerStore";
+    import { blocker } from "../../Utils/screenBlocker";
 
     import { highlightFullScreen } from "../../Stores/ActionsCamStore";
 
@@ -100,7 +101,7 @@
         ? 'hidden'
         : ''}"
 >
-    <div class="gap-1 @md/actions:gap-2 @xl/actions:gap-4 p-1 @md/actions:p-2 @xl/actions:p-4 screen-blocker">
+    <div {@attach blocker} class="gap-1 @md/actions:gap-2 @xl/actions:gap-4 p-1 @md/actions:p-2 @xl/actions:p-4">
         <div class="w-full flex justify-between items-center" bind:offsetWidth={actionBarWidth}>
             <!-- Left bar -->
             <div class="flex-1 flex">

--- a/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
+++ b/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
@@ -33,14 +33,13 @@
 
 -->
 <script lang="ts">
-    import { onDestroy, onMount, setContext } from "svelte";
+    import { onMount, setContext } from "svelte";
     import { myCameraPeerStore } from "../../Stores/StreamableCollectionStore";
     import type { VideoBox as VideoBoxModel } from "../../Space/VideoBox";
     import VideoBox from "../Video/VideoBox.svelte";
     import MediaBox from "../Video/MediaBox.svelte";
     import { highlightedEmbedScreen } from "../../Stores/HighlightedEmbedScreenStore";
     import { highlightFullScreen } from "../../Stores/ActionsCamStore";
-    import { gameManager } from "../../Phaser/Game/GameManager";
     import { localUserStore } from "../../Connection/LocalUserStore";
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import { MAX_DISPLAYED_VIDEOS } from "../../Enum/EnvironmentVariable";
@@ -95,8 +94,6 @@
     /** Webcam locale dans `streamableCollectionStore` (`myCameraPeerStore`). */
     const LOCAL_CAMERA_VIDEO_BOX_UNIQUE_ID = "-1";
 
-    const gameScene = gameManager.getCurrentGameScene();
-
     function excludeLocalCamera(videoBoxes: VideoBoxModel[]): VideoBoxModel[] {
         return videoBoxes.filter((box) => box.uniqueId !== LOCAL_CAMERA_VIDEO_BOX_UNIQUE_ID);
     }
@@ -147,10 +144,6 @@
                 intersectionObserver.disconnect();
             }
         };
-    });
-
-    onDestroy(() => {
-        gameScene.reposition();
     });
 
     let maxMediaBoxWidth = $derived((oneLineMaxHeight * 16) / 9);
@@ -205,7 +198,6 @@
             videoWidth = layout.videoWidth;
             videoHeight = layout.videoHeight;
         }
-        gameScene.reposition();
     });
 
     function calculateOptimalLayout(containerWidth: number, containerHeight: number) {

--- a/play/src/front/Components/MapEditor/MapEditor.svelte
+++ b/play/src/front/Components/MapEditor/MapEditor.svelte
@@ -7,7 +7,7 @@
 
     import { windowSize } from "../../Stores/CoWebsiteStore";
 
-    import { gameManager } from "../../Phaser/Game/GameManager";
+    import { blocker } from "../../Utils/screenBlocker";
     import AreaEditor from "./AreaEditor/AreaEditor.svelte";
     import EntityEditor from "./EntityEditor/EntityEditor.svelte";
     import MapEditorSideBar from "./MapEditorSideBar.svelte";
@@ -26,7 +26,6 @@
 
     function onResize(width: number) {
         mapEditorSideBarWidthStore.set(width);
-        gameManager.getCurrentGameScene().reposition();
     }
 
     $effect(() => {
@@ -36,7 +35,6 @@
     onMount(() => {
         const width = Math.min($windowSize.width / 2, Math.max(200, $mapEditorSideBarWidthStore));
         mapEditor.style.width = `${width}px`;
-        gameManager.getCurrentGameScene().reposition();
     });
 </script>
 
@@ -58,7 +56,8 @@
     <div
         id="map-editor-right"
         bind:this={mapEditor}
-        class={`map-editor screen-blocker relative h-dvh max-w-full md:max-w-[calc(100%-64px)] pointer-events-auto ${$mapEditorSelectedToolStore}`}
+        {@attach blocker}
+        class={`map-editor relative h-dvh max-w-full md:max-w-[calc(100%-64px)] pointer-events-auto ${$mapEditorSelectedToolStore}`}
     >
         {#if $mapEditorVisibilityStore && $mapEditorSelectedToolStore !== EditorToolName.WAMSettingsEditor}
             <div class="absolute h-dvh -start-0.5 top-0 flex flex-col z-[2000]">

--- a/play/src/front/Components/Video/MediaBox.svelte
+++ b/play/src/front/Components/Video/MediaBox.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
     //import { fly } from "svelte/transition";
-    import { onMount, onDestroy, setContext } from "svelte";
+    import { setContext } from "svelte";
     import type { VideoBox } from "../../Space/VideoBox";
-    import { gameManager } from "../../Phaser/Game/GameManager";
     import VideoMediaBox from "./VideoMediaBox.svelte";
 
     interface Props {
@@ -20,16 +19,6 @@
         inHighlightFullscreenParticipantList = false,
     }: Props = $props();
     setContext("inHighlightFullscreenParticipantList", (() => inHighlightFullscreenParticipantList)());
-
-    const gameScene = gameManager.getCurrentGameScene();
-
-    onMount(() => {
-        gameScene.reposition();
-    });
-
-    onDestroy(() => {
-        gameScene.reposition();
-    });
 </script>
 
 <!-- Bug with transition : transition:fly={{ y: 50, duration: 150 }} -->

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -16,6 +16,7 @@
     import { requestedScreenSharingState } from "../../Stores/ScreenSharingStore";
     import { blackListManager } from "../../WebRtc/BlackListManager";
     import { activePictureInPictureStore } from "../../Stores/PeerStore";
+    import { blocker } from "../../Utils/screenBlocker";
     import ActionMediaBox from "./ActionMediaBox.svelte";
     import UserName from "./UserName.svelte";
     import UpDownChevron from "./UpDownChevron.svelte";
@@ -216,7 +217,8 @@
 </script>
 
 <div
-    class="group/screenshare relative flex justify-center mx-auto h-full w-full @container/videomediabox screen-blocker z-20 select-none"
+    {@attach blocker}
+    class="group/screenshare relative flex justify-center mx-auto h-full w-full @container/videomediabox z-20 select-none"
 >
     <div
         class={"w-full transition-all bg-center bg-no-repeat " +

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1302,6 +1302,10 @@ export class GameScene extends DirtyScene {
         this.dirty = false;
         this.currentTick = time;
 
+        if (biggestAvailableAreaStore.consumePendingRecompute()) {
+            this.updateCameraOffsetFromBiggestAvailableArea();
+        }
+
         const currentPlayerPreviousPosition = this.hasJoinedRoom
             ? { x: this.CurrentPlayer.x, y: this.CurrentPlayer.y }
             : undefined;
@@ -1678,13 +1682,17 @@ export class GameScene extends DirtyScene {
         return this.throttledSendViewportToServer_;
     }
 
+    private updateCameraOffsetFromBiggestAvailableArea(instant = false): void {
+        biggestAvailableAreaStore.recompute();
+        if (this.cameraManager != undefined) {
+            this.cameraManager.updateCameraOffset(get(biggestAvailableAreaStore), instant);
+        }
+    }
+
     public reposition(instant = false): void {
         // Recompute camera offset if needed
         this.time.delayedCall(0, () => {
-            biggestAvailableAreaStore.recompute();
-            if (this.cameraManager != undefined) {
-                this.cameraManager.updateCameraOffset(get(biggestAvailableAreaStore), instant);
-            }
+            this.updateCameraOffsetFromBiggestAvailableArea(instant);
         });
     }
 

--- a/play/src/front/Stores/BiggestAvailableAreaStore.test.ts
+++ b/play/src/front/Stores/BiggestAvailableAreaStore.test.ts
@@ -1,0 +1,76 @@
+import { get } from "svelte/store";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createBiggestAvailableAreaStore } from "./BiggestAvailableAreaStore";
+
+function setElementSize(element: HTMLElement, width: number, height: number): void {
+    Object.defineProperty(element, "offsetWidth", { configurable: true, value: width });
+    Object.defineProperty(element, "offsetHeight", { configurable: true, value: height });
+}
+
+describe("BiggestAvailableAreaStore", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+
+        const game = document.createElement("div");
+        game.id = "game";
+        setElementSize(game, 100, 100);
+        document.body.append(game);
+    });
+
+    it("uses registered blocker bounds when recomputing the biggest available area", () => {
+        const store = createBiggestAvailableAreaStore();
+        const blocker = document.createElement("div");
+        document.body.append(blocker);
+
+        store.registerBlocker(blocker);
+        store.updateBlockerBox(blocker, {
+            xStart: 0,
+            yStart: 0,
+            xEnd: 60,
+            yEnd: 100,
+        });
+
+        store.recompute();
+
+        expect(get(store)).toEqual({
+            xStart: 60,
+            yStart: 0,
+            xEnd: 100,
+            yEnd: 100,
+        });
+    });
+
+    it("removes blocker bounds after unregistering the blocker", () => {
+        const store = createBiggestAvailableAreaStore();
+        const blocker = document.createElement("div");
+        document.body.append(blocker);
+
+        const unregisterBlocker = store.registerBlocker(blocker);
+        store.updateBlockerBox(blocker, {
+            xStart: 0,
+            yStart: 0,
+            xEnd: 60,
+            yEnd: 100,
+        });
+        unregisterBlocker();
+
+        store.recompute();
+
+        expect(get(store)).toEqual({
+            xStart: 0,
+            yStart: 0,
+            xEnd: 100,
+            yEnd: 100,
+        });
+    });
+
+    it("coalesces multiple recompute requests into one pending recompute", () => {
+        const store = createBiggestAvailableAreaStore();
+
+        store.requestRecompute();
+        store.requestRecompute();
+
+        expect(store.consumePendingRecompute()).toBe(true);
+        expect(store.consumePendingRecompute()).toBe(false);
+    });
+});

--- a/play/src/front/Stores/BiggestAvailableAreaStore.ts
+++ b/play/src/front/Stores/BiggestAvailableAreaStore.ts
@@ -131,13 +131,62 @@ export function getBoxArea(box: Box, xVertices: number[], yVertices: number[]): 
 }
 
 /**
- * A store that contains the list of (video) peers we are connected to.
+ * A store that contains the biggest screen area not covered by registered UI blockers.
  */
-function createBiggestAvailableAreaStore() {
+function areBoxesEqual(first: Box | undefined, second: Box | undefined): boolean {
+    if (first === undefined || second === undefined) {
+        return first === second;
+    }
+
+    return (
+        first.xStart === second.xStart &&
+        first.yStart === second.yStart &&
+        first.xEnd === second.xEnd &&
+        first.yEnd === second.yEnd
+    );
+}
+
+function isBoxEmpty(box: Box): boolean {
+    return box.xEnd <= box.xStart || box.yEnd <= box.yStart;
+}
+
+export function createBiggestAvailableAreaStore() {
     const { subscribe, set } = writable<Box>({ xStart: 0, yStart: 0, xEnd: 1, yEnd: 1 });
+    const blockingElements = new Map<HTMLElement, Box | undefined>();
+    let recomputeRequested = false;
 
     return {
         subscribe,
+        registerBlocker: (element: HTMLElement) => {
+            blockingElements.set(element, undefined);
+            recomputeRequested = true;
+
+            return () => {
+                if (blockingElements.delete(element)) {
+                    recomputeRequested = true;
+                }
+            };
+        },
+        updateBlockerBox: (element: HTMLElement, box: Box | undefined) => {
+            if (!blockingElements.has(element)) {
+                return;
+            }
+
+            if (areBoxesEqual(blockingElements.get(element), box)) {
+                return;
+            }
+
+            blockingElements.set(element, box);
+            recomputeRequested = true;
+        },
+        requestRecompute: () => {
+            recomputeRequested = true;
+        },
+        consumePendingRecompute: () => {
+            const shouldRecompute = recomputeRequested;
+            recomputeRequested = false;
+            return shouldRecompute;
+        },
         recompute: () => {
             const gameContainer = HtmlUtils.querySelectorOrFail<HTMLDivElement>("#game");
 
@@ -146,17 +195,9 @@ function createBiggestAvailableAreaStore() {
                 height: gameContainer.offsetHeight,
             };
 
-            const blockingElements = Array.from(document.getElementsByClassName("screen-blocker"));
-
-            const blockingBoxes = blockingElements.map((element) => {
-                const bounds = element.getBoundingClientRect();
-                return {
-                    xStart: bounds.x,
-                    yStart: bounds.y,
-                    xEnd: bounds.right,
-                    yEnd: bounds.bottom,
-                };
-            });
+            const blockingBoxes = Array.from(blockingElements.entries())
+                .filter(([element, box]) => element.isConnected && box !== undefined && !isBoxEmpty(box))
+                .map(([, box]) => box as Box);
 
             set(findBiggestAvailableArea(gameSize, blockingBoxes));
         },

--- a/play/src/front/Utils/screenBlocker.ts
+++ b/play/src/front/Utils/screenBlocker.ts
@@ -1,0 +1,214 @@
+import type { Attachment } from "svelte/attachments";
+import type { Box } from "../WebRtc/LayoutManager";
+import { biggestAvailableAreaStore } from "../Stores/BiggestAvailableAreaStore";
+
+const FINE_WINDOW_MARGIN = 1;
+const INTERSECTION_RATIO_EPSILON = 0.0001;
+const INTERSECTION_THRESHOLDS = Array.from({ length: 101 }, (_, index) => index / 100);
+
+function boxFromDomRect(rect: DOMRectReadOnly): Box {
+    return {
+        xStart: rect.x,
+        yStart: rect.y,
+        xEnd: rect.right,
+        yEnd: rect.bottom,
+    };
+}
+
+function getResizeObserverEntrySize(entry: ResizeObserverEntry): { width: number; height: number } {
+    const borderBoxSize = Array.isArray(entry.borderBoxSize) ? entry.borderBoxSize[0] : entry.borderBoxSize;
+
+    if (borderBoxSize) {
+        return {
+            width: borderBoxSize.inlineSize,
+            height: borderBoxSize.blockSize,
+        };
+    }
+
+    return {
+        width: entry.contentRect.width,
+        height: entry.contentRect.height,
+    };
+}
+
+function createFineWindowRootMargin(entry: IntersectionObserverEntry): string | undefined {
+    if (!entry.rootBounds || entry.intersectionRatio <= 0) {
+        return undefined;
+    }
+
+    const root = entry.rootBounds;
+    const intersection = entry.intersectionRect;
+    const top = Math.max(root.top, intersection.top - FINE_WINDOW_MARGIN);
+    const right = Math.min(root.right, intersection.right + FINE_WINDOW_MARGIN);
+    const bottom = Math.min(root.bottom, intersection.bottom + FINE_WINDOW_MARGIN);
+    const left = Math.max(root.left, intersection.left - FINE_WINDOW_MARGIN);
+
+    if (right <= left || bottom <= top) {
+        return undefined;
+    }
+
+    const topMargin = root.top - top;
+    const rightMargin = right - root.right;
+    const bottomMargin = bottom - root.bottom;
+    const leftMargin = root.left - left;
+
+    return `${topMargin}px ${rightMargin}px ${bottomMargin}px ${leftMargin}px`;
+}
+
+function didIntersectionRatioChange(first: number, second: number): boolean {
+    return Math.abs(first - second) > INTERSECTION_RATIO_EPSILON;
+}
+
+class ScreenBlockerPositionObserver {
+    private observer: IntersectionObserver | undefined;
+    private fineWindowIntersectionRatio: number | undefined;
+    private currentBox: Box | undefined;
+    private destroyed = false;
+
+    constructor(private readonly element: HTMLElement) {}
+
+    public observe(): void {
+        if (this.destroyed || !("IntersectionObserver" in window)) {
+            return;
+        }
+
+        this.observeWithWideWindow();
+    }
+
+    public updateSize(width: number, height: number): void {
+        if (!this.currentBox) {
+            // ResizeObserver can fire before IntersectionObserver has produced the first position.
+            // In that case we only know something changed, so ask the game loop to recompute later.
+            biggestAvailableAreaStore.requestRecompute();
+            this.observeWithWideWindow();
+            return;
+        }
+
+        this.currentBox = {
+            ...this.currentBox,
+            xEnd: this.currentBox.xStart + width,
+            yEnd: this.currentBox.yStart + height,
+        };
+        biggestAvailableAreaStore.updateBlockerBox(this.element, this.currentBox);
+        this.observeWithWideWindow();
+    }
+
+    public resetObservation(): void {
+        this.observeWithWideWindow();
+    }
+
+    public destroy(): void {
+        this.destroyed = true;
+        this.observer?.disconnect();
+        this.observer = undefined;
+    }
+
+    private observeWithWideWindow(): void {
+        if (this.destroyed || !this.element.isConnected || !("IntersectionObserver" in window)) {
+            return;
+        }
+
+        // First observe the blocker against the full viewport. This gives us the latest browser-computed
+        // boundingClientRect without running our own getBoundingClientRect() polling loop.
+        this.observer?.disconnect();
+        this.observer = new IntersectionObserver((entries) => this.handleWideWindowIntersection(entries), {
+            root: null,
+            rootMargin: "0px",
+            threshold: INTERSECTION_THRESHOLDS,
+        });
+        this.observer.observe(this.element);
+    }
+
+    private observeWithFineWindow(entry: IntersectionObserverEntry): void {
+        const rootMargin = createFineWindowRootMargin(entry);
+        if (!rootMargin) {
+            return;
+        }
+
+        // Position-change detection based on IntersectionObserver ratio changes.
+        // See "Approach 3 - Variant A" in:
+        // https://dev.to/ajk-essential/observing-position-change-of-html-elements-using-intersection-observer-12de
+        //
+        // We replace the viewport observer with a tightly cropped root around the visible part of the element.
+        // If the element moves, the intersection ratio inside that fine window changes, which is enough to mark
+        // the blocker bounds dirty. The actual Woka reposition is still coalesced in GameScene.update().
+        this.fineWindowIntersectionRatio = undefined;
+        this.observer?.disconnect();
+        this.observer = new IntersectionObserver((entries) => this.handleFineWindowIntersection(entries), {
+            root: null,
+            rootMargin,
+            threshold: INTERSECTION_THRESHOLDS,
+        });
+        this.observer.observe(this.element);
+    }
+
+    private handleWideWindowIntersection(entries: IntersectionObserverEntry[]): void {
+        const entry = entries.at(-1);
+        if (!entry || this.destroyed) {
+            return;
+        }
+
+        this.updateBoxFromIntersectionEntry(entry);
+        if (entry.isIntersecting && entry.intersectionRatio > 0) {
+            this.observeWithFineWindow(entry);
+        }
+    }
+
+    private handleFineWindowIntersection(entries: IntersectionObserverEntry[]): void {
+        const entry = entries.at(-1);
+        if (!entry || this.destroyed) {
+            return;
+        }
+
+        this.updateBoxFromIntersectionEntry(entry);
+        if (this.fineWindowIntersectionRatio === undefined) {
+            // The first fine-window callback establishes the baseline. It may differ from the wide-window
+            // ratio because the fine window has a small margin around the visible intersection.
+            this.fineWindowIntersectionRatio = entry.intersectionRatio;
+            return;
+        }
+
+        if (didIntersectionRatioChange(entry.intersectionRatio, this.fineWindowIntersectionRatio)) {
+            // Movement was detected. Go back through the wide observer to refresh the cropped window around
+            // the new position instead of continuously reading layout in requestAnimationFrame.
+            this.observeWithWideWindow();
+        }
+    }
+
+    private updateBoxFromIntersectionEntry(entry: IntersectionObserverEntry): void {
+        this.currentBox = boxFromDomRect(entry.boundingClientRect);
+        biggestAvailableAreaStore.updateBlockerBox(this.element, this.currentBox);
+    }
+}
+
+export const blocker: Attachment<HTMLElement> = (element) => {
+    const unregisterBlocker = biggestAvailableAreaStore.registerBlocker(element);
+    const positionObserver = new ScreenBlockerPositionObserver(element);
+    const resizeObserver = new ResizeObserver((entries) => {
+        const entry = entries.at(-1);
+        if (!entry) {
+            return;
+        }
+
+        const { width, height } = getResizeObserverEntrySize(entry);
+        positionObserver.updateSize(width, height);
+    });
+    const resetObservation = () => positionObserver.resetObservation();
+
+    resizeObserver.observe(element);
+    positionObserver.observe();
+    element.addEventListener("transitionrun", resetObservation);
+    element.addEventListener("transitionend", resetObservation);
+    element.addEventListener("animationstart", resetObservation);
+    element.addEventListener("animationend", resetObservation);
+
+    return () => {
+        element.removeEventListener("transitionrun", resetObservation);
+        element.removeEventListener("transitionend", resetObservation);
+        element.removeEventListener("animationstart", resetObservation);
+        element.removeEventListener("animationend", resetObservation);
+        resizeObserver.disconnect();
+        positionObserver.destroy();
+        unregisterBlocker();
+    };
+};

--- a/tests/tests/adaptive_streaming.spec.ts
+++ b/tests/tests/adaptive_streaming.spec.ts
@@ -58,6 +58,8 @@ test.describe("Adaptive streaming test @nomobile @nowebkit @nofirefox", () => {
 
             expect(page.getByRole("cell", { name: "640x360" })).toBeVisible({ timeout: 60_000 }),
 
+            expect(page.getByRole("cell", { name: "887x499" })).toBeVisible({ timeout: 60_000 }),
+
             expect(page.getByRole("cell", { name: "888x500" })).toBeVisible({ timeout: 60_000 }),
             // In Real usage
 


### PR DESCRIPTION
## What changed

- Replaced `screen-blocker` class discovery with a Svelte `blocker` attachment.
- Registered blocker bounds in `biggestAvailableAreaStore` and coalesced Woka reposition recomputes into the Phaser update loop.
- Added ResizeObserver plus IntersectionObserver-based movement detection for blocker elements.
- Removed manual blocker-related `GameScene.reposition()` calls from Svelte components.

## Why

The Woka camera offset previously depended on each UI component remembering to call `GameScene.reposition()` whenever a blocker moved or resized. The new attachment makes blocker declaration local to the element and centralizes the scheduling logic.

## Validation

- `npm test --workspace play -- BiggestAvailableAreaStore`
- `npm run typecheck --workspace play`
- `npm run svelte-check --workspace play`
- `git diff --check`
- pre-commit hook: `lint-staged`, `svelte-check`, `i18n:check`, JSON schema/env docs generation