### PR TITLE
Add GitHub E2E report viewer

### DIFF
--- a/contrib/tools/e2e-report/README.md
+++ b/contrib/tools/e2e-report/README.md
@@ -1,0 +1,29 @@
+# E2E report viewer
+
+Download and open a Playwright HTML report from the latest GitHub Actions run associated with the current branch or pull request.
+
+## Requirements
+
+- Node.js and the repository dependencies
+- [GitHub CLI](https://cli.github.com/) authenticated with access to the repository
+
+## Usage
+
+From the repository root:
+
+```bash
+npm run e2e:report
+```
+
+The command finds the current pull request, selects the newest `build-test-and-deploy.yml` run containing Playwright artifacts, and asks which browser and shard to open. Reports are cached under `~/.cache/workadventure/e2e-reports/`.
+
+Filters and non-interactive usage:
+
+```bash
+npm run e2e:report -- --project firefox --shard 3
+npm run e2e:report -- --run 28080895737
+npm run e2e:report -- --list
+npm run e2e:report -- --refresh
+```
+
+Run `npm run e2e:report -- --help` for all options. Stop the report server with Ctrl+C.

--- a/contrib/tools/e2e-report/package.json
+++ b/contrib/tools/e2e-report/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@workadventure/e2e-report",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Download and open Playwright reports from the current branch's GitHub Actions run",
+  "scripts": {
+    "start": "tsx src/cli.ts",
+    "test": "tsx --test src/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "tsx": "^4.22.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/contrib/tools/e2e-report/src/artifacts.test.ts
+++ b/contrib/tools/e2e-report/src/artifacts.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildReports,
+  formatBytes,
+  getJobCoordinates,
+  parsePlaywrightArtifact,
+} from "./artifacts.js";
+
+test("parses projects containing hyphens from the right-hand shard suffix", () => {
+  const report = parsePlaywrightArtifact({
+    id: 1,
+    name: "playwright-report-single-domain-2-4",
+    size_in_bytes: 1024,
+    expired: false,
+  });
+
+  assert.equal(report?.project, "single-domain");
+  assert.equal(report?.shard, 2);
+  assert.equal(report?.shardCount, 4);
+});
+
+test("correlates report artifacts with standard and deployment jobs", () => {
+  const artifacts = [
+    {
+      id: 1,
+      name: "playwright-report-firefox-3-4",
+      size_in_bytes: 1024,
+      expired: false,
+    },
+    {
+      id: 2,
+      name: "playwright-report-helm-1-2",
+      size_in_bytes: 2048,
+      expired: false,
+    },
+  ];
+  const reports = buildReports(artifacts, [
+    { name: "End to end tests with firefox 3/4", conclusion: "failure" },
+    { name: "End to end tests in Kubernetes (1/2)", conclusion: "success" },
+  ]);
+
+  assert.deepEqual(
+    reports.map(({ project, shard, conclusion }) => ({
+      project,
+      shard,
+      conclusion,
+    })),
+    [
+      { project: "firefox", shard: 3, conclusion: "failure" },
+      { project: "helm", shard: 1, conclusion: "success" },
+    ],
+  );
+});
+
+test("recognizes all current workflow job naming schemes", () => {
+  assert.deepEqual(getJobCoordinates("End to end tests with chromium 1/4"), {
+    project: "chromium",
+    shard: 1,
+    shardCount: 4,
+  });
+  assert.deepEqual(getJobCoordinates("Test production docker compose (2/2)"), {
+    project: "single-domain",
+    shard: 2,
+    shardCount: 2,
+  });
+  assert.deepEqual(getJobCoordinates("End to end tests in Kubernetes (1/2)"), {
+    project: "helm",
+    shard: 1,
+    shardCount: 2,
+  });
+});
+
+test("filters expired and unrelated artifacts", () => {
+  const reports = buildReports(
+    [
+      {
+        id: 1,
+        name: "playwright-report-webkit-1-3",
+        size_in_bytes: 1,
+        expired: true,
+      },
+      { id: 2, name: "play", size_in_bytes: 1, expired: false },
+    ],
+    [],
+  );
+
+  assert.deepEqual(reports, []);
+});
+
+test("formats artifact sizes", () => {
+  assert.equal(formatBytes(999), "999 B");
+  assert.equal(formatBytes(1024), "1.0 KB");
+  assert.equal(formatBytes(5 * 1024 * 1024), "5.0 MB");
+});

--- a/contrib/tools/e2e-report/src/artifacts.ts
+++ b/contrib/tools/e2e-report/src/artifacts.ts
@@ -1,0 +1,182 @@
+export type Conclusion =
+  | "success"
+  | "failure"
+  | "cancelled"
+  | "skipped"
+  | "neutral"
+  | "timed_out"
+  | "action_required"
+  | null;
+
+export interface GithubArtifact {
+  id: number;
+  name: string;
+  size_in_bytes: number;
+  expired: boolean;
+}
+
+export interface GithubJob {
+  name: string;
+  conclusion: Conclusion;
+}
+
+export interface PlaywrightReport {
+  artifact: GithubArtifact;
+  project: string;
+  shard: number;
+  shardCount: number;
+  conclusion: Conclusion;
+}
+
+const artifactPattern = /^playwright-report-(.+)-(\d+)-(\d+)$/;
+
+export function parsePlaywrightArtifact(
+  artifact: GithubArtifact,
+): Omit<PlaywrightReport, "conclusion"> | undefined {
+  const match = artifact.name.match(artifactPattern);
+  if (match === null) {
+    return undefined;
+  }
+
+  const [, project, shard, shardCount] = match;
+  if (
+    project === undefined ||
+    shard === undefined ||
+    shardCount === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    artifact,
+    project,
+    shard: Number.parseInt(shard, 10),
+    shardCount: Number.parseInt(shardCount, 10),
+  };
+}
+
+export function getJobCoordinates(
+  name: string,
+): { project: string; shard: number; shardCount: number } | undefined {
+  const standard = name.match(/^End to end tests with (.+) (\d+)\/(\d+)$/);
+  if (standard !== null) {
+    return coordinatesFromMatch(standard);
+  }
+
+  const singleDomain = name.match(
+    /^Test production docker compose \((\d+)\/(\d+)\)$/,
+  );
+  if (singleDomain !== null) {
+    return coordinatesFromMatch(singleDomain, "single-domain");
+  }
+
+  const helm = name.match(/^End to end tests in Kubernetes \((\d+)\/(\d+)\)$/);
+  if (helm !== null) {
+    return coordinatesFromMatch(helm, "helm");
+  }
+
+  return undefined;
+}
+
+function coordinatesFromMatch(
+  match: RegExpMatchArray,
+  fixedProject?: string,
+): { project: string; shard: number; shardCount: number } | undefined {
+  const project = fixedProject ?? match[1];
+  const shard = fixedProject === undefined ? match[2] : match[1];
+  const shardCount = fixedProject === undefined ? match[3] : match[2];
+
+  if (
+    project === undefined ||
+    shard === undefined ||
+    shardCount === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    project,
+    shard: Number.parseInt(shard, 10),
+    shardCount: Number.parseInt(shardCount, 10),
+  };
+}
+
+export function buildReports(
+  artifacts: GithubArtifact[],
+  jobs: GithubJob[],
+): PlaywrightReport[] {
+  const conclusions = new Map<string, Conclusion>();
+  for (const job of jobs) {
+    const coordinates = getJobCoordinates(job.name);
+    if (coordinates !== undefined) {
+      conclusions.set(
+        reportKey(
+          coordinates.project,
+          coordinates.shard,
+          coordinates.shardCount,
+        ),
+        job.conclusion,
+      );
+    }
+  }
+
+  return artifacts
+    .filter((artifact) => !artifact.expired)
+    .map(parsePlaywrightArtifact)
+    .filter(
+      (report): report is Omit<PlaywrightReport, "conclusion"> =>
+        report !== undefined,
+    )
+    .map((report) => ({
+      ...report,
+      conclusion:
+        conclusions.get(
+          reportKey(report.project, report.shard, report.shardCount),
+        ) ?? null,
+    }))
+    .sort((left, right) => {
+      const projectComparison = left.project.localeCompare(
+        right.project,
+        undefined,
+        { numeric: true },
+      );
+      return projectComparison === 0
+        ? left.shard - right.shard
+        : projectComparison;
+    });
+}
+
+function reportKey(project: string, shard: number, shardCount: number): string {
+  return `${project}:${shard}:${shardCount}`;
+}
+
+export function formatProject(project: string): string {
+  const knownProjects: Record<string, string> = {
+    chromium: "Chromium",
+    firefox: "Firefox",
+    webkit: "WebKit",
+    mobilechromium: "Mobile Chromium",
+    mobilefirefox: "Mobile Firefox",
+    mobilewebkit: "Mobile WebKit",
+    "single-domain": "Single domain",
+    helm: "Helm",
+  };
+
+  return knownProjects[project] ?? project;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  const units = ["KB", "MB", "GB"];
+  let value = bytes / 1024;
+  let unit = units[0];
+  for (let index = 1; index < units.length && value >= 1024; index += 1) {
+    value /= 1024;
+    unit = units[index];
+  }
+
+  return `${value.toFixed(1)} ${unit}`;
+}

--- a/contrib/tools/e2e-report/src/cli.ts
+++ b/contrib/tools/e2e-report/src/cli.ts
@@ -1,0 +1,416 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { access, mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+
+import {
+  buildReports,
+  formatBytes,
+  formatProject,
+  type GithubArtifact,
+  type PlaywrightReport,
+} from "./artifacts.js";
+import {
+  getCurrentBranch,
+  getCurrentPullRequest,
+  getRepository,
+  getWorkflowRun,
+  listArtifacts,
+  listJobs,
+  listWorkflowRuns,
+  run,
+  type PullRequest,
+  type WorkflowRun,
+} from "./github.js";
+
+interface Options {
+  runId?: number;
+  project?: string;
+  shard?: number;
+  workflow: string;
+  refresh: boolean;
+  listOnly: boolean;
+  help: boolean;
+}
+
+const help = `Download and open a Playwright report from GitHub Actions.
+
+Usage:
+  npm run e2e:report
+  npm run e2e:report -- --project firefox --shard 3
+  npm run e2e:report -- --run 28080895737
+
+Options:
+  --run <id>          Select a specific workflow run
+  --project <name>    Filter by Playwright project
+  --shard <number>    Filter by shard number
+  --workflow <file>   Workflow file (default: build-test-and-deploy.yml)
+  --refresh           Download again instead of using the cached report
+  --list              List available reports without downloading
+  -h, --help          Show this help
+`;
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  if (options.help) {
+    console.log(help);
+    return;
+  }
+
+  await ensureCommand(
+    "gh",
+    ["--version"],
+    "Install and authenticate the GitHub CLI first: https://cli.github.com/",
+  );
+
+  const repository = await getRepository();
+  const pullRequest =
+    options.runId === undefined ? await getCurrentPullRequest() : undefined;
+  const branch =
+    options.runId === undefined
+      ? (pullRequest?.headRefName ?? (await getCurrentBranch()))
+      : undefined;
+  const { workflowRun, artifacts } = await selectWorkflowRun(
+    repository,
+    options,
+    branch,
+  );
+  const jobs = await listJobs(workflowRun.databaseId);
+  const allReports = buildReports(artifacts, jobs);
+  const reports = filterReports(allReports, options);
+
+  printContext(repository, pullRequest, branch, workflowRun);
+  if (reports.length === 0) {
+    throw new Error(
+      allReports.length === 0
+        ? "This workflow run has no unexpired Playwright report artifacts."
+        : "No report matches the requested project and shard.",
+    );
+  }
+
+  if (options.listOnly) {
+    printReports(reports);
+    return;
+  }
+
+  const report =
+    reports.length === 1 ? reports[0] : await promptForReport(reports);
+  if (report === undefined) {
+    throw new Error("No report selected.");
+  }
+
+  const reportDirectory = await downloadReport(
+    repository,
+    workflowRun.databaseId,
+    report.artifact,
+    options.refresh,
+  );
+  console.log(`\nOpening ${formatReportName(report)} from ${reportDirectory}`);
+  await showReport(reportDirectory);
+}
+
+async function selectWorkflowRun(
+  repository: string,
+  options: Options,
+  branch?: string,
+): Promise<{ workflowRun: WorkflowRun; artifacts: GithubArtifact[] }> {
+  if (options.runId !== undefined) {
+    const [workflowRun, artifacts] = await Promise.all([
+      getWorkflowRun(options.runId),
+      listArtifacts(repository, options.runId),
+    ]);
+    return { workflowRun, artifacts };
+  }
+
+  if (branch === undefined) {
+    throw new Error("Could not determine a branch.");
+  }
+
+  const workflowRuns = await listWorkflowRuns(branch, options.workflow);
+  for (const workflowRun of workflowRuns) {
+    const artifacts = await listArtifacts(repository, workflowRun.databaseId);
+    if (
+      artifacts.some(
+        (artifact) =>
+          artifact.name.startsWith("playwright-report-") && !artifact.expired,
+      )
+    ) {
+      return { workflowRun, artifacts };
+    }
+  }
+
+  throw new Error(
+    `No recent ${options.workflow} run on ${branch} contains an unexpired Playwright report.`,
+  );
+}
+
+function filterReports(
+  reports: PlaywrightReport[],
+  options: Options,
+): PlaywrightReport[] {
+  return reports.filter(
+    (report) =>
+      (options.project === undefined ||
+        report.project.toLowerCase() === options.project.toLowerCase()) &&
+      (options.shard === undefined || report.shard === options.shard),
+  );
+}
+
+function printContext(
+  repository: string,
+  pullRequest: PullRequest | undefined,
+  branch: string | undefined,
+  runInfo: WorkflowRun,
+): void {
+  console.log("");
+  console.log(
+    pullRequest === undefined
+      ? `${repository}${branch === undefined ? "" : ` — ${branch}`}`
+      : `PR #${pullRequest.number} — ${pullRequest.title}`,
+  );
+  console.log(
+    `Run #${runInfo.databaseId} — ${runInfo.status}/${runInfo.conclusion || "pending"} — ${new Date(
+      runInfo.createdAt,
+    ).toLocaleString()}`,
+  );
+  console.log(runInfo.url);
+}
+
+function printReports(reports: PlaywrightReport[]): void {
+  console.log("");
+  reports.forEach((report, index) => {
+    console.log(
+      `${String(index + 1).padStart(2)}. ${formatReportLine(report)}`,
+    );
+  });
+}
+
+async function promptForReport(
+  reports: PlaywrightReport[],
+): Promise<PlaywrightReport | undefined> {
+  if (!stdin.isTTY || !stdout.isTTY) {
+    throw new Error(
+      "Multiple reports match. Pass --project and --shard when running non-interactively.",
+    );
+  }
+
+  printReports(reports);
+  const readline = createInterface({ input: stdin, output: stdout });
+  try {
+    const answer = await readline.question("\nSelect a report [1]: ");
+    const selection = answer.trim() === "" ? 1 : Number.parseInt(answer, 10);
+    if (
+      !Number.isInteger(selection) ||
+      selection < 1 ||
+      selection > reports.length
+    ) {
+      throw new Error(`Choose a number between 1 and ${reports.length}.`);
+    }
+    return reports[selection - 1];
+  } finally {
+    readline.close();
+  }
+}
+
+function formatReportLine(report: PlaywrightReport): string {
+  const name = formatReportName(report).padEnd(24);
+  const conclusion = (report.conclusion ?? "unknown").padEnd(10);
+  return `${name} ${conclusion} ${formatBytes(report.artifact.size_in_bytes).padStart(9)}`;
+}
+
+function formatReportName(report: PlaywrightReport): string {
+  return `${formatProject(report.project)} ${report.shard}/${report.shardCount}`;
+}
+
+async function downloadReport(
+  repository: string,
+  runId: number,
+  artifact: GithubArtifact,
+  refresh: boolean,
+): Promise<string> {
+  const cacheRoot = process.env.XDG_CACHE_HOME ?? join(homedir(), ".cache");
+  const destination = join(
+    cacheRoot,
+    "workadventure",
+    "e2e-reports",
+    String(runId),
+    artifact.name,
+  );
+  const marker = join(destination, ".download-complete");
+
+  if (!refresh && (await exists(marker))) {
+    console.log(`\nUsing cached report ${destination}`);
+    return destination;
+  }
+
+  const temporary = `${destination}.tmp-${process.pid}`;
+  await rm(temporary, { recursive: true, force: true });
+  if (refresh) {
+    await rm(destination, { recursive: true, force: true });
+  }
+  await mkdir(temporary, { recursive: true });
+
+  console.log(
+    `\nDownloading ${artifact.name} (${formatBytes(artifact.size_in_bytes)})...`,
+  );
+  try {
+    await run("gh", [
+      "run",
+      "download",
+      String(runId),
+      "--repo",
+      repository,
+      "--name",
+      artifact.name,
+      "--dir",
+      temporary,
+    ]);
+    await writeFile(
+      join(temporary, ".download-complete"),
+      `${artifact.id}\n`,
+      "utf8",
+    );
+    await rm(destination, { recursive: true, force: true });
+    await mkdir(resolve(destination, ".."), { recursive: true });
+    await rename(temporary, destination);
+  } catch (error) {
+    await rm(temporary, { recursive: true, force: true });
+    throw error;
+  }
+
+  return destination;
+}
+
+async function showReport(reportDirectory: string): Promise<void> {
+  await new Promise<void>((resolvePromise, reject) => {
+    const child = spawn(
+      "npm",
+      [
+        "exec",
+        "--workspace=workadventure-e2e-tests",
+        "--",
+        "playwright",
+        "show-report",
+        "--host",
+        "127.0.0.1",
+        reportDirectory,
+      ],
+      {
+        cwd: findRepositoryRoot(),
+        stdio: "inherit",
+        shell: false,
+      },
+    );
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0 || signal === "SIGINT") {
+        resolvePromise();
+      } else {
+        reject(
+          new Error(
+            `Playwright report server exited with code ${code ?? "unknown"}.`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+function findRepositoryRoot(): string {
+  return resolve(import.meta.dirname, "../../../..");
+}
+
+async function ensureCommand(
+  command: string,
+  args: string[],
+  failureMessage: string,
+): Promise<void> {
+  try {
+    await run(command, args);
+  } catch {
+    throw new Error(failureMessage);
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseOptions(args: string[]): Options {
+  const options: Options = {
+    workflow: "build-test-and-deploy.yml",
+    refresh: false,
+    listOnly: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    switch (argument) {
+      case "--run":
+        options.runId = parsePositiveInteger(
+          readValue(args, ++index, argument),
+          argument,
+        );
+        break;
+      case "--project":
+        options.project = readValue(args, ++index, argument);
+        break;
+      case "--shard":
+        options.shard = parsePositiveInteger(
+          readValue(args, ++index, argument),
+          argument,
+        );
+        break;
+      case "--workflow":
+        options.workflow = readValue(args, ++index, argument);
+        break;
+      case "--refresh":
+        options.refresh = true;
+        break;
+      case "--list":
+        options.listOnly = true;
+        break;
+      case "--help":
+      case "-h":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${argument}\n\n${help}`);
+    }
+  }
+
+  return options;
+}
+
+function readValue(args: string[], index: number, option: string): string {
+  const value = args[index];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${option} requires a value.`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(value: string, option: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${option} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+main().catch((error: unknown) => {
+  console.error(
+    `\nError: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exitCode = 1;
+});

--- a/contrib/tools/e2e-report/src/github.ts
+++ b/contrib/tools/e2e-report/src/github.ts
@@ -1,0 +1,153 @@
+import { spawn } from "node:child_process";
+
+import type { GithubArtifact, GithubJob } from "./artifacts.js";
+
+export interface PullRequest {
+  number: number;
+  title: string;
+  headRefName: string;
+  url: string;
+}
+
+export interface WorkflowRun {
+  databaseId: number;
+  displayTitle: string;
+  status: string;
+  conclusion: string;
+  createdAt: string;
+  url: string;
+}
+
+interface ArtifactResponse {
+  artifacts: GithubArtifact[];
+}
+
+interface JobsResponse {
+  jobs: GithubJob[];
+}
+
+export async function run(
+  command: string,
+  args: string[],
+  options: { allowFailure?: boolean } = {},
+): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: false,
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0 || options.allowFailure === true) {
+        resolve(stdout.trim());
+        return;
+      }
+
+      reject(
+        new Error(`${command} ${args.join(" ")} failed:\n${stderr.trim()}`),
+      );
+    });
+  });
+}
+
+export async function getRepository(): Promise<string> {
+  const output = await run("gh", [
+    "repo",
+    "view",
+    "--json",
+    "nameWithOwner",
+    "--jq",
+    ".nameWithOwner",
+  ]);
+  if (output === "") {
+    throw new Error("Could not determine the GitHub repository.");
+  }
+  return output;
+}
+
+export async function getCurrentBranch(): Promise<string> {
+  const branch = await run("git", ["branch", "--show-current"]);
+  if (branch === "") {
+    throw new Error(
+      "The repository is in detached HEAD state. Pass --run <id> to select a workflow run.",
+    );
+  }
+  return branch;
+}
+
+export async function getCurrentPullRequest(): Promise<
+  PullRequest | undefined
+> {
+  const output = await run(
+    "gh",
+    ["pr", "view", "--json", "number,title,headRefName,url"],
+    { allowFailure: true },
+  );
+  return output === "" ? undefined : (JSON.parse(output) as PullRequest);
+}
+
+export async function listWorkflowRuns(
+  branch: string,
+  workflow: string,
+): Promise<WorkflowRun[]> {
+  const output = await run("gh", [
+    "run",
+    "list",
+    "--branch",
+    branch,
+    "--workflow",
+    workflow,
+    "--limit",
+    "10",
+    "--json",
+    "databaseId,displayTitle,status,conclusion,createdAt,url",
+  ]);
+  return JSON.parse(output) as WorkflowRun[];
+}
+
+export async function getWorkflowRun(runId: number): Promise<WorkflowRun> {
+  const output = await run("gh", [
+    "run",
+    "view",
+    String(runId),
+    "--json",
+    "databaseId,displayTitle,status,conclusion,createdAt,url",
+  ]);
+  return JSON.parse(output) as WorkflowRun;
+}
+
+export async function listArtifacts(
+  repository: string,
+  runId: number,
+): Promise<GithubArtifact[]> {
+  const output = await run("gh", [
+    "api",
+    `repos/${repository}/actions/runs/${runId}/artifacts`,
+    "--paginate",
+    "--slurp",
+  ]);
+  const pages = JSON.parse(output) as ArtifactResponse[];
+  return pages.flatMap((page) => page.artifacts);
+}
+
+export async function listJobs(runId: number): Promise<GithubJob[]> {
+  const output = await run("gh", [
+    "run",
+    "view",
+    String(runId),
+    "--json",
+    "jobs",
+  ]);
+  return (JSON.parse(output) as JobsResponse).jobs;
+}

--- a/contrib/tools/e2e-report/tsconfig.json
+++ b/contrib/tools/e2e-report/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "uploader",
         "play/packages/iframe-api-typings",
         "tests",
-        "contrib/tools/generate-env-docs"
+        "contrib/tools/generate-env-docs",
+        "contrib/tools/e2e-report"
       ],
       "devDependencies": {
         "husky": "^9.1.7",
@@ -84,6 +85,15 @@
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.3",
         "ws": "^8.21.0"
+      }
+    },
+    "contrib/tools/e2e-report": {
+      "name": "@workadventure/e2e-report",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^25.9.1",
+        "tsx": "^4.22.3",
+        "typescript": "^5.9.3"
       }
     },
     "contrib/tools/generate-env-docs": {
@@ -6530,6 +6540,10 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@workadventure/e2e-report": {
+      "resolved": "contrib/tools/e2e-report",
+      "link": true
     },
     "node_modules/@workadventure/eslint-config": {
       "resolved": "libs/eslint-config",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "prepare": "husky install || echo 'Husky not found. Maybe you are installing only a subproject.'",
     "generate-env-docs": "npm run generate --workspace=contrib/tools/generate-env-docs",
-    "check-env-docs": "npm run check --workspace=contrib/tools/generate-env-docs"
+    "check-env-docs": "npm run check --workspace=contrib/tools/generate-env-docs",
+    "e2e:report": "npm exec --workspace=@workadventure/e2e-report -- tsx src/cli.ts"
   },
   "workspaces": [
     "play",
@@ -19,6 +20,7 @@
     "uploader",
     "play/packages/iframe-api-typings",
     "tests",
-    "contrib/tools/generate-env-docs"
+    "contrib/tools/generate-env-docs",
+    "contrib/tools/e2e-report"
   ]
 }


### PR DESCRIPTION
## Why

Inspecting E2E failures currently requires manually finding an Actions artifact, downloading and extracting it, and starting a report server. This tool reduces that workflow to one interactive command.

## What changed

- add a repo-local `npm run e2e:report` CLI
- discover the current branch or pull request and its latest workflow run containing Playwright reports
- list reports by project, shard, job conclusion, and artifact size
- download and cache the selected artifact, then open it with Playwright's report server
- support explicit `--run`, `--project`, `--shard`, `--workflow`, `--list`, and `--refresh` options
- support standard browser, mobile browser, single-domain, and Helm report naming schemes
