### PR TITLE
Adding Sentry roomId tag in front

### DIFF
--- a/play/src/front/Connection/ConnectionManager.ts
+++ b/play/src/front/Connection/ConnectionManager.ts
@@ -435,6 +435,7 @@ class ConnectionManager {
         lastCommandId?: string,
         retryAttempt = 0,
     ): Promise<OnConnectInterface> {
+        Sentry.setTag("roomId", roomUrl);
         return new Promise<OnConnectInterface>((resolve, reject) => {
             const connection = new RoomConnection(
                 this.authToken,


### PR DESCRIPTION
This way, when an issue happens on a given map, we can filter out per map.