### PR TITLE
Making the AdminAPI /capabilities endpoint compulsory

### DIFF
--- a/libs/shared-utils/src/SharedAdminApi.ts
+++ b/libs/shared-utils/src/SharedAdminApi.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { Capabilities } from "@workadventure/messages";
 import { isCapabilities } from "@workadventure/messages";
-import axios, { type AxiosResponse, isAxiosError } from "axios";
+import axios, { type AxiosResponse } from "axios";
 import { Deferred } from "./Deferred";
 
 export const AdminBannedData = z.object({
@@ -41,20 +41,6 @@ export class SharedAdminApi {
                 console.info(`Capabilities query successful. Found capabilities: ${JSON.stringify(this.capabilities)}`);
                 resolve(0);
             } catch (ex) {
-                // ignore errors when querying capabilities
-                if (isAxiosError(ex) && ex.response?.status === 404) {
-                    // 404 probably means an older api version
-
-                    this.capabilities = {
-                        "api/woka/list": "v1",
-                    };
-                    this.capabilitiesDeferred.resolve(this.capabilities);
-
-                    resolve(0);
-                    console.warn(`Admin API server does not implement capabilities, default to basic capabilities`);
-                    return;
-                }
-
                 // if we get here, it might be due to connectivity issues
                 if (!warnIssued)
                     console.warn(

--- a/play/src/pusher/services/AdminApi.ts
+++ b/play/src/pusher/services/AdminApi.ts
@@ -165,20 +165,6 @@ class AdminApi implements AdminInterface {
                 console.info(`Capabilities query successful. Found capabilities: ${JSON.stringify(this.capabilities)}`);
                 resolve(0);
             } catch (ex) {
-                // ignore errors when querying capabilities
-                if (isAxiosError(ex) && ex.response?.status === 404) {
-                    // 404 probably means an older api version
-
-                    this.capabilities = {
-                        "api/woka/list": "v1",
-                    };
-                    this.capabilitiesDeferred.resolve(this.capabilities);
-
-                    resolve(0);
-                    console.warn(`Admin API server does not implement capabilities, default to basic capabilities`);
-                    return;
-                }
-
                 // if we get here, it might be due to connectivity issues
                 if (!warnIssued)
                     console.warn(


### PR DESCRIPTION
# Important change for AdminAPI authors

When we added the /capabilities endpoint, we first made it optional. The idea was not to disrupt existing AdminAPI integrations.

The /capabilities endpoint now exists for several years and AdminAPI implementations have had time to add it. We are now making it compulsory.

Indeed, the /capabilities endpoint of the admin can return 404 for a number of reasons and retrying when we get a 404 is safer than assuming we are targetting an old AdminAPI.