### PR TITLE
Detect sustained background noise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6556,9 +6556,9 @@
       "link": true
     },
     "node_modules/@workadventure/noise-suppression": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@workadventure/noise-suppression/-/noise-suppression-0.1.0.tgz",
-      "integrity": "sha512-MX4QMtBp0iX41cvl2soVWw7ge+27xIosN3bLdTU1czFoWDkHBQtyykvFzWYT6NKuPz34+E0sN9tFnjP8O1ZZKw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@workadventure/noise-suppression/-/noise-suppression-0.1.1.tgz",
+      "integrity": "sha512-G2RmkYpLgHy44mFasv+XNQUqQv27r0XqO9lJ2FSr9fnK2QWP97gXPrgRRPtsoqChb5849Cdk0AhbeW1Zc1tKPw==",
       "license": "MIT",
       "dependencies": {
         "@ricky0123/vad-web": "^0.0.30",
@@ -20504,7 +20504,7 @@
         "@workadventure/map-editor": "1.0.0",
         "@workadventure/math-utils": "1.0.0",
         "@workadventure/messages": "1.0.0",
-        "@workadventure/noise-suppression": "^0.1.0",
+        "@workadventure/noise-suppression": "^0.1.1",
         "@workadventure/shared-utils": "1.0.0",
         "@workadventure/simple-peer": "^12.0.1",
         "@workadventure/store-utils": "1.0.0",

--- a/play/package.json
+++ b/play/package.json
@@ -121,7 +121,7 @@
     "@workadventure/map-editor": "1.0.0",
     "@workadventure/math-utils": "1.0.0",
     "@workadventure/messages": "1.0.0",
-    "@workadventure/noise-suppression": "^0.1.0",
+    "@workadventure/noise-suppression": "^0.1.1",
     "@workadventure/shared-utils": "1.0.0",
     "@workadventure/simple-peer": "^12.0.1",
     "@workadventure/store-utils": "1.0.0",

--- a/play/src/front/Components/Toasts/LoudEnvironmentToast.svelte
+++ b/play/src/front/Components/Toasts/LoudEnvironmentToast.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+    import { LL } from "../../../i18n/i18n-svelte";
+    import { noiseSuppressionEnabledStore } from "../../Stores/NoiseSuppressionStore";
+    import { toastStore } from "../../Stores/ToastStore";
+    import ToastContainer from "./ToastContainer.svelte";
+
+    interface Props {
+        toastUuid: string;
+    }
+
+    let { toastUuid }: Props = $props();
+
+    function closeToast(): void {
+        toastStore.removeToast(toastUuid);
+    }
+
+    function enableNoiseSuppression(): void {
+        noiseSuppressionEnabledStore.setEnabled(true);
+        closeToast();
+    }
+</script>
+
+<ToastContainer extraClasses="w-full min-w-72 max-w-sm sm:min-w-80 sm:max-w-md" theme="error" {toastUuid}>
+    <p class="m-0 text-sm leading-snug text-white text-center">
+        {$LL.actionbar.microphone.loudEnvironmentWarning()}
+    </p>
+    {#snippet buttons()}
+        <button
+            type="button"
+            class="btn btn-ghost btn-sm flex-1"
+            data-testid="loud-environment-ignore"
+            onclick={(event) => {
+                event.stopPropagation();
+                event.preventDefault();
+                closeToast();
+            }}
+        >
+            {$LL.actionbar.microphone.ignore()}
+        </button>
+        <button
+            type="button"
+            class="btn btn-danger btn-sm flex-1"
+            data-testid="loud-environment-enable-noise-suppression"
+            onclick={(event) => {
+                event.stopPropagation();
+                event.preventDefault();
+                enableNoiseSuppression();
+            }}
+        >
+            {$LL.actionbar.microphone.enableNoiseSuppression()}
+        </button>
+    {/snippet}
+</ToastContainer>

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -119,9 +119,11 @@ import {
     speakerSelectedStore,
 } from "../../Stores/MediaStore";
 import NoMicrophoneSoundToast from "../../Components/Toasts/NoMicrophoneSoundToast.svelte";
+import LoudEnvironmentToast from "../../Components/Toasts/LoudEnvironmentToast.svelte";
 import BrowserNoSoundInfoToast from "../../Components/Toasts/BrowserNoSoundInfoToast.svelte";
 import { LL, locale } from "../../../i18n/i18n-svelte";
 import { toastStore } from "../../Stores/ToastStore";
+import { loudEnvironmentWarningStore } from "../../Stores/LoudEnvironmentWarningStore";
 import { GameSceneUserInputHandler } from "../UserInput/GameSceneUserInputHandler";
 import { followUsersColorStore, followUsersStore } from "../../Stores/FollowStore";
 import { axiosWithRetry, hideConnectionIssueMessage, showConnectionIssueMessage } from "../../Connection/AxiosUtils";
@@ -2745,6 +2747,17 @@ export class GameScene extends DirtyScene {
                     toastStore.addToast(NoMicrophoneSoundToast, {}, NO_MICROPHONE_SOUND_TOAST_ID);
                 } else {
                     toastStore.removeToast(NO_MICROPHONE_SOUND_TOAST_ID);
+                }
+            }),
+        );
+
+        const LOUD_ENVIRONMENT_TOAST_ID = "loud-environment-toast";
+        this.unsubscribers.push(
+            loudEnvironmentWarningStore.subscribe((show) => {
+                if (show) {
+                    toastStore.addToast(LoudEnvironmentToast, {}, LOUD_ENVIRONMENT_TOAST_ID);
+                } else {
+                    toastStore.removeToast(LOUD_ENVIRONMENT_TOAST_ID);
                 }
             }),
         );

--- a/play/src/front/Stores/LoudEnvironmentDetectionController.ts
+++ b/play/src/front/Stores/LoudEnvironmentDetectionController.ts
@@ -1,0 +1,147 @@
+import type { Readable, Unsubscriber } from "svelte/store";
+import type {
+    BackgroundNoiseDetectorHandle,
+    BackgroundNoiseDetectorOutboundMessage,
+} from "@workadventure/noise-suppression/background-noise";
+
+export interface LoudEnvironmentInput {
+    track: MediaStreamTrack | undefined;
+    microphoneRequested: boolean;
+    silent: boolean;
+    noiseSuppressionEnabled: boolean;
+    requestedDeviceId: string | undefined;
+}
+
+export interface LoudEnvironmentDetectorDependencies {
+    createDetector(context: AudioContext, stream: MediaStream): Promise<BackgroundNoiseDetectorHandle>;
+    observeDetector(
+        handle: BackgroundNoiseDetectorHandle,
+        listener: (message: BackgroundNoiseDetectorOutboundMessage) => void,
+    ): Unsubscriber;
+    getAudioContext(): AudioContext;
+    reportError(error: unknown): void;
+}
+
+export class LoudEnvironmentDetectionController {
+    private detector: BackgroundNoiseDetectorHandle | undefined;
+    private stopObserving: Unsubscriber | undefined;
+    private currentTrack: MediaStreamTrack | undefined;
+    private currentRequestedDeviceId: string | undefined;
+    private initializationFailed = false;
+    private warningLatched = false;
+    private starting = false;
+    private generation = 0;
+    private readonly unsubscribeInput: Unsubscriber;
+
+    public constructor(
+        input: Readable<LoudEnvironmentInput>,
+        private readonly setWarning: (warning: boolean) => void,
+        private readonly dependencies: LoudEnvironmentDetectorDependencies,
+    ) {
+        this.unsubscribeInput = input.subscribe((value) => this.update(value));
+    }
+
+    public destroy(): void {
+        this.unsubscribeInput();
+        this.endSession();
+    }
+
+    private update(input: LoudEnvironmentInput): void {
+        const deviceChanged = input.requestedDeviceId !== this.currentRequestedDeviceId;
+        const trackChanged = input.track !== this.currentTrack;
+
+        if (deviceChanged || trackChanged) {
+            this.endSession();
+            this.currentTrack = input.track;
+            this.currentRequestedDeviceId = input.requestedDeviceId;
+            this.currentTrack?.addEventListener("ended", this.handleTrackEnded);
+        }
+
+        const track = this.currentTrack;
+        const requestedDeviceIsCurrent =
+            input.requestedDeviceId === undefined || track?.getSettings().deviceId === input.requestedDeviceId;
+        const shouldDetect =
+            input.microphoneRequested &&
+            !input.silent &&
+            !input.noiseSuppressionEnabled &&
+            track?.readyState === "live" &&
+            requestedDeviceIsCurrent;
+
+        if (!shouldDetect || this.warningLatched || this.initializationFailed) {
+            this.stopDetector();
+            return;
+        }
+
+        if (this.detector === undefined && !this.starting) {
+            this.startDetector(track).catch((error: unknown) => {
+                console.error("Unexpected loud environment detection error", error);
+            });
+        }
+    }
+
+    private readonly handleTrackEnded = (): void => {
+        this.endSession();
+    };
+
+    private async startDetector(track: MediaStreamTrack): Promise<void> {
+        const generation = ++this.generation;
+        this.starting = true;
+
+        try {
+            const context = this.dependencies.getAudioContext();
+            if (context.state === "suspended") {
+                await context.resume();
+            }
+
+            const detector = await this.dependencies.createDetector(context, new MediaStream([track]));
+            if (generation !== this.generation || track !== this.currentTrack) {
+                detector.dispose();
+                return;
+            }
+
+            this.starting = false;
+            this.detector = detector;
+            this.stopObserving = this.dependencies.observeDetector(detector, (message) => {
+                if (message.type !== "background-noise-detected" || generation !== this.generation) {
+                    return;
+                }
+                this.warningLatched = true;
+                this.setWarning(true);
+                this.stopDetector();
+            });
+
+            await detector.ready;
+            if (generation !== this.generation || track !== this.currentTrack) {
+                if (this.detector === detector) {
+                    this.stopDetector();
+                }
+            }
+        } catch (error) {
+            if (generation !== this.generation) {
+                return;
+            }
+            this.stopDetector();
+            this.initializationFailed = true;
+            console.error("Failed to initialize loud environment detection", error);
+            this.dependencies.reportError(error);
+        }
+    }
+
+    private stopDetector(): void {
+        this.generation++;
+        this.starting = false;
+        this.stopObserving?.();
+        this.stopObserving = undefined;
+        this.detector?.dispose();
+        this.detector = undefined;
+    }
+
+    private endSession(): void {
+        this.stopDetector();
+        this.currentTrack?.removeEventListener("ended", this.handleTrackEnded);
+        this.currentTrack = undefined;
+        this.initializationFailed = false;
+        this.warningLatched = false;
+        this.setWarning(false);
+    }
+}

--- a/play/src/front/Stores/LoudEnvironmentWarningStore.test.ts
+++ b/play/src/front/Stores/LoudEnvironmentWarningStore.test.ts
@@ -1,0 +1,220 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { writable } from "svelte/store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BackgroundNoiseDetectorHandle } from "@workadventure/noise-suppression/background-noise";
+import {
+    LoudEnvironmentDetectionController,
+    type LoudEnvironmentDetectorDependencies,
+    type LoudEnvironmentInput,
+} from "./LoudEnvironmentDetectionController";
+
+function createTrack(deviceId = "default"): MediaStreamTrack {
+    const target = new EventTarget();
+    return Object.assign(target, {
+        kind: "audio",
+        readyState: "live",
+        getSettings: () => ({ deviceId }),
+    }) as MediaStreamTrack;
+}
+
+function createHandle(): BackgroundNoiseDetectorHandle {
+    return {
+        ready: Promise.resolve({
+            type: "ready",
+            sampleRate: 16_000,
+            frameSamples: 512,
+            frameDurationMs: 32,
+            sileroModel: "v5",
+        }),
+        dispose: vi.fn(),
+    };
+}
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+describe("LoudEnvironmentDetectionController", () => {
+    let input: ReturnType<typeof writable<LoudEnvironmentInput>>;
+    let listener: ((message: { type: string }) => void) | undefined;
+    let dependencies: LoudEnvironmentDetectorDependencies;
+    let warnings: boolean[];
+
+    beforeEach(() => {
+        input = writable({
+            track: undefined,
+            microphoneRequested: false,
+            silent: false,
+            noiseSuppressionEnabled: false,
+            requestedDeviceId: undefined,
+        });
+        warnings = [];
+        listener = undefined;
+        dependencies = {
+            createDetector: vi.fn(() => Promise.resolve(createHandle())),
+            observeDetector: vi.fn((_handle, callback) => {
+                listener = callback;
+                return vi.fn();
+            }),
+            getAudioContext: vi.fn(() => ({ state: "running" }) as AudioContext),
+            reportError: vi.fn(),
+        };
+    });
+
+    it("starts only for an active raw microphone with suppression disabled", async () => {
+        const controller = new LoudEnvironmentDetectionController(
+            input,
+            (warning) => warnings.push(warning),
+            dependencies,
+        );
+        const track = createTrack();
+
+        input.set({
+            track,
+            microphoneRequested: false,
+            silent: false,
+            noiseSuppressionEnabled: false,
+            requestedDeviceId: undefined,
+        });
+        input.update((value) => ({ ...value, microphoneRequested: true, silent: true }));
+        input.update((value) => ({ ...value, silent: false, noiseSuppressionEnabled: true }));
+        expect(dependencies.createDetector).not.toHaveBeenCalled();
+
+        input.update((value) => ({ ...value, noiseSuppressionEnabled: false }));
+        await vi.waitFor(() => expect(dependencies.createDetector).toHaveBeenCalledTimes(1));
+        expect(dependencies.getAudioContext).toHaveBeenCalledTimes(1);
+        expect((dependencies.createDetector as ReturnType<typeof vi.fn>).mock.calls[0]?.[1].getAudioTracks()).toEqual([
+            track,
+        ]);
+
+        controller.destroy();
+    });
+
+    it("latches the warning and disposes the detector after one event per track session", async () => {
+        const handle = createHandle();
+        dependencies.createDetector = vi.fn(() => Promise.resolve(handle));
+        const controller = new LoudEnvironmentDetectionController(
+            input,
+            (warning) => warnings.push(warning),
+            dependencies,
+        );
+        const track = createTrack();
+
+        input.set({
+            track,
+            microphoneRequested: true,
+            silent: false,
+            noiseSuppressionEnabled: false,
+            requestedDeviceId: undefined,
+        });
+        await vi.waitFor(() => expect(listener).toBeDefined());
+        listener?.({ type: "background-noise-detected" });
+
+        expect(warnings.at(-1)).toBe(true);
+        expect(handle.dispose).toHaveBeenCalledTimes(1);
+        input.update((value) => ({ ...value, silent: true }));
+        input.update((value) => ({ ...value, silent: false }));
+        expect(dependencies.createDetector).toHaveBeenCalledTimes(1);
+
+        input.update((value) => ({ ...value, track: createTrack("other") }));
+        await vi.waitFor(() => expect(dependencies.createDetector).toHaveBeenCalledTimes(2));
+        expect(warnings.at(-1)).toBe(false);
+        controller.destroy();
+    });
+
+    it("disposes on suppression and requested device changes", async () => {
+        const firstHandle = createHandle();
+        const secondHandle = createHandle();
+        dependencies.createDetector = vi.fn().mockResolvedValueOnce(firstHandle).mockResolvedValueOnce(secondHandle);
+        const controller = new LoudEnvironmentDetectionController(input, vi.fn(), dependencies);
+        const track = createTrack("first");
+
+        input.set({
+            track,
+            microphoneRequested: true,
+            silent: false,
+            noiseSuppressionEnabled: false,
+            requestedDeviceId: "first",
+        });
+        await vi.waitFor(() => expect(dependencies.observeDetector).toHaveBeenCalledTimes(1));
+        input.update((value) => ({ ...value, noiseSuppressionEnabled: true }));
+        expect(firstHandle.dispose).toHaveBeenCalledTimes(1);
+
+        input.set({
+            track: createTrack("second"),
+            microphoneRequested: true,
+            silent: false,
+            noiseSuppressionEnabled: false,
+            requestedDeviceId: "second",
+        });
+        await vi.waitFor(() => expect(dependencies.observeDetector).toHaveBeenCalledTimes(2));
+        input.update((value) => ({ ...value, requestedDeviceId: "third" }));
+        expect(secondHandle.dispose).toHaveBeenCalledTimes(1);
+        controller.destroy();
+    });
+
+    it("disposes stale asynchronous initialization", async () => {
+        const pending = deferred<BackgroundNoiseDetectorHandle>();
+        const staleHandle = createHandle();
+        dependencies.createDetector = vi
+            .fn()
+            .mockReturnValueOnce(pending.promise)
+            .mockResolvedValueOnce(createHandle());
+        const controller = new LoudEnvironmentDetectionController(input, vi.fn(), dependencies);
+
+        input.set({
+            track: createTrack("first"),
+            microphoneRequested: true,
+            silent: false,
+            noiseSuppressionEnabled: false,
+            requestedDeviceId: "first",
+        });
+        input.set({
+            track: createTrack("second"),
+            microphoneRequested: true,
+            silent: false,
+            noiseSuppressionEnabled: false,
+            requestedDeviceId: "second",
+        });
+        pending.resolve(staleHandle);
+
+        await vi.waitFor(() => expect(staleHandle.dispose).toHaveBeenCalledTimes(1));
+        expect(dependencies.createDetector).toHaveBeenCalledTimes(2);
+        controller.destroy();
+    });
+
+    it("reports initialization failure once and retries only for a new track session", async () => {
+        const error = new Error("Silero failed");
+        dependencies.createDetector = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce(createHandle());
+        const controller = new LoudEnvironmentDetectionController(input, vi.fn(), dependencies);
+
+        input.set({
+            track: createTrack("first"),
+            microphoneRequested: true,
+            silent: false,
+            noiseSuppressionEnabled: false,
+            requestedDeviceId: "first",
+        });
+        await vi.waitFor(() => expect(dependencies.reportError).toHaveBeenCalledWith(error));
+        input.update((value) => ({ ...value, silent: true }));
+        input.update((value) => ({ ...value, silent: false }));
+        expect(dependencies.createDetector).toHaveBeenCalledTimes(1);
+
+        input.set({
+            track: createTrack("second"),
+            microphoneRequested: true,
+            silent: false,
+            noiseSuppressionEnabled: false,
+            requestedDeviceId: "second",
+        });
+        await vi.waitFor(() => expect(dependencies.createDetector).toHaveBeenCalledTimes(2));
+        expect(dependencies.reportError).toHaveBeenCalledTimes(1);
+        controller.destroy();
+    });
+});

--- a/play/src/front/Stores/LoudEnvironmentWarningStore.ts
+++ b/play/src/front/Stores/LoudEnvironmentWarningStore.ts
@@ -1,0 +1,59 @@
+import { derived, readable } from "svelte/store";
+import * as Sentry from "@sentry/svelte";
+import type * as BackgroundNoise from "@workadventure/noise-suppression/background-noise";
+import type { Unsubscriber } from "svelte/store";
+import { audioContextManager } from "../WebRtc/AudioContextManager";
+import {
+    rawLocalAudioTrackStore,
+    requestedMicrophoneDeviceIdStore,
+    requestedMicrophoneState,
+    silentStore,
+} from "./MediaStore";
+import { noiseSuppressionEnabledStore } from "./NoiseSuppressionStore";
+import { LoudEnvironmentDetectionController } from "./LoudEnvironmentDetectionController";
+
+const BACKGROUND_NOISE_SAMPLE_RATE = 16_000;
+const detectorObservers = new WeakMap<
+    BackgroundNoise.BackgroundNoiseDetectorHandle,
+    (listener: (message: BackgroundNoise.BackgroundNoiseDetectorOutboundMessage) => void) => Unsubscriber
+>();
+
+const loudEnvironmentInputStore = derived(
+    [
+        rawLocalAudioTrackStore,
+        requestedMicrophoneState,
+        silentStore,
+        noiseSuppressionEnabledStore,
+        requestedMicrophoneDeviceIdStore,
+    ],
+    ([$rawTrack, $microphoneRequested, $silent, $noiseSuppressionEnabled, $requestedDeviceId]) => ({
+        track: $rawTrack.type === "success" ? $rawTrack.track : undefined,
+        microphoneRequested: $microphoneRequested,
+        silent: $silent,
+        noiseSuppressionEnabled: $noiseSuppressionEnabled,
+        requestedDeviceId: $requestedDeviceId,
+    }),
+);
+
+export const loudEnvironmentWarningStore = readable(false, (set) => {
+    const controller = new LoudEnvironmentDetectionController(loudEnvironmentInputStore, set, {
+        createDetector: async (context, stream) => {
+            const module = await import("@workadventure/noise-suppression/background-noise");
+            const handle = await module.createBackgroundNoiseDetector(context, stream);
+            detectorObservers.set(handle, (listener) =>
+                module.observeBackgroundNoiseDetectorMessages(handle, listener),
+            );
+            return handle;
+        },
+        observeDetector: (handle, listener) => {
+            const observe = detectorObservers.get(handle);
+            if (observe === undefined) {
+                throw new Error("Background noise detector observer was not initialized");
+            }
+            return observe(listener);
+        },
+        getAudioContext: () => audioContextManager.getContext(BACKGROUND_NOISE_SAMPLE_RATE),
+        reportError: (error) => Sentry.captureException(error),
+    });
+    return () => controller.destroy();
+});

--- a/play/src/i18n/ar-SA/actionbar.ts
+++ b/play/src/i18n/ar-SA/actionbar.ts
@@ -45,6 +45,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         noSoundWarning: "لم يتم اكتشاف أي صوت من الميكروفون. قد تكون هناك مشكلة — جرب تغيير الميكروفون في الإعدادات.",
         noSoundWarningPressEnter: "لم يتم اكتشاف أي صوت من الميكروفون. اضغط على Enter لفتح الإعدادات.",
         noiseSuppressionBeta: "تقليل الضوضاء (تجريبي)",
+        loudEnvironmentWarning: "تم اكتشاف ضوضاء خلفية مستمرة في الميكروفون.",
+        enableNoiseSuppression: "تفعيل تقليل الضوضاء",
         noiseSuppressionInitializing: "جارٍ تهيئة تقليل الضوضاء المخصص...",
         noiseSuppressionUnsupported: "لا يمكن لهذا المتصفح تشغيل تقليل الضوضاء المخصص.",
         noiseSuppressionError: "فشل تقليل الضوضاء المخصص. يتم الرجوع إلى تقليل الضوضاء الأصلي في المتصفح.",

--- a/play/src/i18n/ca-ES/actionbar.ts
+++ b/play/src/i18n/ca-ES/actionbar.ts
@@ -46,6 +46,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
             "No s'ha detectat cap so del micròfon. Pot haver-hi un problema; prova de canviar el micròfon a la configuració.",
         noSoundWarningPressEnter: "No s'ha detectat cap so del micròfon. Prem Enter per obrir la configuració.",
         noiseSuppressionBeta: "Supressió de soroll (beta)",
+        loudEnvironmentWarning: "S'ha detectat soroll de fons continu al micròfon.",
+        enableNoiseSuppression: "Activa la supressió de soroll",
         noiseSuppressionInitializing: "S'està inicialitzant la supressió de soroll personalitzada...",
         noiseSuppressionUnsupported: "Aquest navegador no pot executar la supressió de soroll personalitzada.",
         noiseSuppressionError:

--- a/play/src/i18n/de-DE/actionbar.ts
+++ b/play/src/i18n/de-DE/actionbar.ts
@@ -47,6 +47,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         noSoundWarningPressEnter:
             "Kein Ton von Ihrem Mikrofon erkannt. Drücken Sie Enter, um die Einstellungen zu öffnen.",
         noiseSuppressionBeta: "Geräuschunterdrückung (Beta)",
+        loudEnvironmentWarning: "An Ihrem Mikrofon wurden anhaltende Hintergrundgeräusche erkannt.",
+        enableNoiseSuppression: "Geräuschunterdrückung aktivieren",
         noiseSuppressionInitializing: "Benutzerdefinierte Geräuschunterdrückung wird initialisiert...",
         noiseSuppressionUnsupported:
             "Dieser Browser kann die benutzerdefinierte Geräuschunterdrückung nicht ausführen.",

--- a/play/src/i18n/dsb-DE/actionbar.ts
+++ b/play/src/i18n/dsb-DE/actionbar.ts
@@ -46,6 +46,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
             "Žedyn zwuk z wašogo mikrofona namakany. Móžo problem byś; wopytajśo mikrofon w nastajenjach změniś.",
         noSoundWarningPressEnter: "Žedyn zwuk z wašogo mikrofona namakany. Tłóčće Enter, aby nastajenja wócyniś.",
         noiseSuppressionBeta: "Wótpóranje šuma (beta)",
+        loudEnvironmentWarning: "Na wašom mikrofonje jo se trajny slězynowy šum namakał.",
+        enableNoiseSuppression: "Wótpóranje šuma zmóžniś",
         noiseSuppressionInitializing: "Swójske wótpóranje šuma se inicializěrujo...",
         noiseSuppressionUnsupported: "Toś ten wobglědowak njamóžo swójske wótpóranje šuma wuwjasć.",
         noiseSuppressionError:

--- a/play/src/i18n/en-US/actionbar.ts
+++ b/play/src/i18n/en-US/actionbar.ts
@@ -46,6 +46,8 @@ const actionbar: BaseTranslation = {
             "No sound detected from your microphone. There may be a problem; try changing your microphone in settings.",
         noSoundWarningPressEnter: "No sound detected from your microphone. Press Enter to open settings.",
         noiseSuppressionBeta: "Noise suppression (beta)",
+        loudEnvironmentWarning: "Sustained background noise was detected on your microphone.",
+        enableNoiseSuppression: "Enable noise suppression",
         noiseSuppressionInitializing: "Initializing custom noise suppression...",
         noiseSuppressionUnsupported: "This browser cannot run custom noise suppression.",
         noiseSuppressionError: "Custom noise suppression failed. Falling back to browser native noise suppression.",

--- a/play/src/i18n/es-ES/actionbar.ts
+++ b/play/src/i18n/es-ES/actionbar.ts
@@ -46,6 +46,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
             "No se detecta sonido de tu micrófono. Puede haber un problema; prueba a cambiar de micrófono en la configuración.",
         noSoundWarningPressEnter: "No se detecta sonido de tu micrófono. Pulsa Enter para abrir la configuración.",
         noiseSuppressionBeta: "Supresión de ruido (beta)",
+        loudEnvironmentWarning: "Se ha detectado ruido de fondo continuo en tu micrófono.",
+        enableNoiseSuppression: "Activar la supresión de ruido",
         noiseSuppressionInitializing: "Inicializando la supresión de ruido personalizada...",
         noiseSuppressionUnsupported: "Este navegador no puede ejecutar la supresión de ruido personalizada.",
         noiseSuppressionError:

--- a/play/src/i18n/fr-FR/actionbar.ts
+++ b/play/src/i18n/fr-FR/actionbar.ts
@@ -48,6 +48,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
             "Aucun son détecté sur votre micro. Un problème est possible; essayez de changer de micro dans les réglages.",
         noSoundWarningPressEnter: "Aucun son détecté sur votre micro. Appuyez sur Entrée pour ouvrir les réglages.",
         noiseSuppressionBeta: "Réduction du bruit (bêta)",
+        loudEnvironmentWarning: "Un bruit de fond continu a été détecté sur votre micro.",
+        enableNoiseSuppression: "Activer la réduction du bruit",
         noiseSuppressionInitializing: "Initialisation de la réduction du bruit personnalisée...",
         noiseSuppressionUnsupported: "Ce navigateur ne peut pas exécuter la réduction du bruit personnalisée.",
         noiseSuppressionError:

--- a/play/src/i18n/hsb-DE/actionbar.ts
+++ b/play/src/i18n/hsb-DE/actionbar.ts
@@ -46,6 +46,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
             "Žadyn zwuk z wašeho mikrofona namakany. Móže problem być; spytajće mikrofon w nastajenjach změnić.",
         noSoundWarningPressEnter: "Žadyn zwuk z wašeho mikrofona namakany. Tłóčće Enter, zo byšte nastajenja wočinili.",
         noiseSuppressionBeta: "Potłóčowanje šuma (beta)",
+        loudEnvironmentWarning: "Na wašim mikrofonje je so trajny pozadkowy šum zwěsćił.",
+        enableNoiseSuppression: "Potłóčowanje šuma zmóžnić",
         noiseSuppressionInitializing: "Swójske potłóčowanje šuma so inicializuje...",
         noiseSuppressionUnsupported: "Tutón wobhladowak njemóže swójske potłóčowanje šuma wuwjesć.",
         noiseSuppressionError:

--- a/play/src/i18n/it-IT/actionbar.ts
+++ b/play/src/i18n/it-IT/actionbar.ts
@@ -46,6 +46,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
             "Nessun suono rilevato dal microfono. Potrebbe esserci un problema; prova a cambiare microfono nelle impostazioni.",
         noSoundWarningPressEnter: "Nessun suono rilevato dal microfono. Premi Invio per aprire le impostazioni.",
         noiseSuppressionBeta: "Soppressione del rumore (beta)",
+        loudEnvironmentWarning: "È stato rilevato un rumore di fondo continuo sul microfono.",
+        enableNoiseSuppression: "Attiva la soppressione del rumore",
         noiseSuppressionInitializing: "Inizializzazione della soppressione del rumore personalizzata...",
         noiseSuppressionUnsupported: "Questo browser non può eseguire la soppressione del rumore personalizzata.",
         noiseSuppressionError:

--- a/play/src/i18n/ja-JP/actionbar.ts
+++ b/play/src/i18n/ja-JP/actionbar.ts
@@ -46,6 +46,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
             "マイクから音が検出されません。問題がある可能性があります — 設定でマイクを変更してみてください。",
         noSoundWarningPressEnter: "マイクから音が検出されません。Enterキーを押して設定を開いてください。",
         noiseSuppressionBeta: "ノイズ抑制（ベータ）",
+        loudEnvironmentWarning: "マイクで継続的な背景ノイズが検出されました。",
+        enableNoiseSuppression: "ノイズ抑制を有効にする",
         noiseSuppressionInitializing: "カスタムノイズ抑制を初期化しています...",
         noiseSuppressionUnsupported: "このブラウザではカスタムノイズ抑制を実行できません。",
         noiseSuppressionError: "カスタムノイズ抑制に失敗しました。ブラウザ標準のノイズ抑制に戻します。",

--- a/play/src/i18n/ko-KR/actionbar.ts
+++ b/play/src/i18n/ko-KR/actionbar.ts
@@ -47,6 +47,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
             "마이크에서 소리가 감지되지 않습니다. 문제가 있을 수 있습니다 — 설정에서 마이크를 변경해 보세요.",
         noSoundWarningPressEnter: "마이크에서 소리가 감지되지 않습니다. Enter를 눌러 설정을 엽니다.",
         noiseSuppressionBeta: "소음 억제(베타)",
+        loudEnvironmentWarning: "마이크에서 지속적인 배경 소음이 감지되었습니다.",
+        enableNoiseSuppression: "소음 억제 활성화",
         noiseSuppressionInitializing: "사용자 지정 소음 억제를 초기화하는 중...",
         noiseSuppressionUnsupported: "이 브라우저에서는 사용자 지정 소음 억제를 실행할 수 없습니다.",
         noiseSuppressionError: "사용자 지정 소음 억제에 실패했습니다. 브라우저 기본 소음 억제로 돌아갑니다.",

--- a/play/src/i18n/nl-NL/actionbar.ts
+++ b/play/src/i18n/nl-NL/actionbar.ts
@@ -47,6 +47,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         noSoundWarningPressEnter:
             "Geen geluid gedetecteerd van je microfoon. Druk op Enter om de instellingen te openen.",
         noiseSuppressionBeta: "Ruisonderdrukking (bèta)",
+        loudEnvironmentWarning: "Er is aanhoudend achtergrondgeluid op je microfoon gedetecteerd.",
+        enableNoiseSuppression: "Ruisonderdrukking inschakelen",
         noiseSuppressionInitializing: "Aangepaste ruisonderdrukking initialiseren...",
         noiseSuppressionUnsupported: "Deze browser kan aangepaste ruisonderdrukking niet uitvoeren.",
         noiseSuppressionError:

--- a/play/src/i18n/pt-BR/actionbar.ts
+++ b/play/src/i18n/pt-BR/actionbar.ts
@@ -50,6 +50,8 @@ const actionbar: BaseTranslation = {
             "Nenhum som detectado do seu microfone. Pode haver um problema; tente trocar o microfone nas configurações.",
         noSoundWarningPressEnter: "Nenhum som detectado do seu microfone. Pressione Enter para abrir as configurações.",
         noiseSuppressionBeta: "Supressão de ruído (beta)",
+        loudEnvironmentWarning: "Foi detectado ruído de fundo contínuo no seu microfone.",
+        enableNoiseSuppression: "Ativar supressão de ruído",
         noiseSuppressionInitializing: "Inicializando a supressão de ruído personalizada...",
         noiseSuppressionUnsupported: "Este navegador não pode executar a supressão de ruído personalizada.",
         noiseSuppressionError:

--- a/play/src/i18n/zh-CN/actionbar.ts
+++ b/play/src/i18n/zh-CN/actionbar.ts
@@ -45,6 +45,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         noSoundWarning: "未检测到麦克风声音。可能存在问题 — 请尝试在设置中更换麦克风。",
         noSoundWarningPressEnter: "未检测到麦克风声音。按 Enter 打开设置。",
         noiseSuppressionBeta: "噪声抑制（测试版）",
+        loudEnvironmentWarning: "检测到麦克风中存在持续的背景噪声。",
+        enableNoiseSuppression: "启用噪声抑制",
         noiseSuppressionInitializing: "正在初始化自定义噪声抑制...",
         noiseSuppressionUnsupported: "此浏览器无法运行自定义噪声抑制。",
         noiseSuppressionError: "自定义噪声抑制失败。正在回退到浏览器原生噪声抑制。",

--- a/play/src/i18n/zh-TW/actionbar.ts
+++ b/play/src/i18n/zh-TW/actionbar.ts
@@ -45,6 +45,8 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         noSoundWarning: "未偵測到麥克風聲音。可能有問題 — 請嘗試在設定中更換麥克風。",
         noSoundWarningPressEnter: "未偵測到麥克風聲音。按 Enter 開啟設定。",
         noiseSuppressionBeta: "噪音抑制（測試版）",
+        loudEnvironmentWarning: "偵測到麥克風中存在持續的背景噪音。",
+        enableNoiseSuppression: "啟用噪音抑制",
         noiseSuppressionInitializing: "正在初始化自訂噪音抑制...",
         noiseSuppressionUnsupported: "此瀏覽器無法執行自訂噪音抑制。",
         noiseSuppressionError: "自訂噪音抑制失敗。正在回復到瀏覽器原生噪音抑制。",

--- a/play/vite.config.ts
+++ b/play/vite.config.ts
@@ -87,8 +87,12 @@ export default defineConfig(({ mode }) => {
             },
         },
         optimizeDeps: {
-            include: ["olm"],
-            exclude: ["svelte-modals", "@mediapipe/selfie_segmentation"],
+            include: ["olm", "@ricky0123/vad-web"],
+            exclude: [
+                "svelte-modals",
+                "@mediapipe/selfie_segmentation",
+                "@workadventure/noise-suppression/background-noise",
+            ],
             esbuildOptions: {
                 define: {
                     global: "globalThis",


### PR DESCRIPTION
## Root cause and behavior

Users currently receive no indication when sustained non-speech noise is being published while noise suppression is disabled. The new controller starts only for an active, non-silent raw microphone track, latches after the first warning in that microphone session, and reports initialization failures once through Sentry.

Enabling suppression uses the existing `noiseSuppressionEnabledStore`, keeping the configured provider and media controller authoritative. Ignoring the toast changes no microphone setting and resets only when a new microphone session begins.

## Summary

- lazily analyze the raw published microphone stream with the Silero VAD background-noise detector
- show a session-scoped, non-blocking toast that can enable noise suppression or dismiss the warning
- dispose and invalidate detector instances across microphone, track, device, session, and suppression changes
- update the noise-suppression package to 0.1.1 and configure Vite dependency optimization for the detector assets
- add translated toast copy across all action-bar locales

