### PR TITLE
Fix virtual background blur rendering in Safari

### DIFF
--- a/play/src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.ts
@@ -1,9 +1,18 @@
+import { BLUR_ITERATIONS, WebGlBlurPipeline } from "./WebGlBlurPipeline";
+
+export {
+    BLUR_FRAGMENT_SHADER,
+    BLUR_ITERATIONS,
+    BLUR_VERTEX_SHADER,
+    COMPOSITE_FRAGMENT_SHADER,
+    getDualKawaseBlurOffset,
+    getWebGlBlurRadius,
+    getWebGlBlurSize,
+} from "./WebGlBlurPipeline";
+
 export type BlurBackend = "webgl-blur" | "cpu-blur" | "none";
 
 const CPU_BLUR_MAX_SIDE = 224;
-export const BLUR_ITERATIONS = 2;
-const WEBGL_MIN_BLUR_MAX_SIDE = 112;
-const WEBGL_BLUR_MAX_RADIUS = 18;
 
 const loggedBackends = new Set<BlurBackend>();
 let loggedWebGlFailure = false;
@@ -17,16 +26,6 @@ export function resetCanvasBlurRendererForTests(): void {
 
 export function getCpuBlurSize(width: number, height: number): { width: number; height: number; scale: number } {
     return getBlurRenderSize(width, height, CPU_BLUR_MAX_SIDE);
-}
-
-export function getWebGlBlurSize(
-    width: number,
-    height: number,
-    blurAmount: number,
-): { width: number; height: number; scale: number } {
-    const normalizedBlurAmount = clamp(blurAmount, 0, 50);
-    const maxSide = Math.max(WEBGL_MIN_BLUR_MAX_SIDE, CPU_BLUR_MAX_SIDE - normalizedBlurAmount * 2);
-    return getBlurRenderSize(width, height, maxSide);
 }
 
 function getBlurRenderSize(
@@ -53,14 +52,6 @@ export function getCpuBlurRadius(blurAmount: number, scale: number): number {
     }
 
     return Math.max(1, Math.min(18, Math.round(blurAmount * scale * 0.75)));
-}
-
-export function getWebGlBlurRadius(blurAmount: number, scale: number): number {
-    if (blurAmount <= 0 || scale <= 0) {
-        return 0;
-    }
-
-    return Math.max(1, Math.min(WEBGL_BLUR_MAX_RADIUS, Math.round(blurAmount * scale * 1.1)));
 }
 
 export function boxBlurImageData(
@@ -201,614 +192,8 @@ function logWebGlFailure(error: unknown): void {
     console.warn("[BackgroundProcessor] WebGL blur renderer failed; using CPU fallback.", error);
 }
 
-export const BLUR_VERTEX_SHADER = `
-attribute vec2 a_position;
-attribute vec2 a_texCoord;
-
-varying vec2 v_texCoord;
-
-void main() {
-    gl_Position = vec4(a_position, 0.0, 1.0);
-    v_texCoord = a_texCoord;
-}
-`;
-
-export const BLUR_FRAGMENT_SHADER = `
-precision mediump float;
-
-uniform sampler2D u_texture;
-uniform vec2 u_texelOffset;
-uniform float u_radius;
-
-varying vec2 v_texCoord;
-
-void main() {
-    float centerWeight = max(u_radius + 1.0, 1.0);
-    vec4 color = texture2D(u_texture, v_texCoord) * centerWeight;
-    float weight = centerWeight;
-
-    for (int i = 1; i <= 18; i++) {
-        float sampleOffset = float(i);
-        float enabled = step(sampleOffset, u_radius);
-        float sampleWeight = (u_radius + 1.0 - sampleOffset) * enabled;
-        vec2 offset = u_texelOffset * sampleOffset;
-        color += texture2D(u_texture, v_texCoord + offset) * sampleWeight;
-        color += texture2D(u_texture, v_texCoord - offset) * sampleWeight;
-        weight += sampleWeight * 2.0;
-    }
-
-    gl_FragColor = color / weight;
-}
-`;
-
-export const COMPOSITE_FRAGMENT_SHADER = `
-precision mediump float;
-
-uniform sampler2D u_sharpTexture;
-uniform sampler2D u_blurredTexture;
-uniform sampler2D u_maskTexture;
-
-varying vec2 v_texCoord;
-
-void main() {
-    float confidence = texture2D(u_maskTexture, v_texCoord).r;
-    float foregroundAlpha = smoothstep(0.45, 0.65, confidence);
-    vec4 blurredBackground = texture2D(u_blurredTexture, v_texCoord);
-    vec4 sharpForeground = texture2D(u_sharpTexture, v_texCoord);
-
-    gl_FragColor = mix(blurredBackground, sharpForeground, foregroundAlpha);
-}
-`;
-
-class WebGlBlurRenderer {
-    private canvas = document.createElement("canvas");
-    private gl: WebGLRenderingContext | null = null;
-    private program: WebGLProgram | null = null;
-    private compositeProgram: WebGLProgram | null = null;
-    private positionBuffer: WebGLBuffer | null = null;
-    private texCoordBuffer: WebGLBuffer | null = null;
-    private sourceTexture: WebGLTexture | null = null;
-    private maskTexture: WebGLTexture | null = null;
-    private firstPassTexture: WebGLTexture | null = null;
-    private secondPassTexture: WebGLTexture | null = null;
-    private firstPassFramebuffer: WebGLFramebuffer | null = null;
-    private secondPassFramebuffer: WebGLFramebuffer | null = null;
-    private framebufferWidth = 0;
-    private framebufferHeight = 0;
-    private positionLocation = -1;
-    private texCoordLocation = -1;
-    private textureLocation: WebGLUniformLocation | null = null;
-    private texelOffsetLocation: WebGLUniformLocation | null = null;
-    private radiusLocation: WebGLUniformLocation | null = null;
-    private compositePositionLocation = -1;
-    private compositeTexCoordLocation = -1;
-    private sharpTextureLocation: WebGLUniformLocation | null = null;
-    private blurredTextureLocation: WebGLUniformLocation | null = null;
-    private maskTextureLocation: WebGLUniformLocation | null = null;
-    private contextLost = false;
-
-    private readonly handleContextLost = (event: Event): void => {
-        event.preventDefault();
-        this.contextLost = true;
-        this.releaseResources();
-    };
-
-    private readonly handleContextRestored = (): void => {
-        this.contextLost = false;
-        this.releaseResources();
-        this.gl = null;
-    };
-
-    constructor() {
-        this.canvas.addEventListener("webglcontextlost", this.handleContextLost, false);
-        this.canvas.addEventListener("webglcontextrestored", this.handleContextRestored, false);
-    }
-
-    public draw(
-        source: CanvasImageSource,
-        width: number,
-        height: number,
-        blurAmount: number,
-    ): HTMLCanvasElement | null {
-        if (this.contextLost) {
-            return null;
-        }
-
-        const blurSize = getWebGlBlurSize(width, height, blurAmount);
-        if (!blurSize.width || !blurSize.height) {
-            return null;
-        }
-
-        const gl = this.getContext();
-        if (gl.isContextLost()) {
-            this.contextLost = true;
-            return null;
-        }
-
-        if (this.canvas.width !== blurSize.width || this.canvas.height !== blurSize.height) {
-            this.canvas.width = blurSize.width;
-            this.canvas.height = blurSize.height;
-        }
-
-        this.ensureProgram(gl);
-        this.ensureBuffers(gl);
-        this.ensureTextures(gl, blurSize.width, blurSize.height);
-
-        try {
-            const blurredTexture = this.renderBlurredTexture(gl, source, blurSize, blurAmount);
-            this.drawPass(gl, blurredTexture, null, 0, 0, 0);
-            gl.flush();
-        } catch (error) {
-            if (gl.isContextLost()) {
-                this.contextLost = true;
-                return null;
-            }
-            throw error;
-        }
-
-        return this.canvas;
-    }
-
-    public drawComposite(
-        source: CanvasImageSource,
-        segmentationMask: CanvasImageSource,
-        width: number,
-        height: number,
-        blurAmount: number,
-    ): HTMLCanvasElement | null {
-        if (this.contextLost) {
-            return null;
-        }
-
-        const blurSize = getWebGlBlurSize(width, height, blurAmount);
-        if (!blurSize.width || !blurSize.height) {
-            return null;
-        }
-
-        const gl = this.getContext();
-        if (gl.isContextLost()) {
-            this.contextLost = true;
-            return null;
-        }
-
-        if (this.canvas.width !== width || this.canvas.height !== height) {
-            this.canvas.width = width;
-            this.canvas.height = height;
-        }
-
-        this.ensureProgram(gl);
-        this.ensureCompositeProgram(gl);
-        this.ensureBuffers(gl);
-        this.ensureTextures(gl, blurSize.width, blurSize.height);
-        this.ensureMaskTexture(gl);
-
-        try {
-            const blurredTexture = this.renderBlurredTexture(gl, source, blurSize, blurAmount);
-
-            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-            gl.activeTexture(gl.TEXTURE0 + 2);
-            gl.bindTexture(gl.TEXTURE_2D, this.maskTexture);
-            this.configureTexture(gl);
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, segmentationMask as TexImageSource);
-
-            this.drawCompositePass(gl, this.sourceTexture!, blurredTexture, this.maskTexture!, width, height);
-            gl.flush();
-        } catch (error) {
-            if (gl.isContextLost()) {
-                this.contextLost = true;
-                return null;
-            }
-            throw error;
-        }
-
-        return this.canvas;
-    }
-
-    public close(): void {
-        this.canvas.removeEventListener("webglcontextlost", this.handleContextLost, false);
-        this.canvas.removeEventListener("webglcontextrestored", this.handleContextRestored, false);
-        this.releaseResources();
-        this.gl = null;
-        this.canvas.width = 0;
-        this.canvas.height = 0;
-    }
-
-    private getContext(): WebGLRenderingContext {
-        if (this.gl) {
-            return this.gl;
-        }
-
-        const gl = this.canvas.getContext("webgl", {
-            alpha: false,
-            antialias: false,
-            depth: false,
-            stencil: false,
-            preserveDrawingBuffer: true,
-            premultipliedAlpha: false,
-        });
-
-        if (!gl) {
-            throw new Error("Unable to create WebGL blur context");
-        }
-
-        this.gl = gl;
-        return this.gl;
-    }
-
-    private ensureProgram(gl: WebGLRenderingContext): void {
-        if (this.program) {
-            return;
-        }
-
-        const vertexShader = this.createShader(gl, gl.VERTEX_SHADER, BLUR_VERTEX_SHADER);
-        const fragmentShader = this.createShader(gl, gl.FRAGMENT_SHADER, BLUR_FRAGMENT_SHADER);
-        const program = gl.createProgram();
-
-        if (!program) {
-            throw new Error("Unable to create WebGL blur program");
-        }
-
-        gl.attachShader(program, vertexShader);
-        gl.attachShader(program, fragmentShader);
-        gl.linkProgram(program);
-
-        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-            const message = gl.getProgramInfoLog(program) ?? "Unknown WebGL program link error";
-            gl.deleteProgram(program);
-            gl.deleteShader(vertexShader);
-            gl.deleteShader(fragmentShader);
-            throw new Error(message);
-        }
-
-        gl.deleteShader(vertexShader);
-        gl.deleteShader(fragmentShader);
-
-        this.program = program;
-        this.positionLocation = gl.getAttribLocation(program, "a_position");
-        this.texCoordLocation = gl.getAttribLocation(program, "a_texCoord");
-        this.textureLocation = gl.getUniformLocation(program, "u_texture");
-        this.texelOffsetLocation = gl.getUniformLocation(program, "u_texelOffset");
-        this.radiusLocation = gl.getUniformLocation(program, "u_radius");
-
-        if (
-            this.positionLocation < 0 ||
-            this.texCoordLocation < 0 ||
-            !this.textureLocation ||
-            !this.texelOffsetLocation ||
-            !this.radiusLocation
-        ) {
-            throw new Error("Unable to resolve WebGL blur shader locations");
-        }
-    }
-
-    private ensureCompositeProgram(gl: WebGLRenderingContext): void {
-        if (this.compositeProgram) {
-            return;
-        }
-
-        const vertexShader = this.createShader(gl, gl.VERTEX_SHADER, BLUR_VERTEX_SHADER);
-        const fragmentShader = this.createShader(gl, gl.FRAGMENT_SHADER, COMPOSITE_FRAGMENT_SHADER);
-        const program = gl.createProgram();
-
-        if (!program) {
-            throw new Error("Unable to create WebGL blur composite program");
-        }
-
-        gl.attachShader(program, vertexShader);
-        gl.attachShader(program, fragmentShader);
-        gl.linkProgram(program);
-
-        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-            const message = gl.getProgramInfoLog(program) ?? "Unknown WebGL composite program link error";
-            gl.deleteProgram(program);
-            gl.deleteShader(vertexShader);
-            gl.deleteShader(fragmentShader);
-            throw new Error(message);
-        }
-
-        gl.deleteShader(vertexShader);
-        gl.deleteShader(fragmentShader);
-
-        this.compositeProgram = program;
-        this.compositePositionLocation = gl.getAttribLocation(program, "a_position");
-        this.compositeTexCoordLocation = gl.getAttribLocation(program, "a_texCoord");
-        this.sharpTextureLocation = gl.getUniformLocation(program, "u_sharpTexture");
-        this.blurredTextureLocation = gl.getUniformLocation(program, "u_blurredTexture");
-        this.maskTextureLocation = gl.getUniformLocation(program, "u_maskTexture");
-
-        if (
-            this.compositePositionLocation < 0 ||
-            this.compositeTexCoordLocation < 0 ||
-            !this.sharpTextureLocation ||
-            !this.blurredTextureLocation ||
-            !this.maskTextureLocation
-        ) {
-            throw new Error("Unable to resolve WebGL blur composite shader locations");
-        }
-    }
-
-    private createShader(gl: WebGLRenderingContext, type: number, source: string): WebGLShader {
-        const shader = gl.createShader(type);
-        if (!shader) {
-            throw new Error("Unable to create WebGL blur shader");
-        }
-
-        gl.shaderSource(shader, source);
-        gl.compileShader(shader);
-
-        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-            const message = gl.getShaderInfoLog(shader) ?? "Unknown WebGL shader compile error";
-            gl.deleteShader(shader);
-            throw new Error(message);
-        }
-
-        return shader;
-    }
-
-    private ensureBuffers(gl: WebGLRenderingContext): void {
-        if (this.positionBuffer && this.texCoordBuffer) {
-            return;
-        }
-
-        this.positionBuffer = this.createBuffer(gl, new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]));
-        this.texCoordBuffer = this.createBuffer(gl, new Float32Array([0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0]));
-    }
-
-    private createBuffer(gl: WebGLRenderingContext, data: Float32Array): WebGLBuffer {
-        const buffer = gl.createBuffer();
-        if (!buffer) {
-            throw new Error("Unable to create WebGL blur buffer");
-        }
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-        gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
-        return buffer;
-    }
-
-    private ensureTextures(gl: WebGLRenderingContext, width: number, height: number): void {
-        if (!this.sourceTexture) {
-            this.sourceTexture = this.createTexture(gl);
-        }
-
-        if (
-            this.firstPassTexture &&
-            this.secondPassTexture &&
-            this.firstPassFramebuffer &&
-            this.secondPassFramebuffer &&
-            this.framebufferWidth === width &&
-            this.framebufferHeight === height
-        ) {
-            return;
-        }
-
-        this.releaseFramebufferResources(gl);
-
-        const firstPass = this.createFramebufferTexture(gl, width, height);
-        const secondPass = this.createFramebufferTexture(gl, width, height);
-
-        this.firstPassTexture = firstPass.texture;
-        this.firstPassFramebuffer = firstPass.framebuffer;
-        this.secondPassTexture = secondPass.texture;
-        this.secondPassFramebuffer = secondPass.framebuffer;
-        this.framebufferWidth = width;
-        this.framebufferHeight = height;
-    }
-
-    private ensureMaskTexture(gl: WebGLRenderingContext): void {
-        if (!this.maskTexture) {
-            this.maskTexture = this.createTexture(gl);
-        }
-    }
-
-    private createTexture(gl: WebGLRenderingContext): WebGLTexture {
-        const texture = gl.createTexture();
-        if (!texture) {
-            throw new Error("Unable to create WebGL blur texture");
-        }
-
-        gl.bindTexture(gl.TEXTURE_2D, texture);
-        this.configureTexture(gl);
-        return texture;
-    }
-
-    private createFramebufferTexture(
-        gl: WebGLRenderingContext,
-        width: number,
-        height: number,
-    ): { texture: WebGLTexture; framebuffer: WebGLFramebuffer } {
-        const texture = this.createTexture(gl);
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-
-        const framebuffer = gl.createFramebuffer();
-        if (!framebuffer) {
-            gl.deleteTexture(texture);
-            throw new Error("Unable to create WebGL blur framebuffer");
-        }
-
-        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
-        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
-
-        if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
-            gl.deleteTexture(texture);
-            gl.deleteFramebuffer(framebuffer);
-            throw new Error("WebGL blur framebuffer is incomplete");
-        }
-
-        return { texture, framebuffer };
-    }
-
-    private configureTexture(gl: WebGLRenderingContext): void {
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-    }
-
-    private renderBlurredTexture(
-        gl: WebGLRenderingContext,
-        source: CanvasImageSource,
-        blurSize: { width: number; height: number; scale: number },
-        blurAmount: number,
-    ): WebGLTexture {
-        const radius = getWebGlBlurRadius(blurAmount, blurSize.scale);
-
-        gl.viewport(0, 0, blurSize.width, blurSize.height);
-        gl.disable(gl.DEPTH_TEST);
-        gl.disable(gl.BLEND);
-        gl.clearColor(0, 0, 0, 1);
-        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-        gl.activeTexture(gl.TEXTURE0);
-        gl.bindTexture(gl.TEXTURE_2D, this.sourceTexture);
-        this.configureTexture(gl);
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source as TexImageSource);
-
-        let sourceTexture = this.sourceTexture!;
-        for (let iteration = 0; iteration < BLUR_ITERATIONS; iteration++) {
-            this.drawPass(gl, sourceTexture, this.firstPassFramebuffer, 1 / blurSize.width, 0, radius);
-            this.drawPass(gl, this.firstPassTexture!, this.secondPassFramebuffer, 0, 1 / blurSize.height, radius);
-            sourceTexture = this.secondPassTexture!;
-        }
-
-        return sourceTexture;
-    }
-
-    private drawPass(
-        gl: WebGLRenderingContext,
-        texture: WebGLTexture,
-        framebuffer: WebGLFramebuffer | null,
-        texelOffsetX: number,
-        texelOffsetY: number,
-        radius: number,
-    ): void {
-        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
-        gl.clear(gl.COLOR_BUFFER_BIT);
-        gl.useProgram(this.program);
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
-        gl.enableVertexAttribArray(this.positionLocation);
-        gl.vertexAttribPointer(this.positionLocation, 2, gl.FLOAT, false, 0, 0);
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
-        gl.enableVertexAttribArray(this.texCoordLocation);
-        gl.vertexAttribPointer(this.texCoordLocation, 2, gl.FLOAT, false, 0, 0);
-
-        gl.activeTexture(gl.TEXTURE0);
-        gl.bindTexture(gl.TEXTURE_2D, texture);
-        gl.uniform1i(this.textureLocation, 0);
-        gl.uniform2f(this.texelOffsetLocation, texelOffsetX, texelOffsetY);
-        gl.uniform1f(this.radiusLocation, radius);
-        gl.drawArrays(gl.TRIANGLES, 0, 6);
-    }
-
-    private drawCompositePass(
-        gl: WebGLRenderingContext,
-        sharpTexture: WebGLTexture,
-        blurredTexture: WebGLTexture,
-        maskTexture: WebGLTexture,
-        width: number,
-        height: number,
-    ): void {
-        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-        gl.viewport(0, 0, width, height);
-        gl.clear(gl.COLOR_BUFFER_BIT);
-        gl.useProgram(this.compositeProgram);
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
-        gl.enableVertexAttribArray(this.compositePositionLocation);
-        gl.vertexAttribPointer(this.compositePositionLocation, 2, gl.FLOAT, false, 0, 0);
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
-        gl.enableVertexAttribArray(this.compositeTexCoordLocation);
-        gl.vertexAttribPointer(this.compositeTexCoordLocation, 2, gl.FLOAT, false, 0, 0);
-
-        gl.activeTexture(gl.TEXTURE0);
-        gl.bindTexture(gl.TEXTURE_2D, sharpTexture);
-        gl.uniform1i(this.sharpTextureLocation, 0);
-
-        gl.activeTexture(gl.TEXTURE0 + 1);
-        gl.bindTexture(gl.TEXTURE_2D, blurredTexture);
-        gl.uniform1i(this.blurredTextureLocation, 1);
-
-        gl.activeTexture(gl.TEXTURE0 + 2);
-        gl.bindTexture(gl.TEXTURE_2D, maskTexture);
-        gl.uniform1i(this.maskTextureLocation, 2);
-
-        gl.drawArrays(gl.TRIANGLES, 0, 6);
-    }
-
-    private releaseResources(): void {
-        const gl = this.gl;
-        if (!gl || gl.isContextLost()) {
-            this.program = null;
-            this.compositeProgram = null;
-            this.positionBuffer = null;
-            this.texCoordBuffer = null;
-            this.sourceTexture = null;
-            this.maskTexture = null;
-            this.firstPassTexture = null;
-            this.secondPassTexture = null;
-            this.firstPassFramebuffer = null;
-            this.secondPassFramebuffer = null;
-            this.radiusLocation = null;
-            this.sharpTextureLocation = null;
-            this.blurredTextureLocation = null;
-            this.maskTextureLocation = null;
-            return;
-        }
-
-        if (this.program) {
-            gl.deleteProgram(this.program);
-            this.program = null;
-        }
-        if (this.compositeProgram) {
-            gl.deleteProgram(this.compositeProgram);
-            this.compositeProgram = null;
-        }
-        if (this.positionBuffer) {
-            gl.deleteBuffer(this.positionBuffer);
-            this.positionBuffer = null;
-        }
-        if (this.texCoordBuffer) {
-            gl.deleteBuffer(this.texCoordBuffer);
-            this.texCoordBuffer = null;
-        }
-        if (this.sourceTexture) {
-            gl.deleteTexture(this.sourceTexture);
-            this.sourceTexture = null;
-        }
-        if (this.maskTexture) {
-            gl.deleteTexture(this.maskTexture);
-            this.maskTexture = null;
-        }
-
-        this.releaseFramebufferResources(gl);
-    }
-
-    private releaseFramebufferResources(gl: WebGLRenderingContext): void {
-        if (this.firstPassTexture) {
-            gl.deleteTexture(this.firstPassTexture);
-            this.firstPassTexture = null;
-        }
-        if (this.secondPassTexture) {
-            gl.deleteTexture(this.secondPassTexture);
-            this.secondPassTexture = null;
-        }
-        if (this.firstPassFramebuffer) {
-            gl.deleteFramebuffer(this.firstPassFramebuffer);
-            this.firstPassFramebuffer = null;
-        }
-        if (this.secondPassFramebuffer) {
-            gl.deleteFramebuffer(this.secondPassFramebuffer);
-            this.secondPassFramebuffer = null;
-        }
-
-        this.framebufferWidth = 0;
-        this.framebufferHeight = 0;
-    }
-}
-
 export class CanvasBlurRenderer {
-    private webGlRenderer: WebGlBlurRenderer | null = null;
+    private webGlPipeline: WebGlBlurPipeline | null = null;
     private webGlUnavailable = false;
     private cpuCanvas: HTMLCanvasElement | null = null;
     private cpuContext: CanvasRenderingContext2D | null = null;
@@ -880,8 +265,8 @@ export class CanvasBlurRenderer {
     }
 
     public close(): void {
-        this.webGlRenderer?.close();
-        this.webGlRenderer = null;
+        this.webGlPipeline?.close();
+        this.webGlPipeline = null;
         this.cpuCanvas = null;
         this.cpuContext = null;
         this.webGlUnavailable = false;
@@ -895,12 +280,11 @@ export class CanvasBlurRenderer {
         blurAmount: number,
     ): HTMLCanvasElement | null {
         try {
-            this.webGlRenderer = this.webGlRenderer ?? new WebGlBlurRenderer();
-            return this.webGlRenderer.draw(source, width, height, blurAmount);
+            return this.getWebGlPipeline().drawBlurredImage(source, width, height, blurAmount);
         } catch (error) {
             logWebGlFailure(error);
-            this.webGlRenderer?.close();
-            this.webGlRenderer = null;
+            this.webGlPipeline?.close();
+            this.webGlPipeline = null;
             this.webGlUnavailable = true;
             return null;
         }
@@ -914,15 +298,43 @@ export class CanvasBlurRenderer {
         blurAmount: number,
     ): HTMLCanvasElement | null {
         try {
-            this.webGlRenderer = this.webGlRenderer ?? new WebGlBlurRenderer();
-            return this.webGlRenderer.drawComposite(source, segmentationMask, width, height, blurAmount);
+            return this.getWebGlPipeline().drawCompositeWithCanvasMask(
+                source,
+                segmentationMask,
+                width,
+                height,
+                blurAmount,
+            );
         } catch (error) {
             logWebGlFailure(error);
-            this.webGlRenderer?.close();
-            this.webGlRenderer = null;
+            this.webGlPipeline?.close();
+            this.webGlPipeline = null;
             this.webGlUnavailable = true;
             return null;
         }
+    }
+
+    private getWebGlPipeline(): WebGlBlurPipeline {
+        if (this.webGlPipeline) {
+            return this.webGlPipeline;
+        }
+
+        const canvas = document.createElement("canvas");
+        const gl = canvas.getContext("webgl", {
+            alpha: false,
+            antialias: false,
+            depth: false,
+            stencil: false,
+            preserveDrawingBuffer: true,
+            premultipliedAlpha: false,
+        });
+
+        if (!gl) {
+            throw new Error("Unable to create WebGL blur context");
+        }
+
+        this.webGlPipeline = new WebGlBlurPipeline({ canvas, gl, ownsContext: true });
+        return this.webGlPipeline;
     }
 
     private drawWithCpuBlur(

--- a/play/src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.ts
@@ -1,7 +1,7 @@
 export type BlurBackend = "webgl-blur" | "cpu-blur" | "none";
 
 const CPU_BLUR_MAX_SIDE = 224;
-const CPU_BLUR_ITERATIONS = 2;
+export const BLUR_ITERATIONS = 2;
 const WEBGL_MIN_BLUR_MAX_SIDE = 112;
 const WEBGL_BLUR_MAX_RADIUS = 18;
 
@@ -19,7 +19,7 @@ export function getCpuBlurSize(width: number, height: number): { width: number; 
     return getBlurRenderSize(width, height, CPU_BLUR_MAX_SIDE);
 }
 
-function getWebGlBlurSize(
+export function getWebGlBlurSize(
     width: number,
     height: number,
     blurAmount: number,
@@ -55,7 +55,7 @@ export function getCpuBlurRadius(blurAmount: number, scale: number): number {
     return Math.max(1, Math.min(18, Math.round(blurAmount * scale * 0.75)));
 }
 
-function getWebGlBlurRadius(blurAmount: number, scale: number): number {
+export function getWebGlBlurRadius(blurAmount: number, scale: number): number {
     if (blurAmount <= 0 || scale <= 0) {
         return 0;
     }
@@ -68,7 +68,7 @@ export function boxBlurImageData(
     width: number,
     height: number,
     radius: number,
-    iterations = CPU_BLUR_ITERATIONS,
+    iterations = BLUR_ITERATIONS,
 ): void {
     if (width <= 0 || height <= 0 || radius <= 0 || iterations <= 0) {
         return;
@@ -201,7 +201,7 @@ function logWebGlFailure(error: unknown): void {
     console.warn("[BackgroundProcessor] WebGL blur renderer failed; using CPU fallback.", error);
 }
 
-const BLUR_VERTEX_SHADER = `
+export const BLUR_VERTEX_SHADER = `
 attribute vec2 a_position;
 attribute vec2 a_texCoord;
 
@@ -213,7 +213,7 @@ void main() {
 }
 `;
 
-const BLUR_FRAGMENT_SHADER = `
+export const BLUR_FRAGMENT_SHADER = `
 precision mediump float;
 
 uniform sampler2D u_texture;
@@ -241,13 +241,34 @@ void main() {
 }
 `;
 
+export const COMPOSITE_FRAGMENT_SHADER = `
+precision mediump float;
+
+uniform sampler2D u_sharpTexture;
+uniform sampler2D u_blurredTexture;
+uniform sampler2D u_maskTexture;
+
+varying vec2 v_texCoord;
+
+void main() {
+    float confidence = texture2D(u_maskTexture, v_texCoord).r;
+    float foregroundAlpha = smoothstep(0.45, 0.65, confidence);
+    vec4 blurredBackground = texture2D(u_blurredTexture, v_texCoord);
+    vec4 sharpForeground = texture2D(u_sharpTexture, v_texCoord);
+
+    gl_FragColor = mix(blurredBackground, sharpForeground, foregroundAlpha);
+}
+`;
+
 class WebGlBlurRenderer {
     private canvas = document.createElement("canvas");
     private gl: WebGLRenderingContext | null = null;
     private program: WebGLProgram | null = null;
+    private compositeProgram: WebGLProgram | null = null;
     private positionBuffer: WebGLBuffer | null = null;
     private texCoordBuffer: WebGLBuffer | null = null;
     private sourceTexture: WebGLTexture | null = null;
+    private maskTexture: WebGLTexture | null = null;
     private firstPassTexture: WebGLTexture | null = null;
     private secondPassTexture: WebGLTexture | null = null;
     private firstPassFramebuffer: WebGLFramebuffer | null = null;
@@ -259,6 +280,11 @@ class WebGlBlurRenderer {
     private textureLocation: WebGLUniformLocation | null = null;
     private texelOffsetLocation: WebGLUniformLocation | null = null;
     private radiusLocation: WebGLUniformLocation | null = null;
+    private compositePositionLocation = -1;
+    private compositeTexCoordLocation = -1;
+    private sharpTextureLocation: WebGLUniformLocation | null = null;
+    private blurredTextureLocation: WebGLUniformLocation | null = null;
+    private maskTextureLocation: WebGLUniformLocation | null = null;
     private contextLost = false;
 
     private readonly handleContextLost = (event: Event): void => {
@@ -308,26 +334,64 @@ class WebGlBlurRenderer {
         this.ensureBuffers(gl);
         this.ensureTextures(gl, blurSize.width, blurSize.height);
 
-        const radius = getWebGlBlurRadius(blurAmount, blurSize.scale);
+        try {
+            const blurredTexture = this.renderBlurredTexture(gl, source, blurSize, blurAmount);
+            this.drawPass(gl, blurredTexture, null, 0, 0, 0);
+            gl.flush();
+        } catch (error) {
+            if (gl.isContextLost()) {
+                this.contextLost = true;
+                return null;
+            }
+            throw error;
+        }
+
+        return this.canvas;
+    }
+
+    public drawComposite(
+        source: CanvasImageSource,
+        segmentationMask: CanvasImageSource,
+        width: number,
+        height: number,
+        blurAmount: number,
+    ): HTMLCanvasElement | null {
+        if (this.contextLost) {
+            return null;
+        }
+
+        const blurSize = getWebGlBlurSize(width, height, blurAmount);
+        if (!blurSize.width || !blurSize.height) {
+            return null;
+        }
+
+        const gl = this.getContext();
+        if (gl.isContextLost()) {
+            this.contextLost = true;
+            return null;
+        }
+
+        if (this.canvas.width !== width || this.canvas.height !== height) {
+            this.canvas.width = width;
+            this.canvas.height = height;
+        }
+
+        this.ensureProgram(gl);
+        this.ensureCompositeProgram(gl);
+        this.ensureBuffers(gl);
+        this.ensureTextures(gl, blurSize.width, blurSize.height);
+        this.ensureMaskTexture(gl);
 
         try {
-            gl.viewport(0, 0, blurSize.width, blurSize.height);
-            gl.disable(gl.DEPTH_TEST);
-            gl.disable(gl.BLEND);
-            gl.clearColor(0, 0, 0, 1);
-            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-            gl.activeTexture(gl.TEXTURE0);
-            gl.bindTexture(gl.TEXTURE_2D, this.sourceTexture);
-            this.configureTexture(gl);
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source as TexImageSource);
+            const blurredTexture = this.renderBlurredTexture(gl, source, blurSize, blurAmount);
 
-            let sourceTexture = this.sourceTexture!;
-            for (let iteration = 0; iteration < CPU_BLUR_ITERATIONS; iteration++) {
-                this.drawPass(gl, sourceTexture, this.firstPassFramebuffer, 1 / blurSize.width, 0, radius);
-                this.drawPass(gl, this.firstPassTexture!, this.secondPassFramebuffer, 0, 1 / blurSize.height, radius);
-                sourceTexture = this.secondPassTexture!;
-            }
-            this.drawPass(gl, sourceTexture, null, 0, 0, 0);
+            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+            gl.activeTexture(gl.TEXTURE0 + 2);
+            gl.bindTexture(gl.TEXTURE_2D, this.maskTexture);
+            this.configureTexture(gl);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, segmentationMask as TexImageSource);
+
+            this.drawCompositePass(gl, this.sourceTexture!, blurredTexture, this.maskTexture!, width, height);
             gl.flush();
         } catch (error) {
             if (gl.isContextLost()) {
@@ -417,6 +481,52 @@ class WebGlBlurRenderer {
         }
     }
 
+    private ensureCompositeProgram(gl: WebGLRenderingContext): void {
+        if (this.compositeProgram) {
+            return;
+        }
+
+        const vertexShader = this.createShader(gl, gl.VERTEX_SHADER, BLUR_VERTEX_SHADER);
+        const fragmentShader = this.createShader(gl, gl.FRAGMENT_SHADER, COMPOSITE_FRAGMENT_SHADER);
+        const program = gl.createProgram();
+
+        if (!program) {
+            throw new Error("Unable to create WebGL blur composite program");
+        }
+
+        gl.attachShader(program, vertexShader);
+        gl.attachShader(program, fragmentShader);
+        gl.linkProgram(program);
+
+        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+            const message = gl.getProgramInfoLog(program) ?? "Unknown WebGL composite program link error";
+            gl.deleteProgram(program);
+            gl.deleteShader(vertexShader);
+            gl.deleteShader(fragmentShader);
+            throw new Error(message);
+        }
+
+        gl.deleteShader(vertexShader);
+        gl.deleteShader(fragmentShader);
+
+        this.compositeProgram = program;
+        this.compositePositionLocation = gl.getAttribLocation(program, "a_position");
+        this.compositeTexCoordLocation = gl.getAttribLocation(program, "a_texCoord");
+        this.sharpTextureLocation = gl.getUniformLocation(program, "u_sharpTexture");
+        this.blurredTextureLocation = gl.getUniformLocation(program, "u_blurredTexture");
+        this.maskTextureLocation = gl.getUniformLocation(program, "u_maskTexture");
+
+        if (
+            this.compositePositionLocation < 0 ||
+            this.compositeTexCoordLocation < 0 ||
+            !this.sharpTextureLocation ||
+            !this.blurredTextureLocation ||
+            !this.maskTextureLocation
+        ) {
+            throw new Error("Unable to resolve WebGL blur composite shader locations");
+        }
+    }
+
     private createShader(gl: WebGLRenderingContext, type: number, source: string): WebGLShader {
         const shader = gl.createShader(type);
         if (!shader) {
@@ -484,6 +594,12 @@ class WebGlBlurRenderer {
         this.framebufferHeight = height;
     }
 
+    private ensureMaskTexture(gl: WebGLRenderingContext): void {
+        if (!this.maskTexture) {
+            this.maskTexture = this.createTexture(gl);
+        }
+    }
+
     private createTexture(gl: WebGLRenderingContext): WebGLTexture {
         const texture = gl.createTexture();
         if (!texture) {
@@ -528,6 +644,34 @@ class WebGlBlurRenderer {
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
     }
 
+    private renderBlurredTexture(
+        gl: WebGLRenderingContext,
+        source: CanvasImageSource,
+        blurSize: { width: number; height: number; scale: number },
+        blurAmount: number,
+    ): WebGLTexture {
+        const radius = getWebGlBlurRadius(blurAmount, blurSize.scale);
+
+        gl.viewport(0, 0, blurSize.width, blurSize.height);
+        gl.disable(gl.DEPTH_TEST);
+        gl.disable(gl.BLEND);
+        gl.clearColor(0, 0, 0, 1);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, this.sourceTexture);
+        this.configureTexture(gl);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source as TexImageSource);
+
+        let sourceTexture = this.sourceTexture!;
+        for (let iteration = 0; iteration < BLUR_ITERATIONS; iteration++) {
+            this.drawPass(gl, sourceTexture, this.firstPassFramebuffer, 1 / blurSize.width, 0, radius);
+            this.drawPass(gl, this.firstPassTexture!, this.secondPassFramebuffer, 0, 1 / blurSize.height, radius);
+            sourceTexture = this.secondPassTexture!;
+        }
+
+        return sourceTexture;
+    }
+
     private drawPass(
         gl: WebGLRenderingContext,
         texture: WebGLTexture,
@@ -556,24 +700,69 @@ class WebGlBlurRenderer {
         gl.drawArrays(gl.TRIANGLES, 0, 6);
     }
 
+    private drawCompositePass(
+        gl: WebGLRenderingContext,
+        sharpTexture: WebGLTexture,
+        blurredTexture: WebGLTexture,
+        maskTexture: WebGLTexture,
+        width: number,
+        height: number,
+    ): void {
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.viewport(0, 0, width, height);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.useProgram(this.compositeProgram);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+        gl.enableVertexAttribArray(this.compositePositionLocation);
+        gl.vertexAttribPointer(this.compositePositionLocation, 2, gl.FLOAT, false, 0, 0);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
+        gl.enableVertexAttribArray(this.compositeTexCoordLocation);
+        gl.vertexAttribPointer(this.compositeTexCoordLocation, 2, gl.FLOAT, false, 0, 0);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, sharpTexture);
+        gl.uniform1i(this.sharpTextureLocation, 0);
+
+        gl.activeTexture(gl.TEXTURE0 + 1);
+        gl.bindTexture(gl.TEXTURE_2D, blurredTexture);
+        gl.uniform1i(this.blurredTextureLocation, 1);
+
+        gl.activeTexture(gl.TEXTURE0 + 2);
+        gl.bindTexture(gl.TEXTURE_2D, maskTexture);
+        gl.uniform1i(this.maskTextureLocation, 2);
+
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
+
     private releaseResources(): void {
         const gl = this.gl;
         if (!gl || gl.isContextLost()) {
             this.program = null;
+            this.compositeProgram = null;
             this.positionBuffer = null;
             this.texCoordBuffer = null;
             this.sourceTexture = null;
+            this.maskTexture = null;
             this.firstPassTexture = null;
             this.secondPassTexture = null;
             this.firstPassFramebuffer = null;
             this.secondPassFramebuffer = null;
             this.radiusLocation = null;
+            this.sharpTextureLocation = null;
+            this.blurredTextureLocation = null;
+            this.maskTextureLocation = null;
             return;
         }
 
         if (this.program) {
             gl.deleteProgram(this.program);
             this.program = null;
+        }
+        if (this.compositeProgram) {
+            gl.deleteProgram(this.compositeProgram);
+            this.compositeProgram = null;
         }
         if (this.positionBuffer) {
             gl.deleteBuffer(this.positionBuffer);
@@ -586,6 +775,10 @@ class WebGlBlurRenderer {
         if (this.sourceTexture) {
             gl.deleteTexture(this.sourceTexture);
             this.sourceTexture = null;
+        }
+        if (this.maskTexture) {
+            gl.deleteTexture(this.maskTexture);
+            this.maskTexture = null;
         }
 
         this.releaseFramebufferResources(gl);
@@ -659,6 +852,33 @@ export class CanvasBlurRenderer {
         return this.lastBackend;
     }
 
+    public drawBlurredImageWithMask(
+        destinationContext: CanvasRenderingContext2D,
+        source: CanvasImageSource,
+        segmentationMask: CanvasImageSource,
+        width: number,
+        height: number,
+        blurAmount = 15,
+    ): BlurBackend {
+        if (!width || !height || width <= 0 || height <= 0) {
+            this.lastBackend = "none";
+            return this.lastBackend;
+        }
+
+        if (!this.webGlUnavailable) {
+            const webGlCanvas = this.drawWithWebGlComposite(source, segmentationMask, width, height, blurAmount);
+            if (webGlCanvas) {
+                this.drawScaledCanvas(destinationContext, webGlCanvas, width, height, width, height);
+                this.lastBackend = "webgl-blur";
+                logSelectedBackend(this.lastBackend);
+                return this.lastBackend;
+            }
+        }
+
+        this.lastBackend = "none";
+        return this.lastBackend;
+    }
+
     public close(): void {
         this.webGlRenderer?.close();
         this.webGlRenderer = null;
@@ -677,6 +897,25 @@ export class CanvasBlurRenderer {
         try {
             this.webGlRenderer = this.webGlRenderer ?? new WebGlBlurRenderer();
             return this.webGlRenderer.draw(source, width, height, blurAmount);
+        } catch (error) {
+            logWebGlFailure(error);
+            this.webGlRenderer?.close();
+            this.webGlRenderer = null;
+            this.webGlUnavailable = true;
+            return null;
+        }
+    }
+
+    private drawWithWebGlComposite(
+        source: CanvasImageSource,
+        segmentationMask: CanvasImageSource,
+        width: number,
+        height: number,
+        blurAmount: number,
+    ): HTMLCanvasElement | null {
+        try {
+            this.webGlRenderer = this.webGlRenderer ?? new WebGlBlurRenderer();
+            return this.webGlRenderer.drawComposite(source, segmentationMask, width, height, blurAmount);
         } catch (error) {
             logWebGlFailure(error);
             this.webGlRenderer?.close();

--- a/play/src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.ts
@@ -1,23 +1,45 @@
-export type BlurBackend = "cpu-blur" | "none";
+export type BlurBackend = "webgl-blur" | "cpu-blur" | "none";
 
 const CPU_BLUR_MAX_SIDE = 224;
 const CPU_BLUR_ITERATIONS = 2;
+const WEBGL_MIN_BLUR_MAX_SIDE = 112;
+const WEBGL_BLUR_MAX_RADIUS = 18;
 
 const loggedBackends = new Set<BlurBackend>();
+let loggedWebGlFailure = false;
 let loggedCpuFailure = false;
 
 export function resetCanvasBlurRendererForTests(): void {
     loggedBackends.clear();
+    loggedWebGlFailure = false;
     loggedCpuFailure = false;
 }
 
 export function getCpuBlurSize(width: number, height: number): { width: number; height: number; scale: number } {
+    return getBlurRenderSize(width, height, CPU_BLUR_MAX_SIDE);
+}
+
+function getWebGlBlurSize(
+    width: number,
+    height: number,
+    blurAmount: number,
+): { width: number; height: number; scale: number } {
+    const normalizedBlurAmount = clamp(blurAmount, 0, 50);
+    const maxSide = Math.max(WEBGL_MIN_BLUR_MAX_SIDE, CPU_BLUR_MAX_SIDE - normalizedBlurAmount * 2);
+    return getBlurRenderSize(width, height, maxSide);
+}
+
+function getBlurRenderSize(
+    width: number,
+    height: number,
+    maxRenderSide: number,
+): { width: number; height: number; scale: number } {
     const maxSide = Math.max(width, height);
     if (maxSide <= 0) {
         return { width: 0, height: 0, scale: 0 };
     }
 
-    const scale = Math.min(1, CPU_BLUR_MAX_SIDE / maxSide);
+    const scale = Math.min(1, maxRenderSide / maxSide);
     return {
         width: Math.max(1, Math.round(width * scale)),
         height: Math.max(1, Math.round(height * scale)),
@@ -31,6 +53,14 @@ export function getCpuBlurRadius(blurAmount: number, scale: number): number {
     }
 
     return Math.max(1, Math.min(18, Math.round(blurAmount * scale * 0.75)));
+}
+
+function getWebGlBlurRadius(blurAmount: number, scale: number): number {
+    if (blurAmount <= 0 || scale <= 0) {
+        return 0;
+    }
+
+    return Math.max(1, Math.min(WEBGL_BLUR_MAX_RADIUS, Math.round(blurAmount * scale * 1.1)));
 }
 
 export function boxBlurImageData(
@@ -153,10 +183,440 @@ function logSelectedBackend(backend: BlurBackend): void {
     }
 
     loggedBackends.add(backend);
-    console.info("[BackgroundProcessor] Using CPU background blur renderer.");
+
+    if (backend === "webgl-blur") {
+        console.info("[BackgroundProcessor] Using WebGL background blur renderer.");
+        return;
+    }
+
+    console.warn("[BackgroundProcessor] Using CPU background blur fallback.");
+}
+
+function logWebGlFailure(error: unknown): void {
+    if (loggedWebGlFailure) {
+        return;
+    }
+
+    loggedWebGlFailure = true;
+    console.warn("[BackgroundProcessor] WebGL blur renderer failed; using CPU fallback.", error);
+}
+
+const BLUR_VERTEX_SHADER = `
+attribute vec2 a_position;
+attribute vec2 a_texCoord;
+
+varying vec2 v_texCoord;
+
+void main() {
+    gl_Position = vec4(a_position, 0.0, 1.0);
+    v_texCoord = a_texCoord;
+}
+`;
+
+const BLUR_FRAGMENT_SHADER = `
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_texelOffset;
+uniform float u_radius;
+
+varying vec2 v_texCoord;
+
+void main() {
+    float centerWeight = max(u_radius + 1.0, 1.0);
+    vec4 color = texture2D(u_texture, v_texCoord) * centerWeight;
+    float weight = centerWeight;
+
+    for (int i = 1; i <= 18; i++) {
+        float sampleOffset = float(i);
+        float enabled = step(sampleOffset, u_radius);
+        float sampleWeight = (u_radius + 1.0 - sampleOffset) * enabled;
+        vec2 offset = u_texelOffset * sampleOffset;
+        color += texture2D(u_texture, v_texCoord + offset) * sampleWeight;
+        color += texture2D(u_texture, v_texCoord - offset) * sampleWeight;
+        weight += sampleWeight * 2.0;
+    }
+
+    gl_FragColor = color / weight;
+}
+`;
+
+class WebGlBlurRenderer {
+    private canvas = document.createElement("canvas");
+    private gl: WebGLRenderingContext | null = null;
+    private program: WebGLProgram | null = null;
+    private positionBuffer: WebGLBuffer | null = null;
+    private texCoordBuffer: WebGLBuffer | null = null;
+    private sourceTexture: WebGLTexture | null = null;
+    private firstPassTexture: WebGLTexture | null = null;
+    private secondPassTexture: WebGLTexture | null = null;
+    private firstPassFramebuffer: WebGLFramebuffer | null = null;
+    private secondPassFramebuffer: WebGLFramebuffer | null = null;
+    private framebufferWidth = 0;
+    private framebufferHeight = 0;
+    private positionLocation = -1;
+    private texCoordLocation = -1;
+    private textureLocation: WebGLUniformLocation | null = null;
+    private texelOffsetLocation: WebGLUniformLocation | null = null;
+    private radiusLocation: WebGLUniformLocation | null = null;
+    private contextLost = false;
+
+    private readonly handleContextLost = (event: Event): void => {
+        event.preventDefault();
+        this.contextLost = true;
+        this.releaseResources();
+    };
+
+    private readonly handleContextRestored = (): void => {
+        this.contextLost = false;
+        this.releaseResources();
+        this.gl = null;
+    };
+
+    constructor() {
+        this.canvas.addEventListener("webglcontextlost", this.handleContextLost, false);
+        this.canvas.addEventListener("webglcontextrestored", this.handleContextRestored, false);
+    }
+
+    public draw(
+        source: CanvasImageSource,
+        width: number,
+        height: number,
+        blurAmount: number,
+    ): HTMLCanvasElement | null {
+        if (this.contextLost) {
+            return null;
+        }
+
+        const blurSize = getWebGlBlurSize(width, height, blurAmount);
+        if (!blurSize.width || !blurSize.height) {
+            return null;
+        }
+
+        const gl = this.getContext();
+        if (gl.isContextLost()) {
+            this.contextLost = true;
+            return null;
+        }
+
+        if (this.canvas.width !== blurSize.width || this.canvas.height !== blurSize.height) {
+            this.canvas.width = blurSize.width;
+            this.canvas.height = blurSize.height;
+        }
+
+        this.ensureProgram(gl);
+        this.ensureBuffers(gl);
+        this.ensureTextures(gl, blurSize.width, blurSize.height);
+
+        const radius = getWebGlBlurRadius(blurAmount, blurSize.scale);
+
+        try {
+            gl.viewport(0, 0, blurSize.width, blurSize.height);
+            gl.disable(gl.DEPTH_TEST);
+            gl.disable(gl.BLEND);
+            gl.clearColor(0, 0, 0, 1);
+            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+            gl.activeTexture(gl.TEXTURE0);
+            gl.bindTexture(gl.TEXTURE_2D, this.sourceTexture);
+            this.configureTexture(gl);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source as TexImageSource);
+
+            let sourceTexture = this.sourceTexture!;
+            for (let iteration = 0; iteration < CPU_BLUR_ITERATIONS; iteration++) {
+                this.drawPass(gl, sourceTexture, this.firstPassFramebuffer, 1 / blurSize.width, 0, radius);
+                this.drawPass(gl, this.firstPassTexture!, this.secondPassFramebuffer, 0, 1 / blurSize.height, radius);
+                sourceTexture = this.secondPassTexture!;
+            }
+            this.drawPass(gl, sourceTexture, null, 0, 0, 0);
+            gl.flush();
+        } catch (error) {
+            if (gl.isContextLost()) {
+                this.contextLost = true;
+                return null;
+            }
+            throw error;
+        }
+
+        return this.canvas;
+    }
+
+    public close(): void {
+        this.canvas.removeEventListener("webglcontextlost", this.handleContextLost, false);
+        this.canvas.removeEventListener("webglcontextrestored", this.handleContextRestored, false);
+        this.releaseResources();
+        this.gl = null;
+        this.canvas.width = 0;
+        this.canvas.height = 0;
+    }
+
+    private getContext(): WebGLRenderingContext {
+        if (this.gl) {
+            return this.gl;
+        }
+
+        const gl = this.canvas.getContext("webgl", {
+            alpha: false,
+            antialias: false,
+            depth: false,
+            stencil: false,
+            preserveDrawingBuffer: true,
+            premultipliedAlpha: false,
+        });
+
+        if (!gl) {
+            throw new Error("Unable to create WebGL blur context");
+        }
+
+        this.gl = gl;
+        return this.gl;
+    }
+
+    private ensureProgram(gl: WebGLRenderingContext): void {
+        if (this.program) {
+            return;
+        }
+
+        const vertexShader = this.createShader(gl, gl.VERTEX_SHADER, BLUR_VERTEX_SHADER);
+        const fragmentShader = this.createShader(gl, gl.FRAGMENT_SHADER, BLUR_FRAGMENT_SHADER);
+        const program = gl.createProgram();
+
+        if (!program) {
+            throw new Error("Unable to create WebGL blur program");
+        }
+
+        gl.attachShader(program, vertexShader);
+        gl.attachShader(program, fragmentShader);
+        gl.linkProgram(program);
+
+        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+            const message = gl.getProgramInfoLog(program) ?? "Unknown WebGL program link error";
+            gl.deleteProgram(program);
+            gl.deleteShader(vertexShader);
+            gl.deleteShader(fragmentShader);
+            throw new Error(message);
+        }
+
+        gl.deleteShader(vertexShader);
+        gl.deleteShader(fragmentShader);
+
+        this.program = program;
+        this.positionLocation = gl.getAttribLocation(program, "a_position");
+        this.texCoordLocation = gl.getAttribLocation(program, "a_texCoord");
+        this.textureLocation = gl.getUniformLocation(program, "u_texture");
+        this.texelOffsetLocation = gl.getUniformLocation(program, "u_texelOffset");
+        this.radiusLocation = gl.getUniformLocation(program, "u_radius");
+
+        if (
+            this.positionLocation < 0 ||
+            this.texCoordLocation < 0 ||
+            !this.textureLocation ||
+            !this.texelOffsetLocation ||
+            !this.radiusLocation
+        ) {
+            throw new Error("Unable to resolve WebGL blur shader locations");
+        }
+    }
+
+    private createShader(gl: WebGLRenderingContext, type: number, source: string): WebGLShader {
+        const shader = gl.createShader(type);
+        if (!shader) {
+            throw new Error("Unable to create WebGL blur shader");
+        }
+
+        gl.shaderSource(shader, source);
+        gl.compileShader(shader);
+
+        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+            const message = gl.getShaderInfoLog(shader) ?? "Unknown WebGL shader compile error";
+            gl.deleteShader(shader);
+            throw new Error(message);
+        }
+
+        return shader;
+    }
+
+    private ensureBuffers(gl: WebGLRenderingContext): void {
+        if (this.positionBuffer && this.texCoordBuffer) {
+            return;
+        }
+
+        this.positionBuffer = this.createBuffer(gl, new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]));
+        this.texCoordBuffer = this.createBuffer(gl, new Float32Array([0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0]));
+    }
+
+    private createBuffer(gl: WebGLRenderingContext, data: Float32Array): WebGLBuffer {
+        const buffer = gl.createBuffer();
+        if (!buffer) {
+            throw new Error("Unable to create WebGL blur buffer");
+        }
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+        gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
+        return buffer;
+    }
+
+    private ensureTextures(gl: WebGLRenderingContext, width: number, height: number): void {
+        if (!this.sourceTexture) {
+            this.sourceTexture = this.createTexture(gl);
+        }
+
+        if (
+            this.firstPassTexture &&
+            this.secondPassTexture &&
+            this.firstPassFramebuffer &&
+            this.secondPassFramebuffer &&
+            this.framebufferWidth === width &&
+            this.framebufferHeight === height
+        ) {
+            return;
+        }
+
+        this.releaseFramebufferResources(gl);
+
+        const firstPass = this.createFramebufferTexture(gl, width, height);
+        const secondPass = this.createFramebufferTexture(gl, width, height);
+
+        this.firstPassTexture = firstPass.texture;
+        this.firstPassFramebuffer = firstPass.framebuffer;
+        this.secondPassTexture = secondPass.texture;
+        this.secondPassFramebuffer = secondPass.framebuffer;
+        this.framebufferWidth = width;
+        this.framebufferHeight = height;
+    }
+
+    private createTexture(gl: WebGLRenderingContext): WebGLTexture {
+        const texture = gl.createTexture();
+        if (!texture) {
+            throw new Error("Unable to create WebGL blur texture");
+        }
+
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        this.configureTexture(gl);
+        return texture;
+    }
+
+    private createFramebufferTexture(
+        gl: WebGLRenderingContext,
+        width: number,
+        height: number,
+    ): { texture: WebGLTexture; framebuffer: WebGLFramebuffer } {
+        const texture = this.createTexture(gl);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
+        const framebuffer = gl.createFramebuffer();
+        if (!framebuffer) {
+            gl.deleteTexture(texture);
+            throw new Error("Unable to create WebGL blur framebuffer");
+        }
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+        if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
+            gl.deleteTexture(texture);
+            gl.deleteFramebuffer(framebuffer);
+            throw new Error("WebGL blur framebuffer is incomplete");
+        }
+
+        return { texture, framebuffer };
+    }
+
+    private configureTexture(gl: WebGLRenderingContext): void {
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    }
+
+    private drawPass(
+        gl: WebGLRenderingContext,
+        texture: WebGLTexture,
+        framebuffer: WebGLFramebuffer | null,
+        texelOffsetX: number,
+        texelOffsetY: number,
+        radius: number,
+    ): void {
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.useProgram(this.program);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+        gl.enableVertexAttribArray(this.positionLocation);
+        gl.vertexAttribPointer(this.positionLocation, 2, gl.FLOAT, false, 0, 0);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
+        gl.enableVertexAttribArray(this.texCoordLocation);
+        gl.vertexAttribPointer(this.texCoordLocation, 2, gl.FLOAT, false, 0, 0);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.uniform1i(this.textureLocation, 0);
+        gl.uniform2f(this.texelOffsetLocation, texelOffsetX, texelOffsetY);
+        gl.uniform1f(this.radiusLocation, radius);
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
+
+    private releaseResources(): void {
+        const gl = this.gl;
+        if (!gl || gl.isContextLost()) {
+            this.program = null;
+            this.positionBuffer = null;
+            this.texCoordBuffer = null;
+            this.sourceTexture = null;
+            this.firstPassTexture = null;
+            this.secondPassTexture = null;
+            this.firstPassFramebuffer = null;
+            this.secondPassFramebuffer = null;
+            this.radiusLocation = null;
+            return;
+        }
+
+        if (this.program) {
+            gl.deleteProgram(this.program);
+            this.program = null;
+        }
+        if (this.positionBuffer) {
+            gl.deleteBuffer(this.positionBuffer);
+            this.positionBuffer = null;
+        }
+        if (this.texCoordBuffer) {
+            gl.deleteBuffer(this.texCoordBuffer);
+            this.texCoordBuffer = null;
+        }
+        if (this.sourceTexture) {
+            gl.deleteTexture(this.sourceTexture);
+            this.sourceTexture = null;
+        }
+
+        this.releaseFramebufferResources(gl);
+    }
+
+    private releaseFramebufferResources(gl: WebGLRenderingContext): void {
+        if (this.firstPassTexture) {
+            gl.deleteTexture(this.firstPassTexture);
+            this.firstPassTexture = null;
+        }
+        if (this.secondPassTexture) {
+            gl.deleteTexture(this.secondPassTexture);
+            this.secondPassTexture = null;
+        }
+        if (this.firstPassFramebuffer) {
+            gl.deleteFramebuffer(this.firstPassFramebuffer);
+            this.firstPassFramebuffer = null;
+        }
+        if (this.secondPassFramebuffer) {
+            gl.deleteFramebuffer(this.secondPassFramebuffer);
+            this.secondPassFramebuffer = null;
+        }
+
+        this.framebufferWidth = 0;
+        this.framebufferHeight = 0;
+    }
 }
 
 export class CanvasBlurRenderer {
+    private webGlRenderer: WebGlBlurRenderer | null = null;
+    private webGlUnavailable = false;
     private cpuCanvas: HTMLCanvasElement | null = null;
     private cpuContext: CanvasRenderingContext2D | null = null;
     private lastBackend: BlurBackend = "none";
@@ -177,15 +637,53 @@ export class CanvasBlurRenderer {
             return this.lastBackend;
         }
 
+        if (!this.webGlUnavailable) {
+            const webGlCanvas = this.drawWithWebGlBlur(source, width, height, blurAmount);
+            if (webGlCanvas) {
+                this.drawScaledCanvas(
+                    destinationContext,
+                    webGlCanvas,
+                    webGlCanvas.width,
+                    webGlCanvas.height,
+                    width,
+                    height,
+                );
+                this.lastBackend = "webgl-blur";
+                logSelectedBackend(this.lastBackend);
+                return this.lastBackend;
+            }
+        }
+
         this.lastBackend = this.drawWithCpuBlur(destinationContext, source, width, height, blurAmount);
         logSelectedBackend(this.lastBackend);
         return this.lastBackend;
     }
 
     public close(): void {
+        this.webGlRenderer?.close();
+        this.webGlRenderer = null;
         this.cpuCanvas = null;
         this.cpuContext = null;
+        this.webGlUnavailable = false;
         this.lastBackend = "none";
+    }
+
+    private drawWithWebGlBlur(
+        source: CanvasImageSource,
+        width: number,
+        height: number,
+        blurAmount: number,
+    ): HTMLCanvasElement | null {
+        try {
+            this.webGlRenderer = this.webGlRenderer ?? new WebGlBlurRenderer();
+            return this.webGlRenderer.draw(source, width, height, blurAmount);
+        } catch (error) {
+            logWebGlFailure(error);
+            this.webGlRenderer?.close();
+            this.webGlRenderer = null;
+            this.webGlUnavailable = true;
+            return null;
+        }
     }
 
     private drawWithCpuBlur(
@@ -222,13 +720,7 @@ export class CanvasBlurRenderer {
             boxBlurImageData(imageData.data, blurSize.width, blurSize.height, radius);
             cpuContext.putImageData(imageData, 0, 0);
 
-            const previousImageSmoothingEnabled = destinationContext.imageSmoothingEnabled;
-            const previousImageSmoothingQuality = destinationContext.imageSmoothingQuality;
-            destinationContext.imageSmoothingEnabled = true;
-            destinationContext.imageSmoothingQuality = "high";
-            destinationContext.drawImage(this.cpuCanvas, 0, 0, blurSize.width, blurSize.height, 0, 0, width, height);
-            destinationContext.imageSmoothingEnabled = previousImageSmoothingEnabled;
-            destinationContext.imageSmoothingQuality = previousImageSmoothingQuality;
+            this.drawScaledCanvas(destinationContext, this.cpuCanvas, blurSize.width, blurSize.height, width, height);
 
             return "cpu-blur";
         } catch (error) {
@@ -254,5 +746,32 @@ export class CanvasBlurRenderer {
         }
 
         return this.cpuContext;
+    }
+
+    private drawScaledCanvas(
+        destinationContext: CanvasRenderingContext2D,
+        sourceCanvas: HTMLCanvasElement,
+        sourceWidth: number,
+        sourceHeight: number,
+        destinationWidth: number,
+        destinationHeight: number,
+    ): void {
+        const previousImageSmoothingEnabled = destinationContext.imageSmoothingEnabled;
+        const previousImageSmoothingQuality = destinationContext.imageSmoothingQuality;
+        destinationContext.imageSmoothingEnabled = true;
+        destinationContext.imageSmoothingQuality = "high";
+        destinationContext.drawImage(
+            sourceCanvas,
+            0,
+            0,
+            sourceWidth,
+            sourceHeight,
+            0,
+            0,
+            destinationWidth,
+            destinationHeight,
+        );
+        destinationContext.imageSmoothingEnabled = previousImageSmoothingEnabled;
+        destinationContext.imageSmoothingQuality = previousImageSmoothingQuality;
     }
 }

--- a/play/src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.ts
@@ -1,0 +1,258 @@
+export type BlurBackend = "cpu-blur" | "none";
+
+const CPU_BLUR_MAX_SIDE = 224;
+const CPU_BLUR_ITERATIONS = 2;
+
+const loggedBackends = new Set<BlurBackend>();
+let loggedCpuFailure = false;
+
+export function resetCanvasBlurRendererForTests(): void {
+    loggedBackends.clear();
+    loggedCpuFailure = false;
+}
+
+export function getCpuBlurSize(width: number, height: number): { width: number; height: number; scale: number } {
+    const maxSide = Math.max(width, height);
+    if (maxSide <= 0) {
+        return { width: 0, height: 0, scale: 0 };
+    }
+
+    const scale = Math.min(1, CPU_BLUR_MAX_SIDE / maxSide);
+    return {
+        width: Math.max(1, Math.round(width * scale)),
+        height: Math.max(1, Math.round(height * scale)),
+        scale,
+    };
+}
+
+export function getCpuBlurRadius(blurAmount: number, scale: number): number {
+    if (blurAmount <= 0 || scale <= 0) {
+        return 0;
+    }
+
+    return Math.max(1, Math.min(18, Math.round(blurAmount * scale * 0.75)));
+}
+
+export function boxBlurImageData(
+    data: Uint8ClampedArray,
+    width: number,
+    height: number,
+    radius: number,
+    iterations = CPU_BLUR_ITERATIONS,
+): void {
+    if (width <= 0 || height <= 0 || radius <= 0 || iterations <= 0) {
+        return;
+    }
+
+    const source = new Uint8ClampedArray(data);
+    const target = new Uint8ClampedArray(data.length);
+
+    for (let iteration = 0; iteration < iterations; iteration++) {
+        boxBlurHorizontal(source, target, width, height, radius);
+        boxBlurVertical(target, source, width, height, radius);
+    }
+
+    data.set(source);
+}
+
+function boxBlurHorizontal(
+    source: Uint8ClampedArray,
+    target: Uint8ClampedArray,
+    width: number,
+    height: number,
+    radius: number,
+): void {
+    const windowSize = radius * 2 + 1;
+
+    for (let y = 0; y < height; y++) {
+        let red = 0;
+        let green = 0;
+        let blue = 0;
+        let alpha = 0;
+
+        for (let offset = -radius; offset <= radius; offset++) {
+            const x = clamp(offset, 0, width - 1);
+            const index = (y * width + x) * 4;
+            red += source[index];
+            green += source[index + 1];
+            blue += source[index + 2];
+            alpha += source[index + 3];
+        }
+
+        for (let x = 0; x < width; x++) {
+            const index = (y * width + x) * 4;
+            target[index] = red / windowSize;
+            target[index + 1] = green / windowSize;
+            target[index + 2] = blue / windowSize;
+            target[index + 3] = alpha / windowSize;
+
+            const removeX = clamp(x - radius, 0, width - 1);
+            const addX = clamp(x + radius + 1, 0, width - 1);
+            const removeIndex = (y * width + removeX) * 4;
+            const addIndex = (y * width + addX) * 4;
+
+            red += source[addIndex] - source[removeIndex];
+            green += source[addIndex + 1] - source[removeIndex + 1];
+            blue += source[addIndex + 2] - source[removeIndex + 2];
+            alpha += source[addIndex + 3] - source[removeIndex + 3];
+        }
+    }
+}
+
+function boxBlurVertical(
+    source: Uint8ClampedArray,
+    target: Uint8ClampedArray,
+    width: number,
+    height: number,
+    radius: number,
+): void {
+    const windowSize = radius * 2 + 1;
+
+    for (let x = 0; x < width; x++) {
+        let red = 0;
+        let green = 0;
+        let blue = 0;
+        let alpha = 0;
+
+        for (let offset = -radius; offset <= radius; offset++) {
+            const y = clamp(offset, 0, height - 1);
+            const index = (y * width + x) * 4;
+            red += source[index];
+            green += source[index + 1];
+            blue += source[index + 2];
+            alpha += source[index + 3];
+        }
+
+        for (let y = 0; y < height; y++) {
+            const index = (y * width + x) * 4;
+            target[index] = red / windowSize;
+            target[index + 1] = green / windowSize;
+            target[index + 2] = blue / windowSize;
+            target[index + 3] = alpha / windowSize;
+
+            const removeY = clamp(y - radius, 0, height - 1);
+            const addY = clamp(y + radius + 1, 0, height - 1);
+            const removeIndex = (removeY * width + x) * 4;
+            const addIndex = (addY * width + x) * 4;
+
+            red += source[addIndex] - source[removeIndex];
+            green += source[addIndex + 1] - source[removeIndex + 1];
+            blue += source[addIndex + 2] - source[removeIndex + 2];
+            alpha += source[addIndex + 3] - source[removeIndex + 3];
+        }
+    }
+}
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
+}
+
+function logSelectedBackend(backend: BlurBackend): void {
+    if (backend === "none" || loggedBackends.has(backend)) {
+        return;
+    }
+
+    loggedBackends.add(backend);
+    console.info("[BackgroundProcessor] Using CPU background blur renderer.");
+}
+
+export class CanvasBlurRenderer {
+    private cpuCanvas: HTMLCanvasElement | null = null;
+    private cpuContext: CanvasRenderingContext2D | null = null;
+    private lastBackend: BlurBackend = "none";
+
+    public getLastBackend(): BlurBackend {
+        return this.lastBackend;
+    }
+
+    public drawBlurredImage(
+        destinationContext: CanvasRenderingContext2D,
+        source: CanvasImageSource,
+        width: number,
+        height: number,
+        blurAmount = 15,
+    ): BlurBackend {
+        if (!width || !height || width <= 0 || height <= 0) {
+            this.lastBackend = "none";
+            return this.lastBackend;
+        }
+
+        this.lastBackend = this.drawWithCpuBlur(destinationContext, source, width, height, blurAmount);
+        logSelectedBackend(this.lastBackend);
+        return this.lastBackend;
+    }
+
+    public close(): void {
+        this.cpuCanvas = null;
+        this.cpuContext = null;
+        this.lastBackend = "none";
+    }
+
+    private drawWithCpuBlur(
+        destinationContext: CanvasRenderingContext2D,
+        source: CanvasImageSource,
+        width: number,
+        height: number,
+        blurAmount: number,
+    ): BlurBackend {
+        try {
+            const cpuContext = this.getCpuContext();
+            const blurSize = getCpuBlurSize(width, height);
+
+            if (!blurSize.width || !blurSize.height) {
+                return "none";
+            }
+
+            if (
+                !this.cpuCanvas ||
+                this.cpuCanvas.width !== blurSize.width ||
+                this.cpuCanvas.height !== blurSize.height
+            ) {
+                this.cpuCanvas = this.cpuCanvas ?? document.createElement("canvas");
+                this.cpuCanvas.width = blurSize.width;
+                this.cpuCanvas.height = blurSize.height;
+            }
+
+            cpuContext.filter = "none";
+            cpuContext.globalCompositeOperation = "source-over";
+            cpuContext.drawImage(source, 0, 0, blurSize.width, blurSize.height);
+
+            const imageData = cpuContext.getImageData(0, 0, blurSize.width, blurSize.height);
+            const radius = getCpuBlurRadius(blurAmount, blurSize.scale);
+            boxBlurImageData(imageData.data, blurSize.width, blurSize.height, radius);
+            cpuContext.putImageData(imageData, 0, 0);
+
+            const previousImageSmoothingEnabled = destinationContext.imageSmoothingEnabled;
+            const previousImageSmoothingQuality = destinationContext.imageSmoothingQuality;
+            destinationContext.imageSmoothingEnabled = true;
+            destinationContext.imageSmoothingQuality = "high";
+            destinationContext.drawImage(this.cpuCanvas, 0, 0, blurSize.width, blurSize.height, 0, 0, width, height);
+            destinationContext.imageSmoothingEnabled = previousImageSmoothingEnabled;
+            destinationContext.imageSmoothingQuality = previousImageSmoothingQuality;
+
+            return "cpu-blur";
+        } catch (error) {
+            if (!loggedCpuFailure) {
+                loggedCpuFailure = true;
+                console.warn("[BackgroundProcessor] CPU blur renderer failed; drawing the unblurred frame.", error);
+            }
+            destinationContext.drawImage(source, 0, 0, width, height);
+            return "none";
+        }
+    }
+
+    private getCpuContext(): CanvasRenderingContext2D {
+        if (!this.cpuCanvas) {
+            this.cpuCanvas = document.createElement("canvas");
+        }
+
+        if (!this.cpuContext) {
+            this.cpuContext = this.cpuCanvas.getContext("2d", { willReadFrequently: true });
+            if (!this.cpuContext) {
+                throw new Error("Unable to create CPU blur canvas context");
+            }
+        }
+
+        return this.cpuContext;
+    }
+}

--- a/play/src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.ts
@@ -1,3 +1,4 @@
+import { logOnce, resetLogOnceForTests } from "./logOnce";
 import { BLUR_ITERATIONS, WebGlBlurPipeline } from "./WebGlBlurPipeline";
 
 export {
@@ -14,14 +15,8 @@ export type BlurBackend = "webgl-blur" | "cpu-blur" | "none";
 
 const CPU_BLUR_MAX_SIDE = 224;
 
-const loggedBackends = new Set<BlurBackend>();
-let loggedWebGlFailure = false;
-let loggedCpuFailure = false;
-
 export function resetCanvasBlurRendererForTests(): void {
-    loggedBackends.clear();
-    loggedWebGlFailure = false;
-    loggedCpuFailure = false;
+    resetLogOnceForTests();
 }
 
 export function getCpuBlurSize(width: number, height: number): { width: number; height: number; scale: number } {
@@ -169,27 +164,23 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 function logSelectedBackend(backend: BlurBackend): void {
-    if (backend === "none" || loggedBackends.has(backend)) {
+    if (backend === "none") {
         return;
     }
 
-    loggedBackends.add(backend);
-
-    if (backend === "webgl-blur") {
-        console.info("[BackgroundProcessor] Using WebGL background blur renderer.");
-        return;
-    }
-
-    console.warn("[BackgroundProcessor] Using CPU background blur fallback.");
+    logOnce(`canvas-blur:backend:${backend}`, () => {
+        if (backend === "webgl-blur") {
+            console.info("[BackgroundProcessor] Using WebGL background blur renderer.");
+        } else {
+            console.warn("[BackgroundProcessor] Using CPU background blur fallback.");
+        }
+    });
 }
 
 function logWebGlFailure(error: unknown): void {
-    if (loggedWebGlFailure) {
-        return;
-    }
-
-    loggedWebGlFailure = true;
-    console.warn("[BackgroundProcessor] WebGL blur renderer failed; using CPU fallback.", error);
+    logOnce("canvas-blur:webgl-failure", () =>
+        console.warn("[BackgroundProcessor] WebGL blur renderer failed; using CPU fallback.", error),
+    );
 }
 
 export class CanvasBlurRenderer {
@@ -375,10 +366,9 @@ export class CanvasBlurRenderer {
 
             return "cpu-blur";
         } catch (error) {
-            if (!loggedCpuFailure) {
-                loggedCpuFailure = true;
-                console.warn("[BackgroundProcessor] CPU blur renderer failed; drawing the unblurred frame.", error);
-            }
+            logOnce("canvas-blur:cpu-failure", () =>
+                console.warn("[BackgroundProcessor] CPU blur renderer failed; drawing the unblurred frame.", error),
+            );
             destinationContext.drawImage(source, 0, 0, width, height);
             return "none";
         }

--- a/play/src/front/WebRtc/BackgroundProcessor/FallbackBackgroundTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/FallbackBackgroundTransformer.ts
@@ -3,7 +3,7 @@ import type { BackgroundConfig, BackgroundTransformer } from "./createBackground
 
 /**
  * Fallback transformer that doesn't transform anything
- * Used when MediaStreamTrackProcessor is not available or fails
+ * Used when MediaPipe initialization or processing is not available.
  */
 export class FallbackBackgroundTransformer implements BackgroundTransformer {
     private outputTrack: MediaStreamTrack | null = null;

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
@@ -2,6 +2,7 @@ import type { SelfieSegmentationResults } from "@mediapipe/selfie_segmentation";
 import { SelfieSegmentation } from "@mediapipe/selfie_segmentation";
 import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
+import { CanvasBlurRenderer } from "./CanvasBlurRenderer";
 import type { BackgroundTransformer } from "./createBackgroundTransformer";
 
 /**
@@ -29,6 +30,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
     // Reusable temporary canvas to avoid WebGL context leaks
     private tempCanvas: HTMLCanvasElement | null = null;
     private tempCtx: CanvasRenderingContext2D | null = null;
+    private blurRenderer = new CanvasBlurRenderer();
 
     constructor(
         private config: {
@@ -145,9 +147,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
         }
 
         // Step 1: Draw the entire image with blur as background
-        this.ctx.filter = `blur(${this.config.blurAmount || 15}px)`;
-        this.ctx.drawImage(results.image, 0, 0, width, height);
-        this.ctx.filter = "none";
+        this.blurRenderer.drawBlurredImage(this.ctx, results.image, width, height, this.config.blurAmount || 15);
 
         // Step 2: Use reusable temporary canvas for the person (sharp)
         if (!this.tempCanvas || !this.tempCtx) {
@@ -261,6 +261,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
             frameCount: this.frameCount,
             elapsed: Math.round(elapsed),
             closed: this.closed,
+            blurBackend: this.config.mode === "blur" ? this.blurRenderer.getLastBackend() : "none",
         };
     }
     public stop(): void {
@@ -307,6 +308,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
         // Clean up temporary canvas
         this.tempCanvas = null;
         this.tempCtx = null;
+        this.blurRenderer.close();
     }
 
     public async transform(inputStream: MediaStream, signal?: AbortSignal): Promise<MediaStream> {

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
@@ -5,6 +5,12 @@ import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
 import { CanvasBlurRenderer } from "./CanvasBlurRenderer";
 import type { BackgroundTransformer } from "./createBackgroundTransformer";
 
+// requestVideoFrameCallback is preferred to confirm a real frame has been
+// presented, but it can stay silent (e.g. in a backgrounded tab where frame
+// callbacks are suspended). After this delay we fall back to the readyState
+// signal so frame processing is never gated on rVFC indefinitely.
+const VIDEO_FRAME_CALLBACK_GRACE_MS = 500;
+
 /**
  * MediaPipe-based background transformer for video streams
  * Uses a simpler approach with setTimeout for reliable frame processing
@@ -28,6 +34,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
     private initPromise: Promise<void>;
     private frameRate = 33;
     private lastVideoFrameTime = 0;
+    private videoFrameTrackingStartTime = 0;
     private videoFrameCallbackId: number | null = null;
     // Reusable temporary canvas to avoid WebGL context leaks
     private tempCanvas: HTMLCanvasElement | null = null;
@@ -343,6 +350,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
         // Setup input video
         this.stopVideoFrameTracking();
         this.lastVideoFrameTime = 0;
+        this.videoFrameTrackingStartTime = 0;
         this.inputVideo.srcObject = inputStream;
 
         // Wait for video metadata to be loaded
@@ -465,7 +473,17 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
         }
 
         if ("requestVideoFrameCallback" in this.inputVideo) {
-            return this.lastVideoFrameTime > 0;
+            if (this.lastVideoFrameTime > 0) {
+                return true;
+            }
+
+            // requestVideoFrameCallback has not delivered a frame yet. Wait for it
+            // briefly, then fall back to readyState so a silent rVFC (e.g. in a
+            // backgrounded tab) never freezes the output stream.
+            return (
+                this.videoFrameTrackingStartTime > 0 &&
+                performance.now() - this.videoFrameTrackingStartTime >= VIDEO_FRAME_CALLBACK_GRACE_MS
+            );
         }
 
         return true;
@@ -475,6 +493,8 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
         if (!("requestVideoFrameCallback" in this.inputVideo) || this.videoFrameCallbackId !== null) {
             return;
         }
+
+        this.videoFrameTrackingStartTime = performance.now();
 
         const onVideoFrame = () => {
             if (this.closed || !("requestVideoFrameCallback" in this.inputVideo)) {

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
@@ -146,6 +146,18 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
             return;
         }
 
+        const compositeBackend = this.blurRenderer.drawBlurredImageWithMask(
+            this.ctx,
+            results.image,
+            results.segmentationMask,
+            width,
+            height,
+            this.config.blurAmount || 15,
+        );
+        if (compositeBackend !== "none") {
+            return;
+        }
+
         // Step 1: Draw the entire image with blur as background
         this.blurRenderer.drawBlurredImage(this.ctx, results.image, width, height, this.config.blurAmount || 15);
 

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
@@ -27,6 +27,8 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
     private startTime = performance.now();
     private initPromise: Promise<void>;
     private frameRate = 33;
+    private lastVideoFrameTime = 0;
+    private videoFrameCallbackId: number | null = null;
     // Reusable temporary canvas to avoid WebGL context leaks
     private tempCanvas: HTMLCanvasElement | null = null;
     private tempCtx: CanvasRenderingContext2D | null = null;
@@ -282,6 +284,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
             clearTimeout(this.timeoutId);
             this.timeoutId = null;
         }
+        this.stopVideoFrameTracking();
     }
 
     public close(): void {
@@ -292,6 +295,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
             clearTimeout(this.timeoutId);
             this.timeoutId = null;
         }
+        this.stopVideoFrameTracking();
 
         // Stop output stream
         if (this.outputStream) {
@@ -337,6 +341,8 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
         }
 
         // Setup input video
+        this.stopVideoFrameTracking();
+        this.lastVideoFrameTime = 0;
         this.inputVideo.srcObject = inputStream;
 
         // Wait for video metadata to be loaded
@@ -354,6 +360,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
 
         const playPromise = this.inputVideo.play();
         await raceAbort(playPromise, signal);
+        this.startVideoFrameTracking();
         if (signal?.aborted) {
             throw signal.reason ?? new AbortError("Transform aborted while starting video playback");
         }
@@ -413,7 +420,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
                 return;
             }
 
-            if (this.inputVideo.readyState >= 2 && this.selfieSegmentation) {
+            if (this.hasUsableVideoFrame() && this.selfieSegmentation) {
                 // HAVE_CURRENT_DATA
                 this.selfieSegmentation
                     .send({ image: this.inputVideo })
@@ -441,5 +448,54 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
         };
 
         processFrame();
+    }
+
+    private hasUsableVideoFrame(): boolean {
+        if (this.inputVideo.readyState < 2) {
+            return false;
+        }
+
+        const stream = this.inputVideo.srcObject instanceof MediaStream ? this.inputVideo.srcObject : null;
+        const hasLiveVideoTrack =
+            stream?.getVideoTracks().some((track) => track.readyState === "live" && track.enabled && !track.muted) ??
+            false;
+
+        if (!hasLiveVideoTrack) {
+            return false;
+        }
+
+        if ("requestVideoFrameCallback" in this.inputVideo) {
+            return this.lastVideoFrameTime > 0;
+        }
+
+        return true;
+    }
+
+    private startVideoFrameTracking(): void {
+        if (!("requestVideoFrameCallback" in this.inputVideo) || this.videoFrameCallbackId !== null) {
+            return;
+        }
+
+        const onVideoFrame = () => {
+            if (this.closed || !("requestVideoFrameCallback" in this.inputVideo)) {
+                this.videoFrameCallbackId = null;
+                return;
+            }
+
+            this.lastVideoFrameTime = performance.now();
+            this.videoFrameCallbackId = this.inputVideo.requestVideoFrameCallback(onVideoFrame);
+        };
+
+        this.videoFrameCallbackId = this.inputVideo.requestVideoFrameCallback(onVideoFrame);
+    }
+
+    private stopVideoFrameTracking(): void {
+        if (this.videoFrameCallbackId === null || !("cancelVideoFrameCallback" in this.inputVideo)) {
+            this.videoFrameCallbackId = null;
+            return;
+        }
+
+        this.inputVideo.cancelVideoFrameCallback(this.videoFrameCallbackId);
+        this.videoFrameCallbackId = null;
     }
 }

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
@@ -4,34 +4,26 @@ import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
 import { isFirefox, isIOS } from "../DeviceUtils";
 import { CanvasBlurRenderer, type BlurBackend } from "./CanvasBlurRenderer";
+import { logOnce } from "./logOnce";
 import { TasksVisionBlurCompositor } from "./TasksVisionBlurCompositor";
 import type { BackgroundConfig, BackgroundTransformer } from "./createBackgroundTransformer";
 
 type CaptureBackend = "webgl-capture" | "2d-copy-capture";
 
-const loggedCaptureBackends = new Set<CaptureBackend>();
-let loggedWebGlCaptureFailure = false;
-
 function logCaptureBackend(backend: CaptureBackend): void {
-    if (loggedCaptureBackends.has(backend)) {
-        return;
-    }
-
-    loggedCaptureBackends.add(backend);
-    console.info(
-        backend === "webgl-capture"
-            ? "[MediaPipe Tasks Vision] Using WebGL canvas capture backend."
-            : "[MediaPipe Tasks Vision] Using 2D copy canvas capture backend.",
+    logOnce(`tasks-vision-capture:${backend}`, () =>
+        console.info(
+            backend === "webgl-capture"
+                ? "[MediaPipe Tasks Vision] Using WebGL canvas capture backend."
+                : "[MediaPipe Tasks Vision] Using 2D copy canvas capture backend.",
+        ),
     );
 }
 
 function logWebGlCaptureFailure(error: unknown): void {
-    if (loggedWebGlCaptureFailure) {
-        return;
-    }
-
-    loggedWebGlCaptureFailure = true;
-    console.warn("[MediaPipe Tasks Vision] WebGL canvas capture failed; falling back to 2D copy capture.", error);
+    logOnce("tasks-vision-capture:webgl-failure", () =>
+        console.warn("[MediaPipe Tasks Vision] WebGL canvas capture failed; falling back to 2D copy capture.", error),
+    );
 }
 
 /**

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
@@ -2,21 +2,23 @@ import type { MPMask } from "@mediapipe/tasks-vision";
 import { ImageSegmenter, FilesetResolver, DrawingUtils } from "@mediapipe/tasks-vision";
 import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
-import { CanvasBlurRenderer } from "./CanvasBlurRenderer";
+import { CanvasBlurRenderer, type BlurBackend } from "./CanvasBlurRenderer";
+import { TasksVisionBlurCompositor } from "./TasksVisionBlurCompositor";
 import type { BackgroundConfig, BackgroundTransformer } from "./createBackgroundTransformer";
 
 /**
  * MediaPipe Tasks Vision-based background transformer for video streams
- * Uses the modern @mediapipe/tasks-vision API with ImageSegmenter and DrawingUtils
+ * Uses the modern @mediapipe/tasks-vision API with ImageSegmenter
  * All compositing is done in WebGL for optimal performance
  */
 export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
-    // WebGL canvas shared between ImageSegmenter and DrawingUtils
+    // WebGL canvas shared between ImageSegmenter, DrawingUtils and the blur compositor.
     private glCanvas: HTMLCanvasElement;
     private gl: WebGL2RenderingContext | null = null;
     private drawingUtils: DrawingUtils | null = null;
+    private blurCompositor: TasksVisionBlurCompositor | null = null;
 
-    // Output canvas for stream capture (we copy from glCanvas to this)
+    // Output canvas for stream capture (we copy from glCanvas to this).
     private outputCanvas: HTMLCanvasElement;
     private outputCtx: CanvasRenderingContext2D;
 
@@ -37,18 +39,17 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
     // Track the last timestamp to guarantee strict monotonic increase
     private lastTimestampMicroseconds = 0;
 
-    // Canvas for blurred background (used as texture source for DrawingUtils)
-    private blurredCanvas: HTMLCanvasElement | null = null;
-    private blurredCtx: CanvasRenderingContext2D | null = null;
-
     // Canvas for background image (pre-rendered to avoid GPU re-upload each frame)
     private backgroundCanvas: HTMLCanvasElement | null = null;
     private backgroundCanvasCtx: CanvasRenderingContext2D | null = null;
 
-    // Canvas for foreground video (updated each frame, but HTMLCanvasElement is faster than HTMLVideoElement)
+    // Fallback canvases used only when the dedicated blur compositor is unavailable.
+    private fallbackBlurredCanvas: HTMLCanvasElement | null = null;
+    private fallbackBlurredCtx: CanvasRenderingContext2D | null = null;
     private foregroundCanvas: HTMLCanvasElement | null = null;
     private foregroundCtx: CanvasRenderingContext2D | null = null;
     private blurRenderer = new CanvasBlurRenderer();
+    private blurBackend: BlurBackend = "none";
 
     constructor(private config: BackgroundConfig) {
         // Create WebGL canvas for MediaPipe (shared with ImageSegmenter and DrawingUtils)
@@ -74,9 +75,6 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
         try {
             await this.initializeMediaPipe();
             await this.loadBackgroundResources();
-            // Initialize canvases for optimized rendering
-            this.initializeBlurredCanvas();
-            this.initializeForegroundCanvas();
         } catch (error) {
             console.error("[MediaPipe Tasks Vision] Initialization failed:", error);
             throw error;
@@ -135,11 +133,12 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
 
         // Create DrawingUtils with the same WebGL context
         this.drawingUtils = new DrawingUtils(this.gl);
+        this.blurCompositor = new TasksVisionBlurCompositor(this.gl);
     }
 
-    private initializeBlurredCanvas(): void {
-        this.blurredCanvas = document.createElement("canvas");
-        this.blurredCtx = this.blurredCanvas.getContext("2d")!;
+    private initializeFallbackBlurredCanvas(): void {
+        this.fallbackBlurredCanvas = document.createElement("canvas");
+        this.fallbackBlurredCtx = this.fallbackBlurredCanvas.getContext("2d")!;
     }
 
     private initializeForegroundCanvas(): void {
@@ -293,32 +292,39 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
         const { width, height } = this.outputCanvas;
 
         // Skip processing if canvas has invalid dimensions
-        if (!width || !height || width === 0 || height === 0 || !this.drawingUtils) {
+        if (!width || !height || width === 0 || height === 0) {
             return;
         }
 
-        // For blur mode, we create a blurred version of the input on a 2D canvas
-        // then use DrawingUtils to composite: blurred background + sharp person
-        if (!this.blurredCanvas || !this.blurredCtx) {
-            this.initializeBlurredCanvas();
+        if (this.blurCompositor?.draw(this.inputVideo, mask, width, height, this.config.blurAmount || 15)) {
+            this.blurBackend = "webgl-blur";
+            return;
+        }
+
+        if (!this.drawingUtils) {
+            this.blurBackend = "none";
+            return;
+        }
+
+        if (!this.fallbackBlurredCanvas || !this.fallbackBlurredCtx) {
+            this.initializeFallbackBlurredCanvas();
         }
         if (!this.foregroundCanvas || !this.foregroundCtx) {
             this.initializeForegroundCanvas();
         }
 
         // Ensure canvas dimensions match
-        if (this.blurredCanvas!.width !== width || this.blurredCanvas!.height !== height) {
-            this.blurredCanvas!.width = width;
-            this.blurredCanvas!.height = height;
+        if (this.fallbackBlurredCanvas!.width !== width || this.fallbackBlurredCanvas!.height !== height) {
+            this.fallbackBlurredCanvas!.width = width;
+            this.fallbackBlurredCanvas!.height = height;
         }
         if (this.foregroundCanvas!.width !== width || this.foregroundCanvas!.height !== height) {
             this.foregroundCanvas!.width = width;
             this.foregroundCanvas!.height = height;
         }
 
-        // Draw blurred background onto the blurred canvas.
-        this.blurRenderer.drawBlurredImage(
-            this.blurredCtx!,
+        this.blurBackend = this.blurRenderer.drawBlurredImage(
+            this.fallbackBlurredCtx!,
             this.inputVideo,
             width,
             height,
@@ -331,11 +337,10 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
         // Use DrawingUtils to composite:
         // - defaultTexture (low confidence = background) = blurred canvas
         // - overlayTexture (high confidence = person) = foreground canvas
-        // Using HTMLCanvasElement instead of HTMLVideoElement avoids GPU texture re-upload
         this.drawingUtils.drawConfidenceMask(
             mask,
-            this.blurredCanvas!, // Background: blurred video
-            this.foregroundCanvas!, // Foreground: sharp person (canvas for better perf)
+            this.fallbackBlurredCanvas!, // Background: blurred video
+            this.foregroundCanvas!, // Foreground: sharp person
         );
     }
 
@@ -419,36 +424,6 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
         return null;
     }
 
-    private drawBackground(): void {
-        const { width, height } = this.outputCanvas;
-
-        switch (this.config.mode) {
-            case "image":
-                if (this.backgroundImage) {
-                    // Scale image to fit canvas while maintaining aspect ratio
-                    const scale = Math.max(width / this.backgroundImage.width, height / this.backgroundImage.height);
-                    const scaledWidth = this.backgroundImage.width * scale;
-                    const scaledHeight = this.backgroundImage.height * scale;
-                    const x = (width - scaledWidth) / 2;
-                    const y = (height - scaledHeight) / 2;
-
-                    this.outputCtx.drawImage(this.backgroundImage, x, y, scaledWidth, scaledHeight);
-                }
-                break;
-
-            case "video":
-                if (this.backgroundVideo) {
-                    this.outputCtx.drawImage(this.backgroundVideo, 0, 0, width, height);
-                }
-                break;
-
-            default:
-                // Solid color fallback
-                this.outputCtx.fillStyle = "#000000";
-                this.outputCtx.fillRect(0, 0, width, height);
-        }
-    }
-
     public async waitForInitialization(): Promise<void> {
         await this.initPromise;
     }
@@ -472,7 +447,7 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
             frameCount: this.frameCount,
             elapsed: Math.round(elapsed),
             closed: this.closed,
-            blurBackend: this.config.mode === "blur" ? this.blurRenderer.getLastBackend() : "none",
+            blurBackend: this.config.mode === "blur" ? this.blurBackend : "none",
         };
     }
 
@@ -498,6 +473,9 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
             this.outputStream.getVideoTracks().forEach((track) => track.stop());
             this.outputStream = null;
         }
+
+        this.blurCompositor?.close();
+        this.blurCompositor = null;
 
         // Close DrawingUtils (frees WebGL resources)
         if (this.drawingUtils) {
@@ -529,9 +507,9 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
         }
         this.backgroundImage = null;
 
-        // Clean up blurred canvas
-        this.blurredCanvas = null;
-        this.blurredCtx = null;
+        // Clean up fallback canvases
+        this.fallbackBlurredCanvas = null;
+        this.fallbackBlurredCtx = null;
 
         // Clean up background canvas
         this.backgroundCanvas = null;

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
@@ -2,7 +2,7 @@ import type { MPMask } from "@mediapipe/tasks-vision";
 import { ImageSegmenter, FilesetResolver, DrawingUtils } from "@mediapipe/tasks-vision";
 import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
-import { isIOS, isSafari } from "../DeviceUtils";
+import { isFirefox, isIOS } from "../DeviceUtils";
 import { CanvasBlurRenderer, type BlurBackend } from "./CanvasBlurRenderer";
 import { TasksVisionBlurCompositor } from "./TasksVisionBlurCompositor";
 import type { BackgroundConfig, BackgroundTransformer } from "./createBackgroundTransformer";
@@ -32,6 +32,23 @@ function logWebGlCaptureFailure(error: unknown): void {
 
     loggedWebGlCaptureFailure = true;
     console.warn("[MediaPipe Tasks Vision] WebGL canvas capture failed; falling back to 2D copy capture.", error);
+}
+
+/**
+ * captureStream() from a WebGL canvas produces frozen frames on WebKit (Safari and
+ * every iOS browser), so the direct WebGL capture path is restricted to engines
+ * known to capture WebGL canvases correctly. Engines we cannot positively identify
+ * fall back to the always-working 2D-copy path rather than risking a frozen feed.
+ */
+function supportsWebGlCanvasCapture(): boolean {
+    if (isIOS()) {
+        return false;
+    }
+
+    // Chromium-based engines report "Chrome" in their UA (Safari does not); iOS
+    // Chrome/Firefox use "CriOS"/"FxiOS" and are already excluded by isIOS().
+    const isChromium = navigator.userAgent.includes("Chrome");
+    return isChromium || isFirefox();
 }
 
 /**
@@ -664,10 +681,6 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
             return false;
         }
 
-        try {
-            return !isSafari() && !isIOS();
-        } catch {
-            return false;
-        }
+        return supportsWebGlCanvasCapture();
     }
 }

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
@@ -2,6 +2,7 @@ import type { MPMask } from "@mediapipe/tasks-vision";
 import { ImageSegmenter, FilesetResolver, DrawingUtils } from "@mediapipe/tasks-vision";
 import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
+import { CanvasBlurRenderer } from "./CanvasBlurRenderer";
 import type { BackgroundConfig, BackgroundTransformer } from "./createBackgroundTransformer";
 
 /**
@@ -47,6 +48,7 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
     // Canvas for foreground video (updated each frame, but HTMLCanvasElement is faster than HTMLVideoElement)
     private foregroundCanvas: HTMLCanvasElement | null = null;
     private foregroundCtx: CanvasRenderingContext2D | null = null;
+    private blurRenderer = new CanvasBlurRenderer();
 
     constructor(private config: BackgroundConfig) {
         // Create WebGL canvas for MediaPipe (shared with ImageSegmenter and DrawingUtils)
@@ -314,10 +316,14 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
             this.foregroundCanvas!.height = height;
         }
 
-        // Draw blurred background onto the blurred canvas (using CSS filter)
-        this.blurredCtx!.filter = `blur(${this.config.blurAmount || 15}px)`;
-        this.blurredCtx!.drawImage(this.inputVideo, 0, 0, width, height);
-        this.blurredCtx!.filter = "none";
+        // Draw blurred background onto the blurred canvas.
+        this.blurRenderer.drawBlurredImage(
+            this.blurredCtx!,
+            this.inputVideo,
+            width,
+            height,
+            this.config.blurAmount || 15,
+        );
 
         // Draw current video frame to foreground canvas (HTMLCanvasElement is faster than HTMLVideoElement)
         this.foregroundCtx!.drawImage(this.inputVideo, 0, 0, width, height);
@@ -466,6 +472,7 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
             frameCount: this.frameCount,
             elapsed: Math.round(elapsed),
             closed: this.closed,
+            blurBackend: this.config.mode === "blur" ? this.blurRenderer.getLastBackend() : "none",
         };
     }
 
@@ -533,6 +540,8 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
         // Clean up foreground canvas
         this.foregroundCanvas = null;
         this.foregroundCtx = null;
+
+        this.blurRenderer.close();
     }
 
     public async transform(inputStream: MediaStream, signal?: AbortSignal): Promise<MediaStream> {

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
@@ -2,9 +2,37 @@ import type { MPMask } from "@mediapipe/tasks-vision";
 import { ImageSegmenter, FilesetResolver, DrawingUtils } from "@mediapipe/tasks-vision";
 import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
+import { isIOS, isSafari } from "../DeviceUtils";
 import { CanvasBlurRenderer, type BlurBackend } from "./CanvasBlurRenderer";
 import { TasksVisionBlurCompositor } from "./TasksVisionBlurCompositor";
 import type { BackgroundConfig, BackgroundTransformer } from "./createBackgroundTransformer";
+
+type CaptureBackend = "webgl-capture" | "2d-copy-capture";
+
+const loggedCaptureBackends = new Set<CaptureBackend>();
+let loggedWebGlCaptureFailure = false;
+
+function logCaptureBackend(backend: CaptureBackend): void {
+    if (loggedCaptureBackends.has(backend)) {
+        return;
+    }
+
+    loggedCaptureBackends.add(backend);
+    console.info(
+        backend === "webgl-capture"
+            ? "[MediaPipe Tasks Vision] Using WebGL canvas capture backend."
+            : "[MediaPipe Tasks Vision] Using 2D copy canvas capture backend.",
+    );
+}
+
+function logWebGlCaptureFailure(error: unknown): void {
+    if (loggedWebGlCaptureFailure) {
+        return;
+    }
+
+    loggedWebGlCaptureFailure = true;
+    console.warn("[MediaPipe Tasks Vision] WebGL canvas capture failed; falling back to 2D copy capture.", error);
+}
 
 /**
  * MediaPipe Tasks Vision-based background transformer for video streams
@@ -18,7 +46,7 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
     private drawingUtils: DrawingUtils | null = null;
     private blurCompositor: TasksVisionBlurCompositor | null = null;
 
-    // Output canvas for stream capture (we copy from glCanvas to this).
+    // Output canvas used when direct WebGL capture is unavailable or disabled.
     private outputCanvas: HTMLCanvasElement;
     private outputCtx: CanvasRenderingContext2D;
 
@@ -50,6 +78,8 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
     private foregroundCtx: CanvasRenderingContext2D | null = null;
     private blurRenderer = new CanvasBlurRenderer();
     private blurBackend: BlurBackend = "none";
+    private captureBackend: CaptureBackend = "2d-copy-capture";
+    private directWebGlCaptureUnavailable = false;
 
     constructor(private config: BackgroundConfig) {
         // Create WebGL canvas for MediaPipe (shared with ImageSegmenter and DrawingUtils)
@@ -133,7 +163,7 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
 
         // Create DrawingUtils with the same WebGL context
         this.drawingUtils = new DrawingUtils(this.gl);
-        this.blurCompositor = new TasksVisionBlurCompositor(this.gl);
+        this.blurCompositor = new TasksVisionBlurCompositor(this.gl, this.glCanvas);
     }
 
     private initializeFallbackBlurredCanvas(): void {
@@ -277,8 +307,9 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
         // Clean up mask resources
         mask.close();
 
-        // Copy from WebGL canvas to output canvas for stream capture
-        this.outputCtx.drawImage(this.glCanvas, 0, 0, width, height);
+        if (this.captureBackend === "2d-copy-capture") {
+            this.outputCtx.drawImage(this.glCanvas, 0, 0, width, height);
+        }
 
         // Ensure WebGL operations are flushed for captureStream
         if (this.gl) {
@@ -448,6 +479,7 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
             elapsed: Math.round(elapsed),
             closed: this.closed,
             blurBackend: this.config.mode === "blur" ? this.blurBackend : "none",
+            captureBackend: this.captureBackend,
         };
     }
 
@@ -580,8 +612,7 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
             }
         }
 
-        // Create output stream from the 2D output canvas
-        this.outputStream = this.outputCanvas.captureStream(this.frameRate);
+        this.outputStream = this.createOutputStream();
 
         // Copy audio tracks from the original stream
         for (const audioTrack of inputStream.getAudioTracks()) {
@@ -603,5 +634,40 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
         this.processFrame();
 
         return this.outputStream;
+    }
+
+    private createOutputStream(): MediaStream {
+        if (this.canAttemptWebGlCapture()) {
+            try {
+                const stream = this.glCanvas.captureStream(this.frameRate);
+                if (stream.getVideoTracks().length > 0) {
+                    this.captureBackend = "webgl-capture";
+                    logCaptureBackend(this.captureBackend);
+                    return stream;
+                }
+
+                this.directWebGlCaptureUnavailable = true;
+                logWebGlCaptureFailure(new Error("WebGL canvas capture returned no video track"));
+            } catch (error) {
+                this.directWebGlCaptureUnavailable = true;
+                logWebGlCaptureFailure(error);
+            }
+        }
+
+        this.captureBackend = "2d-copy-capture";
+        logCaptureBackend(this.captureBackend);
+        return this.outputCanvas.captureStream(this.frameRate);
+    }
+
+    private canAttemptWebGlCapture(): boolean {
+        if (this.directWebGlCaptureUnavailable || typeof this.glCanvas.captureStream !== "function") {
+            return false;
+        }
+
+        try {
+            return !isSafari() && !isIOS();
+        } catch {
+            return false;
+        }
     }
 }

--- a/play/src/front/WebRtc/BackgroundProcessor/TasksVisionBlurCompositor.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/TasksVisionBlurCompositor.ts
@@ -1,0 +1,440 @@
+import type { MPMask } from "@mediapipe/tasks-vision";
+import {
+    BLUR_FRAGMENT_SHADER,
+    BLUR_ITERATIONS,
+    BLUR_VERTEX_SHADER,
+    COMPOSITE_FRAGMENT_SHADER,
+    getWebGlBlurRadius,
+    getWebGlBlurSize,
+} from "./CanvasBlurRenderer";
+
+let loggedSelectedBackend = false;
+let loggedFailure = false;
+
+function logSelectedBackend(): void {
+    if (loggedSelectedBackend) {
+        return;
+    }
+
+    loggedSelectedBackend = true;
+    console.info("[BackgroundProcessor] Using WebGL background blur compositor.");
+}
+
+function logFailure(error: unknown): void {
+    if (loggedFailure) {
+        return;
+    }
+
+    loggedFailure = true;
+    console.warn("[BackgroundProcessor] WebGL background blur compositor failed; using fallback.", error);
+}
+
+export class TasksVisionBlurCompositor {
+    private blurProgram: WebGLProgram | null = null;
+    private compositeProgram: WebGLProgram | null = null;
+    private positionBuffer: WebGLBuffer | null = null;
+    private texCoordBuffer: WebGLBuffer | null = null;
+    private sourceTexture: WebGLTexture | null = null;
+    private firstPassTexture: WebGLTexture | null = null;
+    private secondPassTexture: WebGLTexture | null = null;
+    private firstPassFramebuffer: WebGLFramebuffer | null = null;
+    private secondPassFramebuffer: WebGLFramebuffer | null = null;
+    private framebufferWidth = 0;
+    private framebufferHeight = 0;
+    private blurPositionLocation = -1;
+    private blurTexCoordLocation = -1;
+    private blurTextureLocation: WebGLUniformLocation | null = null;
+    private texelOffsetLocation: WebGLUniformLocation | null = null;
+    private radiusLocation: WebGLUniformLocation | null = null;
+    private compositePositionLocation = -1;
+    private compositeTexCoordLocation = -1;
+    private sharpTextureLocation: WebGLUniformLocation | null = null;
+    private blurredTextureLocation: WebGLUniformLocation | null = null;
+    private maskTextureLocation: WebGLUniformLocation | null = null;
+    private unavailable = false;
+
+    constructor(private readonly gl: WebGL2RenderingContext) {}
+
+    public draw(source: CanvasImageSource, mask: MPMask, width: number, height: number, blurAmount: number): boolean {
+        if (this.unavailable || !width || !height || width <= 0 || height <= 0 || this.gl.isContextLost()) {
+            return false;
+        }
+
+        if (mask.canvas && mask.canvas !== this.gl.canvas) {
+            return false;
+        }
+
+        const blurSize = getWebGlBlurSize(width, height, blurAmount);
+        if (!blurSize.width || !blurSize.height) {
+            return false;
+        }
+
+        try {
+            this.ensurePrograms();
+            this.ensureBuffers();
+            this.ensureTextures(blurSize.width, blurSize.height);
+
+            const blurredTexture = this.renderBlurredTexture(source, blurSize, blurAmount);
+            this.drawCompositePass(this.sourceTexture!, blurredTexture, mask.getAsWebGLTexture(), width, height);
+            this.gl.flush();
+            logSelectedBackend();
+            return true;
+        } catch (error) {
+            if (!this.gl.isContextLost()) {
+                this.unavailable = true;
+                this.close();
+            }
+            logFailure(error);
+            return false;
+        }
+    }
+
+    public close(): void {
+        const gl = this.gl;
+        if (gl.isContextLost()) {
+            this.clearReferences();
+            return;
+        }
+
+        if (this.blurProgram) {
+            gl.deleteProgram(this.blurProgram);
+        }
+        if (this.compositeProgram) {
+            gl.deleteProgram(this.compositeProgram);
+        }
+        if (this.positionBuffer) {
+            gl.deleteBuffer(this.positionBuffer);
+        }
+        if (this.texCoordBuffer) {
+            gl.deleteBuffer(this.texCoordBuffer);
+        }
+        if (this.sourceTexture) {
+            gl.deleteTexture(this.sourceTexture);
+        }
+
+        this.releaseFramebufferResources();
+        this.clearReferences();
+    }
+
+    private ensurePrograms(): void {
+        if (!this.blurProgram) {
+            this.blurProgram = this.createProgram(BLUR_VERTEX_SHADER, BLUR_FRAGMENT_SHADER, "blur");
+            this.blurPositionLocation = this.gl.getAttribLocation(this.blurProgram, "a_position");
+            this.blurTexCoordLocation = this.gl.getAttribLocation(this.blurProgram, "a_texCoord");
+            this.blurTextureLocation = this.gl.getUniformLocation(this.blurProgram, "u_texture");
+            this.texelOffsetLocation = this.gl.getUniformLocation(this.blurProgram, "u_texelOffset");
+            this.radiusLocation = this.gl.getUniformLocation(this.blurProgram, "u_radius");
+
+            if (
+                this.blurPositionLocation < 0 ||
+                this.blurTexCoordLocation < 0 ||
+                !this.blurTextureLocation ||
+                !this.texelOffsetLocation ||
+                !this.radiusLocation
+            ) {
+                throw new Error("Unable to resolve Tasks Vision blur shader locations");
+            }
+        }
+
+        if (!this.compositeProgram) {
+            this.compositeProgram = this.createProgram(BLUR_VERTEX_SHADER, COMPOSITE_FRAGMENT_SHADER, "composite");
+            this.compositePositionLocation = this.gl.getAttribLocation(this.compositeProgram, "a_position");
+            this.compositeTexCoordLocation = this.gl.getAttribLocation(this.compositeProgram, "a_texCoord");
+            this.sharpTextureLocation = this.gl.getUniformLocation(this.compositeProgram, "u_sharpTexture");
+            this.blurredTextureLocation = this.gl.getUniformLocation(this.compositeProgram, "u_blurredTexture");
+            this.maskTextureLocation = this.gl.getUniformLocation(this.compositeProgram, "u_maskTexture");
+
+            if (
+                this.compositePositionLocation < 0 ||
+                this.compositeTexCoordLocation < 0 ||
+                !this.sharpTextureLocation ||
+                !this.blurredTextureLocation ||
+                !this.maskTextureLocation
+            ) {
+                throw new Error("Unable to resolve Tasks Vision blur composite shader locations");
+            }
+        }
+    }
+
+    private createProgram(vertexSource: string, fragmentSource: string, label: string): WebGLProgram {
+        const gl = this.gl;
+        const vertexShader = this.createShader(gl.VERTEX_SHADER, vertexSource, label);
+        const fragmentShader = this.createShader(gl.FRAGMENT_SHADER, fragmentSource, label);
+        const program = gl.createProgram();
+
+        if (!program) {
+            throw new Error(`Unable to create Tasks Vision ${label} program`);
+        }
+
+        gl.attachShader(program, vertexShader);
+        gl.attachShader(program, fragmentShader);
+        gl.linkProgram(program);
+
+        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+            const message = gl.getProgramInfoLog(program) ?? `Unknown Tasks Vision ${label} program link error`;
+            gl.deleteProgram(program);
+            gl.deleteShader(vertexShader);
+            gl.deleteShader(fragmentShader);
+            throw new Error(message);
+        }
+
+        gl.deleteShader(vertexShader);
+        gl.deleteShader(fragmentShader);
+        return program;
+    }
+
+    private createShader(type: number, source: string, label: string): WebGLShader {
+        const gl = this.gl;
+        const shader = gl.createShader(type);
+        if (!shader) {
+            throw new Error(`Unable to create Tasks Vision ${label} shader`);
+        }
+
+        gl.shaderSource(shader, source);
+        gl.compileShader(shader);
+
+        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+            const message = gl.getShaderInfoLog(shader) ?? `Unknown Tasks Vision ${label} shader compile error`;
+            gl.deleteShader(shader);
+            throw new Error(message);
+        }
+
+        return shader;
+    }
+
+    private ensureBuffers(): void {
+        if (this.positionBuffer && this.texCoordBuffer) {
+            return;
+        }
+
+        this.positionBuffer = this.createBuffer(new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]));
+        this.texCoordBuffer = this.createBuffer(new Float32Array([0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0]));
+    }
+
+    private createBuffer(data: Float32Array): WebGLBuffer {
+        const gl = this.gl;
+        const buffer = gl.createBuffer();
+        if (!buffer) {
+            throw new Error("Unable to create Tasks Vision blur buffer");
+        }
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+        gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
+        return buffer;
+    }
+
+    private ensureTextures(width: number, height: number): void {
+        if (!this.sourceTexture) {
+            this.sourceTexture = this.createTexture();
+        }
+
+        if (
+            this.firstPassTexture &&
+            this.secondPassTexture &&
+            this.firstPassFramebuffer &&
+            this.secondPassFramebuffer &&
+            this.framebufferWidth === width &&
+            this.framebufferHeight === height
+        ) {
+            return;
+        }
+
+        this.releaseFramebufferResources();
+
+        const firstPass = this.createFramebufferTexture(width, height);
+        const secondPass = this.createFramebufferTexture(width, height);
+
+        this.firstPassTexture = firstPass.texture;
+        this.firstPassFramebuffer = firstPass.framebuffer;
+        this.secondPassTexture = secondPass.texture;
+        this.secondPassFramebuffer = secondPass.framebuffer;
+        this.framebufferWidth = width;
+        this.framebufferHeight = height;
+    }
+
+    private createTexture(): WebGLTexture {
+        const texture = this.gl.createTexture();
+        if (!texture) {
+            throw new Error("Unable to create Tasks Vision blur texture");
+        }
+
+        this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
+        this.configureTexture();
+        return texture;
+    }
+
+    private createFramebufferTexture(
+        width: number,
+        height: number,
+    ): {
+        texture: WebGLTexture;
+        framebuffer: WebGLFramebuffer;
+    } {
+        const gl = this.gl;
+        const texture = this.createTexture();
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
+        const framebuffer = gl.createFramebuffer();
+        if (!framebuffer) {
+            gl.deleteTexture(texture);
+            throw new Error("Unable to create Tasks Vision blur framebuffer");
+        }
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+        if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
+            gl.deleteTexture(texture);
+            gl.deleteFramebuffer(framebuffer);
+            throw new Error("Tasks Vision blur framebuffer is incomplete");
+        }
+
+        return { texture, framebuffer };
+    }
+
+    private configureTexture(): void {
+        const gl = this.gl;
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    }
+
+    private renderBlurredTexture(
+        source: CanvasImageSource,
+        blurSize: { width: number; height: number; scale: number },
+        blurAmount: number,
+    ): WebGLTexture {
+        const gl = this.gl;
+        const radius = getWebGlBlurRadius(blurAmount, blurSize.scale);
+
+        gl.viewport(0, 0, blurSize.width, blurSize.height);
+        gl.disable(gl.DEPTH_TEST);
+        gl.disable(gl.BLEND);
+        gl.clearColor(0, 0, 0, 1);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, this.sourceTexture);
+        this.configureTexture();
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source as TexImageSource);
+
+        let sourceTexture = this.sourceTexture!;
+        for (let iteration = 0; iteration < BLUR_ITERATIONS; iteration++) {
+            this.drawBlurPass(sourceTexture, this.firstPassFramebuffer, 1 / blurSize.width, 0, radius);
+            this.drawBlurPass(this.firstPassTexture!, this.secondPassFramebuffer, 0, 1 / blurSize.height, radius);
+            sourceTexture = this.secondPassTexture!;
+        }
+
+        return sourceTexture;
+    }
+
+    private drawBlurPass(
+        texture: WebGLTexture,
+        framebuffer: WebGLFramebuffer | null,
+        texelOffsetX: number,
+        texelOffsetY: number,
+        radius: number,
+    ): void {
+        const gl = this.gl;
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.useProgram(this.blurProgram);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+        gl.enableVertexAttribArray(this.blurPositionLocation);
+        gl.vertexAttribPointer(this.blurPositionLocation, 2, gl.FLOAT, false, 0, 0);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
+        gl.enableVertexAttribArray(this.blurTexCoordLocation);
+        gl.vertexAttribPointer(this.blurTexCoordLocation, 2, gl.FLOAT, false, 0, 0);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.uniform1i(this.blurTextureLocation, 0);
+        gl.uniform2f(this.texelOffsetLocation, texelOffsetX, texelOffsetY);
+        gl.uniform1f(this.radiusLocation, radius);
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
+
+    private drawCompositePass(
+        sharpTexture: WebGLTexture,
+        blurredTexture: WebGLTexture,
+        maskTexture: WebGLTexture,
+        width: number,
+        height: number,
+    ): void {
+        const gl = this.gl;
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.viewport(0, 0, width, height);
+        gl.disable(gl.DEPTH_TEST);
+        gl.disable(gl.BLEND);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.useProgram(this.compositeProgram);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+        gl.enableVertexAttribArray(this.compositePositionLocation);
+        gl.vertexAttribPointer(this.compositePositionLocation, 2, gl.FLOAT, false, 0, 0);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
+        gl.enableVertexAttribArray(this.compositeTexCoordLocation);
+        gl.vertexAttribPointer(this.compositeTexCoordLocation, 2, gl.FLOAT, false, 0, 0);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, sharpTexture);
+        gl.uniform1i(this.sharpTextureLocation, 0);
+
+        gl.activeTexture(gl.TEXTURE0 + 1);
+        gl.bindTexture(gl.TEXTURE_2D, blurredTexture);
+        gl.uniform1i(this.blurredTextureLocation, 1);
+
+        gl.activeTexture(gl.TEXTURE0 + 2);
+        gl.bindTexture(gl.TEXTURE_2D, maskTexture);
+        gl.uniform1i(this.maskTextureLocation, 2);
+
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
+
+    private releaseFramebufferResources(): void {
+        const gl = this.gl;
+
+        if (this.firstPassTexture) {
+            gl.deleteTexture(this.firstPassTexture);
+            this.firstPassTexture = null;
+        }
+        if (this.secondPassTexture) {
+            gl.deleteTexture(this.secondPassTexture);
+            this.secondPassTexture = null;
+        }
+        if (this.firstPassFramebuffer) {
+            gl.deleteFramebuffer(this.firstPassFramebuffer);
+            this.firstPassFramebuffer = null;
+        }
+        if (this.secondPassFramebuffer) {
+            gl.deleteFramebuffer(this.secondPassFramebuffer);
+            this.secondPassFramebuffer = null;
+        }
+
+        this.framebufferWidth = 0;
+        this.framebufferHeight = 0;
+    }
+
+    private clearReferences(): void {
+        this.blurProgram = null;
+        this.compositeProgram = null;
+        this.positionBuffer = null;
+        this.texCoordBuffer = null;
+        this.sourceTexture = null;
+        this.firstPassTexture = null;
+        this.secondPassTexture = null;
+        this.firstPassFramebuffer = null;
+        this.secondPassFramebuffer = null;
+        this.blurTextureLocation = null;
+        this.texelOffsetLocation = null;
+        this.radiusLocation = null;
+        this.sharpTextureLocation = null;
+        this.blurredTextureLocation = null;
+        this.maskTextureLocation = null;
+        this.framebufferWidth = 0;
+        this.framebufferHeight = 0;
+    }
+}

--- a/play/src/front/WebRtc/BackgroundProcessor/TasksVisionBlurCompositor.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/TasksVisionBlurCompositor.ts
@@ -1,25 +1,17 @@
 import type { MPMask } from "@mediapipe/tasks-vision";
+import { logOnce } from "./logOnce";
 import { WebGlBlurPipeline } from "./WebGlBlurPipeline";
 
-let loggedSelectedBackend = false;
-let loggedFailure = false;
-
 function logSelectedBackend(): void {
-    if (loggedSelectedBackend) {
-        return;
-    }
-
-    loggedSelectedBackend = true;
-    console.info("[BackgroundProcessor] Using WebGL background blur compositor.");
+    logOnce("tasks-vision-compositor:selected", () =>
+        console.info("[BackgroundProcessor] Using WebGL background blur compositor."),
+    );
 }
 
 function logFailure(error: unknown): void {
-    if (loggedFailure) {
-        return;
-    }
-
-    loggedFailure = true;
-    console.warn("[BackgroundProcessor] WebGL background blur compositor failed; using fallback.", error);
+    logOnce("tasks-vision-compositor:failure", () =>
+        console.warn("[BackgroundProcessor] WebGL background blur compositor failed; using fallback.", error),
+    );
 }
 
 export class TasksVisionBlurCompositor {

--- a/play/src/front/WebRtc/BackgroundProcessor/TasksVisionBlurCompositor.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/TasksVisionBlurCompositor.ts
@@ -1,12 +1,5 @@
 import type { MPMask } from "@mediapipe/tasks-vision";
-import {
-    BLUR_FRAGMENT_SHADER,
-    BLUR_ITERATIONS,
-    BLUR_VERTEX_SHADER,
-    COMPOSITE_FRAGMENT_SHADER,
-    getWebGlBlurRadius,
-    getWebGlBlurSize,
-} from "./CanvasBlurRenderer";
+import { WebGlBlurPipeline } from "./WebGlBlurPipeline";
 
 let loggedSelectedBackend = false;
 let loggedFailure = false;
@@ -30,30 +23,15 @@ function logFailure(error: unknown): void {
 }
 
 export class TasksVisionBlurCompositor {
-    private blurProgram: WebGLProgram | null = null;
-    private compositeProgram: WebGLProgram | null = null;
-    private positionBuffer: WebGLBuffer | null = null;
-    private texCoordBuffer: WebGLBuffer | null = null;
-    private sourceTexture: WebGLTexture | null = null;
-    private firstPassTexture: WebGLTexture | null = null;
-    private secondPassTexture: WebGLTexture | null = null;
-    private firstPassFramebuffer: WebGLFramebuffer | null = null;
-    private secondPassFramebuffer: WebGLFramebuffer | null = null;
-    private framebufferWidth = 0;
-    private framebufferHeight = 0;
-    private blurPositionLocation = -1;
-    private blurTexCoordLocation = -1;
-    private blurTextureLocation: WebGLUniformLocation | null = null;
-    private texelOffsetLocation: WebGLUniformLocation | null = null;
-    private radiusLocation: WebGLUniformLocation | null = null;
-    private compositePositionLocation = -1;
-    private compositeTexCoordLocation = -1;
-    private sharpTextureLocation: WebGLUniformLocation | null = null;
-    private blurredTextureLocation: WebGLUniformLocation | null = null;
-    private maskTextureLocation: WebGLUniformLocation | null = null;
+    private readonly pipeline: WebGlBlurPipeline;
     private unavailable = false;
 
-    constructor(private readonly gl: WebGL2RenderingContext) {}
+    constructor(
+        private readonly gl: WebGL2RenderingContext,
+        canvas: HTMLCanvasElement,
+    ) {
+        this.pipeline = new WebGlBlurPipeline({ canvas, gl, restoreState: true });
+    }
 
     public draw(source: CanvasImageSource, mask: MPMask, width: number, height: number, blurAmount: number): boolean {
         if (this.unavailable || !width || !height || width <= 0 || height <= 0 || this.gl.isContextLost()) {
@@ -64,25 +42,24 @@ export class TasksVisionBlurCompositor {
             return false;
         }
 
-        const blurSize = getWebGlBlurSize(width, height, blurAmount);
-        if (!blurSize.width || !blurSize.height) {
-            return false;
-        }
-
         try {
-            this.ensurePrograms();
-            this.ensureBuffers();
-            this.ensureTextures(blurSize.width, blurSize.height);
+            const success = this.pipeline.drawCompositeWithTextureMask(
+                source,
+                mask.getAsWebGLTexture(),
+                width,
+                height,
+                blurAmount,
+            );
 
-            const blurredTexture = this.renderBlurredTexture(source, blurSize, blurAmount);
-            this.drawCompositePass(this.sourceTexture!, blurredTexture, mask.getAsWebGLTexture(), width, height);
-            this.gl.flush();
-            logSelectedBackend();
-            return true;
+            if (success) {
+                logSelectedBackend();
+            }
+
+            return success;
         } catch (error) {
             if (!this.gl.isContextLost()) {
                 this.unavailable = true;
-                this.close();
+                this.pipeline.close();
             }
             logFailure(error);
             return false;
@@ -90,351 +67,6 @@ export class TasksVisionBlurCompositor {
     }
 
     public close(): void {
-        const gl = this.gl;
-        if (gl.isContextLost()) {
-            this.clearReferences();
-            return;
-        }
-
-        if (this.blurProgram) {
-            gl.deleteProgram(this.blurProgram);
-        }
-        if (this.compositeProgram) {
-            gl.deleteProgram(this.compositeProgram);
-        }
-        if (this.positionBuffer) {
-            gl.deleteBuffer(this.positionBuffer);
-        }
-        if (this.texCoordBuffer) {
-            gl.deleteBuffer(this.texCoordBuffer);
-        }
-        if (this.sourceTexture) {
-            gl.deleteTexture(this.sourceTexture);
-        }
-
-        this.releaseFramebufferResources();
-        this.clearReferences();
-    }
-
-    private ensurePrograms(): void {
-        if (!this.blurProgram) {
-            this.blurProgram = this.createProgram(BLUR_VERTEX_SHADER, BLUR_FRAGMENT_SHADER, "blur");
-            this.blurPositionLocation = this.gl.getAttribLocation(this.blurProgram, "a_position");
-            this.blurTexCoordLocation = this.gl.getAttribLocation(this.blurProgram, "a_texCoord");
-            this.blurTextureLocation = this.gl.getUniformLocation(this.blurProgram, "u_texture");
-            this.texelOffsetLocation = this.gl.getUniformLocation(this.blurProgram, "u_texelOffset");
-            this.radiusLocation = this.gl.getUniformLocation(this.blurProgram, "u_radius");
-
-            if (
-                this.blurPositionLocation < 0 ||
-                this.blurTexCoordLocation < 0 ||
-                !this.blurTextureLocation ||
-                !this.texelOffsetLocation ||
-                !this.radiusLocation
-            ) {
-                throw new Error("Unable to resolve Tasks Vision blur shader locations");
-            }
-        }
-
-        if (!this.compositeProgram) {
-            this.compositeProgram = this.createProgram(BLUR_VERTEX_SHADER, COMPOSITE_FRAGMENT_SHADER, "composite");
-            this.compositePositionLocation = this.gl.getAttribLocation(this.compositeProgram, "a_position");
-            this.compositeTexCoordLocation = this.gl.getAttribLocation(this.compositeProgram, "a_texCoord");
-            this.sharpTextureLocation = this.gl.getUniformLocation(this.compositeProgram, "u_sharpTexture");
-            this.blurredTextureLocation = this.gl.getUniformLocation(this.compositeProgram, "u_blurredTexture");
-            this.maskTextureLocation = this.gl.getUniformLocation(this.compositeProgram, "u_maskTexture");
-
-            if (
-                this.compositePositionLocation < 0 ||
-                this.compositeTexCoordLocation < 0 ||
-                !this.sharpTextureLocation ||
-                !this.blurredTextureLocation ||
-                !this.maskTextureLocation
-            ) {
-                throw new Error("Unable to resolve Tasks Vision blur composite shader locations");
-            }
-        }
-    }
-
-    private createProgram(vertexSource: string, fragmentSource: string, label: string): WebGLProgram {
-        const gl = this.gl;
-        const vertexShader = this.createShader(gl.VERTEX_SHADER, vertexSource, label);
-        const fragmentShader = this.createShader(gl.FRAGMENT_SHADER, fragmentSource, label);
-        const program = gl.createProgram();
-
-        if (!program) {
-            throw new Error(`Unable to create Tasks Vision ${label} program`);
-        }
-
-        gl.attachShader(program, vertexShader);
-        gl.attachShader(program, fragmentShader);
-        gl.linkProgram(program);
-
-        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-            const message = gl.getProgramInfoLog(program) ?? `Unknown Tasks Vision ${label} program link error`;
-            gl.deleteProgram(program);
-            gl.deleteShader(vertexShader);
-            gl.deleteShader(fragmentShader);
-            throw new Error(message);
-        }
-
-        gl.deleteShader(vertexShader);
-        gl.deleteShader(fragmentShader);
-        return program;
-    }
-
-    private createShader(type: number, source: string, label: string): WebGLShader {
-        const gl = this.gl;
-        const shader = gl.createShader(type);
-        if (!shader) {
-            throw new Error(`Unable to create Tasks Vision ${label} shader`);
-        }
-
-        gl.shaderSource(shader, source);
-        gl.compileShader(shader);
-
-        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-            const message = gl.getShaderInfoLog(shader) ?? `Unknown Tasks Vision ${label} shader compile error`;
-            gl.deleteShader(shader);
-            throw new Error(message);
-        }
-
-        return shader;
-    }
-
-    private ensureBuffers(): void {
-        if (this.positionBuffer && this.texCoordBuffer) {
-            return;
-        }
-
-        this.positionBuffer = this.createBuffer(new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]));
-        this.texCoordBuffer = this.createBuffer(new Float32Array([0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0]));
-    }
-
-    private createBuffer(data: Float32Array): WebGLBuffer {
-        const gl = this.gl;
-        const buffer = gl.createBuffer();
-        if (!buffer) {
-            throw new Error("Unable to create Tasks Vision blur buffer");
-        }
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-        gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
-        return buffer;
-    }
-
-    private ensureTextures(width: number, height: number): void {
-        if (!this.sourceTexture) {
-            this.sourceTexture = this.createTexture();
-        }
-
-        if (
-            this.firstPassTexture &&
-            this.secondPassTexture &&
-            this.firstPassFramebuffer &&
-            this.secondPassFramebuffer &&
-            this.framebufferWidth === width &&
-            this.framebufferHeight === height
-        ) {
-            return;
-        }
-
-        this.releaseFramebufferResources();
-
-        const firstPass = this.createFramebufferTexture(width, height);
-        const secondPass = this.createFramebufferTexture(width, height);
-
-        this.firstPassTexture = firstPass.texture;
-        this.firstPassFramebuffer = firstPass.framebuffer;
-        this.secondPassTexture = secondPass.texture;
-        this.secondPassFramebuffer = secondPass.framebuffer;
-        this.framebufferWidth = width;
-        this.framebufferHeight = height;
-    }
-
-    private createTexture(): WebGLTexture {
-        const texture = this.gl.createTexture();
-        if (!texture) {
-            throw new Error("Unable to create Tasks Vision blur texture");
-        }
-
-        this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
-        this.configureTexture();
-        return texture;
-    }
-
-    private createFramebufferTexture(
-        width: number,
-        height: number,
-    ): {
-        texture: WebGLTexture;
-        framebuffer: WebGLFramebuffer;
-    } {
-        const gl = this.gl;
-        const texture = this.createTexture();
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-
-        const framebuffer = gl.createFramebuffer();
-        if (!framebuffer) {
-            gl.deleteTexture(texture);
-            throw new Error("Unable to create Tasks Vision blur framebuffer");
-        }
-
-        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
-        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
-
-        if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
-            gl.deleteTexture(texture);
-            gl.deleteFramebuffer(framebuffer);
-            throw new Error("Tasks Vision blur framebuffer is incomplete");
-        }
-
-        return { texture, framebuffer };
-    }
-
-    private configureTexture(): void {
-        const gl = this.gl;
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-    }
-
-    private renderBlurredTexture(
-        source: CanvasImageSource,
-        blurSize: { width: number; height: number; scale: number },
-        blurAmount: number,
-    ): WebGLTexture {
-        const gl = this.gl;
-        const radius = getWebGlBlurRadius(blurAmount, blurSize.scale);
-
-        gl.viewport(0, 0, blurSize.width, blurSize.height);
-        gl.disable(gl.DEPTH_TEST);
-        gl.disable(gl.BLEND);
-        gl.clearColor(0, 0, 0, 1);
-        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-        gl.activeTexture(gl.TEXTURE0);
-        gl.bindTexture(gl.TEXTURE_2D, this.sourceTexture);
-        this.configureTexture();
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source as TexImageSource);
-
-        let sourceTexture = this.sourceTexture!;
-        for (let iteration = 0; iteration < BLUR_ITERATIONS; iteration++) {
-            this.drawBlurPass(sourceTexture, this.firstPassFramebuffer, 1 / blurSize.width, 0, radius);
-            this.drawBlurPass(this.firstPassTexture!, this.secondPassFramebuffer, 0, 1 / blurSize.height, radius);
-            sourceTexture = this.secondPassTexture!;
-        }
-
-        return sourceTexture;
-    }
-
-    private drawBlurPass(
-        texture: WebGLTexture,
-        framebuffer: WebGLFramebuffer | null,
-        texelOffsetX: number,
-        texelOffsetY: number,
-        radius: number,
-    ): void {
-        const gl = this.gl;
-        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
-        gl.clear(gl.COLOR_BUFFER_BIT);
-        gl.useProgram(this.blurProgram);
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
-        gl.enableVertexAttribArray(this.blurPositionLocation);
-        gl.vertexAttribPointer(this.blurPositionLocation, 2, gl.FLOAT, false, 0, 0);
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
-        gl.enableVertexAttribArray(this.blurTexCoordLocation);
-        gl.vertexAttribPointer(this.blurTexCoordLocation, 2, gl.FLOAT, false, 0, 0);
-
-        gl.activeTexture(gl.TEXTURE0);
-        gl.bindTexture(gl.TEXTURE_2D, texture);
-        gl.uniform1i(this.blurTextureLocation, 0);
-        gl.uniform2f(this.texelOffsetLocation, texelOffsetX, texelOffsetY);
-        gl.uniform1f(this.radiusLocation, radius);
-        gl.drawArrays(gl.TRIANGLES, 0, 6);
-    }
-
-    private drawCompositePass(
-        sharpTexture: WebGLTexture,
-        blurredTexture: WebGLTexture,
-        maskTexture: WebGLTexture,
-        width: number,
-        height: number,
-    ): void {
-        const gl = this.gl;
-        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-        gl.viewport(0, 0, width, height);
-        gl.disable(gl.DEPTH_TEST);
-        gl.disable(gl.BLEND);
-        gl.clear(gl.COLOR_BUFFER_BIT);
-        gl.useProgram(this.compositeProgram);
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
-        gl.enableVertexAttribArray(this.compositePositionLocation);
-        gl.vertexAttribPointer(this.compositePositionLocation, 2, gl.FLOAT, false, 0, 0);
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
-        gl.enableVertexAttribArray(this.compositeTexCoordLocation);
-        gl.vertexAttribPointer(this.compositeTexCoordLocation, 2, gl.FLOAT, false, 0, 0);
-
-        gl.activeTexture(gl.TEXTURE0);
-        gl.bindTexture(gl.TEXTURE_2D, sharpTexture);
-        gl.uniform1i(this.sharpTextureLocation, 0);
-
-        gl.activeTexture(gl.TEXTURE0 + 1);
-        gl.bindTexture(gl.TEXTURE_2D, blurredTexture);
-        gl.uniform1i(this.blurredTextureLocation, 1);
-
-        gl.activeTexture(gl.TEXTURE0 + 2);
-        gl.bindTexture(gl.TEXTURE_2D, maskTexture);
-        gl.uniform1i(this.maskTextureLocation, 2);
-
-        gl.drawArrays(gl.TRIANGLES, 0, 6);
-    }
-
-    private releaseFramebufferResources(): void {
-        const gl = this.gl;
-
-        if (this.firstPassTexture) {
-            gl.deleteTexture(this.firstPassTexture);
-            this.firstPassTexture = null;
-        }
-        if (this.secondPassTexture) {
-            gl.deleteTexture(this.secondPassTexture);
-            this.secondPassTexture = null;
-        }
-        if (this.firstPassFramebuffer) {
-            gl.deleteFramebuffer(this.firstPassFramebuffer);
-            this.firstPassFramebuffer = null;
-        }
-        if (this.secondPassFramebuffer) {
-            gl.deleteFramebuffer(this.secondPassFramebuffer);
-            this.secondPassFramebuffer = null;
-        }
-
-        this.framebufferWidth = 0;
-        this.framebufferHeight = 0;
-    }
-
-    private clearReferences(): void {
-        this.blurProgram = null;
-        this.compositeProgram = null;
-        this.positionBuffer = null;
-        this.texCoordBuffer = null;
-        this.sourceTexture = null;
-        this.firstPassTexture = null;
-        this.secondPassTexture = null;
-        this.firstPassFramebuffer = null;
-        this.secondPassFramebuffer = null;
-        this.blurTextureLocation = null;
-        this.texelOffsetLocation = null;
-        this.radiusLocation = null;
-        this.sharpTextureLocation = null;
-        this.blurredTextureLocation = null;
-        this.maskTextureLocation = null;
-        this.framebufferWidth = 0;
-        this.framebufferHeight = 0;
+        this.pipeline.close();
     }
 }

--- a/play/src/front/WebRtc/BackgroundProcessor/WebGlBlurPipeline.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/WebGlBlurPipeline.ts
@@ -15,15 +15,8 @@ type WebGlBlurPipelineOptions = {
 };
 
 type WebGlStateSnapshot = {
-    framebuffer: WebGLFramebuffer | null;
-    arrayBuffer: WebGLBuffer | null;
-    currentProgram: WebGLProgram | null;
-    viewport: Int32Array;
-    activeTexture: number;
-    textureBindings: { unit: number; texture: WebGLTexture | null }[];
     blendEnabled: boolean;
     depthTestEnabled: boolean;
-    unpackFlipY: boolean;
 };
 
 type KawaseFramebuffer = {
@@ -460,28 +453,15 @@ export class WebGlBlurPipeline {
 
     private captureState(): WebGlStateSnapshot {
         const gl = this.gl;
-        const activeTexture = gl.getParameter(gl.ACTIVE_TEXTURE) as number;
-        const textureUnits = [gl.TEXTURE0, gl.TEXTURE0 + 1, gl.TEXTURE0 + 2];
-        const textureBindings = textureUnits.map((unit) => {
-            gl.activeTexture(unit);
-            return {
-                unit,
-                texture: gl.getParameter(gl.TEXTURE_BINDING_2D) as WebGLTexture | null,
-            };
-        });
 
-        gl.activeTexture(activeTexture);
-
+        // Only the BLEND/DEPTH_TEST enable bits are read back: gl.isEnabled is a
+        // cheap client-side query, whereas the binding getters (FRAMEBUFFER_BINDING,
+        // CURRENT_PROGRAM, TEXTURE_BINDING_2D, VIEWPORT, ...) force a driver
+        // round-trip every frame. Those bindings are reset to neutral defaults in
+        // restoreCapturedState() instead of being captured and replayed.
         return {
-            framebuffer: gl.getParameter(gl.FRAMEBUFFER_BINDING) as WebGLFramebuffer | null,
-            arrayBuffer: gl.getParameter(gl.ARRAY_BUFFER_BINDING) as WebGLBuffer | null,
-            currentProgram: gl.getParameter(gl.CURRENT_PROGRAM) as WebGLProgram | null,
-            viewport: gl.getParameter(gl.VIEWPORT) as Int32Array,
-            activeTexture,
-            textureBindings,
             blendEnabled: gl.isEnabled(gl.BLEND),
             depthTestEnabled: gl.isEnabled(gl.DEPTH_TEST),
-            unpackFlipY: gl.getParameter(gl.UNPACK_FLIP_Y_WEBGL) as boolean,
         };
     }
 
@@ -493,18 +473,23 @@ export class WebGlBlurPipeline {
             return;
         }
 
-        for (const binding of snapshot.textureBindings) {
-            gl.activeTexture(binding.unit);
-            gl.bindTexture(gl.TEXTURE_2D, binding.texture);
+        // Reset the state this pipeline mutates back to a clean baseline rather than
+        // reading the previous values back each frame. MediaPipe (the only other
+        // consumer of this shared context) re-specifies its own program, buffers,
+        // textures and viewport before every draw, so neutral defaults are enough.
+        for (let unit = 0; unit < 3; unit++) {
+            gl.activeTexture(gl.TEXTURE0 + unit);
+            gl.bindTexture(gl.TEXTURE_2D, null);
         }
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+        gl.useProgram(null);
+        gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
 
-        gl.activeTexture(snapshot.activeTexture);
-        gl.bindFramebuffer(gl.FRAMEBUFFER, snapshot.framebuffer);
-        gl.bindBuffer(gl.ARRAY_BUFFER, snapshot.arrayBuffer);
-        gl.useProgram(snapshot.currentProgram);
-        gl.viewport(snapshot.viewport[0], snapshot.viewport[1], snapshot.viewport[2], snapshot.viewport[3]);
-        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, snapshot.unpackFlipY);
-
+        // BLEND/DEPTH_TEST are restored to their captured values since MediaPipe may
+        // rely on its own enable state persisting across our draw.
         if (snapshot.blendEnabled) {
             gl.enable(gl.BLEND);
         } else {

--- a/play/src/front/WebRtc/BackgroundProcessor/WebGlBlurPipeline.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/WebGlBlurPipeline.ts
@@ -745,7 +745,8 @@ export class WebGlBlurPipeline {
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
         gl.activeTexture(gl.TEXTURE0 + textureUnit);
         gl.bindTexture(gl.TEXTURE_2D, texture);
-        this.configureTexture();
+        // Texture parameters are already set once in createTexture() and persist on
+        // the texture object, so there is no need to re-apply them on every upload.
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source as TexImageSource);
     }
 

--- a/play/src/front/WebRtc/BackgroundProcessor/WebGlBlurPipeline.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/WebGlBlurPipeline.ts
@@ -1,0 +1,1004 @@
+export type WebGlBlurContext = WebGLRenderingContext | WebGL2RenderingContext;
+
+export const BLUR_ITERATIONS = 2;
+
+const WEBGL_BLUR_BASE_MAX_SIDE = 384;
+const WEBGL_MIN_BLUR_MAX_SIDE = 288;
+const WEBGL_BLUR_MAX_RADIUS = 18;
+const DUAL_KAWASE_MIN_SIDE = 24;
+
+type WebGlBlurPipelineOptions = {
+    canvas: HTMLCanvasElement;
+    gl: WebGlBlurContext;
+    ownsContext?: boolean;
+    restoreState?: boolean;
+};
+
+type WebGlStateSnapshot = {
+    framebuffer: WebGLFramebuffer | null;
+    arrayBuffer: WebGLBuffer | null;
+    currentProgram: WebGLProgram | null;
+    viewport: Int32Array;
+    activeTexture: number;
+    textureBindings: { unit: number; texture: WebGLTexture | null }[];
+    blendEnabled: boolean;
+    depthTestEnabled: boolean;
+    unpackFlipY: boolean;
+};
+
+type KawaseFramebuffer = {
+    texture: WebGLTexture;
+    framebuffer: WebGLFramebuffer;
+    width: number;
+    height: number;
+};
+
+export function getWebGlBlurSize(
+    width: number,
+    height: number,
+    blurAmount: number,
+): { width: number; height: number; scale: number } {
+    const normalizedBlurAmount = clamp(blurAmount, 0, 50);
+    const maxRenderSide = Math.max(WEBGL_MIN_BLUR_MAX_SIDE, WEBGL_BLUR_BASE_MAX_SIDE - normalizedBlurAmount * 1.4);
+    const maxSide = Math.max(width, height);
+
+    if (maxSide <= 0) {
+        return { width: 0, height: 0, scale: 0 };
+    }
+
+    const scale = Math.min(1, maxRenderSide / maxSide);
+    return {
+        width: Math.max(1, Math.round(width * scale)),
+        height: Math.max(1, Math.round(height * scale)),
+        scale,
+    };
+}
+
+export function getWebGlBlurRadius(blurAmount: number, scale: number): number {
+    if (blurAmount <= 0 || scale <= 0) {
+        return 0;
+    }
+
+    return Math.max(1, Math.min(WEBGL_BLUR_MAX_RADIUS, Math.round(blurAmount * scale * 1.1)));
+}
+
+export function getDualKawaseBlurLevels(blurAmount: number): number {
+    const normalizedBlurAmount = clamp(blurAmount, 0, 50);
+    if (normalizedBlurAmount <= 10) {
+        return 2;
+    }
+    if (normalizedBlurAmount <= 25) {
+        return 3;
+    }
+    return 4;
+}
+
+export function getDualKawaseBlurOffset(blurAmount: number): number {
+    const normalizedBlurAmount = clamp(blurAmount, 0, 50);
+    if (normalizedBlurAmount <= 10) {
+        return 0.4 + normalizedBlurAmount * 0.015;
+    }
+    if (normalizedBlurAmount <= 25) {
+        return 0.55 + (normalizedBlurAmount - 10) * 0.015;
+    }
+    return 0.775 + (normalizedBlurAmount - 25) * 0.009;
+}
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
+}
+
+function getNextKawaseSize(width: number, height: number): { width: number; height: number } {
+    const nextWidth = Math.max(1, Math.round(width / 2));
+    const nextHeight = Math.max(1, Math.round(height / 2));
+    const smallestSide = Math.min(nextWidth, nextHeight);
+
+    if (smallestSide >= DUAL_KAWASE_MIN_SIDE) {
+        return { width: nextWidth, height: nextHeight };
+    }
+
+    const scale = DUAL_KAWASE_MIN_SIDE / Math.max(1, smallestSide);
+    return {
+        width: Math.max(DUAL_KAWASE_MIN_SIDE, Math.round(nextWidth * scale)),
+        height: Math.max(DUAL_KAWASE_MIN_SIDE, Math.round(nextHeight * scale)),
+    };
+}
+
+export const BLUR_VERTEX_SHADER = `
+attribute vec2 a_position;
+attribute vec2 a_texCoord;
+
+varying vec2 v_texCoord;
+
+void main() {
+    gl_Position = vec4(a_position, 0.0, 1.0);
+    v_texCoord = a_texCoord;
+}
+`;
+
+export const BLUR_FRAGMENT_SHADER = `
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_texelOffset;
+uniform float u_radius;
+
+varying vec2 v_texCoord;
+
+void main() {
+    float centerWeight = max(u_radius + 1.0, 1.0);
+    vec4 color = texture2D(u_texture, v_texCoord) * centerWeight;
+    float weight = centerWeight;
+
+    for (int i = 1; i <= 18; i++) {
+        float sampleOffset = float(i);
+        float enabled = step(sampleOffset, u_radius);
+        float sampleWeight = (u_radius + 1.0 - sampleOffset) * enabled;
+        vec2 offset = u_texelOffset * sampleOffset;
+        color += texture2D(u_texture, v_texCoord + offset) * sampleWeight;
+        color += texture2D(u_texture, v_texCoord - offset) * sampleWeight;
+        weight += sampleWeight * 2.0;
+    }
+
+    gl_FragColor = color / weight;
+}
+`;
+
+const DUAL_KAWASE_DOWN_FRAGMENT_SHADER = `
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_texelSize;
+uniform float u_offset;
+
+varying vec2 v_texCoord;
+
+void main() {
+    vec2 offset = u_texelSize * u_offset;
+    vec4 color = texture2D(u_texture, v_texCoord) * 4.0;
+
+    color += texture2D(u_texture, v_texCoord + vec2(-offset.x, -offset.y));
+    color += texture2D(u_texture, v_texCoord + vec2( offset.x, -offset.y));
+    color += texture2D(u_texture, v_texCoord + vec2(-offset.x,  offset.y));
+    color += texture2D(u_texture, v_texCoord + vec2( offset.x,  offset.y));
+
+    gl_FragColor = color * 0.125;
+}
+`;
+
+const DUAL_KAWASE_UP_FRAGMENT_SHADER = `
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec2 u_texelSize;
+uniform float u_offset;
+
+varying vec2 v_texCoord;
+
+void main() {
+    vec2 offset = u_texelSize * u_offset;
+    vec4 color = vec4(0.0);
+
+    color += texture2D(u_texture, v_texCoord + vec2(-offset.x * 2.0, 0.0));
+    color += texture2D(u_texture, v_texCoord + vec2(-offset.x,  offset.y)) * 2.0;
+    color += texture2D(u_texture, v_texCoord + vec2(0.0,  offset.y * 2.0));
+    color += texture2D(u_texture, v_texCoord + vec2( offset.x,  offset.y)) * 2.0;
+    color += texture2D(u_texture, v_texCoord + vec2( offset.x * 2.0, 0.0));
+    color += texture2D(u_texture, v_texCoord + vec2( offset.x, -offset.y)) * 2.0;
+    color += texture2D(u_texture, v_texCoord + vec2(0.0, -offset.y * 2.0));
+    color += texture2D(u_texture, v_texCoord + vec2(-offset.x, -offset.y)) * 2.0;
+
+    gl_FragColor = color / 12.0;
+}
+`;
+
+export const COMPOSITE_FRAGMENT_SHADER = `
+precision mediump float;
+
+uniform sampler2D u_sharpTexture;
+uniform sampler2D u_blurredTexture;
+uniform sampler2D u_maskTexture;
+uniform float u_maskAlphaWeight;
+uniform vec2 u_maskTexelSize;
+
+varying vec2 v_texCoord;
+
+float readMask(vec2 texCoord) {
+    vec4 maskColor = texture2D(u_maskTexture, texCoord);
+    return mix(maskColor.r, maskColor.a, u_maskAlphaWeight);
+}
+
+void main() {
+    vec2 featherOffset = u_maskTexelSize * 1.15;
+    float confidence = readMask(v_texCoord) * 0.36;
+    confidence += readMask(v_texCoord + vec2( featherOffset.x, 0.0)) * 0.1;
+    confidence += readMask(v_texCoord + vec2(-featherOffset.x, 0.0)) * 0.1;
+    confidence += readMask(v_texCoord + vec2(0.0,  featherOffset.y)) * 0.1;
+    confidence += readMask(v_texCoord + vec2(0.0, -featherOffset.y)) * 0.1;
+    confidence += readMask(v_texCoord + vec2( featherOffset.x,  featherOffset.y)) * 0.06;
+    confidence += readMask(v_texCoord + vec2(-featherOffset.x,  featherOffset.y)) * 0.06;
+    confidence += readMask(v_texCoord + vec2( featherOffset.x, -featherOffset.y)) * 0.06;
+    confidence += readMask(v_texCoord + vec2(-featherOffset.x, -featherOffset.y)) * 0.06;
+
+    float foregroundAlpha = smoothstep(0.24, 0.62, confidence);
+    vec4 blurredBackground = texture2D(u_blurredTexture, v_texCoord);
+    vec4 sharpForeground = texture2D(u_sharpTexture, v_texCoord);
+
+    gl_FragColor = mix(blurredBackground, sharpForeground, foregroundAlpha);
+}
+`;
+
+export class WebGlBlurPipeline {
+    private downsampleProgram: WebGLProgram | null = null;
+    private upsampleProgram: WebGLProgram | null = null;
+    private compositeProgram: WebGLProgram | null = null;
+    private positionBuffer: WebGLBuffer | null = null;
+    private texCoordBuffer: WebGLBuffer | null = null;
+    private internalTexCoordBuffer: WebGLBuffer | null = null;
+    private sourceTexture: WebGLTexture | null = null;
+    private maskTexture: WebGLTexture | null = null;
+    private finalBlurFramebuffer: KawaseFramebuffer | null = null;
+    private kawaseFramebuffers: KawaseFramebuffer[] = [];
+    private framebufferWidth = 0;
+    private framebufferHeight = 0;
+    private framebufferLevels = 0;
+    private downsamplePositionLocation = -1;
+    private downsampleTexCoordLocation = -1;
+    private downsampleTextureLocation: WebGLUniformLocation | null = null;
+    private downsampleTexelSizeLocation: WebGLUniformLocation | null = null;
+    private downsampleOffsetLocation: WebGLUniformLocation | null = null;
+    private upsamplePositionLocation = -1;
+    private upsampleTexCoordLocation = -1;
+    private upsampleTextureLocation: WebGLUniformLocation | null = null;
+    private upsampleTexelSizeLocation: WebGLUniformLocation | null = null;
+    private upsampleOffsetLocation: WebGLUniformLocation | null = null;
+    private compositePositionLocation = -1;
+    private compositeTexCoordLocation = -1;
+    private sharpTextureLocation: WebGLUniformLocation | null = null;
+    private blurredTextureLocation: WebGLUniformLocation | null = null;
+    private compositeMaskTextureLocation: WebGLUniformLocation | null = null;
+    private maskAlphaWeightLocation: WebGLUniformLocation | null = null;
+    private maskTexelSizeLocation: WebGLUniformLocation | null = null;
+    private contextLost = false;
+
+    private readonly canvas: HTMLCanvasElement;
+    private readonly gl: WebGlBlurContext;
+    private readonly ownsContext: boolean;
+    private readonly restoreState: boolean;
+
+    private readonly handleContextLost = (event: Event): void => {
+        event.preventDefault();
+        this.contextLost = true;
+        this.releaseResources();
+    };
+
+    private readonly handleContextRestored = (): void => {
+        this.contextLost = false;
+        this.releaseResources();
+    };
+
+    constructor(options: WebGlBlurPipelineOptions) {
+        this.canvas = options.canvas;
+        this.gl = options.gl;
+        this.ownsContext = options.ownsContext ?? false;
+        this.restoreState = options.restoreState ?? false;
+
+        if (this.ownsContext) {
+            this.canvas.addEventListener("webglcontextlost", this.handleContextLost, false);
+            this.canvas.addEventListener("webglcontextrestored", this.handleContextRestored, false);
+        }
+    }
+
+    public drawBlurredImage(
+        source: CanvasImageSource,
+        width: number,
+        height: number,
+        blurAmount: number,
+    ): HTMLCanvasElement | null {
+        if (this.isUnavailable()) {
+            return null;
+        }
+
+        const blurSize = getWebGlBlurSize(width, height, blurAmount);
+        if (!blurSize.width || !blurSize.height) {
+            return null;
+        }
+
+        if (this.canvas.width !== blurSize.width || this.canvas.height !== blurSize.height) {
+            this.canvas.width = blurSize.width;
+            this.canvas.height = blurSize.height;
+        }
+
+        return this.withOptionalStateRestore(() => {
+            const blurLevels = getDualKawaseBlurLevels(blurAmount);
+            this.ensureDualKawasePrograms();
+            this.ensureBuffers();
+            this.ensureTextures(blurSize.width, blurSize.height, blurLevels);
+
+            const blurredTexture = this.renderBlurredTexture(
+                source,
+                blurSize,
+                blurLevels,
+                getDualKawaseBlurOffset(blurAmount),
+            );
+            this.drawKawasePass(
+                this.upsampleProgram,
+                this.upsamplePositionLocation,
+                this.upsampleTexCoordLocation,
+                this.upsampleTextureLocation,
+                this.upsampleTexelSizeLocation,
+                this.upsampleOffsetLocation,
+                blurredTexture.texture,
+                null,
+                blurSize.width,
+                blurSize.height,
+                blurredTexture.width,
+                blurredTexture.height,
+                0,
+                true,
+            );
+            this.gl.flush();
+
+            return this.canvas;
+        });
+    }
+
+    public drawCompositeWithCanvasMask(
+        source: CanvasImageSource,
+        segmentationMask: CanvasImageSource,
+        width: number,
+        height: number,
+        blurAmount: number,
+    ): HTMLCanvasElement | null {
+        if (this.isUnavailable()) {
+            return null;
+        }
+
+        const blurSize = getWebGlBlurSize(width, height, blurAmount);
+        if (!blurSize.width || !blurSize.height) {
+            return null;
+        }
+
+        if (this.canvas.width !== width || this.canvas.height !== height) {
+            this.canvas.width = width;
+            this.canvas.height = height;
+        }
+
+        return this.withOptionalStateRestore(() => {
+            const blurLevels = getDualKawaseBlurLevels(blurAmount);
+            this.ensureDualKawasePrograms();
+            this.ensureCompositeProgram();
+            this.ensureBuffers();
+            this.ensureTextures(blurSize.width, blurSize.height, blurLevels);
+            this.ensureMaskTexture();
+
+            const blurredTexture = this.renderBlurredTexture(
+                source,
+                blurSize,
+                blurLevels,
+                getDualKawaseBlurOffset(blurAmount),
+            );
+            this.uploadTexture(this.maskTexture!, segmentationMask, 2);
+            this.drawCompositePass(this.sourceTexture!, blurredTexture.texture, this.maskTexture!, width, height, 1);
+            this.gl.flush();
+
+            return this.canvas;
+        });
+    }
+
+    public drawCompositeWithTextureMask(
+        source: CanvasImageSource,
+        maskTexture: WebGLTexture,
+        width: number,
+        height: number,
+        blurAmount: number,
+    ): boolean {
+        if (this.isUnavailable()) {
+            return false;
+        }
+
+        const blurSize = getWebGlBlurSize(width, height, blurAmount);
+        if (!blurSize.width || !blurSize.height) {
+            return false;
+        }
+
+        return this.withOptionalStateRestore(() => {
+            const blurLevels = getDualKawaseBlurLevels(blurAmount);
+            this.ensureDualKawasePrograms();
+            this.ensureCompositeProgram();
+            this.ensureBuffers();
+            this.ensureTextures(blurSize.width, blurSize.height, blurLevels);
+
+            const blurredTexture = this.renderBlurredTexture(
+                source,
+                blurSize,
+                blurLevels,
+                getDualKawaseBlurOffset(blurAmount),
+            );
+            this.drawCompositePass(this.sourceTexture!, blurredTexture.texture, maskTexture, width, height, 0);
+            this.gl.flush();
+
+            return true;
+        });
+    }
+
+    public close(): void {
+        if (this.ownsContext) {
+            this.canvas.removeEventListener("webglcontextlost", this.handleContextLost, false);
+            this.canvas.removeEventListener("webglcontextrestored", this.handleContextRestored, false);
+        }
+
+        this.releaseResources();
+
+        if (this.ownsContext) {
+            this.canvas.width = 0;
+            this.canvas.height = 0;
+        }
+    }
+
+    private isUnavailable(): boolean {
+        if (this.contextLost || this.gl.isContextLost()) {
+            this.contextLost = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    private withOptionalStateRestore<T>(callback: () => T): T {
+        if (!this.restoreState) {
+            return callback();
+        }
+
+        const snapshot = this.captureState();
+        try {
+            return callback();
+        } finally {
+            this.restoreCapturedState(snapshot);
+        }
+    }
+
+    private captureState(): WebGlStateSnapshot {
+        const gl = this.gl;
+        const activeTexture = gl.getParameter(gl.ACTIVE_TEXTURE) as number;
+        const textureUnits = [gl.TEXTURE0, gl.TEXTURE0 + 1, gl.TEXTURE0 + 2];
+        const textureBindings = textureUnits.map((unit) => {
+            gl.activeTexture(unit);
+            return {
+                unit,
+                texture: gl.getParameter(gl.TEXTURE_BINDING_2D) as WebGLTexture | null,
+            };
+        });
+
+        gl.activeTexture(activeTexture);
+
+        return {
+            framebuffer: gl.getParameter(gl.FRAMEBUFFER_BINDING) as WebGLFramebuffer | null,
+            arrayBuffer: gl.getParameter(gl.ARRAY_BUFFER_BINDING) as WebGLBuffer | null,
+            currentProgram: gl.getParameter(gl.CURRENT_PROGRAM) as WebGLProgram | null,
+            viewport: gl.getParameter(gl.VIEWPORT) as Int32Array,
+            activeTexture,
+            textureBindings,
+            blendEnabled: gl.isEnabled(gl.BLEND),
+            depthTestEnabled: gl.isEnabled(gl.DEPTH_TEST),
+            unpackFlipY: gl.getParameter(gl.UNPACK_FLIP_Y_WEBGL) as boolean,
+        };
+    }
+
+    private restoreCapturedState(snapshot: WebGlStateSnapshot): void {
+        const gl = this.gl;
+
+        if (gl.isContextLost()) {
+            this.contextLost = true;
+            return;
+        }
+
+        for (const binding of snapshot.textureBindings) {
+            gl.activeTexture(binding.unit);
+            gl.bindTexture(gl.TEXTURE_2D, binding.texture);
+        }
+
+        gl.activeTexture(snapshot.activeTexture);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, snapshot.framebuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, snapshot.arrayBuffer);
+        gl.useProgram(snapshot.currentProgram);
+        gl.viewport(snapshot.viewport[0], snapshot.viewport[1], snapshot.viewport[2], snapshot.viewport[3]);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, snapshot.unpackFlipY);
+
+        if (snapshot.blendEnabled) {
+            gl.enable(gl.BLEND);
+        } else {
+            gl.disable(gl.BLEND);
+        }
+
+        if (snapshot.depthTestEnabled) {
+            gl.enable(gl.DEPTH_TEST);
+        } else {
+            gl.disable(gl.DEPTH_TEST);
+        }
+    }
+
+    private ensureDualKawasePrograms(): void {
+        if (!this.downsampleProgram) {
+            const program = this.createProgram(
+                BLUR_VERTEX_SHADER,
+                DUAL_KAWASE_DOWN_FRAGMENT_SHADER,
+                "dual kawase down",
+            );
+            this.downsampleProgram = program;
+            this.downsamplePositionLocation = this.gl.getAttribLocation(program, "a_position");
+            this.downsampleTexCoordLocation = this.gl.getAttribLocation(program, "a_texCoord");
+            this.downsampleTextureLocation = this.gl.getUniformLocation(program, "u_texture");
+            this.downsampleTexelSizeLocation = this.gl.getUniformLocation(program, "u_texelSize");
+            this.downsampleOffsetLocation = this.gl.getUniformLocation(program, "u_offset");
+
+            if (
+                this.downsamplePositionLocation < 0 ||
+                this.downsampleTexCoordLocation < 0 ||
+                !this.downsampleTextureLocation ||
+                !this.downsampleTexelSizeLocation ||
+                !this.downsampleOffsetLocation
+            ) {
+                throw new Error("Unable to resolve WebGL Dual Kawase downsample shader locations");
+            }
+        }
+
+        if (!this.upsampleProgram) {
+            const program = this.createProgram(BLUR_VERTEX_SHADER, DUAL_KAWASE_UP_FRAGMENT_SHADER, "dual kawase up");
+            this.upsampleProgram = program;
+            this.upsamplePositionLocation = this.gl.getAttribLocation(program, "a_position");
+            this.upsampleTexCoordLocation = this.gl.getAttribLocation(program, "a_texCoord");
+            this.upsampleTextureLocation = this.gl.getUniformLocation(program, "u_texture");
+            this.upsampleTexelSizeLocation = this.gl.getUniformLocation(program, "u_texelSize");
+            this.upsampleOffsetLocation = this.gl.getUniformLocation(program, "u_offset");
+
+            if (
+                this.upsamplePositionLocation < 0 ||
+                this.upsampleTexCoordLocation < 0 ||
+                !this.upsampleTextureLocation ||
+                !this.upsampleTexelSizeLocation ||
+                !this.upsampleOffsetLocation
+            ) {
+                throw new Error("Unable to resolve WebGL Dual Kawase upsample shader locations");
+            }
+        }
+    }
+
+    private ensureCompositeProgram(): void {
+        if (this.compositeProgram) {
+            return;
+        }
+
+        const program = this.createProgram(BLUR_VERTEX_SHADER, COMPOSITE_FRAGMENT_SHADER, "composite");
+        this.compositeProgram = program;
+        this.compositePositionLocation = this.gl.getAttribLocation(program, "a_position");
+        this.compositeTexCoordLocation = this.gl.getAttribLocation(program, "a_texCoord");
+        this.sharpTextureLocation = this.gl.getUniformLocation(program, "u_sharpTexture");
+        this.blurredTextureLocation = this.gl.getUniformLocation(program, "u_blurredTexture");
+        this.compositeMaskTextureLocation = this.gl.getUniformLocation(program, "u_maskTexture");
+        this.maskAlphaWeightLocation = this.gl.getUniformLocation(program, "u_maskAlphaWeight");
+        this.maskTexelSizeLocation = this.gl.getUniformLocation(program, "u_maskTexelSize");
+
+        if (
+            this.compositePositionLocation < 0 ||
+            this.compositeTexCoordLocation < 0 ||
+            !this.sharpTextureLocation ||
+            !this.blurredTextureLocation ||
+            !this.compositeMaskTextureLocation ||
+            !this.maskAlphaWeightLocation ||
+            !this.maskTexelSizeLocation
+        ) {
+            throw new Error("Unable to resolve WebGL blur composite shader locations");
+        }
+    }
+
+    private createProgram(vertexSource: string, fragmentSource: string, label: string): WebGLProgram {
+        const gl = this.gl;
+        const vertexShader = this.createShader(gl.VERTEX_SHADER, vertexSource, label);
+        const fragmentShader = this.createShader(gl.FRAGMENT_SHADER, fragmentSource, label);
+        const program = gl.createProgram();
+
+        if (!program) {
+            throw new Error(`Unable to create WebGL ${label} program`);
+        }
+
+        gl.attachShader(program, vertexShader);
+        gl.attachShader(program, fragmentShader);
+        gl.linkProgram(program);
+
+        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+            const message = gl.getProgramInfoLog(program) ?? `Unknown WebGL ${label} program link error`;
+            gl.deleteProgram(program);
+            gl.deleteShader(vertexShader);
+            gl.deleteShader(fragmentShader);
+            throw new Error(message);
+        }
+
+        gl.deleteShader(vertexShader);
+        gl.deleteShader(fragmentShader);
+
+        return program;
+    }
+
+    private createShader(type: number, source: string, label: string): WebGLShader {
+        const gl = this.gl;
+        const shader = gl.createShader(type);
+        if (!shader) {
+            throw new Error(`Unable to create WebGL ${label} shader`);
+        }
+
+        gl.shaderSource(shader, source);
+        gl.compileShader(shader);
+
+        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+            const message = gl.getShaderInfoLog(shader) ?? `Unknown WebGL ${label} shader compile error`;
+            gl.deleteShader(shader);
+            throw new Error(message);
+        }
+
+        return shader;
+    }
+
+    private ensureBuffers(): void {
+        if (this.positionBuffer && this.texCoordBuffer && this.internalTexCoordBuffer) {
+            return;
+        }
+
+        this.positionBuffer = this.createBuffer(new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]));
+        this.texCoordBuffer = this.createBuffer(new Float32Array([0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0]));
+        this.internalTexCoordBuffer = this.createBuffer(new Float32Array([0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1]));
+    }
+
+    private createBuffer(data: Float32Array): WebGLBuffer {
+        const buffer = this.gl.createBuffer();
+        if (!buffer) {
+            throw new Error("Unable to create WebGL blur buffer");
+        }
+
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, buffer);
+        this.gl.bufferData(this.gl.ARRAY_BUFFER, data, this.gl.STATIC_DRAW);
+        return buffer;
+    }
+
+    private ensureTextures(width: number, height: number, levels: number): void {
+        if (!this.sourceTexture) {
+            this.sourceTexture = this.createTexture();
+        }
+
+        if (
+            this.kawaseFramebuffers.length === levels &&
+            this.finalBlurFramebuffer &&
+            this.framebufferWidth === width &&
+            this.framebufferHeight === height &&
+            this.framebufferLevels === levels
+        ) {
+            return;
+        }
+
+        this.releaseFramebufferResources();
+        this.finalBlurFramebuffer = this.createFramebufferTexture(width, height);
+
+        let framebufferWidth = width;
+        let framebufferHeight = height;
+        for (let level = 0; level < levels; level++) {
+            const nextSize = getNextKawaseSize(framebufferWidth, framebufferHeight);
+            framebufferWidth = nextSize.width;
+            framebufferHeight = nextSize.height;
+            this.kawaseFramebuffers.push(this.createFramebufferTexture(framebufferWidth, framebufferHeight));
+        }
+
+        this.framebufferWidth = width;
+        this.framebufferHeight = height;
+        this.framebufferLevels = levels;
+    }
+
+    private ensureMaskTexture(): void {
+        if (!this.maskTexture) {
+            this.maskTexture = this.createTexture();
+        }
+    }
+
+    private createTexture(): WebGLTexture {
+        const texture = this.gl.createTexture();
+        if (!texture) {
+            throw new Error("Unable to create WebGL blur texture");
+        }
+
+        this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
+        this.configureTexture();
+        return texture;
+    }
+
+    private createFramebufferTexture(width: number, height: number): KawaseFramebuffer {
+        const gl = this.gl;
+        const texture = this.createTexture();
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
+        const framebuffer = gl.createFramebuffer();
+        if (!framebuffer) {
+            gl.deleteTexture(texture);
+            throw new Error("Unable to create WebGL blur framebuffer");
+        }
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+        if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
+            gl.deleteTexture(texture);
+            gl.deleteFramebuffer(framebuffer);
+            throw new Error("WebGL blur framebuffer is incomplete");
+        }
+
+        return { texture, framebuffer, width, height };
+    }
+
+    private configureTexture(): void {
+        const gl = this.gl;
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    }
+
+    private uploadTexture(texture: WebGLTexture, source: CanvasImageSource, textureUnit: number): void {
+        const gl = this.gl;
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+        gl.activeTexture(gl.TEXTURE0 + textureUnit);
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        this.configureTexture();
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source as TexImageSource);
+    }
+
+    private renderBlurredTexture(
+        source: CanvasImageSource,
+        blurSize: { width: number; height: number; scale: number },
+        levels: number,
+        blurOffset: number,
+    ): { texture: WebGLTexture; width: number; height: number } {
+        const gl = this.gl;
+
+        gl.viewport(0, 0, blurSize.width, blurSize.height);
+        gl.disable(gl.DEPTH_TEST);
+        gl.disable(gl.BLEND);
+        gl.clearColor(0, 0, 0, 1);
+        this.uploadTexture(this.sourceTexture!, source, 0);
+
+        let sourceTexture = this.sourceTexture!;
+        let sourceWidth = blurSize.width;
+        let sourceHeight = blurSize.height;
+
+        for (let level = 0; level < levels; level++) {
+            const target = this.kawaseFramebuffers[level];
+            this.drawKawasePass(
+                this.downsampleProgram,
+                this.downsamplePositionLocation,
+                this.downsampleTexCoordLocation,
+                this.downsampleTextureLocation,
+                this.downsampleTexelSizeLocation,
+                this.downsampleOffsetLocation,
+                sourceTexture,
+                target.framebuffer,
+                target.width,
+                target.height,
+                sourceWidth,
+                sourceHeight,
+                blurOffset,
+                false,
+            );
+            sourceTexture = target.texture;
+            sourceWidth = target.width;
+            sourceHeight = target.height;
+        }
+
+        for (let level = levels - 2; level >= 0; level--) {
+            const target = this.kawaseFramebuffers[level];
+            this.drawKawasePass(
+                this.upsampleProgram,
+                this.upsamplePositionLocation,
+                this.upsampleTexCoordLocation,
+                this.upsampleTextureLocation,
+                this.upsampleTexelSizeLocation,
+                this.upsampleOffsetLocation,
+                sourceTexture,
+                target.framebuffer,
+                target.width,
+                target.height,
+                sourceWidth,
+                sourceHeight,
+                blurOffset,
+                false,
+            );
+            sourceTexture = target.texture;
+            sourceWidth = target.width;
+            sourceHeight = target.height;
+        }
+
+        const target = this.finalBlurFramebuffer!;
+        this.drawKawasePass(
+            this.upsampleProgram,
+            this.upsamplePositionLocation,
+            this.upsampleTexCoordLocation,
+            this.upsampleTextureLocation,
+            this.upsampleTexelSizeLocation,
+            this.upsampleOffsetLocation,
+            sourceTexture,
+            target.framebuffer,
+            target.width,
+            target.height,
+            sourceWidth,
+            sourceHeight,
+            blurOffset,
+            false,
+        );
+
+        return { texture: target.texture, width: target.width, height: target.height };
+    }
+
+    private drawKawasePass(
+        program: WebGLProgram | null,
+        positionLocation: number,
+        texCoordLocation: number,
+        textureLocation: WebGLUniformLocation | null,
+        texelSizeLocation: WebGLUniformLocation | null,
+        offsetLocation: WebGLUniformLocation | null,
+        texture: WebGLTexture,
+        framebuffer: WebGLFramebuffer | null,
+        targetWidth: number,
+        targetHeight: number,
+        sourceWidth: number,
+        sourceHeight: number,
+        offset: number,
+        flipVertically: boolean,
+    ): void {
+        const gl = this.gl;
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+        gl.viewport(0, 0, targetWidth, targetHeight);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.useProgram(program);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+        gl.enableVertexAttribArray(positionLocation);
+        gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, flipVertically ? this.texCoordBuffer : this.internalTexCoordBuffer);
+        gl.enableVertexAttribArray(texCoordLocation);
+        gl.vertexAttribPointer(texCoordLocation, 2, gl.FLOAT, false, 0, 0);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.uniform1i(textureLocation, 0);
+        gl.uniform2f(texelSizeLocation, 1 / sourceWidth, 1 / sourceHeight);
+        gl.uniform1f(offsetLocation, offset);
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
+
+    private drawCompositePass(
+        sharpTexture: WebGLTexture,
+        blurredTexture: WebGLTexture,
+        maskTexture: WebGLTexture,
+        width: number,
+        height: number,
+        maskAlphaWeight: number,
+    ): void {
+        const gl = this.gl;
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.viewport(0, 0, width, height);
+        gl.disable(gl.DEPTH_TEST);
+        gl.disable(gl.BLEND);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.useProgram(this.compositeProgram);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+        gl.enableVertexAttribArray(this.compositePositionLocation);
+        gl.vertexAttribPointer(this.compositePositionLocation, 2, gl.FLOAT, false, 0, 0);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
+        gl.enableVertexAttribArray(this.compositeTexCoordLocation);
+        gl.vertexAttribPointer(this.compositeTexCoordLocation, 2, gl.FLOAT, false, 0, 0);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, sharpTexture);
+        gl.uniform1i(this.sharpTextureLocation, 0);
+
+        gl.activeTexture(gl.TEXTURE0 + 1);
+        gl.bindTexture(gl.TEXTURE_2D, blurredTexture);
+        gl.uniform1i(this.blurredTextureLocation, 1);
+
+        gl.activeTexture(gl.TEXTURE0 + 2);
+        gl.bindTexture(gl.TEXTURE_2D, maskTexture);
+        gl.uniform1i(this.compositeMaskTextureLocation, 2);
+        gl.uniform1f(this.maskAlphaWeightLocation, maskAlphaWeight);
+        gl.uniform2f(this.maskTexelSizeLocation, 1 / width, 1 / height);
+
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
+
+    private releaseResources(): void {
+        if (this.gl.isContextLost()) {
+            this.clearReferences();
+            return;
+        }
+
+        if (this.downsampleProgram) {
+            this.gl.deleteProgram(this.downsampleProgram);
+        }
+        if (this.upsampleProgram) {
+            this.gl.deleteProgram(this.upsampleProgram);
+        }
+        if (this.compositeProgram) {
+            this.gl.deleteProgram(this.compositeProgram);
+        }
+        if (this.positionBuffer) {
+            this.gl.deleteBuffer(this.positionBuffer);
+        }
+        if (this.texCoordBuffer) {
+            this.gl.deleteBuffer(this.texCoordBuffer);
+        }
+        if (this.internalTexCoordBuffer) {
+            this.gl.deleteBuffer(this.internalTexCoordBuffer);
+        }
+        if (this.sourceTexture) {
+            this.gl.deleteTexture(this.sourceTexture);
+        }
+        if (this.maskTexture) {
+            this.gl.deleteTexture(this.maskTexture);
+        }
+
+        this.releaseFramebufferResources();
+        this.clearReferences();
+    }
+
+    private releaseFramebufferResources(): void {
+        if (this.gl.isContextLost()) {
+            this.finalBlurFramebuffer = null;
+            this.kawaseFramebuffers = [];
+            this.framebufferWidth = 0;
+            this.framebufferHeight = 0;
+            this.framebufferLevels = 0;
+            return;
+        }
+
+        if (this.finalBlurFramebuffer) {
+            this.gl.deleteTexture(this.finalBlurFramebuffer.texture);
+            this.gl.deleteFramebuffer(this.finalBlurFramebuffer.framebuffer);
+            this.finalBlurFramebuffer = null;
+        }
+
+        for (const framebuffer of this.kawaseFramebuffers) {
+            this.gl.deleteTexture(framebuffer.texture);
+            this.gl.deleteFramebuffer(framebuffer.framebuffer);
+        }
+
+        this.kawaseFramebuffers = [];
+        this.framebufferWidth = 0;
+        this.framebufferHeight = 0;
+        this.framebufferLevels = 0;
+    }
+
+    private clearReferences(): void {
+        this.downsampleProgram = null;
+        this.upsampleProgram = null;
+        this.compositeProgram = null;
+        this.positionBuffer = null;
+        this.texCoordBuffer = null;
+        this.internalTexCoordBuffer = null;
+        this.sourceTexture = null;
+        this.maskTexture = null;
+        this.finalBlurFramebuffer = null;
+        this.kawaseFramebuffers = [];
+        this.downsampleTextureLocation = null;
+        this.downsampleTexelSizeLocation = null;
+        this.downsampleOffsetLocation = null;
+        this.upsampleTextureLocation = null;
+        this.upsampleTexelSizeLocation = null;
+        this.upsampleOffsetLocation = null;
+        this.sharpTextureLocation = null;
+        this.blurredTextureLocation = null;
+        this.compositeMaskTextureLocation = null;
+        this.maskAlphaWeightLocation = null;
+        this.maskTexelSizeLocation = null;
+        this.framebufferWidth = 0;
+        this.framebufferHeight = 0;
+        this.framebufferLevels = 0;
+    }
+}

--- a/play/src/front/WebRtc/BackgroundProcessor/createBackgroundTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/createBackgroundTransformer.ts
@@ -30,11 +30,6 @@ export interface BackgroundTransformer {
  * @returns A MediaPipe transformer instance or fallback
  */
 export function createBackgroundTransformer(config: BackgroundConfig): BackgroundTransformer {
-    // Check browser support for MediaStream APIs
-    if (typeof MediaStreamTrackProcessor === "undefined" || typeof MediaStreamTrackGenerator === "undefined") {
-        return new FallbackBackgroundTransformer();
-    }
-
     const engine = BACKGROUND_TRANSFORMER_ENGINE || "tasks-vision";
     console.info(`[BackgroundProcessor] Using transformer engine: ${engine}`);
 

--- a/play/src/front/WebRtc/BackgroundProcessor/logOnce.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/logOnce.ts
@@ -1,0 +1,20 @@
+const loggedKeys = new Set<string>();
+
+/**
+ * Runs `log` only the first time it is called for a given `key`. Used by the
+ * background processor to emit a diagnostic (selected backend, fallback taken,
+ * ...) once rather than on every frame.
+ */
+export function logOnce(key: string, log: () => void): void {
+    if (loggedKeys.has(key)) {
+        return;
+    }
+
+    loggedKeys.add(key);
+    log();
+}
+
+/** Clears the once-logging state. Test-only. */
+export function resetLogOnceForTests(): void {
+    loggedKeys.clear();
+}

--- a/play/tests/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.test.ts
+++ b/play/tests/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.test.ts
@@ -4,6 +4,9 @@ import {
     CanvasBlurRenderer,
     getCpuBlurRadius,
     getCpuBlurSize,
+    getDualKawaseBlurOffset,
+    getWebGlBlurRadius,
+    getWebGlBlurSize,
     resetCanvasBlurRendererForTests,
 } from "../../../../src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer";
 
@@ -30,8 +33,8 @@ describe("CanvasBlurRenderer", () => {
 
         expect(backend).toBe("webgl-blur");
         expect(renderer.getLastBackend()).toBe("webgl-blur");
-        expect(webGlCanvas.width).toBe(174);
-        expect(webGlCanvas.height).toBe(98);
+        expect(webGlCanvas.width).toBe(349);
+        expect(webGlCanvas.height).toBe(196);
         expect(webGlContext.texImage2D).toHaveBeenCalledWith(
             webGlContext.context.TEXTURE_2D,
             0,
@@ -42,8 +45,43 @@ describe("CanvasBlurRenderer", () => {
         );
         expect(webGlContext.pixelStorei).toHaveBeenCalledWith(webGlContext.context.UNPACK_FLIP_Y_WEBGL, false);
         expect(webGlContext.pixelStorei).not.toHaveBeenCalledWith(webGlContext.context.UNPACK_FLIP_Y_WEBGL, true);
-        expect(webGlContext.drawArrays).toHaveBeenCalledTimes(5);
-        expect(destinationContext.drawImage).toHaveBeenCalledWith(webGlCanvas, 0, 0, 174, 98, 0, 0, 640, 360);
+        expect(webGlContext.drawArrays).toHaveBeenCalledTimes(7);
+        expect(destinationContext.drawImage).toHaveBeenCalledWith(webGlCanvas, 0, 0, 349, 196, 0, 0, 640, 360);
+    });
+
+    it("uses the shared WebGL composite path when a mask is provided", () => {
+        const renderer = new CanvasBlurRenderer();
+        const destinationContext = createDestinationContext();
+        const webGlContext = createWebGlContext();
+        const webGlCanvas = createCanvas(webGlContext.context);
+        const source = createSource();
+        const mask = createSource();
+        mockCanvasCreation(webGlCanvas);
+
+        const backend = renderer.drawBlurredImageWithMask(destinationContext.context, source, mask, 640, 360, 25);
+
+        expect(backend).toBe("webgl-blur");
+        expect(renderer.getLastBackend()).toBe("webgl-blur");
+        expect(webGlCanvas.width).toBe(640);
+        expect(webGlCanvas.height).toBe(360);
+        expect(webGlContext.texImage2D).toHaveBeenCalledWith(
+            webGlContext.context.TEXTURE_2D,
+            0,
+            webGlContext.context.RGBA,
+            webGlContext.context.RGBA,
+            webGlContext.context.UNSIGNED_BYTE,
+            source,
+        );
+        expect(webGlContext.texImage2D).toHaveBeenCalledWith(
+            webGlContext.context.TEXTURE_2D,
+            0,
+            webGlContext.context.RGBA,
+            webGlContext.context.RGBA,
+            webGlContext.context.UNSIGNED_BYTE,
+            mask,
+        );
+        expect(webGlContext.drawArrays).toHaveBeenCalledTimes(7);
+        expect(destinationContext.drawImage).toHaveBeenCalledWith(webGlCanvas, 0, 0, 640, 360, 0, 0, 640, 360);
     });
 
     it("falls back to CPU blur when WebGL is unavailable", () => {
@@ -70,6 +108,25 @@ describe("CanvasBlurRenderer", () => {
 
         expect(getCpuBlurRadius(10, blurSize.scale)).toBeLessThan(getCpuBlurRadius(25, blurSize.scale));
         expect(getCpuBlurRadius(25, blurSize.scale)).toBeLessThan(getCpuBlurRadius(50, blurSize.scale));
+    });
+
+    it("maps the existing blur levels to increasing WebGL blur radii", () => {
+        const lowBlurSize = getWebGlBlurSize(1280, 720, 10);
+        const mediumBlurSize = getWebGlBlurSize(1280, 720, 25);
+        const highBlurSize = getWebGlBlurSize(1280, 720, 50);
+
+        expect(getWebGlBlurRadius(10, lowBlurSize.scale)).toBeLessThan(getWebGlBlurRadius(25, mediumBlurSize.scale));
+        expect(getWebGlBlurRadius(25, mediumBlurSize.scale)).toBeLessThan(getWebGlBlurRadius(50, highBlurSize.scale));
+    });
+
+    it("maps the existing blur levels to increasing Dual Kawase pass counts", () => {
+        expect(getWebGlDrawPassCount(10)).toBeLessThan(getWebGlDrawPassCount(25));
+        expect(getWebGlDrawPassCount(25)).toBeLessThan(getWebGlDrawPassCount(50));
+    });
+
+    it("maps the existing blur levels to increasing Dual Kawase offsets", () => {
+        expect(getDualKawaseBlurOffset(10)).toBeLessThan(getDualKawaseBlurOffset(25));
+        expect(getDualKawaseBlurOffset(25)).toBeLessThan(getDualKawaseBlurOffset(50));
     });
 
     it("spreads a sharp pixel with the CPU blur implementation", () => {
@@ -247,4 +304,16 @@ function createDestinationContext() {
 
 function createSource(): CanvasImageSource {
     return { height: 360, width: 640 } as unknown as CanvasImageSource;
+}
+
+function getWebGlDrawPassCount(blurAmount: number): number {
+    const renderer = new CanvasBlurRenderer();
+    const destinationContext = createDestinationContext();
+    const webGlContext = createWebGlContext();
+    const webGlCanvas = createCanvas(webGlContext.context);
+    mockCanvasCreation(webGlCanvas);
+
+    renderer.drawBlurredImage(destinationContext.context, createSource(), 640, 360, blurAmount);
+
+    return webGlContext.drawArrays.mock.calls.length;
 }

--- a/play/tests/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.test.ts
+++ b/play/tests/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    boxBlurImageData,
+    CanvasBlurRenderer,
+    getCpuBlurRadius,
+    getCpuBlurSize,
+    resetCanvasBlurRendererForTests,
+} from "../../../../src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer";
+
+describe("CanvasBlurRenderer", () => {
+    beforeEach(() => {
+        vi.spyOn(console, "info").mockImplementation(() => undefined);
+        vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        resetCanvasBlurRendererForTests();
+    });
+
+    it("uses WebGL blur as the default renderer", () => {
+        const renderer = new CanvasBlurRenderer();
+        const destinationContext = createDestinationContext();
+        const webGlContext = createWebGlContext();
+        const webGlCanvas = createCanvas(webGlContext.context);
+        const source = createSource();
+        mockCanvasCreation(webGlCanvas);
+
+        const backend = renderer.drawBlurredImage(destinationContext.context, source, 640, 360, 25);
+
+        expect(backend).toBe("webgl-blur");
+        expect(renderer.getLastBackend()).toBe("webgl-blur");
+        expect(webGlCanvas.width).toBe(174);
+        expect(webGlCanvas.height).toBe(98);
+        expect(webGlContext.texImage2D).toHaveBeenCalledWith(
+            webGlContext.context.TEXTURE_2D,
+            0,
+            webGlContext.context.RGBA,
+            webGlContext.context.RGBA,
+            webGlContext.context.UNSIGNED_BYTE,
+            source,
+        );
+        expect(webGlContext.pixelStorei).toHaveBeenCalledWith(webGlContext.context.UNPACK_FLIP_Y_WEBGL, false);
+        expect(webGlContext.pixelStorei).not.toHaveBeenCalledWith(webGlContext.context.UNPACK_FLIP_Y_WEBGL, true);
+        expect(webGlContext.drawArrays).toHaveBeenCalledTimes(5);
+        expect(destinationContext.drawImage).toHaveBeenCalledWith(webGlCanvas, 0, 0, 174, 98, 0, 0, 640, 360);
+    });
+
+    it("falls back to CPU blur when WebGL is unavailable", () => {
+        const renderer = new CanvasBlurRenderer();
+        const destinationContext = createDestinationContext();
+        const cpuContext = createCpuContext();
+        const webGlCanvas = createCanvas(null);
+        const cpuCanvas = createCanvas(cpuContext.context);
+        const source = createSource();
+        mockCanvasCreation(webGlCanvas, cpuCanvas);
+
+        const backend = renderer.drawBlurredImage(destinationContext.context, source, 640, 360, 25);
+
+        expect(backend).toBe("cpu-blur");
+        expect(renderer.getLastBackend()).toBe("cpu-blur");
+        expect(cpuContext.drawImage).toHaveBeenCalledWith(source, 0, 0, 224, 126);
+        expect(cpuContext.getImageData).toHaveBeenCalledWith(0, 0, 224, 126);
+        expect(cpuContext.putImageData).toHaveBeenCalledOnce();
+        expect(destinationContext.drawImage).toHaveBeenCalledWith(cpuCanvas, 0, 0, 224, 126, 0, 0, 640, 360);
+    });
+
+    it("maps the existing blur levels to increasing CPU blur radii", () => {
+        const blurSize = getCpuBlurSize(1280, 720);
+
+        expect(getCpuBlurRadius(10, blurSize.scale)).toBeLessThan(getCpuBlurRadius(25, blurSize.scale));
+        expect(getCpuBlurRadius(25, blurSize.scale)).toBeLessThan(getCpuBlurRadius(50, blurSize.scale));
+    });
+
+    it("spreads a sharp pixel with the CPU blur implementation", () => {
+        const data = new Uint8ClampedArray([
+            0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 255, 255, 0, 0, 0, 255, 0, 0, 0, 255,
+        ]);
+
+        boxBlurImageData(data, 5, 1, 1, 1);
+
+        expect(data[4]).toBeGreaterThan(0);
+        expect(data[8]).toBeLessThan(255);
+        expect(data[12]).toBeGreaterThan(0);
+    });
+
+    it("handles invalid dimensions without drawing", () => {
+        const renderer = new CanvasBlurRenderer();
+        const destinationContext = createDestinationContext();
+
+        const backend = renderer.drawBlurredImage(destinationContext.context, createSource(), 0, 360, 25);
+
+        expect(backend).toBe("none");
+        expect(renderer.getLastBackend()).toBe("none");
+        expect(destinationContext.drawImage).not.toHaveBeenCalled();
+    });
+});
+
+function mockCanvasCreation(...canvases: HTMLCanvasElement[]): void {
+    let canvasIndex = 0;
+
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+        if (tagName !== "canvas") {
+            throw new Error(`Unexpected element creation in CanvasBlurRenderer test: ${tagName}`);
+        }
+
+        const canvas = canvases[canvasIndex];
+        if (!canvas) {
+            throw new Error("Unexpected canvas creation in CanvasBlurRenderer test");
+        }
+
+        canvasIndex++;
+        return canvas;
+    });
+}
+
+function createCanvas(context: CanvasRenderingContext2D | WebGLRenderingContext | null): HTMLCanvasElement {
+    return {
+        width: 0,
+        height: 0,
+        getContext: vi.fn(() => context),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    } as unknown as HTMLCanvasElement;
+}
+
+function createCpuContext() {
+    const drawImage = vi.fn();
+    const getImageData = vi.fn((x: number, y: number, width: number, height: number) => ({
+        data: new Uint8ClampedArray(width * height * 4),
+    }));
+    const putImageData = vi.fn();
+    const context = {
+        filter: "none",
+        globalCompositeOperation: "source-over",
+        drawImage,
+        getImageData,
+        putImageData,
+    } as unknown as CanvasRenderingContext2D;
+
+    return {
+        context,
+        drawImage,
+        getImageData,
+        putImageData,
+    };
+}
+
+function createWebGlContext() {
+    const drawArrays = vi.fn();
+    const pixelStorei = vi.fn();
+    const texImage2D = vi.fn();
+    const context = {
+        ARRAY_BUFFER: 0x8892,
+        BLEND: 0x0be2,
+        CLAMP_TO_EDGE: 0x812f,
+        COLOR_ATTACHMENT0: 0x8ce0,
+        COLOR_BUFFER_BIT: 0x4000,
+        COMPILE_STATUS: 0x8b81,
+        DEPTH_TEST: 0x0b71,
+        FLOAT: 0x1406,
+        FRAGMENT_SHADER: 0x8b30,
+        FRAMEBUFFER: 0x8d40,
+        FRAMEBUFFER_COMPLETE: 0x8cd5,
+        LINEAR: 0x2601,
+        LINK_STATUS: 0x8b82,
+        RGBA: 0x1908,
+        STATIC_DRAW: 0x88e4,
+        TEXTURE0: 0x84c0,
+        TEXTURE_2D: 0x0de1,
+        TEXTURE_MAG_FILTER: 0x2800,
+        TEXTURE_MIN_FILTER: 0x2801,
+        TEXTURE_WRAP_S: 0x2802,
+        TEXTURE_WRAP_T: 0x2803,
+        TRIANGLES: 0x0004,
+        UNPACK_FLIP_Y_WEBGL: 0x9240,
+        UNSIGNED_BYTE: 0x1401,
+        VERTEX_SHADER: 0x8b31,
+        activeTexture: vi.fn(),
+        attachShader: vi.fn(),
+        bindBuffer: vi.fn(),
+        bindFramebuffer: vi.fn(),
+        bindTexture: vi.fn(),
+        bufferData: vi.fn(),
+        checkFramebufferStatus: vi.fn(() => 0x8cd5),
+        clear: vi.fn(),
+        clearColor: vi.fn(),
+        compileShader: vi.fn(),
+        createBuffer: vi.fn(() => ({})),
+        createFramebuffer: vi.fn(() => ({})),
+        createProgram: vi.fn(() => ({})),
+        createShader: vi.fn(() => ({})),
+        createTexture: vi.fn(() => ({})),
+        deleteBuffer: vi.fn(),
+        deleteFramebuffer: vi.fn(),
+        deleteProgram: vi.fn(),
+        deleteShader: vi.fn(),
+        deleteTexture: vi.fn(),
+        disable: vi.fn(),
+        drawArrays,
+        enableVertexAttribArray: vi.fn(),
+        framebufferTexture2D: vi.fn(),
+        getAttribLocation: vi.fn((_program: WebGLProgram, attributeName: string) =>
+            attributeName === "a_position" ? 0 : 1,
+        ),
+        getProgramInfoLog: vi.fn(() => ""),
+        getProgramParameter: vi.fn(() => true),
+        getShaderInfoLog: vi.fn(() => ""),
+        getShaderParameter: vi.fn(() => true),
+        getUniformLocation: vi.fn(() => ({})),
+        isContextLost: vi.fn(() => false),
+        linkProgram: vi.fn(),
+        pixelStorei,
+        shaderSource: vi.fn(),
+        texImage2D,
+        texParameteri: vi.fn(),
+        uniform1i: vi.fn(),
+        uniform1f: vi.fn(),
+        uniform2f: vi.fn(),
+        useProgram: vi.fn(),
+        vertexAttribPointer: vi.fn(),
+        viewport: vi.fn(),
+        flush: vi.fn(),
+    } as unknown as WebGLRenderingContext;
+
+    return {
+        context,
+        drawArrays,
+        pixelStorei,
+        texImage2D,
+    };
+}
+
+function createDestinationContext() {
+    const drawImage = vi.fn();
+    const context = {
+        drawImage,
+        imageSmoothingEnabled: false,
+        imageSmoothingQuality: "low",
+    } as unknown as CanvasRenderingContext2D;
+
+    return {
+        context,
+        drawImage,
+    };
+}
+
+function createSource(): CanvasImageSource {
+    return { height: 360, width: 640 } as unknown as CanvasImageSource;
+}


### PR DESCRIPTION
## What changed

- Replaces the virtual background blur rendering path with shared WebGL blur rendering.
- Adds a WebGL1 blur/composite path for the legacy selfie-segmentation transformer.
- Adds a WebGL2 compositor for the Tasks Vision transformer that uses the MediaPipe mask texture directly.
- Keeps the CPU blur implementation only as a robustness fallback when WebGL blur is unavailable or fails.
- Keeps `blurBackend` diagnostics for transformer performance stats.

## Why

Safari does not reliably apply Canvas 2D `filter` blur, so blur backgrounds could look like the original sharp camera frame. The new WebGL path avoids the unsupported Canvas 2D filter API and keeps the expensive blur/composite work on the GPU by default across both virtual-background engines.

## Validation

- `npm run test -- BackgroundProcessor`
- `npm run typecheck`
- Targeted ESLint on changed background processor files
- Targeted Prettier check on changed background processor files
