### PR TITLE
Refactor Streamable audio state handling

### DIFF
--- a/back/src/RoomManager.ts
+++ b/back/src/RoomManager.ts
@@ -180,7 +180,7 @@ const roomManager = {
                             break;
                         }
                         case "pingMessage": {
-                            // Do nothing
+                            // Do nothing (we are already removing the "pong timeout" when any message is received)
                             break;
                         }
                         case "askPositionMessage": {

--- a/play/src/front/Components/Video/PictureInPicture/AudioStreamWrapper.svelte
+++ b/play/src/front/Components/Video/PictureInPicture/AudioStreamWrapper.svelte
@@ -14,10 +14,10 @@
     let muteAudioStore = $derived($streamable?.muteAudio);
     let muteAudio = $derived($muteAudioStore ?? false);
 
-    let hasAudio = $derived($streamable?.hasAudio ?? writable(false));
+    let canEmitAudio = $derived($streamable?.canEmitAudio ?? writable(false));
 </script>
 
-{#if $streamable && ($streamable?.media.type === "webrtc" || $streamable?.media.type === "livekit") && !muteAudio && $hasAudio}
+{#if $streamable && ($streamable?.media.type === "webrtc" || $streamable?.media.type === "livekit") && !muteAudio && $canEmitAudio}
     <AudioStream
         streamStore={$streamable.media.streamStore}
         volume={$streamable.volume}

--- a/play/src/front/Components/Video/PictureInPicture/AudioStreamWrapper.svelte
+++ b/play/src/front/Components/Video/PictureInPicture/AudioStreamWrapper.svelte
@@ -14,10 +14,10 @@
     let muteAudioStore = $derived($streamable?.muteAudio);
     let muteAudio = $derived($muteAudioStore ?? false);
 
-    let canEmitAudio = $derived($streamable?.canEmitAudio ?? writable(false));
+    let hasAudio = $derived($streamable?.hasAudio ?? writable(false));
 </script>
 
-{#if $streamable && ($streamable?.media.type === "webrtc" || $streamable?.media.type === "livekit") && !muteAudio && $canEmitAudio}
+{#if $streamable && ($streamable?.media.type === "webrtc" || $streamable?.media.type === "livekit") && !muteAudio && $hasAudio}
     <AudioStream
         streamStore={$streamable.media.streamStore}
         volume={$streamable.volume}

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -57,7 +57,7 @@
     let showUserSubMenu = $state(false);
 
     let hasVideoStore = $derived(streamable?.hasVideo);
-    let hasAudioStore = $derived(streamable?.hasAudio);
+    let canEmitAudioStore = $derived(streamable?.canEmitAudio);
     let hasReceivedAudioStore = $derived(streamable?.hasReceivedAudio);
     let isMutedStore = $derived(streamable?.isMuted);
     let volumeMeterStore = $derived(streamable?.volumeStore);
@@ -87,21 +87,21 @@
     // Check if this is the local user's video box
     let isLocalUser = $derived(videoBox.uniqueId === "-1" || extendedSpaceUser?.spaceUserId === "local");
     // Debugging aid for the rare case where the space says the remote microphone is enabled but this receiver has no audio.
-    let hasAudioStateMismatch = $derived(
+    let audioStateMismatch = $derived(
         effectiveStatus === "connected" &&
             streamable?.videoType === "video" &&
             !isLocalUser &&
-            $hasAudioStore === true &&
+            $canEmitAudioStore === true &&
             $isBlockedStore !== true &&
             $microphoneStateStore === true &&
             $hasReceivedAudioStore === false,
     );
-    // Like hasAudioStateMismatch, but with a 3 seconds delay.
+    // Like audioStateMismatch, but with a 3 seconds delay.
     let showAudioStateMismatch = $state(false);
     let loggedAudioMismatchKey: string | undefined = undefined;
 
     $effect(() => {
-        if (!hasAudioStateMismatch) {
+        if (!audioStateMismatch) {
             return;
         }
 
@@ -124,7 +124,7 @@
                 videoType: streamable?.videoType,
                 spaceUserId: extendedSpaceUser?.spaceUserId,
                 status: effectiveStatus,
-                hasAudio: $hasAudioStore,
+                canEmitAudio: $canEmitAudioStore,
                 hasReceivedAudio: $hasReceivedAudioStore,
                 isMuted: $isMutedStore,
                 microphoneState: $microphoneStateStore,
@@ -411,7 +411,7 @@
                                 {/if}
                             </UserName>
 
-                            {#if effectiveStatus === "connected" && $hasAudioStore && !$isBlockedStore}
+                            {#if effectiveStatus === "connected" && $canEmitAudioStore && !$isBlockedStore}
                                 <div
                                     class="z-[251] absolute p-2 right-1 white"
                                     class:top-1={videoEnabled}
@@ -419,7 +419,7 @@
                                     class:text-white={$activePictureInPictureStore}
                                     class:opacity-20={$activePictureInPictureStore}
                                 >
-                                    {#if !$isMutedStore && !hasAudioStateMismatch}
+                                    {#if !$isMutedStore && !audioStateMismatch}
                                         <SoundMeterWidget
                                             volume={volumeMeter}
                                             cssClass="voice-meter-cam-off relative mr-0 ml-auto translate-x-0 transition-transform"

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -59,7 +59,6 @@
     let hasVideoStore = $derived(streamable?.hasVideo);
     let canEmitAudioStore = $derived(streamable?.canEmitAudio);
     let hasAudioStore = $derived(streamable?.hasAudio);
-    let hasReceivedAudioStore = $derived(streamable?.hasReceivedAudio);
     let volumeMeterStore = $derived(streamable?.volumeStore);
     let showVoiceIndicatorStore = $derived(streamable?.showVoiceIndicator);
     let isBlockedStore = $derived(streamable?.media?.isBlocked);
@@ -94,7 +93,7 @@
             $canEmitAudioStore === true &&
             $isBlockedStore !== true &&
             $microphoneStateStore === true &&
-            $hasReceivedAudioStore === false,
+            $hasAudioStore === false,
     );
     // Like audioStateMismatch, but with a 3 seconds delay.
     let showAudioStateMismatch = $state(false);
@@ -126,7 +125,6 @@
                 status: effectiveStatus,
                 canEmitAudio: $canEmitAudioStore,
                 hasAudio: $hasAudioStore,
-                hasReceivedAudio: $hasReceivedAudioStore,
                 microphoneState: $microphoneStateStore,
                 audioTrackCount: audioTracks.length,
                 audioTracks,

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -58,8 +58,8 @@
 
     let hasVideoStore = $derived(streamable?.hasVideo);
     let canEmitAudioStore = $derived(streamable?.canEmitAudio);
+    let hasAudioStore = $derived(streamable?.hasAudio);
     let hasReceivedAudioStore = $derived(streamable?.hasReceivedAudio);
-    let isMutedStore = $derived(streamable?.isMuted);
     let volumeMeterStore = $derived(streamable?.volumeStore);
     let showVoiceIndicatorStore = $derived(streamable?.showVoiceIndicator);
     let isBlockedStore = $derived(streamable?.media?.isBlocked);
@@ -125,8 +125,8 @@
                 spaceUserId: extendedSpaceUser?.spaceUserId,
                 status: effectiveStatus,
                 canEmitAudio: $canEmitAudioStore,
+                hasAudio: $hasAudioStore,
                 hasReceivedAudio: $hasReceivedAudioStore,
-                isMuted: $isMutedStore,
                 microphoneState: $microphoneStateStore,
                 audioTrackCount: audioTracks.length,
                 audioTracks,
@@ -419,7 +419,7 @@
                                     class:text-white={$activePictureInPictureStore}
                                     class:opacity-20={$activePictureInPictureStore}
                                 >
-                                    {#if !$isMutedStore && !audioStateMismatch}
+                                    {#if $hasAudioStore && !audioStateMismatch}
                                         <SoundMeterWidget
                                             volume={volumeMeter}
                                             cssClass="voice-meter-cam-off relative mr-0 ml-auto translate-x-0 transition-transform"

--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -57,7 +57,6 @@
     let showUserSubMenu = $state(false);
 
     let hasVideoStore = $derived(streamable?.hasVideo);
-    let canEmitAudioStore = $derived(streamable?.canEmitAudio);
     let hasAudioStore = $derived(streamable?.hasAudio);
     let volumeMeterStore = $derived(streamable?.volumeStore);
     let showVoiceIndicatorStore = $derived(streamable?.showVoiceIndicator);
@@ -90,7 +89,6 @@
         effectiveStatus === "connected" &&
             streamable?.videoType === "video" &&
             !isLocalUser &&
-            $canEmitAudioStore === true &&
             $isBlockedStore !== true &&
             $microphoneStateStore === true &&
             $hasAudioStore === false,
@@ -123,7 +121,6 @@
                 videoType: streamable?.videoType,
                 spaceUserId: extendedSpaceUser?.spaceUserId,
                 status: effectiveStatus,
-                canEmitAudio: $canEmitAudioStore,
                 hasAudio: $hasAudioStore,
                 microphoneState: $microphoneStateStore,
                 audioTrackCount: audioTracks.length,
@@ -409,7 +406,7 @@
                                 {/if}
                             </UserName>
 
-                            {#if effectiveStatus === "connected" && $canEmitAudioStore && !$isBlockedStore}
+                            {#if effectiveStatus === "connected" && !$isBlockedStore}
                                 <div
                                     class="z-[251] absolute p-2 right-1 white"
                                     class:top-1={videoEnabled}

--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -732,11 +732,7 @@ export class LiveKitRoom implements LiveKitRoomInterface {
 
         //TODO: review implementation - iterating over all participants each time
         this.participants.forEach((participant) => {
-            if (speakersSet.has(participant.participant.sid)) {
-                participant.setActiveSpeaker(true);
-            } else {
-                participant.setActiveSpeaker(false);
-
+            if (!speakersSet.has(participant.participant.sid)) {
                 if (this.previousSpeakers.has(participant.participant.sid)) {
                     // If the participant was previously speaking but is not speaking anymore, we set it as recently spoken
                     const previousSpeakerVideoBox = this.space.allVideoStreamStore.get(

--- a/play/src/front/Livekit/LivekitParticipant.test.ts
+++ b/play/src/front/Livekit/LivekitParticipant.test.ts
@@ -154,51 +154,6 @@ describe("LiveKitParticipant", () => {
         expect(get(participant.getStreamable().hasAudio)).toBe(true);
     });
 
-    it("should mark microphone audio as received only after the microphone track is subscribed", () => {
-        const participant = createParticipant({ publications: [] });
-        const streamable = participant.getStreamable();
-        const microphonePublication = createMicrophonePublication();
-        const microphoneStream = createAudioMediaStream("microphone");
-
-        expect(get(streamable.hasReceivedAudio)).toBe(false);
-
-        participant["handleTrackPublished"](microphonePublication);
-
-        expect(get(streamable.hasAudio)).toBe(true);
-        expect(get(streamable.hasReceivedAudio)).toBe(false);
-
-        const microphoneTrack = createRemoteAudioTrack(microphoneStream);
-        participant["handleTrackSubscribed"](microphoneTrack, microphonePublication);
-
-        expect(get(streamable.hasReceivedAudio)).toBe(true);
-
-        participant["handleTrackMuted"](microphonePublication);
-
-        expect(get(streamable.hasAudio)).toBe(false);
-        expect(get(streamable.hasReceivedAudio)).toBe(false);
-
-        participant["handleTrackUnmuted"](microphonePublication);
-
-        expect(get(streamable.hasReceivedAudio)).toBe(true);
-
-        participant["handleTrackUnsubscribed"](microphoneTrack, microphonePublication);
-
-        expect(get(streamable.hasReceivedAudio)).toBe(false);
-    });
-
-    it("should not use scripting audio as received microphone audio", () => {
-        const participant = createParticipant({ publications: [] });
-        const media = participant.getStreamable().media as LivekitStreamable;
-        const scriptingPublication = createScriptingAudioPublication();
-        const scriptingStream = createAudioMediaStream("scripting");
-
-        participant["handleTrackPublished"](scriptingPublication);
-        participant["handleTrackSubscribed"](createRemoteAudioTrack(scriptingStream), scriptingPublication);
-
-        expect(get(media.streamStore)).toBe(scriptingStream);
-        expect(get(participant.getStreamable().hasReceivedAudio)).toBe(false);
-    });
-
     it("should restart scripting audio without dropping microphone audio", () => {
         const participant = createParticipant({ publications: [] });
         const media = participant.getStreamable().media as LivekitStreamable;

--- a/play/src/front/Livekit/LivekitParticipant.test.ts
+++ b/play/src/front/Livekit/LivekitParticipant.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { Subject } from "rxjs";
 import { get, writable } from "svelte/store";
-import {
-    ConnectionQuality,
-    Track,
-    type RemoteParticipant,
-    type RemoteTrack,
-    type RemoteTrackPublication,
-} from "livekit-client";
+import { Track, type RemoteParticipant, type RemoteTrack, type RemoteTrackPublication } from "livekit-client";
 import type { SpaceInterface, SpaceUserExtended } from "../Space/SpaceInterface";
 import type { StreamableSubjects } from "../Space/SpacePeerManager/SpacePeerManager";
 import type { LivekitStreamable, Streamable } from "../Space/Streamable";
@@ -273,7 +267,6 @@ function createParticipant({ publications }: { publications: RemoteTrackPublicat
         identity: "user-1",
         sid: "sid-1",
         isSpeaking: false,
-        connectionQuality: ConnectionQuality.Excellent,
         name: "Alice",
         on: vi.fn(),
         off: vi.fn(),

--- a/play/src/front/Livekit/LivekitParticipant.test.ts
+++ b/play/src/front/Livekit/LivekitParticipant.test.ts
@@ -205,6 +205,28 @@ describe("LiveKitParticipant", () => {
         expect(get(participant.getStreamable().hasAudio)).toBe(true);
     });
 
+    it("should ignore stale scripting audio events after scripting audio restarts", () => {
+        const participant = createParticipant({ publications: [] });
+        const media = participant.getStreamable().media as LivekitStreamable;
+        const firstScriptingPublication = createScriptingAudioPublication();
+        const secondScriptingPublication = createScriptingAudioPublication();
+        const firstScriptingStream = createAudioMediaStream("scripting-1");
+        const secondScriptingStream = createAudioMediaStream("scripting-2");
+        const firstScriptingTrack = createRemoteAudioTrack(firstScriptingStream);
+
+        participant["handleTrackPublished"](firstScriptingPublication);
+        participant["handleTrackSubscribed"](firstScriptingTrack, firstScriptingPublication);
+        participant["handleTrackPublished"](secondScriptingPublication);
+        participant["handleTrackSubscribed"](createRemoteAudioTrack(secondScriptingStream), secondScriptingPublication);
+
+        participant["handleTrackMuted"](firstScriptingPublication);
+        participant["handleTrackUnsubscribed"](firstScriptingTrack, firstScriptingPublication);
+        participant["handleTrackUnpublished"](firstScriptingPublication);
+
+        expect(get(media.streamStore)).toBe(secondScriptingStream);
+        expect(get(participant.getStreamable().hasAudio)).toBe(true);
+    });
+
     it("should keep microphone audio when scripting audio is unpublished or unsubscribed", () => {
         const participant = createParticipant({ publications: [] });
         const media = participant.getStreamable().media as LivekitStreamable;

--- a/play/src/front/Livekit/LivekitParticipant.test.ts
+++ b/play/src/front/Livekit/LivekitParticipant.test.ts
@@ -151,7 +151,7 @@ describe("LiveKitParticipant", () => {
             microphoneStream.getAudioTracks()[0],
             scriptingStream.getAudioTracks()[0],
         ]);
-        expect(get(participant.getStreamable().isMuted)).toBe(false);
+        expect(get(participant.getStreamable().hasAudio)).toBe(true);
     });
 
     it("should mark microphone audio as received only after the microphone track is subscribed", () => {
@@ -164,7 +164,7 @@ describe("LiveKitParticipant", () => {
 
         participant["handleTrackPublished"](microphonePublication);
 
-        expect(get(streamable.isMuted)).toBe(false);
+        expect(get(streamable.hasAudio)).toBe(true);
         expect(get(streamable.hasReceivedAudio)).toBe(false);
 
         const microphoneTrack = createRemoteAudioTrack(microphoneStream);
@@ -174,7 +174,7 @@ describe("LiveKitParticipant", () => {
 
         participant["handleTrackMuted"](microphonePublication);
 
-        expect(get(streamable.isMuted)).toBe(true);
+        expect(get(streamable.hasAudio)).toBe(false);
         expect(get(streamable.hasReceivedAudio)).toBe(false);
 
         participant["handleTrackUnmuted"](microphonePublication);
@@ -223,7 +223,7 @@ describe("LiveKitParticipant", () => {
             microphoneStream.getAudioTracks()[0],
             secondScriptingStream.getAudioTracks()[0],
         ]);
-        expect(get(participant.getStreamable().isMuted)).toBe(false);
+        expect(get(participant.getStreamable().hasAudio)).toBe(true);
     });
 
     it("should keep microphone audio when scripting audio is unpublished or unsubscribed", () => {
@@ -247,7 +247,7 @@ describe("LiveKitParticipant", () => {
         participant["handleTrackUnpublished"](unpublishedScriptingPublication);
 
         expect(get(media.streamStore)).toBe(microphoneStream);
-        expect(get(participant.getStreamable().isMuted)).toBe(false);
+        expect(get(participant.getStreamable().hasAudio)).toBe(true);
 
         participant["handleTrackPublished"](unsubscribedScriptingPublication);
         const unsubscribedTrack = createRemoteAudioTrack(unsubscribedScriptingStream);
@@ -256,7 +256,7 @@ describe("LiveKitParticipant", () => {
         participant["handleTrackUnsubscribed"](unsubscribedTrack, unsubscribedScriptingPublication);
 
         expect(get(media.streamStore)).toBe(microphoneStream);
-        expect(get(participant.getStreamable().isMuted)).toBe(false);
+        expect(get(participant.getStreamable().hasAudio)).toBe(true);
     });
 });
 

--- a/play/src/front/Livekit/LivekitParticipant.test.ts
+++ b/play/src/front/Livekit/LivekitParticipant.test.ts
@@ -154,6 +154,30 @@ describe("LiveKitParticipant", () => {
         expect(get(participant.getStreamable().hasAudio)).toBe(true);
     });
 
+    it("should expose scripting-only audio as streamable audio", () => {
+        const participant = createParticipant({ publications: [] });
+        const media = participant.getStreamable().media as LivekitStreamable;
+        const scriptingPublication = createScriptingAudioPublication();
+        const scriptingStream = createAudioMediaStream("scripting");
+
+        participant["handleTrackPublished"](scriptingPublication);
+        participant["handleTrackSubscribed"](createRemoteAudioTrack(scriptingStream), scriptingPublication);
+
+        expect(scriptingPublication.setSubscribed).toHaveBeenCalledWith(true);
+        expect(get(media.streamStore)).toBe(scriptingStream);
+        expect(get(participant.getStreamable().hasAudio)).toBe(true);
+
+        participant["handleTrackMuted"](scriptingPublication);
+        expect(get(participant.getStreamable().hasAudio)).toBe(false);
+
+        participant["handleTrackUnmuted"](scriptingPublication);
+        expect(get(participant.getStreamable().hasAudio)).toBe(true);
+
+        participant["handleTrackUnpublished"](scriptingPublication);
+        expect(get(media.streamStore)).toBeUndefined();
+        expect(get(participant.getStreamable().hasAudio)).toBe(false);
+    });
+
     it("should restart scripting audio without dropping microphone audio", () => {
         const participant = createParticipant({ publications: [] });
         const media = participant.getStreamable().media as LivekitStreamable;

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -3,7 +3,6 @@ import type {
     RemoteTrack,
     RemoteTrackPublication,
     TrackPublication,
-    ConnectionQuality,
     RemoteVideoTrack,
 } from "livekit-client";
 import * as Sentry from "@sentry/svelte";
@@ -29,9 +28,7 @@ const VIDEO_UNSUBSCRIBE_DELAY_MS = 75;
 
 export class LiveKitParticipant {
     private _isSpeakingStore: Writable<boolean>;
-    private _connectionQualityStore: Writable<ConnectionQuality>;
     private _audioStreamStore: Writable<MediaStream | undefined> = writable<MediaStream | undefined>(undefined);
-    private _microphoneStreamStore: Writable<MediaStream | undefined> = writable<MediaStream | undefined>(undefined);
     private _actualVideo: Streamable | undefined;
     private _actualScreenShare: Streamable | undefined;
 
@@ -57,7 +54,6 @@ export class LiveKitParticipant {
     private _screenShareRemoteTrack: Writable<RemoteVideoTrack | undefined> = writable<RemoteVideoTrack | undefined>(
         undefined,
     );
-    private _isActiveSpeaker = writable<boolean>(false);
     private _muteAudioStore: Writable<boolean> = writable<boolean>(false);
     private _cameraVideoSubscriptions = new Set<symbol>();
     private _screenShareVideoSubscriptions = new Set<symbol>();
@@ -83,12 +79,11 @@ export class LiveKitParticipant {
     private boundHandleTrackUnsubscribed: (track: RemoteTrack, publication: RemoteTrackPublication) => void;
     private boundHandleTrackMuted: (publication: TrackPublication) => void;
     private boundHandleTrackUnmuted: (publication: TrackPublication) => void;
-    private boundHandleConnectionQualityChanged: (quality: ConnectionQuality) => void;
     private boundHandleIsSpeakingChanged: (isSpeaking: boolean) => void;
 
     constructor(
         public participant: RemoteParticipant,
-        private spaceUser: SpaceUserExtended,
+        spaceUser: SpaceUserExtended,
         private space: SpaceInterface,
         private livekitServerUrl: string,
         private _streamableSubjects: StreamableSubjects,
@@ -103,7 +98,6 @@ export class LiveKitParticipant {
         this.boundHandleTrackUnsubscribed = this.handleTrackUnsubscribed.bind(this);
         this.boundHandleTrackMuted = this.handleTrackMuted.bind(this);
         this.boundHandleTrackUnmuted = this.handleTrackUnmuted.bind(this);
-        this.boundHandleConnectionQualityChanged = this.handleConnectionQualityChanged.bind(this);
         this.boundHandleIsSpeakingChanged = this.handleIsSpeakingChanged.bind(this);
 
         this.participant.on(ParticipantEvent.TrackPublished, this.boundHandleTrackPublished);
@@ -112,12 +106,10 @@ export class LiveKitParticipant {
         this.participant.on(ParticipantEvent.TrackUnsubscribed, this.boundHandleTrackUnsubscribed);
         this.participant.on(ParticipantEvent.TrackMuted, this.boundHandleTrackMuted);
         this.participant.on(ParticipantEvent.TrackUnmuted, this.boundHandleTrackUnmuted);
-        this.participant.on(ParticipantEvent.ConnectionQualityChanged, this.boundHandleConnectionQualityChanged);
         this.participant.on(ParticipantEvent.IsSpeakingChanged, this.boundHandleIsSpeakingChanged);
 
-        this._spaceUser = this.spaceUser;
+        this._spaceUser = spaceUser;
         this._isSpeakingStore = writable(this.participant.isSpeaking);
-        this._connectionQualityStore = writable(this.participant.connectionQuality);
         this._nameStore = writable(this.participant.name);
         this.videoWebrtcStats = this.getWebrtcStats("video");
         this.screenShareWebrtcStats = this.getWebrtcStats("screenShare");
@@ -375,7 +367,6 @@ export class LiveKitParticipant {
             this.refreshLivekitAudioStreamStore();
         } else if (publication.source === Track.Source.Microphone) {
             this._microphoneStream = track.mediaStream;
-            this._microphoneStreamStore.set(track.mediaStream);
             this.refreshLivekitAudioStreamStore();
         }
     }
@@ -418,7 +409,6 @@ export class LiveKitParticipant {
             if (this._microphonePublication === publication) {
                 this._microphonePublication = undefined;
                 this._microphoneStream = undefined;
-                this._microphoneStreamStore.set(undefined);
                 this.refreshLivekitAudioStreamStore();
                 this._hasMicrophoneAudio.set(false);
             }
@@ -449,7 +439,6 @@ export class LiveKitParticipant {
         } else if (publication.source === Track.Source.Microphone) {
             if (this._microphonePublication === publication) {
                 this._microphoneStream = undefined;
-                this._microphoneStreamStore.set(undefined);
                 this.refreshLivekitAudioStreamStore();
                 this._hasMicrophoneAudio.set(false);
             }
@@ -490,10 +479,6 @@ export class LiveKitParticipant {
         ) {
             this._hasScreenShareAudio.set(true);
         }
-    }
-
-    private handleConnectionQualityChanged(quality: ConnectionQuality) {
-        this._connectionQualityStore.set(quality);
     }
 
     private handleIsSpeakingChanged(isSpeaking: boolean) {
@@ -632,10 +617,6 @@ export class LiveKitParticipant {
         );
     }
 
-    public setActiveSpeaker(isActiveSpeaker: boolean) {
-        this._isActiveSpeaker.set(isActiveSpeaker);
-    }
-
     public getStreamable(): Streamable {
         return this.getVideoStream();
     }
@@ -677,7 +658,6 @@ export class LiveKitParticipant {
         this.participant.off(ParticipantEvent.TrackUnsubscribed, this.boundHandleTrackUnsubscribed);
         this.participant.off(ParticipantEvent.TrackMuted, this.boundHandleTrackMuted);
         this.participant.off(ParticipantEvent.TrackUnmuted, this.boundHandleTrackUnmuted);
-        this.participant.off(ParticipantEvent.ConnectionQualityChanged, this.boundHandleConnectionQualityChanged);
         this.participant.off(ParticipantEvent.IsSpeakingChanged, this.boundHandleIsSpeakingChanged);
     }
 }

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -41,7 +41,6 @@ export class LiveKitParticipant {
     );
 
     private _nameStore: Writable<string>;
-    private _canEmitAudio = writable<boolean>(true);
     private _hasVideo = writable<boolean>(false);
     private _hasAudio = writable<boolean>(false);
     private _hasScreenShareVideo = writable<boolean>(false);
@@ -347,7 +346,6 @@ export class LiveKitParticipant {
             }
             publication.setSubscribed(true);
             this._scriptingAudioPublication = publication;
-            this._canEmitAudio.set(true);
         } else if (publication.source === Track.Source.Microphone) {
             if (this._microphonePublication && this._microphonePublication !== publication) {
                 console.warn(
@@ -360,7 +358,6 @@ export class LiveKitParticipant {
             }
             publication.setSubscribed(true);
             this._microphonePublication = publication;
-            this._canEmitAudio.set(true);
             this._hasAudio.set(!publication.isMuted);
         }
     }
@@ -536,7 +533,6 @@ export class LiveKitParticipant {
     private getVideoStream(): Streamable {
         return {
             uniqueId: this.participant.identity,
-            canEmitAudio: this._canEmitAudio,
             hasVideo: this._hasVideo,
             hasAudio: this._hasAudio,
             statusStore: writable("connected"),
@@ -570,7 +566,6 @@ export class LiveKitParticipant {
     private getScreenShareStream(): Streamable {
         return {
             uniqueId: this.participant.sid,
-            canEmitAudio: this._canEmitScreenShareAudio,
             hasVideo: this._hasScreenShareVideo,
             hasAudio: this._hasScreenShareAudio,
             statusStore: writable("connected"),

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -64,9 +64,7 @@ export class LiveKitParticipant {
     private readonly videoWebrtcStats: Readable<WebRtcStats | undefined>;
     private readonly screenShareWebrtcStats: Readable<WebRtcStats | undefined>;
     private readonly _microphoneAudioTrackPresent: Readable<boolean>;
-    private readonly _hasReceivedMicrophoneAudio: Readable<boolean>;
     private readonly _screenShareAudioTrackPresent: Readable<boolean>;
-    private readonly _hasReceivedScreenShareAudio: Readable<boolean>;
     private readonly analyticsStatsUnsubscribers: Unsubscriber[] = [];
 
     private _cameraPublication: RemoteTrackPublication | undefined;
@@ -124,18 +122,9 @@ export class LiveKitParticipant {
         // Receiver-side diagnostic signals used to detect space state vs received stream mismatches.
         // Microphone audio is tracked separately from scripting audio so scripting audio cannot hide a missing mic track.
         this._microphoneAudioTrackPresent = createMediaStreamTrackPresenceStore(this._microphoneStreamStore, "audio");
-        this._hasReceivedMicrophoneAudio = derived(
-            [this._microphoneAudioTrackPresent, this._hasAudio],
-            ([$microphoneAudioTrackPresent, $hasAudio]) => $microphoneAudioTrackPresent && $hasAudio,
-        );
         this._screenShareAudioTrackPresent = createMediaStreamTrackPresenceStore(
             this._audioScreenShareStreamStore,
             "audio",
-        );
-        this._hasReceivedScreenShareAudio = derived(
-            [this._screenShareAudioTrackPresent, this._hasScreenShareAudio],
-            ([$screenShareAudioTrackPresent, $hasScreenShareAudio]) =>
-                $screenShareAudioTrackPresent && $hasScreenShareAudio,
         );
 
         for (const publication of this.participant.getTrackPublications()) {

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -21,7 +21,6 @@ import { screenShareQualityStore } from "../Stores/ScreenSharingStore";
 import { subscribeToVideoQualityAnalytics } from "../WebRtc/VideoQualityAnalytics";
 import { createLivekitWebRtcStats } from "../WebRtc/WebRtcStatsFactory";
 import type { Streamable } from "../Space/Streamable";
-import { createMediaStreamTrackPresenceStore } from "../Space/MediaStreamTrackPresenceStore";
 import { SCRIPTING_AUDIO_TRACK_NAME } from "./LivekitConstants";
 
 // Maximize/minimize can briefly mount 2 video components for the same participant.
@@ -42,7 +41,12 @@ export class LiveKitParticipant {
 
     private _nameStore: Writable<string>;
     private _hasVideo = writable<boolean>(false);
-    private _hasAudio = writable<boolean>(false);
+    private _hasMicrophoneAudio = writable<boolean>(false);
+    private _hasScriptingAudio = writable<boolean>(false);
+    private _hasAudio: Readable<boolean> = derived(
+        [this._hasMicrophoneAudio, this._hasScriptingAudio],
+        ([$hasMicrophoneAudio, $hasScriptingAudio]) => $hasMicrophoneAudio || $hasScriptingAudio,
+    );
     private _hasScreenShareVideo = writable<boolean>(false);
     private _canEmitScreenShareAudio = writable<boolean>(false);
     private _hasScreenShareAudio = writable<boolean>(false);
@@ -63,8 +67,6 @@ export class LiveKitParticipant {
     private _screenShareUnsubscribeTimeout: ReturnType<typeof setTimeout> | undefined;
     private readonly videoWebrtcStats: Readable<WebRtcStats | undefined>;
     private readonly screenShareWebrtcStats: Readable<WebRtcStats | undefined>;
-    private readonly _microphoneAudioTrackPresent: Readable<boolean>;
-    private readonly _screenShareAudioTrackPresent: Readable<boolean>;
     private readonly analyticsStatsUnsubscribers: Unsubscriber[] = [];
 
     private _cameraPublication: RemoteTrackPublication | undefined;
@@ -119,14 +121,6 @@ export class LiveKitParticipant {
         this._nameStore = writable(this.participant.name);
         this.videoWebrtcStats = this.getWebrtcStats("video");
         this.screenShareWebrtcStats = this.getWebrtcStats("screenShare");
-        // Receiver-side diagnostic signals used to detect space state vs received stream mismatches.
-        // Microphone audio is tracked separately from scripting audio so scripting audio cannot hide a missing mic track.
-        this._microphoneAudioTrackPresent = createMediaStreamTrackPresenceStore(this._microphoneStreamStore, "audio");
-        this._screenShareAudioTrackPresent = createMediaStreamTrackPresenceStore(
-            this._audioScreenShareStreamStore,
-            "audio",
-        );
-
         for (const publication of this.participant.getTrackPublications()) {
             if (publication.isLocal) {
                 continue;
@@ -335,6 +329,7 @@ export class LiveKitParticipant {
             }
             publication.setSubscribed(true);
             this._scriptingAudioPublication = publication;
+            this._hasScriptingAudio.set(!publication.isMuted);
         } else if (publication.source === Track.Source.Microphone) {
             if (this._microphonePublication && this._microphonePublication !== publication) {
                 console.warn(
@@ -347,7 +342,7 @@ export class LiveKitParticipant {
             }
             publication.setSubscribed(true);
             this._microphonePublication = publication;
-            this._hasAudio.set(!publication.isMuted);
+            this._hasMicrophoneAudio.set(!publication.isMuted);
         }
     }
 
@@ -417,6 +412,7 @@ export class LiveKitParticipant {
                 this._scriptingAudioStream = undefined;
                 this.refreshLivekitAudioStreamStore();
             }
+            this._hasScriptingAudio.set(false);
         } else if (publication.source === Track.Source.Microphone) {
             publication.setSubscribed(false);
             if (this._microphonePublication === publication) {
@@ -425,7 +421,7 @@ export class LiveKitParticipant {
                 this._microphoneStreamStore.set(undefined);
                 this.refreshLivekitAudioStreamStore();
             }
-            this._hasAudio.set(false);
+            this._hasMicrophoneAudio.set(false);
         }
     }
 
@@ -455,8 +451,10 @@ export class LiveKitParticipant {
     }
 
     private handleTrackMuted(publication: TrackPublication) {
-        if (publication.source === Track.Source.Microphone) {
-            this._hasAudio.set(false);
+        if (this.isScriptingAudioPublication(publication)) {
+            this._hasScriptingAudio.set(false);
+        } else if (publication.source === Track.Source.Microphone) {
+            this._hasMicrophoneAudio.set(false);
         } else if (publication.source === Track.Source.Camera) {
             this._hasVideo.set(false);
         } else if (publication.source === Track.Source.ScreenShare) {
@@ -468,8 +466,10 @@ export class LiveKitParticipant {
     }
 
     private handleTrackUnmuted(publication: TrackPublication) {
-        if (publication.source === Track.Source.Microphone) {
-            this._hasAudio.set(true);
+        if (this.isScriptingAudioPublication(publication)) {
+            this._hasScriptingAudio.set(true);
+        } else if (publication.source === Track.Source.Microphone) {
+            this._hasMicrophoneAudio.set(true);
         } else if (publication.source === Track.Source.Camera) {
             this._hasVideo.set(true);
         } else if (publication.source === Track.Source.ScreenShare) {

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -537,19 +537,8 @@ export class LiveKitParticipant {
         return {
             uniqueId: this.participant.identity,
             canEmitAudio: this._canEmitAudio,
-            hasReceivedAudio: this._hasReceivedMicrophoneAudio,
-            hasVideo: derived(
-                [this._spaceUser.reactiveUser.cameraState, this._hasVideo],
-                ([$spaceCameraState, $livekitHasVideo]) => {
-                    return $spaceCameraState && $livekitHasVideo;
-                },
-            ),
-            hasAudio: derived(
-                [this._spaceUser.reactiveUser.microphoneState, this._hasAudio],
-                ([$spaceMicrophoneState, $livekitHasAudio]) => {
-                    return $spaceMicrophoneState && $livekitHasAudio;
-                },
-            ),
+            hasVideo: this._hasVideo,
+            hasAudio: this._hasAudio,
             statusStore: writable("connected"),
             spaceUserId: this._spaceUser.spaceUserId,
             name: this._nameStore,
@@ -582,7 +571,6 @@ export class LiveKitParticipant {
         return {
             uniqueId: this.participant.sid,
             canEmitAudio: this._canEmitScreenShareAudio,
-            hasReceivedAudio: this._hasReceivedScreenShareAudio,
             hasVideo: this._hasScreenShareVideo,
             hasAudio: this._hasScreenShareAudio,
             statusStore: writable("connected"),

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -400,19 +400,19 @@ export class LiveKitParticipant {
             publication.setSubscribed(false);
             if (this._screenShareAudioPublication === publication) {
                 this._screenShareAudioPublication = undefined;
+                this._audioScreenShareStreamStore.set(undefined);
+                this._canEmitScreenShareAudio.set(false);
+                this._hasScreenShareAudio.set(false);
+                this.refreshLivekitScreenShareStreamStore();
             }
-            this._audioScreenShareStreamStore.set(undefined);
-            this._canEmitScreenShareAudio.set(false);
-            this._hasScreenShareAudio.set(false);
-            this.refreshLivekitScreenShareStreamStore();
         } else if (this.isScriptingAudioPublication(publication)) {
             publication.setSubscribed(false);
             if (this._scriptingAudioPublication === publication) {
                 this._scriptingAudioPublication = undefined;
                 this._scriptingAudioStream = undefined;
                 this.refreshLivekitAudioStreamStore();
+                this._hasScriptingAudio.set(false);
             }
-            this._hasScriptingAudio.set(false);
         } else if (publication.source === Track.Source.Microphone) {
             publication.setSubscribed(false);
             if (this._microphonePublication === publication) {
@@ -420,8 +420,8 @@ export class LiveKitParticipant {
                 this._microphoneStream = undefined;
                 this._microphoneStreamStore.set(undefined);
                 this.refreshLivekitAudioStreamStore();
+                this._hasMicrophoneAudio.set(false);
             }
-            this._hasMicrophoneAudio.set(false);
         }
     }
 
@@ -435,47 +435,59 @@ export class LiveKitParticipant {
                 this._screenShareRemoteTrack.set(undefined);
             }
         } else if (publication.source === Track.Source.ScreenShareAudio) {
-            this._audioScreenShareStreamStore.set(undefined);
+            if (this._screenShareAudioPublication === publication) {
+                this._audioScreenShareStreamStore.set(undefined);
+                this._hasScreenShareAudio.set(false);
+                this.refreshLivekitScreenShareStreamStore();
+            }
         } else if (this.isScriptingAudioPublication(publication)) {
             if (this._scriptingAudioPublication === publication) {
                 this._scriptingAudioStream = undefined;
                 this.refreshLivekitAudioStreamStore();
+                this._hasScriptingAudio.set(false);
             }
         } else if (publication.source === Track.Source.Microphone) {
             if (this._microphonePublication === publication) {
                 this._microphoneStream = undefined;
                 this._microphoneStreamStore.set(undefined);
                 this.refreshLivekitAudioStreamStore();
+                this._hasMicrophoneAudio.set(false);
             }
         }
     }
 
     private handleTrackMuted(publication: TrackPublication) {
-        if (this.isScriptingAudioPublication(publication)) {
+        if (this.isScriptingAudioPublication(publication) && this._scriptingAudioPublication === publication) {
             this._hasScriptingAudio.set(false);
-        } else if (publication.source === Track.Source.Microphone) {
+        } else if (publication.source === Track.Source.Microphone && this._microphonePublication === publication) {
             this._hasMicrophoneAudio.set(false);
         } else if (publication.source === Track.Source.Camera) {
             this._hasVideo.set(false);
         } else if (publication.source === Track.Source.ScreenShare) {
             this._hasScreenShareVideo.set(false);
             this.refreshLivekitScreenShareStreamStore();
-        } else if (publication.source === Track.Source.ScreenShareAudio) {
+        } else if (
+            publication.source === Track.Source.ScreenShareAudio &&
+            this._screenShareAudioPublication === publication
+        ) {
             this._hasScreenShareAudio.set(false);
         }
     }
 
     private handleTrackUnmuted(publication: TrackPublication) {
-        if (this.isScriptingAudioPublication(publication)) {
+        if (this.isScriptingAudioPublication(publication) && this._scriptingAudioPublication === publication) {
             this._hasScriptingAudio.set(true);
-        } else if (publication.source === Track.Source.Microphone) {
+        } else if (publication.source === Track.Source.Microphone && this._microphonePublication === publication) {
             this._hasMicrophoneAudio.set(true);
         } else if (publication.source === Track.Source.Camera) {
             this._hasVideo.set(true);
         } else if (publication.source === Track.Source.ScreenShare) {
             this._hasScreenShareVideo.set(true);
             this.refreshLivekitScreenShareStreamStore();
-        } else if (publication.source === Track.Source.ScreenShareAudio) {
+        } else if (
+            publication.source === Track.Source.ScreenShareAudio &&
+            this._screenShareAudioPublication === publication
+        ) {
             this._hasScreenShareAudio.set(true);
         }
     }

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -43,10 +43,10 @@ export class LiveKitParticipant {
     private _nameStore: Writable<string>;
     private _canEmitAudio = writable<boolean>(true);
     private _hasVideo = writable<boolean>(false);
-    private _isMuted = writable<boolean>(true);
+    private _hasAudio = writable<boolean>(false);
     private _hasScreenShareVideo = writable<boolean>(false);
+    private _canEmitScreenShareAudio = writable<boolean>(false);
     private _hasScreenShareAudio = writable<boolean>(false);
-    private _isScreenShareAudioMuted = writable<boolean>(true);
     private _spaceUser: SpaceUserExtended;
     private _videoRemoteTrack: Writable<RemoteVideoTrack | undefined> = writable<RemoteVideoTrack | undefined>(
         undefined,
@@ -126,17 +126,17 @@ export class LiveKitParticipant {
         // Microphone audio is tracked separately from scripting audio so scripting audio cannot hide a missing mic track.
         this._microphoneAudioTrackPresent = createMediaStreamTrackPresenceStore(this._microphoneStreamStore, "audio");
         this._hasReceivedMicrophoneAudio = derived(
-            [this._microphoneAudioTrackPresent, this._isMuted],
-            ([$microphoneAudioTrackPresent, $isMuted]) => $microphoneAudioTrackPresent && !$isMuted,
+            [this._microphoneAudioTrackPresent, this._hasAudio],
+            ([$microphoneAudioTrackPresent, $hasAudio]) => $microphoneAudioTrackPresent && $hasAudio,
         );
         this._screenShareAudioTrackPresent = createMediaStreamTrackPresenceStore(
             this._audioScreenShareStreamStore,
             "audio",
         );
         this._hasReceivedScreenShareAudio = derived(
-            [this._screenShareAudioTrackPresent, this._isScreenShareAudioMuted],
-            ([$screenShareAudioTrackPresent, $isScreenShareAudioMuted]) =>
-                $screenShareAudioTrackPresent && !$isScreenShareAudioMuted,
+            [this._screenShareAudioTrackPresent, this._hasScreenShareAudio],
+            ([$screenShareAudioTrackPresent, $hasScreenShareAudio]) =>
+                $screenShareAudioTrackPresent && $hasScreenShareAudio,
         );
 
         for (const publication of this.participant.getTrackPublications()) {
@@ -332,8 +332,8 @@ export class LiveKitParticipant {
             }
             publication.setSubscribed(true);
             this._screenShareAudioPublication = publication;
-            this._hasScreenShareAudio.set(true);
-            this._isScreenShareAudioMuted.set(publication.isMuted);
+            this._canEmitScreenShareAudio.set(true);
+            this._hasScreenShareAudio.set(!publication.isMuted);
             this.refreshLivekitScreenShareStreamStore();
         } else if (this.isScriptingAudioPublication(publication)) {
             if (this._scriptingAudioPublication && this._scriptingAudioPublication !== publication) {
@@ -361,7 +361,7 @@ export class LiveKitParticipant {
             publication.setSubscribed(true);
             this._microphonePublication = publication;
             this._canEmitAudio.set(true);
-            this._isMuted.set(publication.isMuted);
+            this._hasAudio.set(!publication.isMuted);
         }
     }
 
@@ -421,8 +421,8 @@ export class LiveKitParticipant {
                 this._screenShareAudioPublication = undefined;
             }
             this._audioScreenShareStreamStore.set(undefined);
+            this._canEmitScreenShareAudio.set(false);
             this._hasScreenShareAudio.set(false);
-            this._isScreenShareAudioMuted.set(true);
             this.refreshLivekitScreenShareStreamStore();
         } else if (this.isScriptingAudioPublication(publication)) {
             publication.setSubscribed(false);
@@ -439,7 +439,7 @@ export class LiveKitParticipant {
                 this._microphoneStreamStore.set(undefined);
                 this.refreshLivekitAudioStreamStore();
             }
-            this._isMuted.set(true);
+            this._hasAudio.set(false);
         }
     }
 
@@ -470,27 +470,27 @@ export class LiveKitParticipant {
 
     private handleTrackMuted(publication: TrackPublication) {
         if (publication.source === Track.Source.Microphone) {
-            this._isMuted.set(true);
+            this._hasAudio.set(false);
         } else if (publication.source === Track.Source.Camera) {
             this._hasVideo.set(false);
         } else if (publication.source === Track.Source.ScreenShare) {
             this._hasScreenShareVideo.set(false);
             this.refreshLivekitScreenShareStreamStore();
         } else if (publication.source === Track.Source.ScreenShareAudio) {
-            this._isScreenShareAudioMuted.set(true);
+            this._hasScreenShareAudio.set(false);
         }
     }
 
     private handleTrackUnmuted(publication: TrackPublication) {
         if (publication.source === Track.Source.Microphone) {
-            this._isMuted.set(false);
+            this._hasAudio.set(true);
         } else if (publication.source === Track.Source.Camera) {
             this._hasVideo.set(true);
         } else if (publication.source === Track.Source.ScreenShare) {
             this._hasScreenShareVideo.set(true);
             this.refreshLivekitScreenShareStreamStore();
         } else if (publication.source === Track.Source.ScreenShareAudio) {
-            this._isScreenShareAudioMuted.set(false);
+            this._hasScreenShareAudio.set(true);
         }
     }
 
@@ -516,7 +516,7 @@ export class LiveKitParticipant {
     }
 
     private refreshLivekitScreenShareStreamStore() {
-        const shouldHaveScreenShareStream = get(this._hasScreenShareVideo) || get(this._hasScreenShareAudio);
+        const shouldHaveScreenShareStream = get(this._hasScreenShareVideo) || get(this._canEmitScreenShareAudio);
 
         if (!shouldHaveScreenShareStream) {
             if (this._actualScreenShare) {
@@ -544,10 +544,10 @@ export class LiveKitParticipant {
                     return $spaceCameraState && $livekitHasVideo;
                 },
             ),
-            isMuted: derived(
-                [this._spaceUser.reactiveUser.microphoneState, this._isMuted],
-                ([$spaceMicrophoneState, $livekitIsMuted]) => {
-                    return !$spaceMicrophoneState || $livekitIsMuted;
+            hasAudio: derived(
+                [this._spaceUser.reactiveUser.microphoneState, this._hasAudio],
+                ([$spaceMicrophoneState, $livekitHasAudio]) => {
+                    return $spaceMicrophoneState && $livekitHasAudio;
                 },
             ),
             statusStore: writable("connected"),
@@ -581,10 +581,10 @@ export class LiveKitParticipant {
     private getScreenShareStream(): Streamable {
         return {
             uniqueId: this.participant.sid,
-            canEmitAudio: this._hasScreenShareAudio,
+            canEmitAudio: this._canEmitScreenShareAudio,
             hasReceivedAudio: this._hasReceivedScreenShareAudio,
             hasVideo: this._hasScreenShareVideo,
-            isMuted: this._isScreenShareAudioMuted,
+            hasAudio: this._hasScreenShareAudio,
             statusStore: writable("connected"),
             spaceUserId: this._spaceUser.spaceUserId,
             name: this._nameStore,

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -41,7 +41,7 @@ export class LiveKitParticipant {
     );
 
     private _nameStore: Writable<string>;
-    private _hasAudio = writable<boolean>(true);
+    private _canEmitAudio = writable<boolean>(true);
     private _hasVideo = writable<boolean>(false);
     private _isMuted = writable<boolean>(true);
     private _hasScreenShareVideo = writable<boolean>(false);
@@ -347,7 +347,7 @@ export class LiveKitParticipant {
             }
             publication.setSubscribed(true);
             this._scriptingAudioPublication = publication;
-            this._hasAudio.set(true);
+            this._canEmitAudio.set(true);
         } else if (publication.source === Track.Source.Microphone) {
             if (this._microphonePublication && this._microphonePublication !== publication) {
                 console.warn(
@@ -360,7 +360,7 @@ export class LiveKitParticipant {
             }
             publication.setSubscribed(true);
             this._microphonePublication = publication;
-            this._hasAudio.set(true);
+            this._canEmitAudio.set(true);
             this._isMuted.set(publication.isMuted);
         }
     }
@@ -536,7 +536,7 @@ export class LiveKitParticipant {
     private getVideoStream(): Streamable {
         return {
             uniqueId: this.participant.identity,
-            hasAudio: this._hasAudio,
+            canEmitAudio: this._canEmitAudio,
             hasReceivedAudio: this._hasReceivedMicrophoneAudio,
             hasVideo: derived(
                 [this._spaceUser.reactiveUser.cameraState, this._hasVideo],
@@ -581,7 +581,7 @@ export class LiveKitParticipant {
     private getScreenShareStream(): Streamable {
         return {
             uniqueId: this.participant.sid,
-            hasAudio: this._hasScreenShareAudio,
+            canEmitAudio: this._hasScreenShareAudio,
             hasReceivedAudio: this._hasReceivedScreenShareAudio,
             hasVideo: this._hasScreenShareVideo,
             isMuted: this._isScreenShareAudioMuted,

--- a/play/src/front/Space/Streamable.ts
+++ b/play/src/front/Space/Streamable.ts
@@ -44,14 +44,21 @@ export interface Streamable {
     readonly uniqueId: string;
     readonly media: LivekitStreamable | WebRtcStreamable | ScriptingVideoStreamable | ComponentStreamable;
     readonly volumeStore: Readable<number[] | undefined> | undefined;
+    /**
+     * True when this streamable currently has a video stream that should be displayed.
+     */
     readonly hasVideo: Readable<boolean>;
     readonly canEmitAudio: Readable<boolean>;
     /**
+     * True when this streamable currently has audio, symmetrically to hasVideo.
+     * This is the current audio state; use canEmitAudio to know whether audio controls should be displayed.
+     */
+    readonly hasAudio: Readable<boolean>;
+    /**
      * Receiver-side diagnostic signal: true only when this client actually has a usable incoming audio track.
-     * Keep it separate from canEmitAudio/isMuted so we can detect mismatches between the space state and the stream received.
+     * Keep it separate from canEmitAudio/hasAudio so we can detect mismatches between the space state and the stream received.
      */
     readonly hasReceivedAudio: Readable<boolean>;
-    readonly isMuted: Readable<boolean>;
     readonly statusStore: Readable<PeerStatus>;
     readonly name: Readable<string>;
     readonly showVoiceIndicator: Readable<boolean>;

--- a/play/src/front/Space/Streamable.ts
+++ b/play/src/front/Space/Streamable.ts
@@ -46,23 +46,20 @@ export interface Streamable {
     readonly volumeStore: Readable<number[] | undefined> | undefined;
     /**
      * True when this streamable currently has a video stream that should be displayed.
+     * Note: this value is tied to the real transport (WebRTC, Livekit, ...), not to the spaceUser cameraState
      */
     readonly hasVideo: Readable<boolean>;
+    /**
+     * True when this streamable currently has audio, symmetrically to hasVideo.
+     * This is the current audio state; use canEmitAudio to know whether audio controls should be displayed.
+     * Note: this value is tied to the real transport (WebRTC, Livekit, ...), not to the spaceUser microphoneState
+     */
+    readonly hasAudio: Readable<boolean>;
     /**
      * True when this streamable is able to emit audio (capability / UI affordance).
      * Use this to decide whether audio controls (e.g. the microphone icon) should be displayed.
      */
     readonly canEmitAudio: Readable<boolean>;
-    /**
-     * True when this streamable currently has audio, symmetrically to hasVideo.
-     * This is the current audio state; use canEmitAudio to know whether audio controls should be displayed.
-     */
-    readonly hasAudio: Readable<boolean>;
-    /**
-     * Receiver-side diagnostic signal: true only when this client actually has a usable incoming audio track.
-     * Keep it separate from canEmitAudio/hasAudio so we can detect mismatches between the space state and the stream received.
-     */
-    readonly hasReceivedAudio: Readable<boolean>;
     readonly statusStore: Readable<PeerStatus>;
     readonly name: Readable<string>;
     readonly showVoiceIndicator: Readable<boolean>;

--- a/play/src/front/Space/Streamable.ts
+++ b/play/src/front/Space/Streamable.ts
@@ -51,15 +51,9 @@ export interface Streamable {
     readonly hasVideo: Readable<boolean>;
     /**
      * True when this streamable currently has audio, symmetrically to hasVideo.
-     * This is the current audio state; use canEmitAudio to know whether audio controls should be displayed.
      * Note: this value is tied to the real transport (WebRTC, Livekit, ...), not to the spaceUser microphoneState
      */
     readonly hasAudio: Readable<boolean>;
-    /**
-     * True when this streamable is able to emit audio (capability / UI affordance).
-     * Use this to decide whether audio controls (e.g. the microphone icon) should be displayed.
-     */
-    readonly canEmitAudio: Readable<boolean>;
     readonly statusStore: Readable<PeerStatus>;
     readonly name: Readable<string>;
     readonly showVoiceIndicator: Readable<boolean>;

--- a/play/src/front/Space/Streamable.ts
+++ b/play/src/front/Space/Streamable.ts
@@ -48,6 +48,10 @@ export interface Streamable {
      * True when this streamable currently has a video stream that should be displayed.
      */
     readonly hasVideo: Readable<boolean>;
+    /**
+     * True when this streamable is able to emit audio (capability / UI affordance).
+     * Use this to decide whether audio controls (e.g. the microphone icon) should be displayed.
+     */
     readonly canEmitAudio: Readable<boolean>;
     /**
      * True when this streamable currently has audio, symmetrically to hasVideo.

--- a/play/src/front/Space/Streamable.ts
+++ b/play/src/front/Space/Streamable.ts
@@ -45,10 +45,10 @@ export interface Streamable {
     readonly media: LivekitStreamable | WebRtcStreamable | ScriptingVideoStreamable | ComponentStreamable;
     readonly volumeStore: Readable<number[] | undefined> | undefined;
     readonly hasVideo: Readable<boolean>;
-    readonly hasAudio: Readable<boolean>;
+    readonly canEmitAudio: Readable<boolean>;
     /**
      * Receiver-side diagnostic signal: true only when this client actually has a usable incoming audio track.
-     * Keep it separate from hasAudio/isMuted so we can detect mismatches between the space state and the stream received.
+     * Keep it separate from canEmitAudio/isMuted so we can detect mismatches between the space state and the stream received.
      */
     readonly hasReceivedAudio: Readable<boolean>;
     readonly isMuted: Readable<boolean>;

--- a/play/src/front/Space/tests/Space.test.ts
+++ b/play/src/front/Space/tests/Space.test.ts
@@ -144,7 +144,6 @@ function createStreamable(uniqueId: string, spaceUserId: string, videoType: Stre
         },
         volumeStore: undefined,
         hasVideo: writable(true),
-        canEmitAudio: writable(true),
         hasAudio: writable(true),
         statusStore: writable<PeerStatus>("connected"),
         name: writable(uniqueId),

--- a/play/src/front/Space/tests/Space.test.ts
+++ b/play/src/front/Space/tests/Space.test.ts
@@ -145,7 +145,6 @@ function createStreamable(uniqueId: string, spaceUserId: string, videoType: Stre
         volumeStore: undefined,
         hasVideo: writable(true),
         canEmitAudio: writable(true),
-        hasReceivedAudio: writable(true),
         hasAudio: writable(true),
         statusStore: writable<PeerStatus>("connected"),
         name: writable(uniqueId),

--- a/play/src/front/Space/tests/Space.test.ts
+++ b/play/src/front/Space/tests/Space.test.ts
@@ -144,7 +144,7 @@ function createStreamable(uniqueId: string, spaceUserId: string, videoType: Stre
         },
         volumeStore: undefined,
         hasVideo: writable(true),
-        hasAudio: writable(true),
+        canEmitAudio: writable(true),
         hasReceivedAudio: writable(true),
         isMuted: writable(false),
         statusStore: writable<PeerStatus>("connected"),

--- a/play/src/front/Space/tests/Space.test.ts
+++ b/play/src/front/Space/tests/Space.test.ts
@@ -146,7 +146,7 @@ function createStreamable(uniqueId: string, spaceUserId: string, videoType: Stre
         hasVideo: writable(true),
         canEmitAudio: writable(true),
         hasReceivedAudio: writable(true),
-        isMuted: writable(false),
+        hasAudio: writable(true),
         statusStore: writable<PeerStatus>("connected"),
         name: writable(uniqueId),
         showVoiceIndicator: writable(false),

--- a/play/src/front/Stores/ScreenSharingStore.ts
+++ b/play/src/front/Stores/ScreenSharingStore.ts
@@ -288,9 +288,9 @@ const screenSharingLocalMedia = readable<Streamable | undefined>(undefined, func
         localMediaStreamStore,
         ($localMediaStreamStore) => ($localMediaStreamStore?.getAudioTracks().length ?? 0) > 0,
     );
-    const isMediaMuted = derived(
+    const hasAudio = derived(
         localMediaStreamStore,
-        ($localMediaStreamStore) => ($localMediaStreamStore?.getAudioTracks().length ?? 0) === 0,
+        ($localMediaStreamStore) => ($localMediaStreamStore?.getAudioTracks().length ?? 0) > 0,
     );
 
     const localMedia = {
@@ -305,12 +305,9 @@ const screenSharingLocalMedia = readable<Streamable | undefined>(undefined, func
         } satisfies WebRtcStreamable,
         spaceUserId: undefined,
         canEmitAudio: canEmitAudio,
-        hasReceivedAudio: derived(
-            [canEmitAudio, isMediaMuted],
-            ([$canEmitAudio, $isMediaMuted]) => $canEmitAudio && !$isMediaMuted,
-        ),
+        hasReceivedAudio: derived([canEmitAudio, hasAudio], ([$canEmitAudio, $hasAudio]) => $canEmitAudio && $hasAudio),
         hasVideo: writable(true),
-        isMuted: isMediaMuted,
+        hasAudio,
         name: writable(""),
         showVoiceIndicator: writable(false),
         statusStore: writable("connected"),

--- a/play/src/front/Stores/ScreenSharingStore.ts
+++ b/play/src/front/Stores/ScreenSharingStore.ts
@@ -284,10 +284,6 @@ const screenSharingLocalMedia = readable<Streamable | undefined>(undefined, func
     const localMediaStreamStore = writable<MediaStream | undefined>(undefined);
     const mutedLocalMediaStreamStore = muteMediaStreamStore(localMediaStreamStore);
 
-    const canEmitAudio = derived(
-        localMediaStreamStore,
-        ($localMediaStreamStore) => ($localMediaStreamStore?.getAudioTracks().length ?? 0) > 0,
-    );
     const hasAudio = derived(
         localMediaStreamStore,
         ($localMediaStreamStore) => ($localMediaStreamStore?.getAudioTracks().length ?? 0) > 0,
@@ -304,7 +300,6 @@ const screenSharingLocalMedia = readable<Streamable | undefined>(undefined, func
             },
         } satisfies WebRtcStreamable,
         spaceUserId: undefined,
-        canEmitAudio: canEmitAudio,
         hasVideo: writable(true),
         hasAudio,
         name: writable(""),

--- a/play/src/front/Stores/ScreenSharingStore.ts
+++ b/play/src/front/Stores/ScreenSharingStore.ts
@@ -305,7 +305,6 @@ const screenSharingLocalMedia = readable<Streamable | undefined>(undefined, func
         } satisfies WebRtcStreamable,
         spaceUserId: undefined,
         canEmitAudio: canEmitAudio,
-        hasReceivedAudio: derived([canEmitAudio, hasAudio], ([$canEmitAudio, $hasAudio]) => $canEmitAudio && $hasAudio),
         hasVideo: writable(true),
         hasAudio,
         name: writable(""),

--- a/play/src/front/Stores/ScreenSharingStore.ts
+++ b/play/src/front/Stores/ScreenSharingStore.ts
@@ -284,7 +284,7 @@ const screenSharingLocalMedia = readable<Streamable | undefined>(undefined, func
     const localMediaStreamStore = writable<MediaStream | undefined>(undefined);
     const mutedLocalMediaStreamStore = muteMediaStreamStore(localMediaStreamStore);
 
-    const hasAudio = derived(
+    const canEmitAudio = derived(
         localMediaStreamStore,
         ($localMediaStreamStore) => ($localMediaStreamStore?.getAudioTracks().length ?? 0) > 0,
     );
@@ -304,10 +304,10 @@ const screenSharingLocalMedia = readable<Streamable | undefined>(undefined, func
             },
         } satisfies WebRtcStreamable,
         spaceUserId: undefined,
-        hasAudio: hasAudio,
+        canEmitAudio: canEmitAudio,
         hasReceivedAudio: derived(
-            [hasAudio, isMediaMuted],
-            ([$hasAudio, $isMediaMuted]) => $hasAudio && !$isMediaMuted,
+            [canEmitAudio, isMediaMuted],
+            ([$canEmitAudio, $isMediaMuted]) => $canEmitAudio && !$isMediaMuted,
         ),
         hasVideo: writable(true),
         isMuted: isMediaMuted,

--- a/play/src/front/Stores/ScriptingVideoStore.ts
+++ b/play/src/front/Stores/ScriptingVideoStore.ts
@@ -17,7 +17,6 @@ function createStreamableFromVideo(url: string, config: VideoConfig): Streamable
         volumeStore: undefined,
         spaceUserId: undefined,
         hasVideo: writable(true),
-        canEmitAudio: writable(false),
         hasAudio: writable(true),
         statusStore: writable("connected"),
         name: writable(config.name ?? ""),

--- a/play/src/front/Stores/ScriptingVideoStore.ts
+++ b/play/src/front/Stores/ScriptingVideoStore.ts
@@ -17,7 +17,7 @@ function createStreamableFromVideo(url: string, config: VideoConfig): Streamable
         volumeStore: undefined,
         spaceUserId: undefined,
         hasVideo: writable(true),
-        hasAudio: writable(false),
+        canEmitAudio: writable(false),
         hasReceivedAudio: writable(false),
         isMuted: writable(false),
         statusStore: writable("connected"),

--- a/play/src/front/Stores/ScriptingVideoStore.ts
+++ b/play/src/front/Stores/ScriptingVideoStore.ts
@@ -19,7 +19,7 @@ function createStreamableFromVideo(url: string, config: VideoConfig): Streamable
         hasVideo: writable(true),
         canEmitAudio: writable(false),
         hasReceivedAudio: writable(false),
-        isMuted: writable(false),
+        hasAudio: writable(true),
         statusStore: writable("connected"),
         name: writable(config.name ?? ""),
         showVoiceIndicator: writable(false),

--- a/play/src/front/Stores/ScriptingVideoStore.ts
+++ b/play/src/front/Stores/ScriptingVideoStore.ts
@@ -18,7 +18,6 @@ function createStreamableFromVideo(url: string, config: VideoConfig): Streamable
         spaceUserId: undefined,
         hasVideo: writable(true),
         canEmitAudio: writable(false),
-        hasReceivedAudio: writable(false),
         hasAudio: writable(true),
         statusStore: writable("connected"),
         name: writable(config.name ?? ""),

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -70,8 +70,8 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL], set) 
                 stream.getVideoTracks().length > 0
             );
         }),
-        // hasAudio = true because the webcam has a microphone attached and could potentially play sound
-        hasAudio: writable(true),
+        // canEmitAudio = true because the webcam has a microphone attached and could potentially play sound
+        canEmitAudio: writable(true),
         hasReceivedAudio: requestedMicrophoneState,
         isMuted: derived(requestedMicrophoneState, (micState) => !micState),
         statusStore: writable("connected" as const),
@@ -105,7 +105,7 @@ const listenerBoxStreamable: Streamable = {
     },
     volumeStore: undefined,
     hasVideo: writable(true),
-    hasAudio: writable(false),
+    canEmitAudio: writable(false),
     hasReceivedAudio: writable(false),
     isMuted: writable(true),
     statusStore: writable("connected" as const),

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -73,7 +73,7 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL], set) 
         // canEmitAudio = true because the webcam has a microphone attached and could potentially play sound
         canEmitAudio: writable(true),
         hasReceivedAudio: requestedMicrophoneState,
-        isMuted: derived(requestedMicrophoneState, (micState) => !micState),
+        hasAudio: requestedMicrophoneState,
         statusStore: writable("connected" as const),
         name: writable($LL.camera.my.nameTag()),
         showVoiceIndicator: localVoiceIndicatorStore,
@@ -107,7 +107,7 @@ const listenerBoxStreamable: Streamable = {
     hasVideo: writable(true),
     canEmitAudio: writable(false),
     hasReceivedAudio: writable(false),
-    isMuted: writable(true),
+    hasAudio: writable(false),
     statusStore: writable("connected" as const),
     name: writable("Listener"),
     showVoiceIndicator: writable(false),

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -70,9 +70,8 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL], set) 
                 stream.getVideoTracks().length > 0
             );
         }),
-        // canEmitAudio = true because the webcam has a microphone attached and could potentially play sound
+        // canEmitAudio = true because the webcam has a microphone attached and could potentially emit audio
         canEmitAudio: writable(true),
-        hasReceivedAudio: requestedMicrophoneState,
         hasAudio: requestedMicrophoneState,
         statusStore: writable("connected" as const),
         name: writable($LL.camera.my.nameTag()),
@@ -106,7 +105,6 @@ const listenerBoxStreamable: Streamable = {
     volumeStore: undefined,
     hasVideo: writable(true),
     canEmitAudio: writable(false),
-    hasReceivedAudio: writable(false),
     hasAudio: writable(false),
     statusStore: writable("connected" as const),
     name: writable("Listener"),

--- a/play/src/front/Stores/StreamableCollectionStore.ts
+++ b/play/src/front/Stores/StreamableCollectionStore.ts
@@ -70,8 +70,6 @@ export const myCameraPeerStore: Readable<VideoBox> = derived([LL], ([$LL], set) 
                 stream.getVideoTracks().length > 0
             );
         }),
-        // canEmitAudio = true because the webcam has a microphone attached and could potentially emit audio
-        canEmitAudio: writable(true),
         hasAudio: requestedMicrophoneState,
         statusStore: writable("connected" as const),
         name: writable($LL.camera.my.nameTag()),
@@ -104,7 +102,6 @@ const listenerBoxStreamable: Streamable = {
     },
     volumeStore: undefined,
     hasVideo: writable(true),
-    canEmitAudio: writable(false),
     hasAudio: writable(false),
     statusStore: writable("connected" as const),
     name: writable("Listener"),

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -54,7 +54,6 @@ export class RemotePeer extends Peer implements Streamable {
     private readonly localStreamStoreSubscribe: Unsubscriber;
     private readonly _hasVideo: Readable<boolean>;
     private readonly _hasAudio: Readable<boolean>;
-    private readonly _hasReceivedAudio: Readable<boolean>;
     private readonly showVoiceIndicatorStore: ForwardableStore<boolean> = new ForwardableStore(false);
     public readonly flipX = false;
     public readonly muteAudio: Writable<boolean> = writable(false);
@@ -268,6 +267,8 @@ export class RemotePeer extends Peer implements Streamable {
         super(peerConfig);
 
         this.volume = writable(defaultVolume);
+        // TODO: this negates the usefulness of canEmitAudio.
+        // In theory, canEmitAudio should return false for screenshares with no audio track or for scripting videos with no audio
         this._canEmitAudio = writable<boolean>(true);
         this.videoType = type;
         this.displayMode = type === "video" ? "cover" : "fit";
@@ -386,9 +387,6 @@ export class RemotePeer extends Peer implements Streamable {
             };
         });*/
         this._hasVideo = createMediaStreamTrackPresenceStore(this._remoteStreamStore, "video");
-
-        // Receiver-side diagnostic signal used to spot "space says microphone is enabled, but no audio track arrived".
-        this._hasReceivedAudio = createMediaStreamTrackPresenceStore(this._remoteStreamStore, "audio");
 
         this._hasAudio = derived(this._remoteStreamStore, ($remoteStream, set) => {
             if (!$remoteStream) {
@@ -830,10 +828,6 @@ export class RemotePeer extends Peer implements Streamable {
 
     get canEmitAudio(): Readable<boolean> {
         return this._canEmitAudio;
-    }
-
-    get hasReceivedAudio(): Readable<boolean> {
-        return this._hasReceivedAudio;
     }
 
     get hasAudio(): Readable<boolean> {

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -57,7 +57,6 @@ export class RemotePeer extends Peer implements Streamable {
     private readonly showVoiceIndicatorStore: ForwardableStore<boolean> = new ForwardableStore(false);
     public readonly flipX = false;
     public readonly muteAudio: Writable<boolean> = writable(false);
-    private readonly _canEmitAudio: Readable<boolean>;
     public readonly displayMode: "fit" | "cover";
     public readonly usePresentationMode: boolean;
     public readonly displayInPictureInPictureMode = true;
@@ -267,9 +266,6 @@ export class RemotePeer extends Peer implements Streamable {
         super(peerConfig);
 
         this.volume = writable(defaultVolume);
-        // TODO: this negates the usefulness of canEmitAudio.
-        // In theory, canEmitAudio should return false for screenshares with no audio track or for scripting videos with no audio
-        this._canEmitAudio = writable<boolean>(true);
         this.videoType = type;
         this.displayMode = type === "video" ? "cover" : "fit";
         this.usePresentationMode = !(type === "video");
@@ -824,10 +820,6 @@ export class RemotePeer extends Peer implements Streamable {
 
     get hasVideo(): Readable<boolean> {
         return this._hasVideo;
-    }
-
-    get canEmitAudio(): Readable<boolean> {
-        return this._canEmitAudio;
     }
 
     get hasAudio(): Readable<boolean> {

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -53,7 +53,7 @@ export class RemotePeer extends Peer implements Streamable {
     private closing = false; //this is used to prevent destroy() from being called twice
     private readonly localStreamStoreSubscribe: Unsubscriber;
     private readonly _hasVideo: Readable<boolean>;
-    private readonly _isMuted: Readable<boolean>;
+    private readonly _hasAudio: Readable<boolean>;
     private readonly _hasReceivedAudio: Readable<boolean>;
     private readonly showVoiceIndicatorStore: ForwardableStore<boolean> = new ForwardableStore(false);
     public readonly flipX = false;
@@ -390,12 +390,12 @@ export class RemotePeer extends Peer implements Streamable {
         // Receiver-side diagnostic signal used to spot "space says microphone is enabled, but no audio track arrived".
         this._hasReceivedAudio = createMediaStreamTrackPresenceStore(this._remoteStreamStore, "audio");
 
-        this._isMuted = derived(this._remoteStreamStore, ($remoteStream, set) => {
+        this._hasAudio = derived(this._remoteStreamStore, ($remoteStream, set) => {
             if (!$remoteStream) {
-                set(true);
+                set(false);
                 return;
             }
-            const update = () => set($remoteStream.getAudioTracks().every((track) => track.enabled === false));
+            const update = () => set($remoteStream.getAudioTracks().some((track) => track.enabled !== false));
             update();
             const onAdd = (e: MediaStreamTrackEvent) => {
                 if (e.track.kind === "audio") update();
@@ -836,8 +836,8 @@ export class RemotePeer extends Peer implements Streamable {
         return this._hasReceivedAudio;
     }
 
-    get isMuted(): Readable<boolean> {
-        return this._isMuted;
+    get hasAudio(): Readable<boolean> {
+        return this._hasAudio;
     }
 
     get name(): Readable<string> {

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -58,7 +58,7 @@ export class RemotePeer extends Peer implements Streamable {
     private readonly showVoiceIndicatorStore: ForwardableStore<boolean> = new ForwardableStore(false);
     public readonly flipX = false;
     public readonly muteAudio: Writable<boolean> = writable(false);
-    private readonly _hasAudio: Readable<boolean>;
+    private readonly _canEmitAudio: Readable<boolean>;
     public readonly displayMode: "fit" | "cover";
     public readonly usePresentationMode: boolean;
     public readonly displayInPictureInPictureMode = true;
@@ -268,7 +268,7 @@ export class RemotePeer extends Peer implements Streamable {
         super(peerConfig);
 
         this.volume = writable(defaultVolume);
-        this._hasAudio = writable<boolean>(true);
+        this._canEmitAudio = writable<boolean>(true);
         this.videoType = type;
         this.displayMode = type === "video" ? "cover" : "fit";
         this.usePresentationMode = !(type === "video");
@@ -828,8 +828,8 @@ export class RemotePeer extends Peer implements Streamable {
         return this._hasVideo;
     }
 
-    get hasAudio(): Readable<boolean> {
-        return this._hasAudio;
+    get canEmitAudio(): Readable<boolean> {
+        return this._canEmitAudio;
     }
 
     get hasReceivedAudio(): Readable<boolean> {

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -362,48 +362,9 @@ export class RemotePeer extends Peer implements Streamable {
             undefined,
         );
 
-        /*this._hasVideo = derived(this._remoteStreamStore, ($remoteStream, set) => {
-            if (!$remoteStream) {
-                set(false);
-                return;
-            }
-            const update = () => set($remoteStream.getVideoTracks().length > 0);
-            update();
-            const onAdd = (e: MediaStreamTrackEvent) => {
-                if (e.track.kind === "video") update();
-            };
-            const onRemove = (e: MediaStreamTrackEvent) => {
-                if (e.track.kind === "video") update();
-            };
-            $remoteStream.addEventListener("addtrack", onAdd);
-            $remoteStream.addEventListener("removetrack", onRemove);
-            return () => {
-                $remoteStream.removeEventListener("addtrack", onAdd);
-                $remoteStream.removeEventListener("removetrack", onRemove);
-            };
-        });*/
         this._hasVideo = createMediaStreamTrackPresenceStore(this._remoteStreamStore, "video");
 
-        this._hasAudio = derived(this._remoteStreamStore, ($remoteStream, set) => {
-            if (!$remoteStream) {
-                set(false);
-                return;
-            }
-            const update = () => set($remoteStream.getAudioTracks().some((track) => track.enabled !== false));
-            update();
-            const onAdd = (e: MediaStreamTrackEvent) => {
-                if (e.track.kind === "audio") update();
-            };
-            const onRemove = (e: MediaStreamTrackEvent) => {
-                if (e.track.kind === "audio") update();
-            };
-            $remoteStream.addEventListener("addtrack", onAdd);
-            $remoteStream.addEventListener("removetrack", onRemove);
-            return () => {
-                $remoteStream.removeEventListener("addtrack", onAdd);
-                $remoteStream.removeEventListener("removetrack", onRemove);
-            };
-        });
+        this._hasAudio = createMediaStreamTrackPresenceStore(this._remoteStreamStore, "audio");
 
         this._isBlocked = derived(this._blockedUsersStore, ($blockedUsersStore) => {
             return $blockedUsersStore.has(this._spaceUserId);


### PR DESCRIPTION
## What changed

- Removed the old `Streamable.hasAudio` capability flag.
- Replaced the public `Streamable.isMuted` state with new positive `hasAudio` state.
- Documented the meanings of `hasVideo` and `hasAudio` in the `Streamable` interface.
- Updated WebRTC, LiveKit, local camera, screen share, scripting video, video box, picture-in-picture, and test call sites.
- Removed `hasReceivedAudio` as it is now similar to hasAudio

## Why

`hasAudio` now mirrors `hasVideo`: it answers whether the streamable currently has audio. `canEmitAudio` carries the separate capability/UI-affordance meaning used to decide whether audio controls such as the microphone icon should be shown.
