### PR TITLE
fix(pusher): downgrade back-lost log on permanent client disconnect

### DIFF
--- a/play/src/pusher/services/PusherRoomSocketController.ts
+++ b/play/src/pusher/services/PusherRoomSocketController.ts
@@ -388,8 +388,13 @@ export class PusherRoomSocketController {
                         this.contextByTabKey.delete(tabId);
                     }
                 };
+                // Terminal teardown: no reconnect retry will replace this transport from here on.
+                const closePermanently = () => {
+                    socket.markPermanentlyDisconnected();
+                    return Promise.resolve(config.close(socket, code, reason));
+                };
                 if (code === 1000 || code === 1001) {
-                    Promise.resolve(config.close(socket, code, reason)).then(forgetContext, (e) => {
+                    closePermanently().then(forgetContext, (e) => {
                         console.error(e);
                         forgetContext();
                     });
@@ -402,7 +407,7 @@ export class PusherRoomSocketController {
                         this.contextCleanupTimeoutsByTabKey.delete(tabId);
 
                         if (this.contextByTabKey.get(tabId)?.socket === socket) {
-                            Promise.resolve(config.close(socket, code, reason)).then(forgetContext, (e) => {
+                            closePermanently().then(forgetContext, (e) => {
                                 console.error(e);
                                 forgetContext();
                             });
@@ -413,7 +418,7 @@ export class PusherRoomSocketController {
                     return;
                 }
 
-                Promise.resolve(config.close(socket, code, reason)).catch((e) => {
+                closePermanently().catch((e) => {
                     console.error(e);
                 });
             },

--- a/play/src/pusher/services/PusherWebSocket.ts
+++ b/play/src/pusher/services/PusherWebSocket.ts
@@ -20,6 +20,7 @@ export class PusherWebSocket {
 
     private socket: RawSocket;
     private _isDisconnecting = false;
+    private _isPermanentlyDisconnected = false;
     private keepAliveInterval: NodeJS.Timeout | undefined;
     private batchTimeout: NodeJS.Timeout | undefined;
     private pingBackpressured = false;
@@ -140,6 +141,22 @@ export class PusherWebSocket {
 
     public isDisconnecting(): boolean {
         return this._isDisconnecting;
+    }
+
+    /**
+     * Marks this logical connection as gone for good: the transport closed and no reconnect retry
+     * will replace it (either a normal client close, or the reconnection retention window expired).
+     */
+    public markPermanentlyDisconnected(): void {
+        this._isPermanentlyDisconnected = true;
+    }
+
+    /**
+     * Returns true once the connection can no longer be revived by a reconnecting transport
+     * (see replaceSocket). Useful to tell an expected teardown apart from an unexpected drop.
+     */
+    public isPermanentlyDisconnected(): boolean {
+        return this._isPermanentlyDisconnected;
     }
 
     public startDisconnecting(): boolean {

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -287,13 +287,18 @@ export class SocketManager implements ZoneEventListener {
                         if (!client.isDisconnecting()) {
                             const connectionCloseReason =
                                 backConnectionCloseReason ?? "No close reason received from back server.";
-                            console.warn(
-                                `Connection lost to back server '${apiClient.getChannel().getTarget()}' for room '${
-                                    socketData.roomId
-                                }' and user '${socketData.userUuid}'/'${
-                                    socketData.name
-                                }'. Reason: ${connectionCloseReason}`,
-                            );
+                            const logMessage = `Connection lost to back server '${apiClient
+                                .getChannel()
+                                .getTarget()}' for room '${socketData.roomId}' and user '${socketData.userUuid}'/'${
+                                socketData.name
+                            }'. Reason: ${connectionCloseReason}`;
+                            if (client.isPermanentlyDisconnected()) {
+                                // Expected teardown: the client closed its WebSocket for good, so we ended the
+                                // back connection ourselves. Not a real "connection lost" event.
+                                debug(logMessage);
+                            } else {
+                                console.warn(logMessage);
+                            }
                             this.closeWebsocketConnection(client, 1011, `Back lost: ${connectionCloseReason}`);
                         }
                     } catch (e: unknown) {


### PR DESCRIPTION
## What

On a normal client WebSocket close (code `1000`/`1001`), or when the reconnection retention window (`CLIENT_DISCONNECTION_RETENTION_MS`) expires without a reconnect, the pusher tears down the back connection itself. The back stream's `end` event then logged a scary `Connection lost to back server` **warning** at `SocketManager.ts` even though the teardown is fully expected.

## How

The "no more reconnect retries" decision is made in `PusherRoomSocketController.close`, at the terminal `config.close(socket, …)` call sites — every path to it is final, while the retention window before it is exactly the "a reconnect via `replaceSocket` could still revive me" state.

- **`PusherWebSocket`**: added a `permanentlyDisconnected` flag with `markPermanentlyDisconnected()` / `isPermanentlyDisconnected()`. Kept separate from `_isDisconnecting`, which means `end()`/`startDisconnecting()` was called on *this* transport.
- **`PusherRoomSocketController`**: funneled the three terminal `config.close(...)` call sites through a single `closePermanently()` helper that sets the flag synchronously *before* `config.close` (so it is already `true` by the time the resulting `backConnection.end()` propagates to the back-stream `end` handler). The retention-window reconnect path never touches it.
- **`SocketManager`**: the back-stream `end` handler now logs at `debug` when the disconnect is permanent (expected teardown) and keeps `console.warn` otherwise (genuinely unexpected back drop).

## Net effect

A normal client close — and an abnormal close whose retention window expires without reconnect — logs at `debug` instead of `warn`; a real, unexpected loss of the back connection still warns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)