### PR TITLE
Improving skipping of tutorial in E2E test

### DIFF
--- a/tests/tests/utils/auth.ts
+++ b/tests/tests/utils/auth.ts
@@ -118,7 +118,8 @@ async function createUser(
     await dismissDuplicateUserConnectedModalIfShown(page);
     await dismissPwaInstallScreenIfShown(page);
     await dismissDoNotDisturbInfoToast(page);
-    await skipOnboardingWhenShown(page);
+    // Let's skip onboarding
+    await page.getByTestId("onboarding-button-welcome-skip").click();
 
     if (browser.browserType().name() !== "webkit") {
         await Menu.expectButtonState(page, "microphone-button", "normal");
@@ -186,21 +187,7 @@ export async function getPage(
     await dismissPwaInstallScreenIfShown(page, true);
     await dismissDuplicateUserConnectedModalIfShown(page, true);
     await dismissDoNotDisturbInfoToast(page);
-    await skipOnboardingWhenShown(page);
 
     await expect(page.getByTestId("microphone-button")).toBeVisible({ timeout: 120_000 });
     return disposeWithContext(page);
-}
-
-async function skipOnboardingWhenShown(page: Page) {
-    await page.addLocatorHandler(page.getByTestId("onboarding-button-welcome-skip"), async () => {
-        try {
-            await page.getByTestId("onboarding-button-welcome-skip").click();
-        } catch (e) {
-            if (e instanceof Error && e.message.includes("Target page, context or browser has been closed")) {
-                return;
-            }
-            throw e;
-        }
-    });
 }


### PR DESCRIPTION
Skipping tutorial was so far implemented using addLocatorHandler. We are refactoring this to skip the tutorial once the first time we log.