### PR TITLE
Switching session affinity cookie to SameSite=None

### DIFF
--- a/contrib/helm/values.yaml
+++ b/contrib/helm/values.yaml
@@ -322,7 +322,7 @@ play:
         name: "wa_ws_affinity"
         httpOnly: true
         secure: true
-        sameSite: "lax"
+        sameSite: "None"
 
 
 # #########################################################


### PR DESCRIPTION
The pusher can be hosted on a domain name different from the play name so we need to accept cookies from other domains

Note: in the future, we should also add the "Partitioned" attribute to the cookie. Alas, nginx-ingress does not support partitionned cookies and never will because it is discontinued.