### PR TITLE
fix(media): restore remote audio in Vivaldi/Brave

### DIFF
--- a/play/src/front/Components/Video/PictureInPicture/AudioStream.svelte
+++ b/play/src/front/Components/Video/PictureInPicture/AudioStream.svelte
@@ -3,6 +3,8 @@
     import Debug from "debug";
     import * as Sentry from "@sentry/svelte";
     import type { Readable } from "svelte/store";
+    import { signalAudioPlaybackBlocked } from "../../../Stores/AudioPlaybackStore";
+    import { userActivationManager } from "../../../Stores/UserActivationStore";
 
     interface Props {
         streamStore: Readable<MediaStream | undefined>;
@@ -84,13 +86,61 @@
 
     let destroyed = false;
 
+    // Some Chromium-based browsers (Brave, Vivaldi) do NOT honor the `autoplay` attribute for a MediaStream
+    // assigned to `srcObject` (verified: the element stays paused regardless of assignment timing), so the
+    // remote peer is inaudible. We therefore start playback explicitly with el.play(). That call only needs
+    // *sticky* user activation (any prior interaction, e.g. moving the avatar), so in normal use no click is
+    // needed. If there has been no interaction at all yet, play() is blocked; we then raise the app-level
+    // BrowserNoSoundInfoToast (see signalAudioPlaybackBlocked) and retry this element once the page gains
+    // activation. The retry is NOT registered in audioPlaybackStore here: that would tie the toast's lifetime
+    // to this component, which BACK_IN_A_MOMENT destroys, making the toast flash and vanish.
+    let activationRetryScheduled = false;
+
+    function playAudio(): void {
+        const el = audioElement;
+        if (!el || destroyed || !el.srcObject) {
+            return;
+        }
+        el.play().catch((e) => {
+            // If the `autoplay` attribute already started playback, this rejection is harmless.
+            if (destroyed || !el.paused) {
+                return;
+            }
+            // Genuine block (missing user activation, e.g. Brave / Vivaldi: "play() can only be initiated
+            // by a user gesture").
+            debug("Audio playback blocked, waiting for a user gesture to retry", e);
+            // Keep the toast + BACK_IN_A_MOMENT status alive at app level (survives this component being
+            // destroyed when the bubble closes).
+            signalAudioPlaybackBlocked();
+            // Retry this specific element once the page gains user activation (covers the case where the
+            // bubble is NOT closed, e.g. when browser notifications are enabled). At most once, to avoid a
+            // tight loop if playback keeps failing for another reason after activation.
+            if (!activationRetryScheduled) {
+                activationRetryScheduled = true;
+                userActivationManager
+                    .waitForUserActivation()
+                    .then(() => {
+                        if (!destroyed) {
+                            playAudio();
+                        }
+                    })
+                    .catch((err: unknown) => Sentry.captureException(err));
+            }
+        });
+    }
+
     let stream = $derived($streamStore ? $streamStore : undefined);
 
-    $effect(() => {
+    // Assign srcObject with $effect.pre (runs *before* the DOM update, matching the Svelte 4 `$:` block this
+    // replaced) and then start playback via playAudio(). The explicit play() is what actually restores sound
+    // in Brave/Vivaldi — those browsers ignore the `autoplay` attribute for a MediaStream even with correct
+    // pre-DOM timing; .pre is kept only for parity with the pre-migration behavior.
+    $effect.pre(() => {
         if (audioElement && stream) {
             if (audioElement.srcObject !== stream) {
                 audioElement.srcObject = stream;
             }
+            playAudio();
         }
     });
 
@@ -104,6 +154,7 @@
                 }
                 audioElement.srcObject = stream ?? null;
                 audioElement.volume = $volume;
+                playAudio();
             }
         })().catch((e) => {
             console.error(e);

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -2227,6 +2227,8 @@ export class GameScene extends DirtyScene {
                 const onStateChange = () => {
                     const state = context.state;
 
+                    // Note: some browsers (Vivaldi / Brave) will start in "running" state directly despite
+                    // no user activation and this will not stop them from blocking WebRTC sound afterwards.
                     if (state === "suspended") {
                         audioInterruptedStore.setInterrupted(false);
                         this.unregisterAudioContextPlaybackRetry = audioPlaybackStore.register(() => {

--- a/play/src/front/Stores/AudioPlaybackStore.ts
+++ b/play/src/front/Stores/AudioPlaybackStore.ts
@@ -18,6 +18,7 @@ export function createAudioPlaybackStore(): AudioPlaybackStore {
 
             let isRegistered = true;
             return () => {
+                console.trace("Audio source unregister called");
                 if (!isRegistered) {
                     return;
                 }
@@ -52,3 +53,28 @@ export function createAudioPlaybackStore(): AudioPlaybackStore {
 }
 
 export const audioPlaybackStore = createAudioPlaybackStore();
+
+let blockedLatchUnregister: Unsubscriber | undefined;
+
+/**
+ * Signals that audio playback was blocked by the browser because the page has no user activation yet.
+ *
+ * This keeps the BrowserNoSoundInfoToast visible (and the user in BACK_IN_A_MOMENT status) until the next
+ * user gesture, INDEPENDENTLY of any single <audio> element. Previously each AudioStream registered its own
+ * retry and removed it on destroy — but registering flips the status to BACK_IN_A_MOMENT, which closes the
+ * proximity bubble and destroys the AudioStream, which removed the registration again, so the toast flashed
+ * and vanished. Owning a single app-lifetime latch here breaks that loop.
+ *
+ * The latch is a no-op retry: it exists only to keep the store non-empty. It is released when the user
+ * interacts with the page (retryAll runs via the toast's gesture listeners); live AudioStreams then retry
+ * their own playback separately. Calling this repeatedly is a no-op while the latch is already set.
+ */
+export function signalAudioPlaybackBlocked(): void {
+    if (blockedLatchUnregister) {
+        return;
+    }
+    blockedLatchUnregister = audioPlaybackStore.register(() => {
+        blockedLatchUnregister?.();
+        blockedLatchUnregister = undefined;
+    });
+}


### PR DESCRIPTION
## Problem

Since **v1.32**, users on **Vivaldi and Brave** cannot hear remote speakers in proximity conversations (WebRTC and LiveKit). Chrome and Firefox are unaffected. Vivaldi's Snap build happened to work, the `.deb`/Windows builds did not.

## Root cause

`AudioStream.svelte` renders `<audio autoplay>` and assigns the remote `MediaStream` to `srcObject`. **Vivaldi/Brave do not honor the `autoplay` attribute for a `srcObject` MediaStream** — verified: the element stays `paused` regardless of *when* `srcObject` is assigned. Chrome re-evaluates autoplay on late assignment, which is why it never surfaced. The Svelte 4→5 migration in v1.32 removed the effective play path (pre-1.32 the `$:` timing happened to keep it alive).

## Fix

- **Start playback explicitly** with `el.play()` after attaching the stream. `play()` only needs *sticky* user activation (any prior interaction, e.g. moving the avatar), so **in normal use there is no click** — it plays as soon as the peer arrives.
- If there has been **zero interaction** yet (e.g. a peer speaks the instant you spawn), `play()` is blocked; we surface the existing `BrowserNoSoundInfoToast` and retry on the next gesture. No browser can autoplay audible sound in that state anyway.

### Toast/status coupling

`audioPlaybackStore.size > 0` switches the user to `BACK_IN_A_MOMENT` (`MediaStore.ts`), which closes the proximity bubble and **destroys `AudioStream`**. Previously the component owned its own `audioPlaybackStore` registration, so destroy unregistered it → the toast flashed and vanished in a loop.

- New **app-lifetime latch** `signalAudioPlaybackBlocked()` in `AudioPlaybackStore.ts`, released only by the toast's `retryAll` on a real user gesture.
- `AudioStream` retries its own element via `userActivationManager.waitForUserActivation()` instead of registering in the store.

This preserves the "switch to `BACK_IN_A_MOMENT` on arrival if you haven't interacted" behavior (all browsers) while letting the toast persist until the user interacts.

`GameScene.ts` gets an explanatory comment only (Vivaldi/Brave start the `AudioContext` in `running` state despite no activation, which is why the AudioStream-level fix is needed).

## Testing

- `eslint` and scoped `svelte-check` clean on the changed files.
- **Needs manual verification in Vivaldi/Brave** (hard-reload — HMR doesn't re-run this effect):
  - Move your avatar, then have a remote user approach → you hear them with **no click**.
  - Arrive with zero interaction → the "turn sound on" toast now **stays** (no flash), you're `BACK_IN_A_MOMENT`, and one click/keypress restores sound and rejoins the bubble.
  - Confirm Chrome/Firefox behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)