### PR TITLE
Switching Screenshare to AV1 encoding

### DIFF
--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -392,7 +392,7 @@ export class LiveKitRoom implements LiveKitRoomInterface {
 
             const screenSharePublishOptions: TrackPublishOptions = {
                 source: Track.Source.ScreenShare,
-                videoCodec: "vp9",
+                videoCodec: "av1",
                 simulcast: true,
                 // Commented out: the default simulcast layers are sufficient for our use case
                 // screenShareSimulcastLayers: [ScreenSharePresets.h720fps30]

--- a/play/src/front/WebRtc/RemotePeer.ts
+++ b/play/src/front/WebRtc/RemotePeer.ts
@@ -233,7 +233,7 @@ export class RemotePeer extends Peer implements Streamable {
         public user: UserSimplePeerInterface,
         initiator: boolean,
         private space: SpaceInterface,
-        private iceServers: IceServer[],
+        iceServers: IceServer[],
         //private spaceUser: SpaceUserExtended,
         isLocalPeer: boolean,
         private localStreamStore: Readable<LocalStreamStoreValue | undefined>,
@@ -259,7 +259,9 @@ export class RemotePeer extends Peer implements Streamable {
                     rtcpMuxPolicy: "require",
                 }),
             },
-            preferredCodecs: { video: ["video/VP9", "video/VP8"] },
+            preferredCodecs: {
+                video: type === "video" ? ["video/VP9", "video/VP8"] : ["video/AV1", "video/VP9", "video/VP8"],
+            },
             // Firefox works better with trickle ICE enabled
             ...(firefoxBrowser && { trickle: true }),
         };

--- a/play/src/front/WebRtc/VideoPresets.ts
+++ b/play/src/front/WebRtc/VideoPresets.ts
@@ -149,7 +149,7 @@ const videoMaxPreset: Preset = {
     },
 };
 
-export const screenSharePresets = {
+/*export const screenSharePresets = {
     h360: {
         pixels: 640 * 360,
         bitrate: {
@@ -203,7 +203,7 @@ const screenShareMaxPreset: Preset = {
         recommended: 30,
         high: 60,
     },
-};
+};*/
 
 /**
  * Select the most appropriate bandwidth and fps for your resolution.
@@ -218,19 +218,13 @@ export function selectVideoPreset(
     fps: number;
 } {
     if (isScreenShare) {
-        return selectPreset(
-            displayWidth,
-            displayHeight,
-            Object.values(screenSharePresets),
-            screenShareMaxPreset,
-            quality,
-        );
+        return selectAV1Preset(displayWidth, displayHeight, quality);
     } else {
-        return selectPreset(displayWidth, displayHeight, Object.values(videoPresets), videoMaxPreset, quality);
+        return selectVP9Preset(displayWidth, displayHeight, Object.values(videoPresets), videoMaxPreset, quality);
     }
 }
 
-function selectPreset(
+function selectVP9Preset(
     width: number,
     height: number,
     presets: Preset[],
@@ -251,5 +245,37 @@ function selectPreset(
     return {
         bitrate: maxPreset.bitrate[quality],
         fps: maxPreset.fps[quality],
+    };
+}
+
+/**
+ * The bitrate for AV1 is computed linearly from the number of pixels to encode, with a strong maximum set at 4.5 Mbps (in high mode)
+ */
+export function selectAV1Preset(
+    width: number,
+    height: number,
+    quality: VideoQualitySetting,
+): { bitrate: number; fps: number } {
+    let maxBitrate: number;
+    switch (quality) {
+        case "low":
+            maxBitrate = 1_000_000;
+            break;
+        case "recommended":
+            maxBitrate = 3_000_000;
+            break;
+        case "high":
+            maxBitrate = 4_500_000;
+            break;
+        default: {
+            const _exhaustiveCheck: never = quality;
+            throw new Error(`Unhandled quality setting: ${_exhaustiveCheck}`);
+        }
+    }
+
+    const bitrate = Math.min(maxBitrate, Math.sqrt((width * height) / (1920 * 1080)) * maxBitrate);
+    return {
+        bitrate,
+        fps: 30,
     };
 }

--- a/play/src/front/WebRtc/VideoPresets.ts
+++ b/play/src/front/WebRtc/VideoPresets.ts
@@ -249,7 +249,7 @@ function selectVP9Preset(
 }
 
 /**
- * The bitrate for AV1 is computed linearly from the number of pixels to encode, with a strong maximum set at 4.5 Mbps (in high mode)
+ * The bitrate for AV1 scales with the frame size (sqrt of the pixel ratio vs 1920x1080) and is capped by the selected quality maximum.
  */
 export function selectAV1Preset(
     width: number,
@@ -273,7 +273,7 @@ export function selectAV1Preset(
         }
     }
 
-    const bitrate = Math.min(maxBitrate, Math.sqrt((width * height) / (1920 * 1080)) * maxBitrate);
+    const bitrate = Math.round(Math.min(maxBitrate, Math.sqrt((width * height) / (1920 * 1080)) * maxBitrate));
     return {
         bitrate,
         fps: 30,


### PR DESCRIPTION
Screen-share is now encoded in AV1 with generous bandwidth (3Mbit/s in recommended mode and 4.5Mbit/s in high) Video stays in VP9 for now (for CPU reasons in P2P mode where we might have a lot of videos to encode). We will reconsider this choice later.