### PR TITLE
Removing incorrect virtual background support check

### DIFF
--- a/play/src/front/WebRtc/BackgroundProcessor/createBackgroundTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/createBackgroundTransformer.ts
@@ -30,11 +30,6 @@ export interface BackgroundTransformer {
  * @returns A MediaPipe transformer instance or fallback
  */
 export function createBackgroundTransformer(config: BackgroundConfig): BackgroundTransformer {
-    // Check browser support for MediaStream APIs
-    if (typeof MediaStreamTrackProcessor === "undefined" || typeof MediaStreamTrackGenerator === "undefined") {
-        return new FallbackBackgroundTransformer();
-    }
-
     const engine = BACKGROUND_TRANSFORMER_ENGINE || "tasks-vision";
     console.info(`[BackgroundProcessor] Using transformer engine: ${engine}`);
 


### PR DESCRIPTION
The app was checking that MediaStreamTrackProcessor and MediaStreamTrackGenerator are supported but those are useless for background processing. As a result, virtual background was not working on Firefox despite Firefox supporting those perfectly.

- [ ] Safari does not support the blur feature on canvas. We should replace it with a WebGL shader.