### PR TITLE
feat(chat): authenticated Matrix media (MSC3916 / spec v1.11)

### DIFF
--- a/play/public/matrix-media-service-worker.js
+++ b/play/public/matrix-media-service-worker.js
@@ -1,0 +1,186 @@
+/*
+ * Matrix authenticated media (MSC3916 / Matrix spec v1.11) support.
+ *
+ * Authenticated media is served from `/_matrix/client/v1/media/...` and requires
+ * an `Authorization: Bearer <access_token>` header. DOM elements (`<img>`,
+ * `<audio>`, `<video>`, download links) cannot send that header, so this service
+ * worker intercepts those requests and re-issues them with the header.
+ *
+ * The access token is never stored here: it is requested live from a window
+ * client on demand (so token refreshes on the page are always honoured) and only
+ * cached in-memory for a short time. If no token is available, or the homeserver
+ * origin does not match, the request is passed through unchanged so behaviour is
+ * never worse than without this worker.
+ *
+ * This file is loaded via `importScripts` from `service-worker-dev.js` and
+ * `service-worker-prod.js`; it only adds listeners and never calls
+ * `event.respondWith` for non-Matrix-media requests.
+ */
+(function () {
+    "use strict";
+
+    var AUTHENTICATED_MEDIA_PATH = "/_matrix/client/v1/media/";
+    var CONFIG_REQUEST_TYPE = "matrix-media-auth:get-config";
+    var CONFIG_TTL_MS = 30000;
+    var CLIENT_REPLY_TIMEOUT_MS = 1500;
+
+    // { accessToken, homeserverOrigin, fetchedAt } — short-lived in-memory cache only.
+    var cachedConfig = null;
+
+    self.addEventListener("install", function () {
+        // Take over as soon as possible so authenticated media works without a reload.
+        self.skipWaiting();
+    });
+
+    self.addEventListener("activate", function (event) {
+        event.waitUntil(self.clients.claim());
+    });
+
+    self.addEventListener("fetch", function (event) {
+        var request = event.request;
+        if (request.method !== "GET") {
+            return;
+        }
+        var url;
+        try {
+            url = new URL(request.url);
+        } catch (e) {
+            return;
+        }
+        if (url.pathname.indexOf(AUTHENTICATED_MEDIA_PATH) === -1) {
+            return;
+        }
+        event.respondWith(handleAuthenticatedMediaRequest(request, url));
+    });
+
+    function handleAuthenticatedMediaRequest(request, url) {
+        return getConfig(false)
+            .then(function (config) {
+                if (!isUsableConfig(config, url)) {
+                    // Not our homeserver, or no token available: leave the request untouched.
+                    return fetch(request);
+                }
+                return authenticatedFetch(request, config.accessToken).then(function (response) {
+                    if (response.status !== 401 && response.status !== 403) {
+                        return response;
+                    }
+                    // The cached token may be stale (refreshed on the page): retry once with a fresh one.
+                    return getConfig(true).then(function (freshConfig) {
+                        if (
+                            isUsableConfig(freshConfig, url) &&
+                            freshConfig.accessToken !== config.accessToken
+                        ) {
+                            return authenticatedFetch(request, freshConfig.accessToken);
+                        }
+                        return response;
+                    });
+                });
+            })
+            .catch(function () {
+                // Any unexpected failure must not be worse than the default behaviour.
+                return fetch(request);
+            });
+    }
+
+    function isUsableConfig(config, url) {
+        if (!config || !config.accessToken) {
+            return false;
+        }
+        if (config.homeserverOrigin && url.origin !== config.homeserverOrigin) {
+            return false;
+        }
+        return true;
+    }
+
+    function authenticatedFetch(request, accessToken) {
+        var headers = new Headers();
+        headers.set("Authorization", "Bearer " + accessToken);
+        var range = request.headers.get("range");
+        if (range) {
+            // Preserve range requests so audio/video seeking keeps working.
+            headers.set("Range", range);
+        }
+        return fetch(request.url, {
+            method: "GET",
+            headers: headers,
+            mode: "cors",
+            credentials: "omit",
+            redirect: "follow",
+        }).catch(function () {
+            // CORS / network error: fall back to the original request rather than an error page.
+            return fetch(request);
+        });
+    }
+
+    function getConfig(forceRefresh) {
+        if (!forceRefresh && cachedConfig && Date.now() - cachedConfig.fetchedAt < CONFIG_TTL_MS) {
+            return Promise.resolve(cachedConfig);
+        }
+        return requestConfigFromClients().then(function (config) {
+            if (config && config.accessToken) {
+                cachedConfig = {
+                    accessToken: config.accessToken,
+                    homeserverOrigin: config.homeserverOrigin || null,
+                    fetchedAt: Date.now(),
+                };
+                return cachedConfig;
+            }
+            return config || cachedConfig;
+        });
+    }
+
+    function requestConfigFromClients() {
+        return self.clients
+            .matchAll({ type: "window", includeUncontrolled: true })
+            .then(function (clients) {
+                return requestConfigFromFirstResponder(clients, 0);
+            });
+    }
+
+    function requestConfigFromFirstResponder(clients, index) {
+        if (index >= clients.length) {
+            return Promise.resolve(null);
+        }
+        return requestConfigFromClient(clients[index]).then(function (config) {
+            if (config && config.accessToken) {
+                return config;
+            }
+            return requestConfigFromFirstResponder(clients, index + 1);
+        });
+    }
+
+    function requestConfigFromClient(client) {
+        return new Promise(function (resolve) {
+            var channel = new MessageChannel();
+            var settled = false;
+            var timer = setTimeout(function () {
+                finish(null);
+            }, CLIENT_REPLY_TIMEOUT_MS);
+
+            function finish(value) {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                clearTimeout(timer);
+                channel.port1.onmessage = null;
+                try {
+                    channel.port1.close();
+                } catch (e) {
+                    /* noop */
+                }
+                resolve(value);
+            }
+
+            channel.port1.onmessage = function (event) {
+                finish(event.data || null);
+            };
+
+            try {
+                client.postMessage({ type: CONFIG_REQUEST_TYPE }, [channel.port2]);
+            } catch (e) {
+                finish(null);
+            }
+        });
+    }
+})();

--- a/play/public/service-worker-dev.js
+++ b/play/public/service-worker-dev.js
@@ -1,3 +1,11 @@
+// Matrix authenticated media support (adds its own install/activate/fetch listeners).
+// Wrapped so a missing/updated media worker never breaks the base service worker.
+try {
+    importScripts('/matrix-media-service-worker.js');
+} catch (e) {
+    // Authenticated media unavailable; the rest of the service worker keeps working.
+}
+
 let CACHE_NAME = 'workavdenture-cache-dev';
 let urlsToCache = [
     '/'

--- a/play/public/service-worker-prod.js
+++ b/play/public/service-worker-prod.js
@@ -1,3 +1,11 @@
+// Matrix authenticated media support (adds its own install/activate/fetch listeners).
+// Wrapped so a missing/updated media worker never breaks the base service worker.
+try {
+    importScripts('/matrix-media-service-worker.js');
+} catch (e) {
+    // Authenticated media unavailable; the rest of the service worker keeps working.
+}
+
 let CACHE_NAME = 'workavdenture-cache';
 let urlsToCache = [
     '/'

--- a/play/src/front/Chat/Components/Room/ReactionIcon.svelte
+++ b/play/src/front/Chat/Components/Room/ReactionIcon.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import type { MatrixClient } from "matrix-js-sdk";
+    import { matrixMediaAuthService } from "../../Connection/Matrix/MatrixMediaAuthService";
 
     interface Props {
         // A valid Matrix reaction key is either a Unicode emoji or an mxc URI pointing to an image, or even some text.
@@ -13,7 +14,15 @@
 
     $effect(() => {
         if (key.startsWith("mxc://")) {
-            imageUrl = matrixClient.mxcUrlToHttp(key, 40, 40);
+            imageUrl = matrixClient.mxcUrlToHttp(
+                key,
+                40,
+                40,
+                undefined,
+                undefined,
+                undefined,
+                matrixMediaAuthService.isEnabledForTagSrc(),
+            );
         }
     });
 

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -64,6 +64,7 @@ import {
     pushLocalWokaAndNameToMatrixProfile,
     syncWokaAvatarToMatrixProfileOnWokaChange,
 } from "./services/WaMatrixProfileService";
+import { matrixMediaAuthService } from "./MatrixMediaAuthService";
 
 const debug = Debug("MatrixChatConnection");
 
@@ -552,6 +553,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         try {
             this.client = await this.clientPromise;
             this.matrixSecurity.updateMatrixClientStore(this.client);
+            await matrixMediaAuthService.configure(this.client);
             await this.startMatrixClient();
             this.isGuest.set(this.client.isGuest());
             if (typeof this.client.getVisibleRooms === "function") {
@@ -640,7 +642,15 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             /* profile fetch can fail on restricted networks */
         }
         const profileAvatarPreviewUrl = profileAvatarMxc
-            ? (this.client.mxcUrlToHttp(profileAvatarMxc, 96, 96) ?? undefined)
+            ? (this.client.mxcUrlToHttp(
+                  profileAvatarMxc,
+                  96,
+                  96,
+                  undefined,
+                  undefined,
+                  undefined,
+                  matrixMediaAuthService.isEnabledForTagSrc(),
+              ) ?? undefined)
             : undefined;
         const localDisplayName = localUserStore.getDisplayNameForMatrixProfile();
         const localWoka = get(currentPlayerWokaStore);
@@ -682,7 +692,15 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             /* profile fetch can fail */
         }
         const profileAvatarPreviewUrl = profileAvatarMxc
-            ? (this.client.mxcUrlToHttp(profileAvatarMxc, 96, 96) ?? undefined)
+            ? (this.client.mxcUrlToHttp(
+                  profileAvatarMxc,
+                  96,
+                  96,
+                  undefined,
+                  undefined,
+                  undefined,
+                  matrixMediaAuthService.isEnabledForTagSrc(),
+              ) ?? undefined)
             : undefined;
 
         return {

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
@@ -1,4 +1,4 @@
-import type { MatrixEvent, Room } from "matrix-js-sdk";
+import type { MatrixClient, MatrixEvent, Room } from "matrix-js-sdk";
 import { Direction, EventType, MatrixEventEvent, MsgType, RelationType } from "matrix-js-sdk";
 import type { Writable } from "svelte/store";
 import { writable } from "svelte/store";
@@ -15,8 +15,28 @@ import type {
 import { chatUserFactoryFromRoom } from "./MatrixChatUser";
 import { MatrixChatMessageReaction } from "./MatrixChatMessageReaction";
 import { MatrixChatRelation } from "./MatrixChatRelation";
+import type { MatrixMediaResolveOptions } from "./MatrixMediaResolver";
 import { resolveAttachmentMediaFromEvent, resolveImageMediaFromEvent } from "./MatrixMediaResolver";
+import { matrixMediaAuthService } from "./MatrixMediaAuthService";
 import { shouldRenderQuotedReply } from "./MatrixThreadUtils";
+
+/**
+ * Resolves an `mxc://` URL to an HTTP URL, optionally targeting the authenticated
+ * media endpoints (the media service worker injects the auth header for those).
+ */
+function mxcToHttp(
+    client: MatrixClient,
+    mxcUrl: string | undefined | null,
+    useAuthentication: boolean,
+): string | undefined {
+    if (!mxcUrl) {
+        return undefined;
+    }
+    return (
+        client.mxcUrlToHttp(mxcUrl, undefined, undefined, undefined, undefined, undefined, useAuthentication) ??
+        undefined
+    );
+}
 
 export class MatrixChatMessage implements ChatMessage {
     id: string;
@@ -123,11 +143,13 @@ export class MatrixChatMessage implements ChatMessage {
             };
         }
 
+        const useAuthenticatedUrls = matrixMediaAuthService.isEnabledForTagSrc();
+
         if (this.type === "image") {
             return {
                 body: content.body,
-                url: this.room.client.mxcUrlToHttp(content.url ?? content.file?.url) ?? undefined,
-                thumbnailUrl: this.room.client.mxcUrlToHttp(content.info?.thumbnail_url) ?? undefined,
+                url: mxcToHttp(this.room.client, content.url ?? content.file?.url, useAuthenticatedUrls),
+                thumbnailUrl: mxcToHttp(this.room.client, content.info?.thumbnail_url, useAuthenticatedUrls),
                 mediaState: content.file !== undefined ? "loading" : "ready",
             };
         }
@@ -135,7 +157,7 @@ export class MatrixChatMessage implements ChatMessage {
         if (this.type === "file" || this.type === "audio" || this.type === "video") {
             return {
                 body: content.body,
-                url: this.room.client.mxcUrlToHttp(content.url ?? content.file?.url) ?? undefined,
+                url: mxcToHttp(this.room.client, content.url ?? content.file?.url, useAuthenticatedUrls),
                 mediaState: content.file !== undefined ? "loading" : "ready",
             };
         }
@@ -160,7 +182,12 @@ export class MatrixChatMessage implements ChatMessage {
         this.content.update((content) => ({ ...content, mediaState: "loading", mediaErrorKind: undefined }));
 
         try {
-            const media = await resolveImageMediaFromEvent(this.event, this.room.client, signal);
+            const media = await resolveImageMediaFromEvent(
+                this.event,
+                this.room.client,
+                signal,
+                this.getMediaResolveOptions(),
+            );
             if (signal.aborted) {
                 media.cleanup();
                 return;
@@ -207,7 +234,12 @@ export class MatrixChatMessage implements ChatMessage {
         this.content.update((content) => ({ ...content, mediaState: "loading", mediaErrorKind: undefined }));
 
         try {
-            const media = await resolveAttachmentMediaFromEvent(this.event, this.room.client, signal);
+            const media = await resolveAttachmentMediaFromEvent(
+                this.event,
+                this.room.client,
+                signal,
+                this.getMediaResolveOptions(),
+            );
             if (signal.aborted) {
                 media.cleanup();
                 return;
@@ -278,7 +310,17 @@ export class MatrixChatMessage implements ChatMessage {
     }
 
     public mxcUrlToHttp(url: string) {
-        return this.room.client.mxcUrlToHttp(url);
+        return mxcToHttp(this.room.client, url, matrixMediaAuthService.isEnabledForTagSrc()) ?? null;
+    }
+
+    private getMediaResolveOptions(): MatrixMediaResolveOptions {
+        return {
+            useAuthenticatedUrls: matrixMediaAuthService.isEnabledForTagSrc(),
+            encryptedDownload: {
+                useAuthenticatedUrls: matrixMediaAuthService.isEnabledForDirectFetch(),
+                authorizationHeader: matrixMediaAuthService.getAuthorizationHeader(),
+            },
+        };
     }
     private mapMatrixMessageTypeToChatMessage() {
         const matrixMessageType = this.event.getOriginalContent().msgtype;

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -83,6 +83,7 @@ import { MatrixChatPoll } from "./MatrixChatPoll";
 import { MatrixChatMessageReaction } from "./MatrixChatMessageReaction";
 import { MatrixChatThread } from "./MatrixChatThread";
 import { matrixSecurity } from "./MatrixSecurity";
+import { matrixMediaAuthService } from "./MatrixMediaAuthService";
 import { hasValidViaEntries } from "./MatrixSpaceRelations";
 import { resolveChatUserColor } from "./services/WaMatrixProfileService";
 import { MatrixChatRoomMember } from "./MatrixChatRoomMember";
@@ -223,7 +224,14 @@ export class MatrixChatRoom
         this.hasUnreadMessages = writable(matrixRoom.getUnreadNotificationCount() > 0);
         this.unreadNotificationCount = writable(matrixRoom.getUnreadNotificationCount());
         const roomAvatarStore: PictureStore = readable(
-            matrixRoom.getAvatarUrl(matrixRoom.client.baseUrl, 24, 24, "scale") ?? undefined,
+            matrixRoom.getAvatarUrl(
+                matrixRoom.client.baseUrl,
+                24,
+                24,
+                "scale",
+                undefined,
+                matrixMediaAuthService.isEnabledForTagSrc(),
+            ) ?? undefined,
         );
         this.messages = new SearchableArrayStore((item: MatrixChatMessage) => item.id);
         this.timelinePolls = new SearchableArrayStore((item: MatrixChatPoll) => item.id);

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatUser.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatUser.ts
@@ -4,6 +4,7 @@ import { readable, writable } from "svelte/store";
 import { AvailabilityStatus } from "@workadventure/messages";
 import type { ChatUser } from "../ChatConnection";
 import { matrixAvatarProfile } from "./services/MatrixAvatarProfile";
+import { matrixMediaAuthService } from "./MatrixMediaAuthService";
 
 type ChatUserFactoryOptions = {
     username?: string;
@@ -39,7 +40,16 @@ export function chatUserFactoryFromRoom(room: Room, userId: string): ChatUser | 
     const roomMember = room.getMember(userId);
     const displayName =
         roomMember?.name?.trim() || matrixUser?.displayName?.trim() || matrixUser?.rawDisplayName?.trim();
-    const pictureUrl = roomMember?.getAvatarUrl(room.client.baseUrl, 48, 48, "scale", false, false) ?? undefined;
+    const pictureUrl =
+        roomMember?.getAvatarUrl(
+            room.client.baseUrl,
+            48,
+            48,
+            "scale",
+            false,
+            false,
+            matrixMediaAuthService.isEnabledForTagSrc(),
+        ) ?? undefined;
 
     if (matrixUser) {
         return chatUserFactory(matrixUser, room.client, {

--- a/play/src/front/Chat/Connection/Matrix/MatrixMediaAuthCapability.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixMediaAuthCapability.ts
@@ -1,0 +1,88 @@
+/**
+ * Detects whether the Matrix homeserver supports authenticated media
+ * (MSC3916, stabilised in the Matrix client-server spec v1.11).
+ *
+ * When a homeserver enforces authenticated media, the legacy unauthenticated
+ * endpoints (`/_matrix/media/v3/...`) answer with 401/404, so media URLs must
+ * be switched to the authenticated endpoints (`/_matrix/client/v1/media/...`)
+ * which require an `Authorization: Bearer` header. Older homeservers do not
+ * expose those endpoints, so switching blindly would break media there.
+ *
+ * The detection therefore gates the whole feature: it defaults to `false`
+ * (legacy behaviour, byte-for-byte identical to before) on any uncertainty.
+ */
+import type { MatrixClient } from "matrix-js-sdk";
+import Debug from "debug";
+
+const debug = Debug("matrix-media-auth");
+
+const UNSTABLE_AUTHENTICATED_MEDIA_FEATURE = "org.matrix.msc3916.stable";
+
+type ServerVersions = Awaited<ReturnType<MatrixClient["getVersions"]>>;
+
+const resultByClient = new WeakMap<MatrixClient, boolean>();
+const inflightByClient = new WeakMap<MatrixClient, Promise<boolean>>();
+
+/**
+ * Returns whether the homeserver supports authenticated media.
+ *
+ * The result is memoised per client. Failures are NOT cached (they resolve to
+ * `false` but allow a later retry), so a transient error at startup does not
+ * disable authenticated media for the whole session on a server that supports
+ * it.
+ */
+export function serverSupportsAuthenticatedMedia(client: MatrixClient): Promise<boolean> {
+    const cached = resultByClient.get(client);
+    if (cached !== undefined) {
+        return Promise.resolve(cached);
+    }
+    const inflight = inflightByClient.get(client);
+    if (inflight) {
+        return inflight;
+    }
+
+    const detection = detectAuthenticatedMediaSupport(client)
+        .then((supported) => {
+            resultByClient.set(client, supported);
+            return supported;
+        })
+        .catch((error) => {
+            debug("authenticated media detection failed, falling back to legacy media: %o", error);
+            return false;
+        })
+        .finally(() => {
+            inflightByClient.delete(client);
+        });
+
+    inflightByClient.set(client, detection);
+    return detection;
+}
+
+async function detectAuthenticatedMediaSupport(client: MatrixClient): Promise<boolean> {
+    const versions: ServerVersions = await client.getVersions();
+    if (!versions) {
+        return false;
+    }
+
+    const specVersions = versions.versions ?? [];
+    if (specVersions.some(isSpecVersionAtLeastV1_11)) {
+        return true;
+    }
+
+    return versions.unstable_features?.[UNSTABLE_AUTHENTICATED_MEDIA_FEATURE] === true;
+}
+
+/**
+ * Matrix spec versions look like `r0.6.1` (pre-1.0) or `v1.11`. Authenticated
+ * media is only guaranteed from `v1.11` onwards, so only the `v{major}.{minor}`
+ * scheme is considered and compared numerically.
+ */
+export function isSpecVersionAtLeastV1_11(version: string): boolean {
+    const match = /^v(\d+)\.(\d+)$/.exec(version);
+    if (!match) {
+        return false;
+    }
+    const major = Number(match[1]);
+    const minor = Number(match[2]);
+    return major > 1 || (major === 1 && minor >= 11);
+}

--- a/play/src/front/Chat/Connection/Matrix/MatrixMediaAuthService.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixMediaAuthService.ts
@@ -1,0 +1,142 @@
+/**
+ * Page-side coordinator for Matrix authenticated media (MSC3916 / spec v1.11).
+ *
+ * Media served by the authenticated endpoints (`/_matrix/client/v1/media/...`)
+ * requires an `Authorization: Bearer` header. An `<img>` / `<audio>` / `<video>`
+ * element cannot carry that header, so the header is injected by the media
+ * service worker ({@link file://./../../../../../public/matrix-media-service-worker.js}).
+ *
+ * This service is the bridge between the Matrix client and that service worker:
+ *   - it detects whether the homeserver supports authenticated media,
+ *   - it answers the service worker's requests for the current access token
+ *     (read live from the client, so token refreshes are picked up), and
+ *   - it exposes whether URL producers should emit authenticated URLs.
+ *
+ * The URL producers stay synchronous, so {@link isEnabledForTagSrc} and
+ * {@link isEnabledForDirectFetch} are synchronous. When the feature is not
+ * enabled, callers keep their previous (legacy) behaviour unchanged.
+ */
+import type { MatrixClient } from "matrix-js-sdk";
+import Debug from "debug";
+import { serverSupportsAuthenticatedMedia } from "./MatrixMediaAuthCapability";
+
+const debug = Debug("matrix-media-auth");
+
+/** Message the service worker sends to a window to fetch the current media auth config. */
+export const MEDIA_AUTH_CONFIG_REQUEST = "matrix-media-auth:get-config";
+
+export interface MediaAuthConfig {
+    accessToken: string | null;
+    homeserverOrigin: string | null;
+}
+
+export class MatrixMediaAuthService {
+    private client: MatrixClient | undefined;
+    private homeserverOrigin: string | null = null;
+    private capabilitySupported = false;
+    private messageResponderInstalled = false;
+
+    /**
+     * Wires the service to a freshly initialised Matrix client and runs the
+     * (memoised) homeserver capability detection. Safe to call again on
+     * reconnection.
+     */
+    async configure(client: MatrixClient): Promise<void> {
+        // Never throw into the caller's init flow: any failure just keeps legacy media.
+        try {
+            this.client = client;
+            this.homeserverOrigin = safeOrigin(client.getHomeserverUrl());
+            this.installMessageResponder();
+            this.capabilitySupported = await serverSupportsAuthenticatedMedia(client);
+        } catch (error) {
+            debug("configure failed, keeping legacy media: %o", error);
+            this.capabilitySupported = false;
+        }
+        debug("configured: authenticatedMedia=%s homeserverOrigin=%s", this.capabilitySupported, this.homeserverOrigin);
+    }
+
+    /** Clears the current client and removes the service-worker responder (e.g. on logout / client stop). */
+    reset(): void {
+        if (this.messageResponderInstalled && typeof navigator !== "undefined" && navigator.serviceWorker) {
+            navigator.serviceWorker.removeEventListener("message", this.onServiceWorkerMessage);
+            this.messageResponderInstalled = false;
+        }
+        this.client = undefined;
+        this.homeserverOrigin = null;
+        this.capabilitySupported = false;
+    }
+
+    /**
+     * Whether media URLs consumed by DOM elements (`<img>`, `<audio>`, `<video>`,
+     * download links) should target the authenticated endpoints. Requires both a
+     * capable homeserver AND a controlling service worker able to inject the auth
+     * header — otherwise the authenticated URLs would answer 401.
+     */
+    isEnabledForTagSrc(): boolean {
+        return this.capabilitySupported && this.hasControllingServiceWorker();
+    }
+
+    /**
+     * Whether media fetched directly by the page (encrypted attachments, which
+     * are downloaded and decrypted in-memory) should target the authenticated
+     * endpoints. Does not need the service worker because {@link getAuthorizationHeader}
+     * is applied to the request explicitly.
+     */
+    isEnabledForDirectFetch(): boolean {
+        return this.capabilitySupported;
+    }
+
+    /** Authorization header for a direct authenticated-media fetch, or undefined when unavailable. */
+    getAuthorizationHeader(): Record<string, string> | undefined {
+        const token = this.client?.getAccessToken();
+        return token ? { Authorization: `Bearer ${token}` } : undefined;
+    }
+
+    private hasControllingServiceWorker(): boolean {
+        return typeof navigator !== "undefined" && Boolean(navigator.serviceWorker?.controller);
+    }
+
+    private installMessageResponder(): void {
+        if (this.messageResponderInstalled || typeof navigator === "undefined" || !navigator.serviceWorker) {
+            return;
+        }
+        this.messageResponderInstalled = true;
+        navigator.serviceWorker.addEventListener("message", this.onServiceWorkerMessage);
+    }
+
+    /**
+     * Replies to the media service worker's request for the current access token.
+     * The token is read live from the client so token refreshes are always honoured.
+     */
+    private readonly onServiceWorkerMessage = (event: MessageEvent): void => {
+        if (!isConfigRequest(event.data)) {
+            return;
+        }
+        const port = event.ports[0];
+        if (!port) {
+            return;
+        }
+        const config: MediaAuthConfig = {
+            accessToken: this.client?.getAccessToken() ?? null,
+            homeserverOrigin: this.homeserverOrigin,
+        };
+        port.postMessage(config);
+    };
+}
+
+function isConfigRequest(data: unknown): boolean {
+    return typeof data === "object" && data !== null && (data as { type?: unknown }).type === MEDIA_AUTH_CONFIG_REQUEST;
+}
+
+function safeOrigin(url: string | undefined | null): string | null {
+    if (!url) {
+        return null;
+    }
+    try {
+        return new URL(url).origin;
+    } catch {
+        return null;
+    }
+}
+
+export const matrixMediaAuthService = new MatrixMediaAuthService();

--- a/play/src/front/Chat/Connection/Matrix/MatrixMediaResolver.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixMediaResolver.ts
@@ -18,6 +18,31 @@ export type MatrixResolvedAttachmentMedia = {
     cleanup: () => void;
 };
 
+/**
+ * Authenticated media (MSC3916 / spec v1.11) options.
+ *
+ * When omitted, media resolution keeps its legacy behaviour (unauthenticated
+ * endpoints, plain fetch), so nothing changes on homeservers that do not enforce
+ * authenticated media.
+ */
+export type MatrixMediaResolveOptions = {
+    /**
+     * Emit authenticated (`/_matrix/client/v1/media/...`) URLs for unencrypted
+     * media that is consumed by DOM elements (`<img>`, `<audio>`, `<video>`,
+     * download links). The Authorization header is injected by the media service
+     * worker, so this must only be true when that worker is active.
+     */
+    useAuthenticatedUrls?: boolean;
+    /**
+     * For encrypted media, which is downloaded and decrypted directly by the
+     * page rather than by a DOM element.
+     */
+    encryptedDownload?: {
+        useAuthenticatedUrls?: boolean;
+        authorizationHeader?: Record<string, string> | undefined;
+    };
+};
+
 type BlobUrlRegistry = {
     createFromBuffer: (buffer: ArrayBuffer, mimeType: string | undefined) => string;
     cleanup: () => void;
@@ -129,15 +154,22 @@ function getThumbnailEncryptedFile(content: MediaEventContent): EncryptedFile | 
     return info?.thumbnail_file;
 }
 
-function getHttpUrl(client: MatrixClient, mxcUrl: string | undefined): string | undefined {
+function getHttpUrl(client: MatrixClient, mxcUrl: string | undefined, useAuthentication = false): string | undefined {
     if (mxcUrl === undefined) {
         return undefined;
     }
-    return client.mxcUrlToHttp(mxcUrl) ?? undefined;
+    return (
+        client.mxcUrlToHttp(mxcUrl, undefined, undefined, undefined, undefined, undefined, useAuthentication) ??
+        undefined
+    );
 }
 
-async function downloadArrayBuffer(url: string, signal: AbortSignal): Promise<ArrayBuffer> {
-    const response = await fetch(url, { signal });
+async function downloadArrayBuffer(
+    url: string,
+    signal: AbortSignal,
+    headers?: Record<string, string>,
+): Promise<ArrayBuffer> {
+    const response = await fetch(url, headers ? { signal, headers } : { signal });
     if (!response.ok) {
         throw new MediaDownloadError("media download failed");
     }
@@ -150,12 +182,13 @@ async function resolveEncryptedBlobUrl(
     mimeType: string | undefined,
     blobRegistry: BlobUrlRegistry,
     signal: AbortSignal,
+    encryptedDownload: MatrixMediaResolveOptions["encryptedDownload"],
 ): Promise<string> {
-    const downloadUrl = getHttpUrl(client, encryptedFile.url);
+    const downloadUrl = getHttpUrl(client, encryptedFile.url, encryptedDownload?.useAuthenticatedUrls ?? false);
     if (downloadUrl === undefined) {
         throw new MediaDownloadError("missing encrypted media URL");
     }
-    const encryptedBuffer = await downloadArrayBuffer(downloadUrl, signal);
+    const encryptedBuffer = await downloadArrayBuffer(downloadUrl, signal, encryptedDownload?.authorizationHeader);
     let decryptedBuffer: ArrayBuffer;
     try {
         decryptedBuffer = await decryptEncryptedFile(new Uint8Array(encryptedBuffer), encryptedFile);
@@ -169,10 +202,12 @@ export async function resolveImageMediaFromEvent(
     event: MatrixEvent,
     client: MatrixClient,
     signal: AbortSignal,
+    options: MatrixMediaResolveOptions = {},
 ): Promise<MatrixResolvedImageMedia> {
     const rawContent = event.getOriginalContent();
     const content = toMediaEventContent(rawContent);
     const blobRegistry = createBlobUrlRegistry();
+    const useAuthenticatedUrls = options.useAuthenticatedUrls ?? false;
     if (content === undefined) {
         return {
             sourceUrl: undefined,
@@ -193,8 +228,8 @@ export async function resolveImageMediaFromEvent(
         )?.thumbnail_url;
         return {
             isEncrypted: false,
-            sourceUrl: getHttpUrl(client, content.url),
-            thumbnailUrl: getHttpUrl(client, thumbnailUrl),
+            sourceUrl: getHttpUrl(client, content.url, useAuthenticatedUrls),
+            thumbnailUrl: getHttpUrl(client, thumbnailUrl, useAuthenticatedUrls),
             error: undefined,
             cleanup: blobRegistry.cleanup,
         };
@@ -217,6 +252,7 @@ export async function resolveImageMediaFromEvent(
             content.info?.mimetype,
             blobRegistry,
             signal,
+            options.encryptedDownload,
         );
         const thumbnailFile = getThumbnailEncryptedFile(content);
         if (thumbnailFile === undefined) {
@@ -241,6 +277,7 @@ export async function resolveImageMediaFromEvent(
             )?.thumbnail_info?.mimetype,
             blobRegistry,
             signal,
+            options.encryptedDownload,
         );
         return { sourceUrl, thumbnailUrl, isEncrypted: true, error: undefined, cleanup: blobRegistry.cleanup };
     } catch (error) {
@@ -262,6 +299,7 @@ export async function resolveAttachmentMediaFromEvent(
     event: MatrixEvent,
     client: MatrixClient,
     signal: AbortSignal,
+    options: MatrixMediaResolveOptions = {},
 ): Promise<MatrixResolvedAttachmentMedia> {
     const rawContent = event.getOriginalContent();
     const content = toAttachmentMediaEventContent(rawContent);
@@ -278,7 +316,7 @@ export async function resolveAttachmentMediaFromEvent(
     if (!isEncryptedMediaContent(content)) {
         return {
             isEncrypted: false,
-            sourceUrl: getHttpUrl(client, content.url ?? content.file?.url),
+            sourceUrl: getHttpUrl(client, content.url ?? content.file?.url, options.useAuthenticatedUrls ?? false),
             error: undefined,
             cleanup: blobRegistry.cleanup,
         };
@@ -300,6 +338,7 @@ export async function resolveAttachmentMediaFromEvent(
             content.info?.mimetype,
             blobRegistry,
             signal,
+            options.encryptedDownload,
         );
         return { sourceUrl, isEncrypted: true, error: undefined, cleanup: blobRegistry.cleanup };
     } catch (error) {

--- a/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
@@ -11,6 +11,7 @@ import { matrixRateLimiter } from "../../Services/MatrixRateLimiter";
 import { ignoredSuggestedRoomIdsStore } from "../../Stores/ChatStore";
 import type { RoomFolder } from "../ChatConnection";
 import { MatrixChatRoom } from "./MatrixChatRoom";
+import { matrixMediaAuthService } from "./MatrixMediaAuthService";
 import { hasValidViaEntries } from "./MatrixSpaceRelations";
 
 export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
@@ -288,7 +289,15 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
                     return;
                 }
 
-                const avatarUrl = chatRoom.getAvatarUrl(chatRoom.client.baseUrl, 24, 24, "scale") ?? "";
+                const avatarUrl =
+                    chatRoom.getAvatarUrl(
+                        chatRoom.client.baseUrl,
+                        24,
+                        24,
+                        "scale",
+                        undefined,
+                        matrixMediaAuthService.isEnabledForTagSrc(),
+                    ) ?? "";
                 suggestedRooms.push({
                     name: room.name ?? "",
                     id: roomId,
@@ -313,7 +322,15 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
                 const membership = chatRoom.getMyMembership();
 
                 if (membership !== "join" && membership !== "invite" && membership !== "ban") {
-                    const avatarUrl = chatRoom.getAvatarUrl(chatRoom.client.baseUrl, 24, 24, "scale") ?? "";
+                    const avatarUrl =
+                        chatRoom.getAvatarUrl(
+                            chatRoom.client.baseUrl,
+                            24,
+                            24,
+                            "scale",
+                            undefined,
+                            matrixMediaAuthService.isEnabledForTagSrc(),
+                        ) ?? "";
                     availableRooms.push({
                         name: room.name ?? "",
                         id: roomId,

--- a/play/src/front/Chat/Connection/Matrix/services/MatrixAvatarProfile.ts
+++ b/play/src/front/Chat/Connection/Matrix/services/MatrixAvatarProfile.ts
@@ -3,6 +3,7 @@ import Debug from "debug";
 import { writable } from "svelte/store";
 import type { LazyPictureStore } from "../../../../Stores/PictureStore";
 import type { UserProviderMerger } from "../../../UserProviderMerger/UserProviderMerger";
+import { matrixMediaAuthService } from "../MatrixMediaAuthService";
 import { resolveDirectMessagePeerAvatarUrl } from "./WaMatrixProfileService";
 
 const debug = Debug("MatrixChatConnection");
@@ -69,7 +70,15 @@ export class MatrixAvatarProfile {
         matrixClient: MatrixClient,
         mergerContext: UserProviderMerger | undefined,
     ): string | undefined {
-        const http = roomMember.getAvatarUrl(baseUrl, 96, 96, "scale", false, false);
+        const http = roomMember.getAvatarUrl(
+            baseUrl,
+            96,
+            96,
+            "scale",
+            false,
+            false,
+            matrixMediaAuthService.isEnabledForTagSrc(),
+        );
         const avatarUrl = resolveDirectMessagePeerAvatarUrl(
             matrixUserId,
             http ?? undefined,

--- a/play/src/front/Chat/Connection/Matrix/services/WaMatrixProfileService.ts
+++ b/play/src/front/Chat/Connection/Matrix/services/WaMatrixProfileService.ts
@@ -10,6 +10,7 @@ import Debug from "debug";
 import { getColorByString } from "../../../../Utils/ColorGenerator";
 import { localUserStore } from "../../../../Connection/LocalUserStore";
 import type { UserProviderMerger } from "../../../UserProviderMerger/UserProviderMerger";
+import { matrixMediaAuthService } from "../MatrixMediaAuthService";
 
 const debug = Debug("matrix");
 
@@ -93,22 +94,25 @@ async function sha256HexOfBlob(blob: Blob): Promise<string> {
  */
 async function fetchWokaImageAsBlob(client: MatrixClient, src: string): Promise<Blob | undefined> {
     try {
-        const url = matrixOrPlainUrlToHttp(client, src);
+        if (!src.startsWith("mxc:")) {
+            const response = await fetch(src);
+            return response.ok ? response.blob() : undefined;
+        }
+        // Direct in-page fetch of Matrix content: on an authenticated-media homeserver,
+        // target the authenticated endpoint and carry the Authorization header explicitly.
+        const useAuthentication = matrixMediaAuthService.isEnabledForDirectFetch();
+        const url =
+            client.mxcUrlToHttp(src, undefined, undefined, undefined, undefined, undefined, useAuthentication) ??
+            undefined;
         if (!url) {
             return undefined;
         }
-        const response = await fetch(url);
+        const authorizationHeader = useAuthentication ? matrixMediaAuthService.getAuthorizationHeader() : undefined;
+        const response = await fetch(url, authorizationHeader ? { headers: authorizationHeader } : undefined);
         return response.ok ? response.blob() : undefined;
     } catch {
         return undefined;
     }
-}
-
-function matrixOrPlainUrlToHttp(client: MatrixClient, src: string): string | undefined {
-    if (src.startsWith("mxc:")) {
-        return client.mxcUrlToHttp(src) ?? undefined;
-    }
-    return src;
 }
 
 /**
@@ -200,7 +204,17 @@ function avatarHttp96(client: MatrixClient, mxc: string | null | undefined): str
     if (!mxc) {
         return undefined;
     }
-    return client.mxcUrlToHttp(mxc, 96, 96) ?? undefined;
+    return (
+        client.mxcUrlToHttp(
+            mxc,
+            96,
+            96,
+            undefined,
+            undefined,
+            undefined,
+            matrixMediaAuthService.isEnabledForTagSrc(),
+        ) ?? undefined
+    );
 }
 
 export function resolveDirectMessagePeerAvatarUrl(

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixMediaAuthCapability.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixMediaAuthCapability.test.ts
@@ -1,0 +1,75 @@
+import type { MatrixClient } from "matrix-js-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { isSpecVersionAtLeastV1_11, serverSupportsAuthenticatedMedia } from "../MatrixMediaAuthCapability";
+
+function clientWithVersions(getVersions: MatrixClient["getVersions"]): MatrixClient {
+    return { getVersions } as unknown as MatrixClient;
+}
+
+describe("isSpecVersionAtLeastV1_11", () => {
+    it("accepts v1.11 and later", () => {
+        expect(isSpecVersionAtLeastV1_11("v1.11")).toBe(true);
+        expect(isSpecVersionAtLeastV1_11("v1.12")).toBe(true);
+        expect(isSpecVersionAtLeastV1_11("v1.20")).toBe(true);
+        expect(isSpecVersionAtLeastV1_11("v2.0")).toBe(true);
+    });
+
+    it("rejects earlier or non-v1 spec versions", () => {
+        expect(isSpecVersionAtLeastV1_11("v1.10")).toBe(false);
+        expect(isSpecVersionAtLeastV1_11("v1.9")).toBe(false);
+        expect(isSpecVersionAtLeastV1_11("v1.1")).toBe(false);
+        expect(isSpecVersionAtLeastV1_11("r0.6.1")).toBe(false);
+        expect(isSpecVersionAtLeastV1_11("nonsense")).toBe(false);
+    });
+});
+
+describe("serverSupportsAuthenticatedMedia", () => {
+    it("returns true when the server advertises spec v1.11", async () => {
+        const client = clientWithVersions(
+            vi.fn(() => Promise.resolve({ versions: ["v1.6", "v1.11"], unstable_features: {} })),
+        );
+        await expect(serverSupportsAuthenticatedMedia(client)).resolves.toBe(true);
+    });
+
+    it("returns true when the server advertises the unstable feature", async () => {
+        const client = clientWithVersions(
+            vi.fn(() =>
+                Promise.resolve({ versions: ["v1.6"], unstable_features: { "org.matrix.msc3916.stable": true } }),
+            ),
+        );
+        await expect(serverSupportsAuthenticatedMedia(client)).resolves.toBe(true);
+    });
+
+    it("returns false when neither spec version nor unstable feature are present", async () => {
+        const client = clientWithVersions(
+            vi.fn(() =>
+                Promise.resolve({ versions: ["v1.6"], unstable_features: { "org.matrix.msc3916.stable": false } }),
+            ),
+        );
+        await expect(serverSupportsAuthenticatedMedia(client)).resolves.toBe(false);
+    });
+
+    it("falls back to false (legacy media) when version detection throws", async () => {
+        const client = clientWithVersions(vi.fn(() => Promise.reject(new Error("network"))));
+        await expect(serverSupportsAuthenticatedMedia(client)).resolves.toBe(false);
+    });
+
+    it("memoises a successful result per client", async () => {
+        const getVersions = vi.fn(() => Promise.resolve({ versions: ["v1.11"], unstable_features: {} }));
+        const client = clientWithVersions(getVersions);
+        await serverSupportsAuthenticatedMedia(client);
+        await serverSupportsAuthenticatedMedia(client);
+        expect(getVersions).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries after a failure instead of caching it", async () => {
+        const getVersions = vi
+            .fn()
+            .mockRejectedValueOnce(new Error("transient"))
+            .mockResolvedValue({ versions: ["v1.11"], unstable_features: {} });
+        const client = clientWithVersions(getVersions);
+        await expect(serverSupportsAuthenticatedMedia(client)).resolves.toBe(false);
+        await expect(serverSupportsAuthenticatedMedia(client)).resolves.toBe(true);
+        expect(getVersions).toHaveBeenCalledTimes(2);
+    });
+});

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixMediaResolver.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixMediaResolver.test.ts
@@ -174,3 +174,132 @@ describe("resolveAttachmentMediaFromEvent", () => {
         result.cleanup();
     });
 });
+
+describe("resolveAttachmentMediaFromEvent authenticated media", () => {
+    it("targets the authenticated endpoint for unencrypted media when enabled", async () => {
+        const mxcUrlToHttp = vi.fn(
+            (mxc: string, _w?: number, _h?: number, _rm?: string, _adl?: boolean, _ar?: boolean, useAuth?: boolean) =>
+                `https://hs/${useAuth ? "v1" : "legacy"}?mxc=${encodeURIComponent(mxc)}`,
+        );
+        const client = { mxcUrlToHttp } as unknown as MatrixClient;
+
+        const event = {
+            getOriginalContent: () => ({
+                msgtype: "m.file",
+                body: "report.pdf",
+                url: "mxc://example.org/abcdef",
+            }),
+        } as unknown as MatrixEvent;
+
+        const result = await resolveAttachmentMediaFromEvent(event, client, new AbortController().signal, {
+            useAuthenticatedUrls: true,
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.sourceUrl).toBe("https://hs/v1?mxc=mxc%3A%2F%2Fexample.org%2Fabcdef");
+        expect(mxcUrlToHttp).toHaveBeenCalledWith(
+            "mxc://example.org/abcdef",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            true,
+        );
+        result.cleanup();
+    });
+
+    it("keeps the legacy endpoint for unencrypted media when disabled", async () => {
+        const mxcUrlToHttp = vi.fn(
+            (mxc: string, _w?: number, _h?: number, _rm?: string, _adl?: boolean, _ar?: boolean, useAuth?: boolean) =>
+                `https://hs/${useAuth ? "v1" : "legacy"}?mxc=${encodeURIComponent(mxc)}`,
+        );
+        const client = { mxcUrlToHttp } as unknown as MatrixClient;
+
+        const event = {
+            getOriginalContent: () => ({ msgtype: "m.file", body: "report.pdf", url: "mxc://example.org/abcdef" }),
+        } as unknown as MatrixEvent;
+
+        const result = await resolveAttachmentMediaFromEvent(event, client, new AbortController().signal);
+
+        expect(result.sourceUrl).toBe("https://hs/legacy?mxc=mxc%3A%2F%2Fexample.org%2Fabcdef");
+        expect(mxcUrlToHttp).toHaveBeenCalledWith(
+            "mxc://example.org/abcdef",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            false,
+        );
+        result.cleanup();
+    });
+
+    it("adds the Authorization header when downloading encrypted media with auth", async () => {
+        const encryptedBuffer = new Uint8Array([1, 2, 3]).buffer;
+        const decryptedBuffer = new Uint8Array([4, 5, 6]).buffer;
+        const fetchSpy = vi.fn(() =>
+            Promise.resolve({
+                ok: true,
+                arrayBuffer: () => Promise.resolve(encryptedBuffer),
+            }),
+        );
+        vi.stubGlobal("fetch", fetchSpy);
+        vi.stubGlobal("URL", {
+            createObjectURL: vi.fn(() => "blob:auth"),
+            revokeObjectURL: vi.fn(),
+        });
+        vi.stubGlobal("crypto", {
+            subtle: {
+                digest: vi.fn(() => Promise.resolve(new Uint8Array([9, 8, 7]).buffer)),
+                importKey: vi.fn(() => Promise.resolve("imported-key")),
+                decrypt: vi.fn(() => Promise.resolve(decryptedBuffer)),
+            },
+        });
+
+        const mxcUrlToHttp = vi.fn(
+            (mxc: string, _w?: number, _h?: number, _rm?: string, _adl?: boolean, _ar?: boolean, useAuth?: boolean) =>
+                `https://hs/${useAuth ? "v1" : "legacy"}/${encodeURIComponent(mxc)}`,
+        );
+        const client = { mxcUrlToHttp } as unknown as MatrixClient;
+
+        const event = {
+            getOriginalContent: () => ({
+                msgtype: "m.file",
+                body: "secret.pdf",
+                file: {
+                    url: "mxc://example.org/encrypted",
+                    iv: "AA",
+                    hashes: { sha256: "CQgH" },
+                    key: { k: "AQIDBA", alg: "A256CTR", ext: true, key_ops: ["encrypt", "decrypt"], kty: "oct" },
+                    v: "v2",
+                },
+                info: { mimetype: "application/pdf" },
+            }),
+        } as unknown as MatrixEvent;
+
+        const result = await resolveAttachmentMediaFromEvent(event, client, new AbortController().signal, {
+            encryptedDownload: {
+                useAuthenticatedUrls: true,
+                authorizationHeader: { Authorization: "Bearer token" },
+            },
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.sourceUrl).toBe("blob:auth");
+        expect(mxcUrlToHttp).toHaveBeenCalledWith(
+            "mxc://example.org/encrypted",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            true,
+        );
+        expect(fetchSpy).toHaveBeenCalledWith("https://hs/v1/mxc%3A%2F%2Fexample.org%2Fencrypted", {
+            signal: expect.anything(),
+            headers: { Authorization: "Bearer token" },
+        });
+        result.cleanup();
+    });
+});


### PR DESCRIPTION
## What

Implements authenticated Matrix media (MSC3916, stabilised in the Matrix client-server spec **v1.11**) across the whole chat: avatars, message images / thumbnails / files / audio / video, room avatars, and custom reaction icons.

On a homeserver that enforces authenticated media, the legacy `/_matrix/media/v3/...` endpoints answer `401/404`, which would break **all** media (not just messages — avatars and reactions too). This PR switches media to the authenticated `/_matrix/client/v1/media/...` endpoints and injects the required `Authorization: Bearer` header via a service worker.

## How

- **Capability detection** (`MatrixMediaAuthCapability.ts`) — `getVersions()`, spec `>= v1.11` or the `org.matrix.msc3916.stable` unstable flag. Memoised, retries on transient failure, defaults to `false`.
- **Media service worker** (`public/matrix-media-service-worker.js`) — loaded via `importScripts` from the existing prod/dev service workers (one worker per scope, so we extend rather than register a second one). Intercepts `/_matrix/client/v1/media/` requests to the homeserver origin, injects `Authorization: Bearer`, retries once on `401` with a fresh token, and **falls back to a plain passthrough on any CORS/network error** so it is never worse than today. Preserves `Range` requests (audio/video seeking). Uses `skipWaiting` + `clients.claim` to take control promptly; the `importScripts` is wrapped in try/catch so a missing media worker can never break the base worker.
- **Token handling** (`MatrixMediaAuthService.ts`) — the worker asks a window client for the token over a `MessageChannel`; the page replies with `client.getAccessToken()` read **live**, so SDK token refreshes are always honoured and the token is never persisted (a service worker cannot read `localStorage`).
- **URL producers** thread `useAuthentication` through `mxcUrlToHttp` / `getAvatarUrl` when enabled. Encrypted media (downloaded & decrypted in-page, not by a DOM element) applies the auth header directly.

**Safety:** when the homeserver does not advertise authenticated media, or the service worker is not yet controlling the page, every producer keeps its exact previous behaviour — byte-for-byte, no regression on older homeservers.

## ⚠️ Required Synapse configuration

This feature is only exercised when the homeserver serves authenticated media. On Synapse:

- **`enable_authenticated_media: true`** in `homeserver.yaml`. This is the **default since Synapse 1.120** and will become always-on in a future release. With it on, new uploads are only available over `/_matrix/client/v1/media/download|thumbnail`, and the legacy `/_matrix/media/*` endpoints return `404`. The homeserver must also advertise spec `v1.11` in `/_matrix/client/versions` (modern Synapse does) — that is what the client detects to enable this feature.
- **Reverse proxy / CORS** — play and the homeserver are typically **cross-origin**, and the service worker issues a CORS request carrying an `Authorization` header. The proxy in front of Synapse must:
  - route `/_matrix/client/v1/media/*` (it lives under `/_matrix/client/`, so it is usually already routed — double-check if you have a narrow, media-specific location rule),
  - allow the `OPTIONS` preflight and the `Authorization` request header from the play origin. Synapse itself sets permissive CORS on media endpoints, but a custom reverse proxy can strip or override those headers.

No config change is needed to **ship** this PR safely — on homeservers without authenticated media it is a no-op. But to actually **serve** authenticated media (and to keep media working once Synapse makes authenticated media always-on), the above must be in place.

## Testing

- `typecheck`, `svelte-check` (0 errors / 0 warnings), `eslint`, `prettier` — all clean.
- Unit tests — capability detection + resolver auth options (`MatrixMediaAuthCapability.test.ts`, extended `MatrixMediaResolver.test.ts`); **96/96 pass** in `Matrix/tests/`.
- ⚠️ **Not yet verified against a live authenticated-media homeserver.** Manual QA is recommended before merge on a Synapse with `enable_authenticated_media: true` (ideally cross-origin from play): avatars, message images/files, audio/video, encrypted media, custom reactions, and an upload → download round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
