### PR TITLE
fix(space): coalesce concurrent joins of the same space (race condition)

### DIFF
--- a/play/src/front/Space/SpaceRegistry/SpaceRegistry.ts
+++ b/play/src/front/Space/SpaceRegistry/SpaceRegistry.ts
@@ -49,6 +49,7 @@ export class SpaceRegistry implements SpaceRegistryInterface {
     private spaces: MapStore<string, Space> = new MapStore<string, Space>();
     public readonly spacesEligibleForRecording: Readable<Space[]>;
     private leavingSpacesPromises: Map<string, Promise<void>> = new Map<string, Promise<void>>();
+    private joiningSpacesPromises: Map<string, Promise<Space>> = new Map<string, Promise<Space>>();
     private initSpaceUsersMessageStreamSubscription: Subscription;
     private addSpaceUserMessageStreamSubscription: Subscription;
     private updateSpaceUserMessageStreamSubscription: Subscription;
@@ -285,17 +286,40 @@ export class SpaceRegistry implements SpaceRegistryInterface {
             await leavingPromise;
         }
 
+        // A join for the same space might already be in flight. Because Space.create() awaits a
+        // server round-trip (emitJoinSpace), a naive "exist() check then create" straddles an await:
+        // two rapid join attempts (e.g. quickly re-entering a meeting room) can both pass the
+        // existence check, then the first registers the space and the second throws
+        // SpaceAlreadyExistError (or silently overwrites it, leaking the first Space and leaving
+        // remote users visible). We coalesce concurrent joins on the same name by reusing the
+        // in-flight creation promise.
+        const joiningPromise = this.joiningSpacesPromises.get(spaceName);
+        if (joiningPromise) {
+            return await joiningPromise;
+        }
+
         if (this.exist(spaceName)) throw new SpaceAlreadyExistError(spaceName);
-        const newSpace = await Space.create(
-            spaceName,
-            filterType,
-            this.roomConnection,
-            propertiesToSync,
-            signal,
-            options,
-        );
-        this.spaces.set(newSpace.getName(), newSpace);
-        return newSpace;
+
+        // Reserve the space name synchronously (before the first await) so concurrent joins coalesce.
+        const creationPromise = (async () => {
+            const newSpace = await Space.create(
+                spaceName,
+                filterType,
+                this.roomConnection,
+                propertiesToSync,
+                signal,
+                options,
+            );
+            this.spaces.set(newSpace.getName(), newSpace);
+            return newSpace;
+        })();
+        this.joiningSpacesPromises.set(spaceName, creationPromise);
+
+        try {
+            return await creationPromise;
+        } finally {
+            this.joiningSpacesPromises.delete(spaceName);
+        }
     }
     exist(spaceName: string): boolean {
         return this.spaces.has(spaceName);
@@ -341,6 +365,11 @@ export class SpaceRegistry implements SpaceRegistryInterface {
         this.proximityPublicMessageEventSubscription.unsubscribe();
         this.proximityPrivateMessageEventSubscription.unsubscribe();
         this.spaceDestroyedMessageSubscription.unsubscribe();
+
+        // Wait for any in-flight join to settle so it does not register a space after we have
+        // iterated this.spaces below (which would leak it). allSettled because a join may reject.
+        await Promise.allSettled(Array.from(this.joiningSpacesPromises.values()));
+        this.joiningSpacesPromises.clear();
 
         await Promise.all(Array.from(this.leavingSpacesPromises.values()));
         this.leavingSpacesPromises.clear();

--- a/play/src/front/Space/tests/SpaceRegistry.test.ts
+++ b/play/src/front/Space/tests/SpaceRegistry.test.ts
@@ -293,6 +293,48 @@ describe("SpaceProviderInterface implementation", () => {
                 expect(roomConnectionMock.emitLeaveSpace).toHaveBeenCalledOnce();
                 expect(roomConnectionMock.emitJoinSpace).toHaveBeenCalledTimes(2);
             });
+
+            it("should coalesce concurrent joins of the same space instead of throwing SpaceAlreadyExistError", async () => {
+                const roomConnectionMock = new MockRoomConnectionForSpaces();
+                const spaceRegistry: SpaceRegistryInterface = new SpaceRegistry(roomConnectionMock, new Subject());
+
+                // Delay emitJoinSpace so the server round-trip is still in flight when the second
+                // join starts. This is the window where the old "exist() then create" logic would
+                // let both joins pass the existence check.
+                let resolveJoin: (spaceUserId: string) => void;
+                const joinAnswerPromise = new Promise<string>((resolve) => {
+                    resolveJoin = resolve;
+                });
+                roomConnectionMock.emitJoinSpace.mockImplementation(() => joinAnswerPromise);
+
+                const firstJoin = spaceRegistry.joinSpace(
+                    "concurrent-join-test",
+                    FilterType.ALL_USERS,
+                    [],
+                    new AbortController().signal,
+                );
+                const secondJoin = spaceRegistry.joinSpace(
+                    "concurrent-join-test",
+                    FilterType.ALL_USERS,
+                    [],
+                    new AbortController().signal,
+                );
+
+                // Let the in-flight server answer arrive.
+                resolveJoin!("space-user-id");
+
+                const [firstSpace, secondSpace] = await Promise.all([firstJoin, secondJoin]);
+
+                // Both callers get the same instance, no error is thrown, and only one space is
+                // registered (no leak / overwrite).
+                expect(firstSpace).toBe(secondSpace);
+                expect(firstSpace.getName()).toBe("concurrent-join-test");
+                expect(
+                    spaceRegistry.getAll().filter((space) => space.getName() === "concurrent-join-test"),
+                ).toHaveLength(1);
+                // The second join reused the in-flight creation, so the server was only contacted once.
+                expect(roomConnectionMock.emitJoinSpace).toHaveBeenCalledOnce();
+            });
         });
     });
 });


### PR DESCRIPTION
## Problem

Fixes #6289 — rapidly entering/leaving a meeting room (~10 times) eventually leaves remote users visible even though the local player is no longer in the room, accompanied by `Space n4lxjz-room1 already exists` and cascading errors in the console.

## Root cause

`SpaceRegistry.joinSpace()` had a check-then-act TOCTOU race: it checked `exist(spaceName)` **before** the `await Space.create(...)` server round-trip (`emitJoinSpace`), but registered the space in `this.spaces` only **after**.

On rapid enter/leave, `ProximityChatRoom.joinSpace()` aborts the previous join but does **not** await it before starting a new one, and `RoomConnection.query()` only rejects on abort if the server hasn't already replied. So two joins for the same space name could both pass the existence check, then:

- the first to resolve calls `this.spaces.set(...)`, and
- the second hits `exist() === true` → throws `SpaceAlreadyExistError` (the visible error), **or** silently overwrites the first entry — orphaning a `Space` whose LiveKit/WebRTC subscriptions and video boxes stay alive. That orphaned space is why remote participants linger after leaving.

The existing `leavingSpacesPromises` guard only serializes join-after-**leave**; there was no equivalent for join-after-**join**.

## Fix

- Add a `joiningSpacesPromises` map (symmetric with `leavingSpacesPromises`). `joinSpace()` now reserves the space name **synchronously** — before the first `await` — by storing the in-flight creation promise. A concurrent join for the same name awaits and returns that same promise instead of racing, so it is idempotent and never overwrites/leaks.
- `destroy()` now `allSettled`-awaits in-flight joins before tearing down `this.spaces`, so a join completing mid-teardown cannot leak a registered space.

## Test

Added a unit test that fires two concurrent `joinSpace` calls for the same name while `emitJoinSpace` is still in flight and asserts: both resolve to the **same** `Space` instance, no error is thrown, only one space is registered, and `emitJoinSpace` is called once (coalesced).

## Validation

- `npm test -- --run src/front/Space/tests/SpaceRegistry.test.ts` → 9/9 pass
- `npm run typecheck` → clean
- ESLint + Prettier on changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)