### PR TITLE
Switching session affinity cookie to SameSite=None in E2E tests

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -768,6 +768,11 @@ jobs:
               prometheus.io/scrape: 'true'
               prometheus.io/path: '/metrics'
               prometheus.io/port: '9090'
+            ingress:
+              sticky:
+                cookie:
+                  # The affinity cookie needs to be set to "None" for cross-domain cookies to work (pusher vs play/custom domains)
+                  sameSite: "None"
           back:
             env:
               PROMETHEUS_PORT: "9090"


### PR DESCRIPTION
The pusher can be hosted on a domain name different from the play name so we need to accept cookies from other domains