### PR TITLE
fix(map-storage): do not cache HTTP 500 error responses

### DIFF
--- a/map-storage/src/Upload/UploadController.ts
+++ b/map-storage/src/Upload/UploadController.ts
@@ -625,7 +625,7 @@ export class UploadController {
                 // good practice to catch this error explicitly
                 archive.on("error", function (err) {
                     console.error(`[${new Date().toISOString()}] An error occurred while Zipping file: `, err);
-                    Sentry.captureException(`An error occurred while Zipping file: ${JSON.stringify(err)}`);
+                    Sentry.captureException(err);
                     res.status(500).send("An error occurred");
                 });
 

--- a/map-storage/src/index.ts
+++ b/map-storage/src/index.ts
@@ -146,6 +146,24 @@ if (fs.existsSync("dist-ui")) {
     });
 }
 
+// Error-handling middlewares. They must be registered last, after all routes.
+
+// Capture route errors in Sentry, then delegate to the next error handler.
+Sentry.setupExpressErrorHandler(app);
+
+// Force error responses to be non-cacheable, then delegate to Express's default error handler
+// (which logs the stack and sends the 500).
+// Routes like `proxyFiles` set an aggressive `Cache-Control` header (e.g.
+// "public, max-age=31536000, immutable") *before* the file is fetched. If the fetch then fails
+// (e.g. a transient S3 outage) the request ends up here as a 500. Without overriding the header,
+// the browser/CDN would cache that 500 for up to a year and keep serving it even after S3 recovers.
+app.use((err: unknown, req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (!res.headersSent) {
+        res.setHeader("Cache-Control", "no-store");
+    }
+    next(err);
+});
+
 app.listen(3000, () => {
     console.info(`[${new Date().toISOString()}] Application is running on port 3000`);
 });


### PR DESCRIPTION
## Problem

When fetching a resource from S3 fails (e.g. a transient S3 outage), the HTTP 500 returned by map-storage gets cached client-side. After S3 recovers, the browser/CDN keeps serving the cached 500.

## Root cause

`proxyFiles()` in `map-storage/src/FileFetcher/FileFetcher.ts` sets the `Cache-Control` header **before** the file is fetched from S3. For hashed/UUID assets it uses `public, max-age=31536000, immutable`. When the fetch fails with a non-`NoSuchKey` error (`S3FileSystem.serveStaticFile`), the request is forwarded to Express's error handler as a 500 — but the long-lived `Cache-Control` header is still on the response. Express's default handler doesn't strip it, so the 500 becomes cacheable for up to a year.

## Fix

Two error-handling middlewares registered after all routes in `map-storage/src/index.ts`:

1. `Sentry.setupExpressErrorHandler(app)` — reports route errors to Sentry. This was a pre-existing gap: route errors were logged to the console (Express default) but **not** sent to Sentry.
2. A handler that forces `Cache-Control: no-store` on error responses (when headers aren't already sent), then delegates to Express's default error handler for stack logging and the 500 response.

Net effect: console logging preserved, Sentry capture added, and error 500s are no longer cacheable.

## Notes

- `NoSuchKey` is handled earlier as a 404 (`next()`), so it is unaffected.
- Clients/CDNs that already cached a bad 500 before this deploy will keep it until their TTL expires (or a hard refresh); only new errors benefit immediately.

## Verification

- `npm run typecheck` ✅
- `npx eslint src/index.ts` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)