### PR TITLE
fix(game): restore previous position on reconnect instead of URL hash

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -783,7 +783,8 @@ export class GameScene extends DirtyScene {
             this.gameMapFrontWrapper,
             this.mapFile,
             this.initPosition,
-            urlManager.getStartPositionNameFromUrl(),
+            // On reconnect, ignore any URL hash and restore the previous position (initPosition).
+            this.isReconnecting ? undefined : urlManager.getStartPositionNameFromUrl(),
         );
 
         //create input to move
@@ -2014,7 +2015,8 @@ export class GameScene extends DirtyScene {
                 }
 
                 const startPosition = this.startPositionCalculator.computeStartPosition(
-                    urlManager.getStartPositionNameFromUrl(),
+                    // On reconnect, ignore any URL hash and restore the previous position (initPosition).
+                    this.isReconnecting ? undefined : urlManager.getStartPositionNameFromUrl(),
                 );
 
                 this.createCurrentPlayer(startPosition);


### PR DESCRIPTION
## Problem

When the connection to WorkAdventure is lost and re-established, the player should reappear where they were standing right before the disconnect.

This works when the URL has **no** hash, but if the URL contains a start-position hash (e.g. `https://play.workadventu.re/@/foo/bar#meeting-room`), a reconnect teleports the avatar back to that hashed location instead of its last position — so every network blip can throw the player across the map.

## Root cause

On reconnect, `GameScene.createSuccessorGameScene(true, true)` recreates the scene with `initPosition` = the player's last `{x, y}` and `reconnecting: true`. But the spawn point was still computed from the URL hash via `urlManager.getStartPositionNameFromUrl()`.

In `StartPositionCalculator.computeStartPosition()`, `initPosition` is only honored when **no** start-position name is supplied. So:
- **No hash** → name is `undefined` → returns `initPosition` ✓
- **`#some-place`** → name is `"some-place"` → resolves the hash location, ignoring `initPosition` ✗

## Fix

Ignore the URL hash while reconnecting (using the existing `this.isReconnecting` flag) so the calculator falls back to `initPosition` — identical to the no-hash path. Two call sites in `GameScene.ts` are guarded: the `StartPositionCalculator` constructor and the spawn computation in `connect()`.

The same-map exit-portal teleport path (which intentionally moves the player to a named start layer) is **left untouched** — it is not a reconnection.

`this.isReconnecting` is set to `true` only on the connection-loss path, and only when `initPosition` is defined, so the fallback is always safe. Fresh page loads and the `leaveGame` path (`reconnecting: false`) still honor the hash as before.

## Verification

- `tsc --noEmit`: no type errors in `GameScene.ts`. The change preserves the original `string | undefined` parameter type.
- Manual: open a room with a `#hash` URL, walk away from the hash spot, drop & restore the connection → avatar reappears where it was, not at the hash. Regression-checked that no-hash reconnect and fresh load with `#hash` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)