### PR TITLE
fix(pusher): downgrade missing-room log on leave to debug

### DIFF
--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -756,8 +756,10 @@ export class SocketManager implements ZoneEventListener {
                         room.leave(socket);
                         this.deleteRoomIfEmpty(room);
                     } else {
-                        console.error("Could not find the GameRoom the user is leaving!");
-                        Sentry.captureException("Could not find the GameRoom the user is leaving!");
+                        // The room was already removed from the map. Indeed, there is a race condition
+                        // between the closing if the last user connection to the back and the closing of the room
+                        // connection to the back.
+                        debug("Could not find the GameRoom the user is leaving: %s", socketData.roomId);
                     }
                     //user leave previous room
                     //Client.leave(Client.roomId);


### PR DESCRIPTION
## Problem

Sentry issue **PUSHER-2K** (`Could not find the GameRoom the user is leaving!`) fires continuously in production — **~350×/hour cluster-wide**, with **0 users impacted**.

Investigation of prod logs showed it is **not** caused by back servers going down (the `workadventure-back-*` statefulset had 0 restarts while the error kept firing). It correlates 1:1 with the connection-teardown reason `No close reason received from back server`, which is simply the back's normal echo of an **ordinary user departure** (tab close / refresh / navigation / flaky network). Graceful disconnects that carry a reason (pong timeout, tab replaced, ban, map deleted) never trigger it.

The root cause is a benign race during normal teardown: by the time a user's `leaveRoom()` runs, the `PusherRoom` can already have been removed from the `rooms` map (it emptied, or its back connection was torn down). The old code treated this expected condition as an exception and reported it to Sentry.

## Change

In `SocketManager.leaveRoom()`, replace the `console.error` + `Sentry.captureException` in the missing-room branch with a `debug()` log. A trace is still available under the `socket` debug namespace.

No behavioural change — the user is leaving anyway and the room is already gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)