### PR TITLE
Fixing map-storage UI following Svelte 5 migration

### DIFF
--- a/map-storage/src-ui/main.ts
+++ b/map-storage/src-ui/main.ts
@@ -1,8 +1,9 @@
 //import "./app.css";
+import { mount } from "svelte";
 import App from "./App.svelte";
 
-const app = new App({
-    target: document.getElementById("app"),
+const app = mount(App, {
+    target: document.getElementById("app") as HTMLElement,
 });
 
 export default app;


### PR DESCRIPTION
Svelte 5 migration broke the map-storage UI. We are fixing it here.