### PR TITLE
Show media settings button when in conversation

### DIFF
--- a/play/src/front/Components/ActionBar/ActionBar.svelte
+++ b/play/src/front/Components/ActionBar/ActionBar.svelte
@@ -81,10 +81,12 @@
 
                             {#if smallArrowVisible}
                                 <div
-                                    class="absolute h-3 mobile:h-6 w-7 rounded-b mobile:rounded-t bg-contrast/80 backdrop-blur start-[2.86rem] m-auto p-1 z-10 transition-all -bottom-3 hidden opacity-0 sm:block mobile:-top-12 mobile:block {$inExternalServiceStore
+                                    class="absolute h-3 mobile:h-6 w-7 rounded-b mobile:rounded-t bg-contrast/80 backdrop-blur start-[2.3rem] @xl/actions:start-[2.86rem] m-auto p-1 z-10 transition-all -bottom-3 hidden opacity-0 sm:block mobile:-top-12 mobile:block {$inExternalServiceStore
                                         ? ''
                                         : 'mobile:opacity-100'}
-                                    {$mediaSettingsOpenStore ? 'opacity-100' : 'group-hover/hardware:opacity-100'}"
+                                    {$mediaSettingsOpenStore || $isInRemoteConversation
+                                        ? 'opacity-100'
+                                        : 'group-hover/hardware:opacity-100'}"
                                 >
                                     <!-- svelte-ignore a11y_click_events_have_key_events -->
                                     <!-- svelte-ignore a11y_no_static_element_interactions -->


### PR DESCRIPTION
The little arrow between the camera and the microphone used to select the devices and set a virtual background is now displayed by default when we are in a conversation (no need to hover on the cam/mic icons to see it)