### PR TITLE
Compute max bandwidth based on webcam resolution

### DIFF
--- a/play/src/front/Components/Video/WebRtcStatsBox.svelte
+++ b/play/src/front/Components/Video/WebRtcStatsBox.svelte
@@ -39,7 +39,9 @@
                     <td>{fpsStdDevDisplay}</td>
                 </tr>
                 <tr>
-                    <td>Resolution:</td><td>{webRtcStats.frameWidth}x{webRtcStats.frameHeight}</td>
+                    <td>Resolution:</td><td data-testid="resolution"
+                        >{webRtcStats.frameWidth}x{webRtcStats.frameHeight}</td
+                    >
                 </tr>
                 <tr>
                     <td>Codec:</td><td>{webRtcStats.mimeType}</td>

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -893,19 +893,26 @@ export class RemotePeer extends Peer implements Streamable {
             return;
         }
 
-        // Let's find the best presets
-        const preset = this.getPresetForDimensions(width, height);
-
         const videoSender = pc.getSenders().find((s) => s.track?.kind === "video");
         if (!videoSender || !videoSender.track) {
             console.warn("Adaptive video: no video sender found");
             return;
         }
-
-        // Calculate scale factor based on current capture resolution vs target preset
         const settings = videoSender.track.getSettings();
         const currentWidth = settings.width || 1280;
         const currentHeight = settings.height || 720;
+
+        // If the webcam resolution is less than the remote peer resolution, let's compute
+        // bandwidth and framerate based on the webcam resolution.
+        if (currentWidth < width || currentHeight < height) {
+            width = currentWidth;
+            height = currentHeight;
+        }
+
+        // Let's find the best presets
+        const preset = this.getPresetForDimensions(width, height);
+
+        // Calculate scale factor based on current capture resolution vs target preset
         const scaleFactor = Math.max(1, Math.min(currentWidth / width, currentHeight / height));
 
         // Get current parameters and modify encoding settings

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -902,9 +902,8 @@ export class RemotePeer extends Peer implements Streamable {
         const currentWidth = settings.width || 1280;
         const currentHeight = settings.height || 720;
 
-        // If the webcam resolution is less than the remote peer resolution, let's compute
-        // bandwidth and framerate based on the webcam resolution.
-        if (currentWidth < width || currentHeight < height) {
+        // Compute bandwidth and framerate based on the smallest of the displayed resolution and the capture resolution.
+        if (currentWidth * currentHeight < width * height) {
             width = currentWidth;
             height = currentHeight;
         }

--- a/tests/tests/adaptive_streaming.spec.ts
+++ b/tests/tests/adaptive_streaming.spec.ts
@@ -4,6 +4,7 @@ import { publicTestMapUrl } from "./utils/urls";
 import { getPage } from "./utils/auth";
 import { isMobile } from "./utils/isMobile";
 import Menu from "./utils/menu";
+import { dismissNoMicrophoneSoundInfoToast } from "./utils/noMicrophoneSoundInfoToast";
 
 test.setTimeout(240_000);
 
@@ -28,6 +29,7 @@ test.describe("Adaptive streaming test @nomobile @nowebkit @nofirefox", () => {
         await page.evaluate(() => localStorage.setItem("debug", "*"));
         // Move user Alice to the meeting area
         await Map.teleportToPosition(page, 160, 160);
+        await dismissNoMicrophoneSoundInfoToast(page);
 
         await using userBob = await getPage(
             browser,
@@ -44,28 +46,47 @@ test.describe("Adaptive streaming test @nomobile @nowebkit @nofirefox", () => {
         await page.locator("#closeMenu").click();
         await expect(page.getByRole("cell", { name: "video/VP9" }).first()).toBeVisible();
 
-        await expect(page.getByRole("cell", { name: "223x125" })).toBeVisible({ timeout: 60_000 });
+        const isHeightBetween = async (low: number, high: number): Promise<boolean> => {
+            const text = await page.getByTestId("resolution").textContent();
+            // eslint-disable-next-line playwright/no-conditional-in-test
+            if (text === null) {
+                return false;
+            }
+            const height = Number(text.split("x")[1]);
+            // eslint-disable-next-line playwright/no-conditional-in-test
+            return height >= low && height <= high;
+        };
+
+        await expect
+            .poll(
+                async () => {
+                    return isHeightBetween(124, 126);
+                },
+                {
+                    timeout: 60_000,
+                },
+            )
+            .toBeTruthy();
         await page
             .getByTestId("cameras-container")
             .locator("div", { hasText: "Bob" })
             .locator("button.full-screen-button")
             .click();
-        // @ts-ignore Promise.any not recognized by Playwright Typescript definitions yet
-        await Promise.any([
-            // In CI
 
-            expect(page.getByRole("cell", { name: "480x270" })).toBeVisible({ timeout: 60_000 }),
-
-            expect(page.getByRole("cell", { name: "640x360" })).toBeVisible({ timeout: 60_000 }),
-
-            expect(page.getByRole("cell", { name: "887x499" })).toBeVisible({ timeout: 60_000 }),
-
-            expect(page.getByRole("cell", { name: "888x500" })).toBeVisible({ timeout: 60_000 }),
-            // In Real usage
-
-            expect(page.getByRole("cell", { name: "1280x720" })).toBeVisible({ timeout: 60_000 }),
-        ]);
-
-        // Clean up
+        await expect
+            .poll(
+                async () => {
+                    return (
+                        (await isHeightBetween(269, 271)) || // In CI
+                        (await isHeightBetween(359, 361)) || // In CI
+                        (await isHeightBetween(499, 501)) || // In CI
+                        (await isHeightBetween(719, 721))
+                    ); // In real usage
+                },
+                {
+                    timeout: 60_000,
+                },
+            )
+            .toBeTruthy();
     });
 });

--- a/tests/tests/livekit.spec.ts
+++ b/tests/tests/livekit.spec.ts
@@ -15,6 +15,7 @@ import Megaphone from "./utils/map-editor/megaphone";
 import MapEditor from "./utils/mapeditor";
 import Menu from "./utils/menu";
 import AreaLivekit from "./utils/AreaLivekit";
+import { dismissNoMicrophoneSoundInfoToast } from "./utils/noMicrophoneSoundInfoToast";
 
 test.setTimeout(240_000);
 
@@ -62,9 +63,7 @@ test.describe("Meeting actions test @nomobile @nofirefox @nowebkit", () => {
         await expect(page.locator("#cameras-container").getByText("Mallory")).toBeVisible({ timeout: 30_000 });
 
         // Required because the "No sound" popup can clutter the view and prevent us clicking the "All settings" close button.
-        await page.addLocatorHandler(page.getByTestId("no-microphone-sound-ignore"), async () => {
-            await page.getByTestId("no-microphone-sound-ignore").click();
-        });
+        await dismissNoMicrophoneSoundInfoToast(page);
 
         // Let's enable the video quality display and test it works
         await Menu.openMenu(page);

--- a/tests/tests/map_editor/map_editor_area_rights.spec.ts
+++ b/tests/tests/map_editor/map_editor_area_rights.spec.ts
@@ -11,6 +11,7 @@ import { evaluateScript } from "../utils/scripting";
 import { getPage } from "../utils/auth";
 import { isMobile } from "../utils/isMobile";
 import { clickCoordinates } from "../utils/gameCoordinates";
+import { dismissNoMicrophoneSoundInfoToast } from "../utils/noMicrophoneSoundInfoToast";
 
 test.setTimeout(240_000); // Fix Webkit that can take more than 60s
 test.use({
@@ -274,9 +275,7 @@ test.describe("Map editor area with rights @oidc @nomobile @nowebkit", () => {
         await using page2 = await getPage(browser, "Member1", Map.url("empty"));
 
         // Required for Firefox that somehow does not manage to start the webcam twice (hence the "no sound" warning displayed that we must hide if it appears)
-        await page2.addLocatorHandler(page2.getByTestId("no-microphone-sound-ignore"), async () => {
-            await page2.getByTestId("no-microphone-sound-ignore").click();
-        });
+        await dismissNoMicrophoneSoundInfoToast(page2);
 
         // From browser 2
         // Try to remove entity and click on it to

--- a/tests/tests/utils/noMicrophoneSoundInfoToast.ts
+++ b/tests/tests/utils/noMicrophoneSoundInfoToast.ts
@@ -1,0 +1,8 @@
+import type { Page } from "@playwright/test";
+
+export async function dismissNoMicrophoneSoundInfoToast(page: Page): Promise<void> {
+    // Required because the "No sound" popup can clutter the view and prevent us clicking the "All settings" close button.
+    await page.addLocatorHandler(page.getByTestId("no-microphone-sound-ignore"), async () => {
+        await page.getByTestId("no-microphone-sound-ignore").click();
+    });
+}


### PR DESCRIPTION
The bandwidth used in P2P connections was computed based on the resolution of the viewer but was not taking into account the resolution of the webcam. So a viewer putting a publisher in full-screen on a 4K screen would request the bandwidth of a 4K screen, despite the quality of the webcam stream being limited to H720 (that's a lot more bandwidth for a not so huge quality increase)

We are now taking into account both the viewer video size and the camera resolution and we compute the expected bandwidth on the smallest resolution.