### PR TITLE
test: skip screen-share step on Firefox in megaphone auditorium E2E

### DIFF
--- a/tests/tests/map_editor/map_editor_megaphone_speaker_zone.spec.ts
+++ b/tests/tests/map_editor/map_editor_megaphone_speaker_zone.spec.ts
@@ -575,11 +575,17 @@ test.describe("Map editor @oidc @nomobile @nowebkit", () => {
         }
 
         // A listener may keep their local screen share active, but it must not be published to the megaphone speaker.
-        await pageListener1.getByTestId("screenShareButton").click();
-        await Menu.expectButtonState(pageListener1, "screenShareButton", "active");
-        await expect(pageSpeaker.locator("#highlighted-media").getByText("Admin2", { exact: true })).toBeHidden({
-            timeout: 20_000,
-        });
+        // Skipped on Firefox: Playwright cannot grant getDisplayMedia in Firefox (the request hangs when a display
+        // server is available and rejects with NotFoundError in headless CI), so the screen share never activates.
+        // Same reason as the @nofirefox tag on the other screen-share tests.
+        // eslint-disable-next-line playwright/no-conditional-in-test
+        if (browser.browserType().name() !== "firefox") {
+            await pageListener1.getByTestId("screenShareButton").click();
+            await Menu.expectButtonState(pageListener1, "screenShareButton", "active");
+            await expect(pageSpeaker.locator("#highlighted-media").getByText("Admin2", { exact: true })).toBeHidden({
+                timeout: 20_000,
+            });
+        }
 
         // Verify listeners cannot see each other (only the speaker)
         // Admin2 (listener1) should NOT see Alice, Bob, and John


### PR DESCRIPTION
## Problem

The E2E test "Megaphone auditorium mode with 5 participants" fails repeatedly on the **firefox 2/4** CI job (e.g. [this run](https://github.com/workadventure/workadventure/actions/runs/28683778853/job/85073050170)), always at:

```
Error: expect(locator).toHaveClass(expected) failed
Locator: getByTestId('screenShareButton')
Expected pattern: /bg-secondary/
```

## Root cause

Playwright cannot grant `getDisplayMedia` in Firefox (there is no equivalent of Chromium's `--auto-select-desktop-capture-source` / fake display media). Probing Playwright-Firefox with our exact `firefoxUserPrefs` shows two behaviors:

- **With a display server (local runs):** the `getDisplayMedia` promise hangs forever. The screen-share button turned "active" only because `requestedScreenSharingState` is set on click and is never reset by a rejection — the test passed locally without ever actually screen sharing.
- **Without a display server (headless CI runner):** the call rejects immediately with `NotFoundError`, `ScreenSharingStore` resets `requestedScreenSharingState`, and the button never becomes active → the assertion fails.

This is why the test "works locally" but consistently fails in CI.

## Fix

Skip the screen-share portion of the test on Firefox, consistent with the `@nofirefox` tag on every other screen-share test (`screensharing.spec.ts`, and the "see attendees" test in the same file). The rest of the 5-participant auditorium scenario still runs on Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)