### PR TITLE
Fix map-storage S3 stream leaks

### DIFF
--- a/map-storage/src/Upload/S3FileSystem.ts
+++ b/map-storage/src/Upload/S3FileSystem.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from "http";
 import path from "path";
-import type { Readable } from "stream";
+import { pipeline, type Readable } from "stream";
 import type { ListObjectsV2CommandInput, ListObjectsV2CommandOutput, S3 } from "@aws-sdk/client-s3";
 import {
     CopyObjectCommand,
@@ -269,7 +269,11 @@ export class S3FileSystem implements FileSystemInterface {
                 // Typescript doc is wrong in AWS: see: https://github.com/aws/aws-sdk-js-v3/issues/1877#issuecomment-755387549
                 //eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 //@ts-ignore
-                (result.Body as IncomingMessage).pipe(res);
+                pipeline(result.Body as IncomingMessage, res, (error) => {
+                    if (error && !res.destroyed) {
+                        next(error);
+                    }
+                });
             })
             .catch((err) => {
                 if (err instanceof Error && err.constructor.name === "NoSuchKey") {
@@ -348,22 +352,22 @@ export class S3FileSystem implements FileSystemInterface {
             if (objects) {
                 for (const file of objects) {
                     const key = file.Key;
+
+                    if (!key) {
+                        throw new Error("Failed to get file from S3");
+                    }
+                    if (key.endsWith("/") || key.includes(MapListService.CACHE_NAME)) {
+                        continue;
+                    }
+
                     const { Body } = await this.s3.send(
                         new GetObjectCommand({
                             Bucket: this.bucketName,
                             Key: key,
                         }),
                     );
-                    if (!key || !Body) {
+                    if (!Body) {
                         throw new Error("Failed to get file from S3");
-                    }
-                    if (key.endsWith("/")) {
-                        // a directory. Let's bypass this.
-                        continue;
-                    }
-                    if (key.includes(MapListService.CACHE_NAME)) {
-                        // we do not want cache file to be downloaded
-                        continue;
                     }
 
                     await new Promise<void>((resolve, reject) => {

--- a/map-storage/src/Upload/tests/S3FileSystem.test.ts
+++ b/map-storage/src/Upload/tests/S3FileSystem.test.ts
@@ -1,0 +1,50 @@
+import { PassThrough } from "stream";
+import { GetObjectCommand, ListObjectsV2Command, type S3 } from "@aws-sdk/client-s3";
+import type { Response } from "express";
+import type ZipStream from "zip-stream";
+import { describe, expect, it, vi } from "vitest";
+import { MapListService } from "../../Services/MapListService";
+import { S3FileSystem } from "../S3FileSystem";
+
+vi.mock("../../Services/MapListService", () => ({
+    MapListService: { CACHE_NAME: "__cache.json" },
+}));
+vi.mock("../../Services/S3Client", () => ({
+    s3UploadConcurrencyLimit: vi.fn(),
+}));
+
+describe("S3FileSystem", () => {
+    describe("serveStaticFile", () => {
+        it("destroys the S3 response body when the client disconnects", async () => {
+            const body = new PassThrough();
+            const getObject = vi.fn().mockResolvedValue({ Body: body });
+            const fileSystem = new S3FileSystem({ getObject } as unknown as S3, "bucket");
+            const response = Object.assign(new PassThrough(), { set: vi.fn() }) as unknown as Response;
+            const next = vi.fn();
+
+            fileSystem.serveStaticFile("map/file.png", response, next);
+            await vi.waitFor(() => expect(getObject).toHaveBeenCalledOnce());
+
+            response.destroy();
+
+            await vi.waitFor(() => expect(body.destroyed).toBe(true));
+            expect(next).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("archiveDirectory", () => {
+        it("does not fetch bodies for directories or the map list cache", async () => {
+            const send = vi.fn().mockResolvedValue({
+                Contents: [{ Key: "map/" }, { Key: `map/${MapListService.CACHE_NAME}` }],
+                IsTruncated: false,
+            });
+            const fileSystem = new S3FileSystem({ send } as unknown as S3, "bucket");
+
+            await fileSystem.archiveDirectory({} as ZipStream, "map");
+
+            expect(send).toHaveBeenCalledOnce();
+            expect(send.mock.calls[0]?.[0]).toBeInstanceOf(ListObjectsV2Command);
+            expect(send.mock.calls.some(([command]) => command instanceof GetObjectCommand)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## What changed

- stream S3 file responses through `stream.pipeline()` so client disconnects destroy the upstream S3 body
- skip directory markers and the map-list cache before issuing archive `GetObject` requests
- add regression coverage for client disconnect cleanup and skipped archive entries

## Why

A production map-storage replica exhausted its S3 HTTP agent and returned HTTP 500 errors. The process had accumulated S3 connections in `CLOSE_WAIT` with unread response data. Raw `Body.pipe(res)` did not clean up the S3 response when the downstream client disconnected. The archive path could also fetch bodies and then skip them without consuming or destroying them.

This prevents leaked S3 sockets from consuming the agent's connection pool and avoids unnecessary response bodies in archive generation.

## Validation

- `npm test --workspace=map-storage -- --run`
- `npm run typecheck --workspace=map-storage`
- `npm run lint --workspace=map-storage -- --no-cache`
- `npx prettier --check map-storage/src/Upload/S3FileSystem.ts map-storage/src/Upload/tests/S3FileSystem.test.ts`
- `git diff --check`
