### PR TITLE
fix: base the no-microphone-sound warning on time-domain RMS detection

### DIFF
--- a/play/src/front/Stores/NoMicrophoneSoundWarningVisibleStore.test.ts
+++ b/play/src/front/Stores/NoMicrophoneSoundWarningVisibleStore.test.ts
@@ -1,30 +1,21 @@
 import { get, writable } from "svelte/store";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MicrophoneSignalSample } from "./MicrophoneSignalDetectorStore";
 
 type TestStores = Awaited<ReturnType<typeof setupTestStores>>;
 
 async function setupTestStores() {
     vi.resetModules();
 
-    const rawLocalVolumeStore = writable<number[] | undefined>(undefined);
-    const localVolumeStore = writable<number[] | undefined>(undefined);
-    const silentStore = writable(false);
+    const microphoneSignalDetectedStore = writable<MicrophoneSignalSample | undefined>(undefined);
     const usedMicrophoneDeviceIdStore = writable<string | undefined>("microphone-1");
-    const myMicrophoneStore = writable(true);
-    const isLiveStreamingAudioStore = writable(true);
     const microphoneValidatedForDeviceIdStore = writable<string | undefined>(undefined);
 
+    vi.doMock("./MicrophoneSignalDetectorStore", () => ({
+        microphoneSignalDetectedStore,
+    }));
     vi.doMock("./MediaStore", () => ({
-        rawLocalVolumeStore,
-        localVolumeStore,
-        silentStore,
         usedMicrophoneDeviceIdStore,
-    }));
-    vi.doMock("./MyMediaStore", () => ({
-        myMicrophoneStore,
-    }));
-    vi.doMock("./IsStreamingStore", () => ({
-        isLiveStreamingAudioStore,
     }));
     vi.doMock("./MicrophoneValidatedForDeviceIdStore", () => ({
         microphoneValidatedForDeviceIdStore,
@@ -33,20 +24,17 @@ async function setupTestStores() {
     const { noMicrophoneSoundWarningVisibleStore } = await import("./NoMicrophoneSoundWarningVisibleStore");
 
     return {
-        isLiveStreamingAudioStore,
-        localVolumeStore,
+        microphoneSignalDetectedStore,
         microphoneValidatedForDeviceIdStore,
-        myMicrophoneStore,
         noMicrophoneSoundWarningVisibleStore,
-        rawLocalVolumeStore,
-        silentStore,
         usedMicrophoneDeviceIdStore,
     };
 }
 
-function publishSamples(store: TestStores["rawLocalVolumeStore"], volume: number[] | undefined, count: number): void {
+function publishSamples(store: TestStores["microphoneSignalDetectedStore"], detected: boolean, count: number): void {
     for (let i = 0; i < count; i += 1) {
-        store.set(volume);
+        // A new object per poll, like microphoneSignalDetectedStore does
+        store.set({ detected });
     }
 }
 
@@ -55,63 +43,94 @@ describe("noMicrophoneSoundWarningVisibleStore", () => {
         vi.restoreAllMocks();
     });
 
-    it("shows the warning after 50 zero samples from an unvalidated microphone", async () => {
-        const { noMicrophoneSoundWarningVisibleStore, rawLocalVolumeStore } = await setupTestStores();
+    it("shows the warning after 50 samples without a microphone signal", async () => {
+        const { microphoneSignalDetectedStore, noMicrophoneSoundWarningVisibleStore } = await setupTestStores();
         const unsubscribe = noMicrophoneSoundWarningVisibleStore.subscribe(() => undefined);
 
-        publishSamples(rawLocalVolumeStore, [0, 0, 0, 0, 0, 0, 0], 49);
+        publishSamples(microphoneSignalDetectedStore, false, 49);
         expect(get(noMicrophoneSoundWarningVisibleStore)).toBe(false);
 
-        rawLocalVolumeStore.set([0, 0, 0, 0, 0, 0, 0]);
+        publishSamples(microphoneSignalDetectedStore, false, 1);
 
         expect(get(noMicrophoneSoundWarningVisibleStore)).toBe(true);
         unsubscribe();
     });
 
-    it("validates the current microphone after 10 non-zero raw samples", async () => {
-        const { microphoneValidatedForDeviceIdStore, noMicrophoneSoundWarningVisibleStore, rawLocalVolumeStore } =
-            await setupTestStores();
+    it("keeps the warning visible while silence continues and hides it when a signal is detected", async () => {
+        const { microphoneSignalDetectedStore, noMicrophoneSoundWarningVisibleStore } = await setupTestStores();
         const unsubscribe = noMicrophoneSoundWarningVisibleStore.subscribe(() => undefined);
 
-        publishSamples(rawLocalVolumeStore, [0, 0, 0, 1, 0, 0, 0], 9);
-        expect(get(microphoneValidatedForDeviceIdStore)).toBeUndefined();
+        publishSamples(microphoneSignalDetectedStore, false, 60);
+        expect(get(noMicrophoneSoundWarningVisibleStore)).toBe(true);
 
-        rawLocalVolumeStore.set([0, 0, 0, 1, 0, 0, 0]);
-
-        expect(get(microphoneValidatedForDeviceIdStore)).toBe("microphone-1");
-        unsubscribe();
-    });
-
-    it("does not show the warning for a validated microphone", async () => {
-        const { microphoneValidatedForDeviceIdStore, noMicrophoneSoundWarningVisibleStore, rawLocalVolumeStore } =
-            await setupTestStores();
-        microphoneValidatedForDeviceIdStore.set("microphone-1");
-        const unsubscribe = noMicrophoneSoundWarningVisibleStore.subscribe(() => undefined);
-
-        publishSamples(rawLocalVolumeStore, [0, 0, 0, 0, 0, 0, 0], 50);
+        publishSamples(microphoneSignalDetectedStore, true, 1);
 
         expect(get(noMicrophoneSoundWarningVisibleStore)).toBe(false);
         unsubscribe();
     });
 
-    it("uses raw volume for the warning instead of processed local volume", async () => {
+    it("hides the warning when detection stops being eligible", async () => {
+        const { microphoneSignalDetectedStore, noMicrophoneSoundWarningVisibleStore } = await setupTestStores();
+        const unsubscribe = noMicrophoneSoundWarningVisibleStore.subscribe(() => undefined);
+
+        publishSamples(microphoneSignalDetectedStore, false, 50);
+        expect(get(noMicrophoneSoundWarningVisibleStore)).toBe(true);
+
+        microphoneSignalDetectedStore.set(undefined);
+
+        expect(get(noMicrophoneSoundWarningVisibleStore)).toBe(false);
+        unsubscribe();
+    });
+
+    it("validates the current microphone after 10 samples with a signal", async () => {
         const {
-            localVolumeStore,
+            microphoneSignalDetectedStore,
             microphoneValidatedForDeviceIdStore,
             noMicrophoneSoundWarningVisibleStore,
-            rawLocalVolumeStore,
+        } = await setupTestStores();
+        const unsubscribe = noMicrophoneSoundWarningVisibleStore.subscribe(() => undefined);
+
+        publishSamples(microphoneSignalDetectedStore, true, 9);
+        expect(get(microphoneValidatedForDeviceIdStore)).toBeUndefined();
+
+        publishSamples(microphoneSignalDetectedStore, true, 1);
+
+        expect(get(microphoneValidatedForDeviceIdStore)).toBe("microphone-1");
+        unsubscribe();
+    });
+
+    it("resets the counters when the microphone device changes", async () => {
+        const { microphoneSignalDetectedStore, noMicrophoneSoundWarningVisibleStore, usedMicrophoneDeviceIdStore } =
+            await setupTestStores();
+        const unsubscribe = noMicrophoneSoundWarningVisibleStore.subscribe(() => undefined);
+
+        publishSamples(microphoneSignalDetectedStore, false, 49);
+        usedMicrophoneDeviceIdStore.set("microphone-2");
+
+        publishSamples(microphoneSignalDetectedStore, false, 49);
+        expect(get(noMicrophoneSoundWarningVisibleStore)).toBe(false);
+
+        publishSamples(microphoneSignalDetectedStore, false, 1);
+
+        expect(get(noMicrophoneSoundWarningVisibleStore)).toBe(true);
+        unsubscribe();
+    });
+
+    it("warns for a new unvalidated device after the previous one was validated", async () => {
+        const {
+            microphoneSignalDetectedStore,
+            microphoneValidatedForDeviceIdStore,
+            noMicrophoneSoundWarningVisibleStore,
             usedMicrophoneDeviceIdStore,
         } = await setupTestStores();
         const unsubscribe = noMicrophoneSoundWarningVisibleStore.subscribe(() => undefined);
 
-        localVolumeStore.set([0, 0, 0, 0, 0, 0, 0]);
-        publishSamples(rawLocalVolumeStore, [0, 0, 0, 1, 0, 0, 0], 10);
-
+        publishSamples(microphoneSignalDetectedStore, true, 10);
         expect(get(microphoneValidatedForDeviceIdStore)).toBe("microphone-1");
         expect(get(noMicrophoneSoundWarningVisibleStore)).toBe(false);
 
         usedMicrophoneDeviceIdStore.set("microphone-2");
-        publishSamples(rawLocalVolumeStore, [0, 0, 0, 0, 0, 0, 0], 50);
+        publishSamples(microphoneSignalDetectedStore, false, 50);
 
         expect(get(noMicrophoneSoundWarningVisibleStore)).toBe(true);
         unsubscribe();

--- a/play/src/front/Stores/NoMicrophoneSoundWarningVisibleStore.ts
+++ b/play/src/front/Stores/NoMicrophoneSoundWarningVisibleStore.ts
@@ -1,62 +1,61 @@
-import { derived } from "svelte/store";
-import { myMicrophoneStore } from "./MyMediaStore";
-import { isLiveStreamingAudioStore } from "./IsStreamingStore";
-import { rawLocalVolumeStore, silentStore, usedMicrophoneDeviceIdStore } from "./MediaStore";
+import { derived, get } from "svelte/store";
+import { usedMicrophoneDeviceIdStore } from "./MediaStore";
 import { microphoneValidatedForDeviceIdStore } from "./MicrophoneValidatedForDeviceIdStore";
+import { microphoneSignalDetectedStore } from "./MicrophoneSignalDetectorStore";
 
-const ZERO_SAMPLES_FOR_NO_SOUND_WARNING = 50; // 5 seconds at 100ms (rawLocalVolumeStore updates every 100ms)
+const SILENT_SAMPLES_FOR_NO_SOUND_WARNING = 50; // 5 seconds at 100ms (microphoneSignalDetectedStore polls every 100ms)
 const MIN_SOUND_SAMPLES_BEFORE_VALIDATION = 10; // 1 second of sustained sound on current device before we validate (avoids validating a new mic with residual sound from the previous one)
 
-function isVolumeZero(volume: number[] | undefined): boolean {
-    return volume !== undefined && volume.length > 0 && volume.every((v) => v === 0);
-}
-
-function hasSound(volume: number[] | undefined): boolean {
-    return volume !== undefined && volume.length > 0 && !isVolumeZero(volume);
-}
-
-let noSoundWarningZeroCount = 0;
+let noSoundWarningSilentCount = 0;
 let soundValidationSampleCount = 0;
 let lastDeviceIdForSoundValidation: string | undefined;
 
+/**
+ * Shows the "no sound detected from your microphone" warning after 5 seconds without any signal
+ * from the microphone while we are expected to stream audio.
+ *
+ * Detection relies on microphoneSignalDetectedStore, which computes the time-domain RMS of the raw
+ * (pre-noise-suppression) stream and therefore reacts to a signal anywhere in the spectrum. The
+ * previous implementation sampled a handful of frequency bars in the 3.75-6 kHz range only, and
+ * reported silence for perfectly working microphones producing low-frequency signals (including
+ * the fake microphones used by the E2E tests).
+ */
 export const noMicrophoneSoundWarningVisibleStore = derived(
-    [
-        rawLocalVolumeStore,
-        myMicrophoneStore,
-        isLiveStreamingAudioStore,
-        silentStore,
-        usedMicrophoneDeviceIdStore,
-        microphoneValidatedForDeviceIdStore,
-    ],
-    ([volume, myMic, isLiveStreamingAudioStore, silent, usedDeviceId, validatedDeviceId], set) => {
-        const isStreamingContext = isLiveStreamingAudioStore;
-        const shouldDetect = myMic && isStreamingContext && !silent;
-        const isCurrentDeviceValidated =
-            validatedDeviceId !== undefined && usedDeviceId !== undefined && usedDeviceId === validatedDeviceId;
+    microphoneSignalDetectedStore,
+    (sample, set) => {
+        // No sample: detection is not eligible (microphone off, not streaming audio, silent zone,
+        // or the current device is already validated).
+        if (sample === undefined) {
+            noSoundWarningSilentCount = 0;
+            soundValidationSampleCount = 0;
+            set(false);
+            return;
+        }
 
-        if (shouldDetect && usedDeviceId !== undefined && hasSound(volume)) {
-            if (lastDeviceIdForSoundValidation !== usedDeviceId) {
-                lastDeviceIdForSoundValidation = usedDeviceId;
-                soundValidationSampleCount = 0;
-            }
-            soundValidationSampleCount += 1;
-            if (soundValidationSampleCount >= MIN_SOUND_SAMPLES_BEFORE_VALIDATION) {
-                microphoneValidatedForDeviceIdStore.set(usedDeviceId);
-            }
-        } else {
+        const usedDeviceId = get(usedMicrophoneDeviceIdStore);
+        if (lastDeviceIdForSoundValidation !== usedDeviceId) {
+            lastDeviceIdForSoundValidation = usedDeviceId;
+            noSoundWarningSilentCount = 0;
             soundValidationSampleCount = 0;
         }
 
-        if (shouldDetect && !isCurrentDeviceValidated && isVolumeZero(volume)) {
-            noSoundWarningZeroCount += 1;
-            if (noSoundWarningZeroCount >= ZERO_SAMPLES_FOR_NO_SOUND_WARNING) {
-                set(true);
-                noSoundWarningZeroCount = 0;
+        if (sample.detected) {
+            noSoundWarningSilentCount = 0;
+            if (usedDeviceId !== undefined) {
+                soundValidationSampleCount += 1;
+                if (soundValidationSampleCount >= MIN_SOUND_SAMPLES_BEFORE_VALIDATION) {
+                    microphoneValidatedForDeviceIdStore.set(usedDeviceId);
+                }
             }
+            set(false);
         } else {
-            noSoundWarningZeroCount = 0;
-            if (!shouldDetect || !isVolumeZero(volume) || isCurrentDeviceValidated) {
-                set(false);
+            soundValidationSampleCount = 0;
+            noSoundWarningSilentCount += 1;
+            if (noSoundWarningSilentCount >= SILENT_SAMPLES_FOR_NO_SOUND_WARNING) {
+                // Keep the warning visible while the microphone stays silent: it only hides once a
+                // signal is detected or detection stops being eligible.
+                set(true);
+                noSoundWarningSilentCount = 0;
             }
         }
     },


### PR DESCRIPTION
## Problem

The "No sound detected from your microphone" warning is fed by `rawLocalVolumeStore`, which samples 7 frequency bars from `SoundMeter.getFrequenciesByBar()` — FFT bins 20–32 at `fftSize` 256, i.e. roughly the **3.75–6 kHz** band at a 48 kHz sample rate. Any microphone whose signal lives outside that narrow band reads as fully silent: the device can never be validated and the warning toast appears after 5 seconds in a streaming-audio context.

The fake microphones used by the E2E tests are the extreme case. Probing Playwright's fake devices with the exact `SoundMeter` sampling shows:

- **Firefox** (`media.navigator.streams.fake`): a loud ~1 kHz sine (FFT bin 5, amplitude 237/255) → sampled bars read `[0,0,0,0,0,0,0]` 100% of the time.
- **Chromium** (`--use-fake-device-for-media-stream`): low-frequency pulses (bin 0) → sampled bars also permanently zero.

So in E2E the mic always looks dead, and on slow CI runners the toast pops up mid-test and intercepts pointer events over the action bar menu. This is one of the two failure modes of "Megaphone auditorium mode with 5 participants" on the firefox 2/4 job ([example run](https://github.com/workadventure/workadventure/actions/runs/28683778853/job/85073050170) — attempt 1 times out clicking "Map editor" because the toast's `<p>` intercepts the click). The other failure mode is addressed by #6309.

## Fix

Rewire `noMicrophoneSoundWarningVisibleStore` to `microphoneSignalDetectedStore`, which already computes the **time-domain RMS** of the raw (pre-noise-suppression) stream every 100ms (`getFloatTimeDomainData`, threshold RMS 0.001) and therefore detects a signal anywhere in the spectrum — including low-frequency signals from perfectly valid real microphones, and the E2E fake mics, which now validate within a second.

Behavior is otherwise unchanged:

- same thresholds (50 silent samples / 5s to warn, 10 signal samples / 1s to validate),
- eligibility conditions (mic on, live streaming audio, not silent, device not yet validated) now come from the existing `microphoneSignalDetectionEligibleStore` instead of being duplicated,
- the warning stays sticky while silence continues and hides on signal or when detection stops being eligible,
- new: counters are reset when the microphone device changes, so a new device no longer inherits the silence streak of the previous one.

Unit tests rewritten accordingly (`npm test`, `npm run typecheck`, lint and prettier all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)