### PR TITLE
Detect missing received audio tracks

### DIFF
--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     //STYLE: Classes factorizing tailwind's ones are defined in video-ui.scss
     import { getContext, onDestroy, onMount } from "svelte";
+    import * as Sentry from "@sentry/svelte";
     import type { Subscription } from "rxjs";
     import SoundMeterWidget from "../SoundMeterWidget.svelte";
     import { highlightedEmbedScreen } from "../../Stores/HighlightedEmbedScreenStore";
@@ -47,6 +48,7 @@
 
     let extendedSpaceUser = $derived(videoBox.spaceUser);
     let megaphoneState = $derived(extendedSpaceUser?.reactiveUser.megaphoneState);
+    let microphoneStateStore = $derived(extendedSpaceUser?.reactiveUser.microphoneState);
 
     let pictureStore = $derived(extendedSpaceUser?.pictureStore);
 
@@ -56,10 +58,16 @@
 
     let hasVideoStore = $derived(streamable?.hasVideo);
     let hasAudioStore = $derived(streamable?.hasAudio);
+    let hasReceivedAudioStore = $derived(streamable?.hasReceivedAudio);
     let isMutedStore = $derived(streamable?.isMuted);
     let volumeMeterStore = $derived(streamable?.volumeStore);
     let showVoiceIndicatorStore = $derived(streamable?.showVoiceIndicator);
     let isBlockedStore = $derived(streamable?.media?.isBlocked);
+    let mediaStreamStore = $derived(
+        streamable?.media.type === "webrtc" || streamable?.media.type === "livekit"
+            ? streamable.media.streamStore
+            : undefined,
+    );
     let volumeStore = $derived(streamable?.volume);
     let volumeMeter = $derived($volumeMeterStore);
     let webRtcStatsStore = $derived($displayVideoQualityStore ? streamable?.webrtcStats : undefined);
@@ -78,6 +86,72 @@
 
     // Check if this is the local user's video box
     let isLocalUser = $derived(videoBox.uniqueId === "-1" || extendedSpaceUser?.spaceUserId === "local");
+    // Debugging aid for the rare case where the space says the remote microphone is enabled but this receiver has no audio.
+    let hasAudioStateMismatch = $derived(
+        effectiveStatus === "connected" &&
+            streamable?.videoType === "video" &&
+            !isLocalUser &&
+            $hasAudioStore === true &&
+            $isBlockedStore !== true &&
+            $microphoneStateStore === true &&
+            $hasReceivedAudioStore === false,
+    );
+    let loggedAudioMismatchKey: string | undefined = undefined;
+
+    $effect(() => {
+        if (!hasAudioStateMismatch) {
+            return;
+        }
+
+        const audioMismatchKey = `${streamable?.uniqueId ?? "unknown"}:${extendedSpaceUser?.spaceUserId ?? "unknown"}:${streamable?.media.type ?? "unknown"}`;
+        if (loggedAudioMismatchKey === audioMismatchKey) {
+            return;
+        }
+
+        const timeout = setTimeout(() => {
+            const audioTracks =
+                $mediaStreamStore?.getAudioTracks().map((track) => ({
+                    id: track.id,
+                    enabled: track.enabled,
+                    muted: track.muted,
+                    readyState: track.readyState,
+                })) ?? [];
+            const details = {
+                streamableUniqueId: streamable?.uniqueId,
+                streamableType: streamable?.media.type,
+                videoType: streamable?.videoType,
+                spaceUserId: extendedSpaceUser?.spaceUserId,
+                status: effectiveStatus,
+                hasAudio: $hasAudioStore,
+                hasReceivedAudio: $hasReceivedAudioStore,
+                isMuted: $isMutedStore,
+                microphoneState: $microphoneStateStore,
+                audioTrackCount: audioTracks.length,
+                audioTracks,
+            };
+
+            console.warn(
+                "Audio state mismatch: remote microphone is enabled in the space but no receiver audio track is present",
+                details,
+            );
+            Sentry.captureMessage(
+                "Audio state mismatch: remote microphone is enabled in the space but no receiver audio track is present",
+                {
+                    level: "warning",
+                    tags: {
+                        component: "VideoMediaBox",
+                        streamableType: streamable?.media.type ?? "unknown",
+                        videoType: streamable?.videoType ?? "unknown",
+                    },
+                    extra: details,
+                },
+            );
+
+            loggedAudioMismatchKey = audioMismatchKey;
+        }, 3000);
+
+        return () => clearTimeout(timeout);
+    });
 
     // Check if the local user is streaming with megaphone
     // requestedMegaphoneStore is true when user has requested megaphone
@@ -339,7 +413,7 @@
                                     class:text-white={$activePictureInPictureStore}
                                     class:opacity-20={$activePictureInPictureStore}
                                 >
-                                    {#if !$isMutedStore}
+                                    {#if !$isMutedStore && !hasAudioStateMismatch}
                                         <SoundMeterWidget
                                             volume={volumeMeter}
                                             cssClass="voice-meter-cam-off relative mr-0 ml-auto translate-x-0 transition-transform"
@@ -349,7 +423,9 @@
                                         <IconMicrophoneOff
                                             aria-label={$LL.video.user_is_muted({ name: name ?? "unknown" })}
                                             data-testid={$LL.video.user_is_muted({ name: name ?? "unknown" })}
-                                            class="[filter:drop-shadow(0_0_3px_rgb(0,0,0))_drop-shadow(0_0_6px_rgb(0,0,0))_drop-shadow(0_0_9px_rgb(0,0,0))]"
+                                            class="{hasAudioStateMismatch
+                                                ? 'text-red-500 '
+                                                : ''}[filter:drop-shadow(0_0_3px_rgb(0,0,0))_drop-shadow(0_0_6px_rgb(0,0,0))_drop-shadow(0_0_9px_rgb(0,0,0))]"
                                         />
                                     {/if}
                                 </div>

--- a/play/src/front/Livekit/LivekitParticipant.test.ts
+++ b/play/src/front/Livekit/LivekitParticipant.test.ts
@@ -154,6 +154,51 @@ describe("LiveKitParticipant", () => {
         expect(get(participant.getStreamable().isMuted)).toBe(false);
     });
 
+    it("should mark microphone audio as received only after the microphone track is subscribed", () => {
+        const participant = createParticipant({ publications: [] });
+        const streamable = participant.getStreamable();
+        const microphonePublication = createMicrophonePublication();
+        const microphoneStream = createAudioMediaStream("microphone");
+
+        expect(get(streamable.hasReceivedAudio)).toBe(false);
+
+        participant["handleTrackPublished"](microphonePublication);
+
+        expect(get(streamable.isMuted)).toBe(false);
+        expect(get(streamable.hasReceivedAudio)).toBe(false);
+
+        const microphoneTrack = createRemoteAudioTrack(microphoneStream);
+        participant["handleTrackSubscribed"](microphoneTrack, microphonePublication);
+
+        expect(get(streamable.hasReceivedAudio)).toBe(true);
+
+        participant["handleTrackMuted"](microphonePublication);
+
+        expect(get(streamable.isMuted)).toBe(true);
+        expect(get(streamable.hasReceivedAudio)).toBe(false);
+
+        participant["handleTrackUnmuted"](microphonePublication);
+
+        expect(get(streamable.hasReceivedAudio)).toBe(true);
+
+        participant["handleTrackUnsubscribed"](microphoneTrack, microphonePublication);
+
+        expect(get(streamable.hasReceivedAudio)).toBe(false);
+    });
+
+    it("should not use scripting audio as received microphone audio", () => {
+        const participant = createParticipant({ publications: [] });
+        const media = participant.getStreamable().media as LivekitStreamable;
+        const scriptingPublication = createScriptingAudioPublication();
+        const scriptingStream = createAudioMediaStream("scripting");
+
+        participant["handleTrackPublished"](scriptingPublication);
+        participant["handleTrackSubscribed"](createRemoteAudioTrack(scriptingStream), scriptingPublication);
+
+        expect(get(media.streamStore)).toBe(scriptingStream);
+        expect(get(participant.getStreamable().hasReceivedAudio)).toBe(false);
+    });
+
     it("should restart scripting audio without dropping microphone audio", () => {
         const participant = createParticipant({ publications: [] });
         const media = participant.getStreamable().media as LivekitStreamable;
@@ -294,5 +339,14 @@ function createRemoteAudioTrack(mediaStream: MediaStream): RemoteTrack {
 }
 
 function createAudioMediaStream(id: string): MediaStream {
-    return new MediaStream([{ id, kind: "audio" } as MediaStreamTrack]);
+    const track = new EventTarget() as MediaStreamTrack;
+    Object.defineProperties(track, {
+        id: { value: id },
+        kind: { value: "audio" },
+        readyState: { value: "live" },
+        muted: { value: false },
+        enabled: { value: true, writable: true },
+    });
+
+    return new MediaStream([track]);
 }

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -21,6 +21,7 @@ import { screenShareQualityStore } from "../Stores/ScreenSharingStore";
 import { subscribeToVideoQualityAnalytics } from "../WebRtc/VideoQualityAnalytics";
 import { createLivekitWebRtcStats } from "../WebRtc/WebRtcStatsFactory";
 import type { Streamable } from "../Space/Streamable";
+import { createMediaStreamTrackPresenceStore } from "../Space/MediaStreamTrackPresenceStore";
 import { SCRIPTING_AUDIO_TRACK_NAME } from "./LivekitConstants";
 
 // Maximize/minimize can briefly mount 2 video components for the same participant.
@@ -31,6 +32,7 @@ export class LiveKitParticipant {
     private _isSpeakingStore: Writable<boolean>;
     private _connectionQualityStore: Writable<ConnectionQuality>;
     private _audioStreamStore: Writable<MediaStream | undefined> = writable<MediaStream | undefined>(undefined);
+    private _microphoneStreamStore: Writable<MediaStream | undefined> = writable<MediaStream | undefined>(undefined);
     private _actualVideo: Streamable | undefined;
     private _actualScreenShare: Streamable | undefined;
 
@@ -62,6 +64,10 @@ export class LiveKitParticipant {
     private _screenShareUnsubscribeTimeout: ReturnType<typeof setTimeout> | undefined;
     private readonly videoWebrtcStats: Readable<WebRtcStats | undefined>;
     private readonly screenShareWebrtcStats: Readable<WebRtcStats | undefined>;
+    private readonly _microphoneAudioTrackPresent: Readable<boolean>;
+    private readonly _hasReceivedMicrophoneAudio: Readable<boolean>;
+    private readonly _screenShareAudioTrackPresent: Readable<boolean>;
+    private readonly _hasReceivedScreenShareAudio: Readable<boolean>;
     private readonly analyticsStatsUnsubscribers: Unsubscriber[] = [];
 
     private _cameraPublication: RemoteTrackPublication | undefined;
@@ -116,6 +122,22 @@ export class LiveKitParticipant {
         this._nameStore = writable(this.participant.name);
         this.videoWebrtcStats = this.getWebrtcStats("video");
         this.screenShareWebrtcStats = this.getWebrtcStats("screenShare");
+        // Receiver-side diagnostic signals used to detect space state vs received stream mismatches.
+        // Microphone audio is tracked separately from scripting audio so scripting audio cannot hide a missing mic track.
+        this._microphoneAudioTrackPresent = createMediaStreamTrackPresenceStore(this._microphoneStreamStore, "audio");
+        this._hasReceivedMicrophoneAudio = derived(
+            [this._microphoneAudioTrackPresent, this._isMuted],
+            ([$microphoneAudioTrackPresent, $isMuted]) => $microphoneAudioTrackPresent && !$isMuted,
+        );
+        this._screenShareAudioTrackPresent = createMediaStreamTrackPresenceStore(
+            this._audioScreenShareStreamStore,
+            "audio",
+        );
+        this._hasReceivedScreenShareAudio = derived(
+            [this._screenShareAudioTrackPresent, this._isScreenShareAudioMuted],
+            ([$screenShareAudioTrackPresent, $isScreenShareAudioMuted]) =>
+                $screenShareAudioTrackPresent && !$isScreenShareAudioMuted,
+        );
 
         for (const publication of this.participant.getTrackPublications()) {
             if (publication.isLocal) {
@@ -372,6 +394,7 @@ export class LiveKitParticipant {
             this.refreshLivekitAudioStreamStore();
         } else if (publication.source === Track.Source.Microphone) {
             this._microphoneStream = track.mediaStream;
+            this._microphoneStreamStore.set(track.mediaStream);
             this.refreshLivekitAudioStreamStore();
         }
     }
@@ -413,6 +436,7 @@ export class LiveKitParticipant {
             if (this._microphonePublication === publication) {
                 this._microphonePublication = undefined;
                 this._microphoneStream = undefined;
+                this._microphoneStreamStore.set(undefined);
                 this.refreshLivekitAudioStreamStore();
             }
             this._isMuted.set(true);
@@ -438,6 +462,7 @@ export class LiveKitParticipant {
         } else if (publication.source === Track.Source.Microphone) {
             if (this._microphonePublication === publication) {
                 this._microphoneStream = undefined;
+                this._microphoneStreamStore.set(undefined);
                 this.refreshLivekitAudioStreamStore();
             }
         }
@@ -512,6 +537,7 @@ export class LiveKitParticipant {
         return {
             uniqueId: this.participant.identity,
             hasAudio: this._hasAudio,
+            hasReceivedAudio: this._hasReceivedMicrophoneAudio,
             hasVideo: derived(
                 [this._spaceUser.reactiveUser.cameraState, this._hasVideo],
                 ([$spaceCameraState, $livekitHasVideo]) => {
@@ -556,6 +582,7 @@ export class LiveKitParticipant {
         return {
             uniqueId: this.participant.sid,
             hasAudio: this._hasScreenShareAudio,
+            hasReceivedAudio: this._hasReceivedScreenShareAudio,
             hasVideo: this._hasScreenShareVideo,
             isMuted: this._isScreenShareAudioMuted,
             statusStore: writable("connected"),

--- a/play/src/front/Space/MediaStreamTrackPresenceStore.ts
+++ b/play/src/front/Space/MediaStreamTrackPresenceStore.ts
@@ -1,0 +1,89 @@
+import { derived, type Readable } from "svelte/store";
+
+type MediaStreamTrackKind = "audio" | "video";
+
+export function createMediaStreamTrackPresenceStore(
+    streamStore: Readable<MediaStream | undefined>,
+    kind: MediaStreamTrackKind,
+    isTrackPresent: (track: MediaStreamTrack) => boolean = isUsableMediaStreamTrack,
+): Readable<boolean> {
+    return derived(
+        streamStore,
+        (stream, set) => {
+            if (!stream) {
+                set(false);
+                return;
+            }
+
+            const trackCleanups = new Map<MediaStreamTrack, () => void>();
+
+            const update = () => {
+                syncTrackListeners();
+                set(stream.getTracks().some((track) => track.kind === kind && isTrackPresent(track)));
+            };
+
+            const syncTrackListeners = () => {
+                const currentTracks = new Set(stream.getTracks().filter((track) => track.kind === kind));
+
+                for (const [track, cleanup] of trackCleanups) {
+                    if (!currentTracks.has(track)) {
+                        cleanup();
+                        trackCleanups.delete(track);
+                    }
+                }
+
+                for (const track of currentTracks) {
+                    if (trackCleanups.has(track)) {
+                        continue;
+                    }
+                    if (
+                        typeof track.addEventListener !== "function" ||
+                        typeof track.removeEventListener !== "function"
+                    ) {
+                        continue;
+                    }
+
+                    const onTrackStateChange = () => update();
+                    track.addEventListener("mute", onTrackStateChange);
+                    track.addEventListener("unmute", onTrackStateChange);
+                    track.addEventListener("ended", onTrackStateChange);
+
+                    trackCleanups.set(track, () => {
+                        track.removeEventListener("mute", onTrackStateChange);
+                        track.removeEventListener("unmute", onTrackStateChange);
+                        track.removeEventListener("ended", onTrackStateChange);
+                    });
+                }
+            };
+
+            const canListenToStreamTrackChanges =
+                typeof stream.addEventListener === "function" && typeof stream.removeEventListener === "function";
+            let onStreamTrackChange: ((event: MediaStreamTrackEvent) => void) | undefined;
+
+            if (canListenToStreamTrackChanges) {
+                onStreamTrackChange = (event: MediaStreamTrackEvent) => {
+                    if (event.track.kind === kind) {
+                        update();
+                    }
+                };
+
+                stream.addEventListener("addtrack", onStreamTrackChange);
+                stream.addEventListener("removetrack", onStreamTrackChange);
+            }
+            update();
+
+            return () => {
+                if (onStreamTrackChange) {
+                    stream.removeEventListener("addtrack", onStreamTrackChange);
+                    stream.removeEventListener("removetrack", onStreamTrackChange);
+                }
+                trackCleanups.forEach((cleanup) => cleanup());
+            };
+        },
+        false,
+    );
+}
+
+export function isUsableMediaStreamTrack(track: MediaStreamTrack): boolean {
+    return track.readyState === "live" && !track.muted && track.enabled !== false;
+}

--- a/play/src/front/Space/Streamable.ts
+++ b/play/src/front/Space/Streamable.ts
@@ -46,6 +46,11 @@ export interface Streamable {
     readonly volumeStore: Readable<number[] | undefined> | undefined;
     readonly hasVideo: Readable<boolean>;
     readonly hasAudio: Readable<boolean>;
+    /**
+     * Receiver-side diagnostic signal: true only when this client actually has a usable incoming audio track.
+     * Keep it separate from hasAudio/isMuted so we can detect mismatches between the space state and the stream received.
+     */
+    readonly hasReceivedAudio: Readable<boolean>;
     readonly isMuted: Readable<boolean>;
     readonly statusStore: Readable<PeerStatus>;
     readonly name: Readable<string>;

--- a/play/src/front/Space/tests/Space.test.ts
+++ b/play/src/front/Space/tests/Space.test.ts
@@ -145,6 +145,7 @@ function createStreamable(uniqueId: string, spaceUserId: string, videoType: Stre
         volumeStore: undefined,
         hasVideo: writable(true),
         hasAudio: writable(true),
+        hasReceivedAudio: writable(true),
         isMuted: writable(false),
         statusStore: writable<PeerStatus>("connected"),
         name: writable(uniqueId),

--- a/play/src/front/Stores/ScreenSharingStore.ts
+++ b/play/src/front/Stores/ScreenSharingStore.ts
@@ -305,6 +305,10 @@ const screenSharingLocalMedia = readable<Streamable | undefined>(undefined, func
         } satisfies WebRtcStreamable,
         spaceUserId: undefined,
         hasAudio: hasAudio,
+        hasReceivedAudio: derived(
+            [hasAudio, isMediaMuted],
+            ([$hasAudio, $isMediaMuted]) => $hasAudio && !$isMediaMuted,
+        ),
         hasVideo: writable(true),
         isMuted: isMediaMuted,
         name: writable(""),

--- a/play/src/front/Stores/ScriptingVideoStore.ts
+++ b/play/src/front/Stores/ScriptingVideoStore.ts
@@ -18,6 +18,7 @@ function createStreamableFromVideo(url: string, config: VideoConfig): Streamable
         spaceUserId: undefined,
         hasVideo: writable(true),
         hasAudio: writable(false),
+        hasReceivedAudio: writable(false),
         isMuted: writable(false),
         statusStore: writable("connected"),
         name: writable(config.name ?? ""),

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -72,6 +72,7 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL], set) 
         }),
         // hasAudio = true because the webcam has a microphone attached and could potentially play sound
         hasAudio: writable(true),
+        hasReceivedAudio: requestedMicrophoneState,
         isMuted: derived(requestedMicrophoneState, (micState) => !micState),
         statusStore: writable("connected" as const),
         name: writable($LL.camera.my.nameTag()),
@@ -105,6 +106,7 @@ const listenerBoxStreamable: Streamable = {
     volumeStore: undefined,
     hasVideo: writable(true),
     hasAudio: writable(false),
+    hasReceivedAudio: writable(false),
     isMuted: writable(true),
     statusStore: writable("connected" as const),
     name: writable("Listener"),

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -19,6 +19,7 @@ import { screenShareQualityStore } from "../Stores/ScreenSharingStore";
 import { bandwidthConstrainedPreferenceStore } from "../Stores/BandwidthConstrainedPreferenceStore";
 import type { WebRtcStats } from "../Components/Video/WebRtcStats";
 import type { Streamable, StreamCategory, WebRtcStreamable } from "../Space/Streamable";
+import { createMediaStreamTrackPresenceStore } from "../Space/MediaStreamTrackPresenceStore";
 import type { UserSimplePeerInterface } from "./SimplePeer";
 import { isFirefox } from "./DeviceUtils";
 import { P2PMessage, STREAM_STOPPED_MESSAGE_TYPE } from "./P2PMessages/P2PMessage";
@@ -53,6 +54,7 @@ export class RemotePeer extends Peer implements Streamable {
     private readonly localStreamStoreSubscribe: Unsubscriber;
     private readonly _hasVideo: Readable<boolean>;
     private readonly _isMuted: Readable<boolean>;
+    private readonly _hasReceivedAudio: Readable<boolean>;
     private readonly showVoiceIndicatorStore: ForwardableStore<boolean> = new ForwardableStore(false);
     public readonly flipX = false;
     public readonly muteAudio: Writable<boolean> = writable(false);
@@ -385,6 +387,9 @@ export class RemotePeer extends Peer implements Streamable {
                 $remoteStream.removeEventListener("removetrack", onRemove);
             };
         });
+
+        // Receiver-side diagnostic signal used to spot "space says microphone is enabled, but no audio track arrived".
+        this._hasReceivedAudio = createMediaStreamTrackPresenceStore(this._remoteStreamStore, "audio");
 
         this._isMuted = derived(this._remoteStreamStore, ($remoteStream, set) => {
             if (!$remoteStream) {
@@ -802,6 +807,10 @@ export class RemotePeer extends Peer implements Streamable {
 
     get hasAudio(): Readable<boolean> {
         return this._hasAudio;
+    }
+
+    get hasReceivedAudio(): Readable<boolean> {
+        return this._hasReceivedAudio;
     }
 
     get isMuted(): Readable<boolean> {


### PR DESCRIPTION
This PR is an attempt to detect why some people don't hear remote participants (with the remote participant microphone appearing muted despite the fact the remote participant did not mute their microphone).

When this is happening, only some receivers don't hear the remote participant, not all of them. And it can happen both in WebRTC and Livekit.

The sole purpose of this PR is debugging. We can revert it later when we found the root cause.

## Summary

- add a receiver-side `hasReceivedAudio` signal to separate actual incoming audio-track presence from declared mute state
- wire the signal through WebRTC, LiveKit, local streamables, and screen/scripting streamables
- show the microphone-off icon in red and emit a Sentry warning when the space says a remote microphone is enabled but this receiver has no usable audio track

## Root cause / intent

The previous UI treated an empty or missing remote audio track as equivalent to a muted participant. That made it hard to tell whether the participant was really muted or whether a specific receiver failed to receive the audio track. This PR keeps those concepts separate so production reports can identify the mismatch.
