### PR TITLE
fix(media): broadcast effective mic/camera state to space (away-mode red mic)

### DIFF
--- a/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
+++ b/play/src/front/Space/SpacePeerManager/SpacePeerManager.ts
@@ -9,7 +9,7 @@ import type { Readable, Unsubscriber } from "svelte/store";
 import { get } from "svelte/store";
 import type { SpaceInterface } from "../SpaceInterface";
 import type { LocalStreamStoreValue } from "../../Stores/MediaStore";
-import { requestedCameraState, requestedMicrophoneState } from "../../Stores/MediaStore";
+import { effectiveCameraStateStore, effectiveMicrophoneStateStore } from "../../Stores/MediaStore";
 import { recordingStore } from "../../Stores/RecordingStore";
 import { screenSharingLocalStreamStore } from "../../Stores/ScreenSharingStore";
 import { nbSoundPlayedInBubbleStore } from "../../Stores/ApparentMediaContraintStore";
@@ -153,8 +153,8 @@ export class SpacePeerManager {
     constructor(
         private space: SpaceInterface,
         blockedUsersStore: Readable<Set<string>>,
-        private microphoneStateStore: Readable<boolean> = requestedMicrophoneState,
-        private cameraStateStore: Readable<boolean> = requestedCameraState,
+        private microphoneStateStore: Readable<boolean> = effectiveMicrophoneStateStore,
+        private cameraStateStore: Readable<boolean> = effectiveCameraStateStore,
         _screenSharingLocalStreamStore: Readable<LocalStreamStoreValue> = screenSharingLocalStreamStore,
         _bindMuteEventsToSpace: (space: SpaceInterface) => void = bindMuteEventsToSpace,
         private _notificationPlayingStore = notificationPlayingStore,

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -1103,6 +1103,28 @@ export const backgroundProcessedLocalVideoTrackStore = derived<
     },
 );
 
+/**
+ * The microphone state to broadcast to the space: true only when an audio track is actually
+ * being captured/published. Unlike requestedMicrophoneState, this accounts for privacy shutdown,
+ * energy saving, unavailable status, external services, and getUserMedia not having resolved yet.
+ */
+export const effectiveMicrophoneStateStore = derived(
+    audioProcessedLocalAudioTrackStore,
+    ($audioProcessedLocalAudioTrackStore) =>
+        $audioProcessedLocalAudioTrackStore.type === "success" &&
+        $audioProcessedLocalAudioTrackStore.track !== undefined,
+);
+
+/**
+ * The camera state to broadcast to the space; symmetric to effectiveMicrophoneStateStore.
+ */
+export const effectiveCameraStateStore = derived(
+    backgroundProcessedLocalVideoTrackStore,
+    ($backgroundProcessedLocalVideoTrackStore) =>
+        $backgroundProcessedLocalVideoTrackStore.type === "success" &&
+        $backgroundProcessedLocalVideoTrackStore.track !== undefined,
+);
+
 export const localStreamStore = derived<
     [
         typeof audioProcessedLocalAudioTrackStore,


### PR DESCRIPTION
## Problem

When you form a bubble with a remote user who is **away** (their WorkAdventure tab is not focused) and that user has **"Keep microphone active in away mode" turned OFF**, a **red microphone icon** appears on their `VideoMediaBox`.

The space's `microphoneState`/`cameraState` were broadcast straight from `requestedMicrophoneState`/`requestedCameraState` (`SpacePeerManager.ts` constructor defaults), which only reflect what the user *asked* for and are independent of `privacyShutdownStore`. The privacy logic lives only in the media-constraints path (`MediaStore.ts`, `shouldDisableMicrophoneForPrivacy`), so the local audio track gets dropped while the space still reports `microphoneState: true`. Remote peers then see `microphoneState === true` but receive no audio track → `audioStateMismatch` in `VideoMediaBox.svelte` → after 3s the muted-mic icon turns red.

## Fix

Add `effectiveMicrophoneStateStore` / `effectiveCameraStateStore` in `MediaStore.ts`, derived from the actual local track stores (`audioProcessedLocalAudioTrackStore` / `backgroundProcessedLocalVideoTrackStore`) so the value reports `true` only when a track is really being captured. `SpacePeerManager` now uses these as its constructor defaults.

This reflects what is actually being published, fixing the away/privacy case plus the symmetric camera case and the "mic requested on but `getUserMedia` not yet resolved" case — in both directions.

## Notes / trade-offs

- Behavior change beyond the immediate bug: `microphoneState`/`cameraState` now flip to `true` only once a real track exists, and to `false` whenever the track is dropped for any reason (privacy, energy saving, BUSY/SILENT/DND, external service). This is the intended "effective state" semantics.
- Deriving from the track output (not `mediaStreamConstraintsStore`) means a constraint being set but `getUserMedia` not having resolved no longer reports the mic as on.

## Verification

- Manual (two browsers): User B turns **off** "Keep microphone active in away mode", keeps mic on, switches away from the WA tab. User A bubbles with B → B's tile shows a normal (not red) muted-mic icon. Refocusing B's tab resumes the mic. With the setting **on**, an away B keeps audio and shows no red mic (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)