### PR TITLE
Fix proximity chat active selection style

### DIFF
--- a/play/src/front/Chat/Components/Room/ProximityRoomRow.svelte
+++ b/play/src/front/Chat/Components/Room/ProximityRoomRow.svelte
@@ -49,10 +49,12 @@
 </script>
 
 <div
-    class="wa-chat-item group/chatItem relative mb-[1px] text-md m-0 flex gap-2 flex-row items-center hover:bg-white transition-all hover:bg-opacity-10 hover:rounded hover:!cursor-pointer px-2 py-2 cursor-pointer w-full"
-    class:bg-white={$selectedRoomStore?.id === room.id}
-    class:bg-opacity-10={$selectedRoomStore?.id === room.id}
-    class:rounded={$selectedRoomStore?.id === room.id}
+    class={[
+        "wa-chat-item group/chatItem relative mb-[1px] text-md m-0 flex gap-2 flex-row items-center transition-all hover:bg-white/10 hover:rounded hover:!cursor-pointer px-2 py-2 cursor-pointer w-full",
+        {
+            "bg-white/10 rounded": $selectedRoomStore?.id === room.id,
+        },
+    ]}
     onclick={selectRoom}
     onkeydown={(e) => {
         if (e.key === "Enter" || e.key === " ") {

--- a/play/src/front/Chat/Components/requireConnection.svelte
+++ b/play/src/front/Chat/Components/requireConnection.svelte
@@ -14,7 +14,7 @@
     let { emoji, title, buttonLabel, children }: Props = $props();
 </script>
 
-<div class="flex-col items-center justify-center text-center px-4 py-12">
+<div class="flex flex-col items-center justify-center text-center px-4 py-12">
     {@render children?.()}
     {#if emoji}
         {@render emoji()}


### PR DESCRIPTION
This PR groups two small chat UI styling fixes.

## 1. Active proximity chat highlight

**Problem** — When several proximity chats are open, the **active** proximity chat row was highlighted with a **fully white** background, unlike the selected Matrix chat rooms which use a subtle 10% white overlay.

**Cause** — `ProximityRoomRow.svelte` styled the active row with the legacy Tailwind pair `bg-white` + `bg-opacity-10` applied as two separate classes. The `bg-opacity-10` utility was not taking effect, so only `bg-white` applied → the row rendered fully white. The same issue affected the hover state.

The Matrix `Room.svelte` component uses the modern opacity notation `bg-white/10`, which is why its selection looked correct.

**Fix** — Align `ProximityRoomRow.svelte` with `Room.svelte`, using `bg-white/10 rounded` for both the selected and hover states. Proximity and Matrix selected rows now render identically.

## 2. Empty-state smiley not centered

**Problem** — The "Smiley happy" icon in the chat empty state (`requireConnection.svelte`) was stuck to the left instead of being centered.

**Cause** — The container carried `flex-col items-center justify-center` but was missing the `flex` class, so `display:flex` never applied and none of the flex-centering utilities took effect. Tailwind Preflight renders `img` as `display:block`, so `text-center` did not center it either.

**Fix** — Add the missing `flex` class to the container.

## Testing

- `svelte-check` passes on the components (no new errors).
- Local eslint/vitest can't run here due to the known macOS native-binding issue (node_modules built for Linux); relied on svelte-check for validation.