### PR TITLE
Fixing CSS of Quill editor

### DIFF
--- a/play/src/front/Components/Menu/TextGlobalMessage.svelte
+++ b/play/src/front/Components/Menu/TextGlobalMessage.svelte
@@ -89,7 +89,6 @@
 
 <style lang="scss">
     @use "../../style/breakpoints.scss" as *;
-    @import "quill/dist/quill.snow.css";
 
     section.section-input-send-text {
         --height-toolbar: 20%;

--- a/play/src/front/style/index.scss
+++ b/play/src/front/style/index.scss
@@ -5,6 +5,7 @@
 
 // Style from external libs
 @import "highlight.js/scss/dark";
+@import "quill/dist/quill.snow.css";
 
 // Internal styles
 @import "breakpoints.scss";


### PR DESCRIPTION
This fixes the display of "Send global messages"