### PR TITLE
Review fixes for Safari virtual background blur

### DIFF
--- a/play/src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/CanvasBlurRenderer.ts
@@ -1,3 +1,4 @@
+import { logOnce, resetLogOnceForTests } from "./logOnce";
 import { BLUR_ITERATIONS, WebGlBlurPipeline } from "./WebGlBlurPipeline";
 
 export {
@@ -14,14 +15,8 @@ export type BlurBackend = "webgl-blur" | "cpu-blur" | "none";
 
 const CPU_BLUR_MAX_SIDE = 224;
 
-const loggedBackends = new Set<BlurBackend>();
-let loggedWebGlFailure = false;
-let loggedCpuFailure = false;
-
 export function resetCanvasBlurRendererForTests(): void {
-    loggedBackends.clear();
-    loggedWebGlFailure = false;
-    loggedCpuFailure = false;
+    resetLogOnceForTests();
 }
 
 export function getCpuBlurSize(width: number, height: number): { width: number; height: number; scale: number } {
@@ -169,27 +164,23 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 function logSelectedBackend(backend: BlurBackend): void {
-    if (backend === "none" || loggedBackends.has(backend)) {
+    if (backend === "none") {
         return;
     }
 
-    loggedBackends.add(backend);
-
-    if (backend === "webgl-blur") {
-        console.info("[BackgroundProcessor] Using WebGL background blur renderer.");
-        return;
-    }
-
-    console.warn("[BackgroundProcessor] Using CPU background blur fallback.");
+    logOnce(`canvas-blur:backend:${backend}`, () => {
+        if (backend === "webgl-blur") {
+            console.info("[BackgroundProcessor] Using WebGL background blur renderer.");
+        } else {
+            console.warn("[BackgroundProcessor] Using CPU background blur fallback.");
+        }
+    });
 }
 
 function logWebGlFailure(error: unknown): void {
-    if (loggedWebGlFailure) {
-        return;
-    }
-
-    loggedWebGlFailure = true;
-    console.warn("[BackgroundProcessor] WebGL blur renderer failed; using CPU fallback.", error);
+    logOnce("canvas-blur:webgl-failure", () =>
+        console.warn("[BackgroundProcessor] WebGL blur renderer failed; using CPU fallback.", error),
+    );
 }
 
 export class CanvasBlurRenderer {
@@ -375,10 +366,9 @@ export class CanvasBlurRenderer {
 
             return "cpu-blur";
         } catch (error) {
-            if (!loggedCpuFailure) {
-                loggedCpuFailure = true;
-                console.warn("[BackgroundProcessor] CPU blur renderer failed; drawing the unblurred frame.", error);
-            }
+            logOnce("canvas-blur:cpu-failure", () =>
+                console.warn("[BackgroundProcessor] CPU blur renderer failed; drawing the unblurred frame.", error),
+            );
             destinationContext.drawImage(source, 0, 0, width, height);
             return "none";
         }

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeBackgroundTransformer.ts
@@ -5,6 +5,12 @@ import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
 import { CanvasBlurRenderer } from "./CanvasBlurRenderer";
 import type { BackgroundTransformer } from "./createBackgroundTransformer";
 
+// requestVideoFrameCallback is preferred to confirm a real frame has been
+// presented, but it can stay silent (e.g. in a backgrounded tab where frame
+// callbacks are suspended). After this delay we fall back to the readyState
+// signal so frame processing is never gated on rVFC indefinitely.
+const VIDEO_FRAME_CALLBACK_GRACE_MS = 500;
+
 /**
  * MediaPipe-based background transformer for video streams
  * Uses a simpler approach with setTimeout for reliable frame processing
@@ -28,6 +34,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
     private initPromise: Promise<void>;
     private frameRate = 33;
     private lastVideoFrameTime = 0;
+    private videoFrameTrackingStartTime = 0;
     private videoFrameCallbackId: number | null = null;
     // Reusable temporary canvas to avoid WebGL context leaks
     private tempCanvas: HTMLCanvasElement | null = null;
@@ -343,6 +350,7 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
         // Setup input video
         this.stopVideoFrameTracking();
         this.lastVideoFrameTime = 0;
+        this.videoFrameTrackingStartTime = 0;
         this.inputVideo.srcObject = inputStream;
 
         // Wait for video metadata to be loaded
@@ -465,7 +473,17 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
         }
 
         if ("requestVideoFrameCallback" in this.inputVideo) {
-            return this.lastVideoFrameTime > 0;
+            if (this.lastVideoFrameTime > 0) {
+                return true;
+            }
+
+            // requestVideoFrameCallback has not delivered a frame yet. Wait for it
+            // briefly, then fall back to readyState so a silent rVFC (e.g. in a
+            // backgrounded tab) never freezes the output stream.
+            return (
+                this.videoFrameTrackingStartTime > 0 &&
+                performance.now() - this.videoFrameTrackingStartTime >= VIDEO_FRAME_CALLBACK_GRACE_MS
+            );
         }
 
         return true;
@@ -475,6 +493,8 @@ export class MediaPipeBackgroundTransformer implements BackgroundTransformer {
         if (!("requestVideoFrameCallback" in this.inputVideo) || this.videoFrameCallbackId !== null) {
             return;
         }
+
+        this.videoFrameTrackingStartTime = performance.now();
 
         const onVideoFrame = () => {
             if (this.closed || !("requestVideoFrameCallback" in this.inputVideo)) {

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
@@ -4,34 +4,26 @@ import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
 import { isFirefox, isIOS } from "../DeviceUtils";
 import { CanvasBlurRenderer, type BlurBackend } from "./CanvasBlurRenderer";
+import { logOnce } from "./logOnce";
 import { TasksVisionBlurCompositor } from "./TasksVisionBlurCompositor";
 import type { BackgroundConfig, BackgroundTransformer } from "./createBackgroundTransformer";
 
 type CaptureBackend = "webgl-capture" | "2d-copy-capture";
 
-const loggedCaptureBackends = new Set<CaptureBackend>();
-let loggedWebGlCaptureFailure = false;
-
 function logCaptureBackend(backend: CaptureBackend): void {
-    if (loggedCaptureBackends.has(backend)) {
-        return;
-    }
-
-    loggedCaptureBackends.add(backend);
-    console.info(
-        backend === "webgl-capture"
-            ? "[MediaPipe Tasks Vision] Using WebGL canvas capture backend."
-            : "[MediaPipe Tasks Vision] Using 2D copy canvas capture backend.",
+    logOnce(`tasks-vision-capture:${backend}`, () =>
+        console.info(
+            backend === "webgl-capture"
+                ? "[MediaPipe Tasks Vision] Using WebGL canvas capture backend."
+                : "[MediaPipe Tasks Vision] Using 2D copy canvas capture backend.",
+        ),
     );
 }
 
 function logWebGlCaptureFailure(error: unknown): void {
-    if (loggedWebGlCaptureFailure) {
-        return;
-    }
-
-    loggedWebGlCaptureFailure = true;
-    console.warn("[MediaPipe Tasks Vision] WebGL canvas capture failed; falling back to 2D copy capture.", error);
+    logOnce("tasks-vision-capture:webgl-failure", () =>
+        console.warn("[MediaPipe Tasks Vision] WebGL canvas capture failed; falling back to 2D copy capture.", error),
+    );
 }
 
 /**

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
@@ -2,7 +2,7 @@ import type { MPMask } from "@mediapipe/tasks-vision";
 import { ImageSegmenter, FilesetResolver, DrawingUtils } from "@mediapipe/tasks-vision";
 import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
-import { isIOS, isSafari } from "../DeviceUtils";
+import { isFirefox, isIOS } from "../DeviceUtils";
 import { CanvasBlurRenderer, type BlurBackend } from "./CanvasBlurRenderer";
 import { TasksVisionBlurCompositor } from "./TasksVisionBlurCompositor";
 import type { BackgroundConfig, BackgroundTransformer } from "./createBackgroundTransformer";
@@ -32,6 +32,23 @@ function logWebGlCaptureFailure(error: unknown): void {
 
     loggedWebGlCaptureFailure = true;
     console.warn("[MediaPipe Tasks Vision] WebGL canvas capture failed; falling back to 2D copy capture.", error);
+}
+
+/**
+ * captureStream() from a WebGL canvas produces frozen frames on WebKit (Safari and
+ * every iOS browser), so the direct WebGL capture path is restricted to engines
+ * known to capture WebGL canvases correctly. Engines we cannot positively identify
+ * fall back to the always-working 2D-copy path rather than risking a frozen feed.
+ */
+function supportsWebGlCanvasCapture(): boolean {
+    if (isIOS()) {
+        return false;
+    }
+
+    // Chromium-based engines report "Chrome" in their UA (Safari does not); iOS
+    // Chrome/Firefox use "CriOS"/"FxiOS" and are already excluded by isIOS().
+    const isChromium = navigator.userAgent.includes("Chrome");
+    return isChromium || isFirefox();
 }
 
 /**
@@ -664,10 +681,6 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
             return false;
         }
 
-        try {
-            return !isSafari() && !isIOS();
-        } catch {
-            return false;
-        }
+        return supportsWebGlCanvasCapture();
     }
 }

--- a/play/src/front/WebRtc/BackgroundProcessor/TasksVisionBlurCompositor.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/TasksVisionBlurCompositor.ts
@@ -1,25 +1,17 @@
 import type { MPMask } from "@mediapipe/tasks-vision";
+import { logOnce } from "./logOnce";
 import { WebGlBlurPipeline } from "./WebGlBlurPipeline";
 
-let loggedSelectedBackend = false;
-let loggedFailure = false;
-
 function logSelectedBackend(): void {
-    if (loggedSelectedBackend) {
-        return;
-    }
-
-    loggedSelectedBackend = true;
-    console.info("[BackgroundProcessor] Using WebGL background blur compositor.");
+    logOnce("tasks-vision-compositor:selected", () =>
+        console.info("[BackgroundProcessor] Using WebGL background blur compositor."),
+    );
 }
 
 function logFailure(error: unknown): void {
-    if (loggedFailure) {
-        return;
-    }
-
-    loggedFailure = true;
-    console.warn("[BackgroundProcessor] WebGL background blur compositor failed; using fallback.", error);
+    logOnce("tasks-vision-compositor:failure", () =>
+        console.warn("[BackgroundProcessor] WebGL background blur compositor failed; using fallback.", error),
+    );
 }
 
 export class TasksVisionBlurCompositor {

--- a/play/src/front/WebRtc/BackgroundProcessor/WebGlBlurPipeline.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/WebGlBlurPipeline.ts
@@ -15,15 +15,8 @@ type WebGlBlurPipelineOptions = {
 };
 
 type WebGlStateSnapshot = {
-    framebuffer: WebGLFramebuffer | null;
-    arrayBuffer: WebGLBuffer | null;
-    currentProgram: WebGLProgram | null;
-    viewport: Int32Array;
-    activeTexture: number;
-    textureBindings: { unit: number; texture: WebGLTexture | null }[];
     blendEnabled: boolean;
     depthTestEnabled: boolean;
-    unpackFlipY: boolean;
 };
 
 type KawaseFramebuffer = {
@@ -460,28 +453,15 @@ export class WebGlBlurPipeline {
 
     private captureState(): WebGlStateSnapshot {
         const gl = this.gl;
-        const activeTexture = gl.getParameter(gl.ACTIVE_TEXTURE) as number;
-        const textureUnits = [gl.TEXTURE0, gl.TEXTURE0 + 1, gl.TEXTURE0 + 2];
-        const textureBindings = textureUnits.map((unit) => {
-            gl.activeTexture(unit);
-            return {
-                unit,
-                texture: gl.getParameter(gl.TEXTURE_BINDING_2D) as WebGLTexture | null,
-            };
-        });
 
-        gl.activeTexture(activeTexture);
-
+        // Only the BLEND/DEPTH_TEST enable bits are read back: gl.isEnabled is a
+        // cheap client-side query, whereas the binding getters (FRAMEBUFFER_BINDING,
+        // CURRENT_PROGRAM, TEXTURE_BINDING_2D, VIEWPORT, ...) force a driver
+        // round-trip every frame. Those bindings are reset to neutral defaults in
+        // restoreCapturedState() instead of being captured and replayed.
         return {
-            framebuffer: gl.getParameter(gl.FRAMEBUFFER_BINDING) as WebGLFramebuffer | null,
-            arrayBuffer: gl.getParameter(gl.ARRAY_BUFFER_BINDING) as WebGLBuffer | null,
-            currentProgram: gl.getParameter(gl.CURRENT_PROGRAM) as WebGLProgram | null,
-            viewport: gl.getParameter(gl.VIEWPORT) as Int32Array,
-            activeTexture,
-            textureBindings,
             blendEnabled: gl.isEnabled(gl.BLEND),
             depthTestEnabled: gl.isEnabled(gl.DEPTH_TEST),
-            unpackFlipY: gl.getParameter(gl.UNPACK_FLIP_Y_WEBGL) as boolean,
         };
     }
 
@@ -493,18 +473,23 @@ export class WebGlBlurPipeline {
             return;
         }
 
-        for (const binding of snapshot.textureBindings) {
-            gl.activeTexture(binding.unit);
-            gl.bindTexture(gl.TEXTURE_2D, binding.texture);
+        // Reset the state this pipeline mutates back to a clean baseline rather than
+        // reading the previous values back each frame. MediaPipe (the only other
+        // consumer of this shared context) re-specifies its own program, buffers,
+        // textures and viewport before every draw, so neutral defaults are enough.
+        for (let unit = 0; unit < 3; unit++) {
+            gl.activeTexture(gl.TEXTURE0 + unit);
+            gl.bindTexture(gl.TEXTURE_2D, null);
         }
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+        gl.useProgram(null);
+        gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
 
-        gl.activeTexture(snapshot.activeTexture);
-        gl.bindFramebuffer(gl.FRAMEBUFFER, snapshot.framebuffer);
-        gl.bindBuffer(gl.ARRAY_BUFFER, snapshot.arrayBuffer);
-        gl.useProgram(snapshot.currentProgram);
-        gl.viewport(snapshot.viewport[0], snapshot.viewport[1], snapshot.viewport[2], snapshot.viewport[3]);
-        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, snapshot.unpackFlipY);
-
+        // BLEND/DEPTH_TEST are restored to their captured values since MediaPipe may
+        // rely on its own enable state persisting across our draw.
         if (snapshot.blendEnabled) {
             gl.enable(gl.BLEND);
         } else {

--- a/play/src/front/WebRtc/BackgroundProcessor/WebGlBlurPipeline.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/WebGlBlurPipeline.ts
@@ -745,7 +745,8 @@ export class WebGlBlurPipeline {
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
         gl.activeTexture(gl.TEXTURE0 + textureUnit);
         gl.bindTexture(gl.TEXTURE_2D, texture);
-        this.configureTexture();
+        // Texture parameters are already set once in createTexture() and persist on
+        // the texture object, so there is no need to re-apply them on every upload.
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source as TexImageSource);
     }
 

--- a/play/src/front/WebRtc/BackgroundProcessor/logOnce.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/logOnce.ts
@@ -1,0 +1,20 @@
+const loggedKeys = new Set<string>();
+
+/**
+ * Runs `log` only the first time it is called for a given `key`. Used by the
+ * background processor to emit a diagnostic (selected backend, fallback taken,
+ * ...) once rather than on every frame.
+ */
+export function logOnce(key: string, log: () => void): void {
+    if (loggedKeys.has(key)) {
+        return;
+    }
+
+    loggedKeys.add(key);
+    log();
+}
+
+/** Clears the once-logging state. Test-only. */
+export function resetLogOnceForTests(): void {
+    loggedKeys.clear();
+}


### PR DESCRIPTION
Follow-up fixes from a code review of #6248, each as a separate commit. Targets the `fix-safari-background-blur` branch.

## Changes

1. **Prevent rVFC liveness gate from stalling the blur loop** — The selfie-segmentation transformer gated all frame processing on `requestVideoFrameCallback` having fired once. If the first callback never arrives (e.g. the stream starts while the tab is hidden and frame callbacks are suspended), the output stayed frozen with no recovery. Now falls back to the `readyState` signal after a short grace period.

2. **Drop redundant per-frame texture parameter setup** — `uploadTexture` re-applied all four `texParameteri` values on every upload; they are sticky and already set once in `createTexture()`.

3. **Avoid per-frame GL state read-back in the blur pipeline** — In `restoreState` mode (shared MediaPipe WebGL2 context), ~12 `gl.getParameter`/`isEnabled` values were read back every composited frame. Reset the mutated state to neutral defaults instead — MediaPipe re-specifies its own program/buffers/textures/viewport before each draw. Only the cheap `BLEND`/`DEPTH_TEST` enable bits are still captured and replayed.

4. **Harden WebGL-capture engine gate** — `canAttemptWebGlCapture()` used `!isSafari() && !isIOS()`, where `isSafari()` throws on unrecognised UAs and the catch silently downgraded capable browsers. Replaced with a non-throwing positive allowlist (Chromium or Firefox, excluding iOS). A true frame-liveness capability probe is noted as a follow-up.

5. **Deduplicate once-logging** — The "log this backend/failure once" pattern was reimplemented three times with separate module globals. Extracted a single `logOnce(key, fn)` helper.

## Not included

The deep-fallback privacy point (showing the unblurred frame when both WebGL and CPU blur fail) was intentionally left as-is: the user has live video feedback and will immediately see blur is not working.

## Validation

- `npm run typecheck` (play) — clean
- `npx vitest run CanvasBlurRenderer.test.ts` — 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)