### PR TITLE
fix(chat): stop emoji (SAS) verification intermittently hanging (per-attempt dialog latch)

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/MatrixSecurity.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixSecurity.ts
@@ -303,11 +303,20 @@ export class MatrixSecurity {
 
             let sasListenerAttached = false;
             let sasStartRequested = false;
+            let startRetries = 0;
+            // Per-attempt idempotency latch for opening the emoji dialog. It must NOT reuse the shared
+            // this.isVerifyingDevice singleton: that flag is a re-entrancy guard for the modal openers and can
+            // legitimately be true here — left set by an aborted earlier attempt (it is reset only on
+            // Done/Cancelled), or flipped by a concurrent openChooseDeviceVerificationMethodModal fired from a
+            // store subscription during the Ready->ShowSas window. Reading it made showSasHandler silently bail
+            // so the spinner hung forever; a closure-local latch makes each attempt independent and immune.
+            let emojiDialogOpened = false;
 
             const showSasHandler = (showSasCallbacks: ShowSasCallbacks) => {
                 const emojis = showSasCallbacks.sas.emoji;
-                if (!emojis || this.isVerifyingDevice) return;
+                if (!emojis || emojiDialogOpened) return;
 
+                emojiDialogOpened = true;
                 this.isVerifyingDevice = true;
 
                 startVerificationDeferred.resolve({
@@ -361,6 +370,13 @@ export class MatrixSecurity {
                     };
                     startSasVerification().catch((error) => {
                         console.error("Failed to start SAS verification from the initiating device", error);
+                        // sasStartRequested is set before the awaits, so a transient reject (e.g. the other
+                        // device's keys still propagating just after getUserDeviceInfo) would otherwise latch
+                        // the request at Ready forever. Allow a small, bounded number of retries on the next
+                        // Change instead of giving up permanently.
+                        if (startRetries++ < 2) {
+                            sasStartRequested = false;
+                        }
                     });
                 }
 

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixSecurity.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixSecurity.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MatrixClient } from "matrix-js-sdk";
-import { VerificationPhase, VerificationRequestEvent } from "matrix-js-sdk/lib/crypto-api";
+import { VerificationPhase, VerificationRequestEvent, VerifierEvent } from "matrix-js-sdk/lib/crypto-api";
 import { VerificationMethod } from "matrix-js-sdk/lib/types";
 import { writable } from "svelte/store";
 import { MatrixSecurity } from "../MatrixSecurity";
@@ -200,6 +200,83 @@ describe("MatrixSecurity", () => {
             await flush();
 
             expect(request.startVerification).not.toHaveBeenCalled();
+        });
+
+        it("opens the emoji dialog even when isVerifyingDevice is already true (stuck flag / concurrent opener)", async () => {
+            const openModal = vi.fn();
+
+            const verifier = Object.assign(new EventEmitter(), {
+                getShowSasCallbacks: vi.fn(() => null),
+                verify: vi.fn(() => new Promise(() => {})),
+            });
+
+            const request = Object.assign(new EventEmitter(), {
+                phase: VerificationPhase.Requested,
+                initiatedByMe: true,
+                chosenMethod: null,
+                verifier: undefined,
+                otherPartySupportsMethod: vi.fn(() => true),
+                startVerification: vi.fn((): Promise<unknown> => Promise.resolve(verifier)),
+            }) as unknown as EventEmitter & {
+                phase: number;
+                chosenMethod: string | null;
+                verifier: unknown;
+                startVerification: ReturnType<typeof vi.fn>;
+            };
+
+            const crypto = {
+                requestOwnUserVerification: vi.fn().mockResolvedValue(request),
+                getUserDeviceInfo: vi.fn().mockResolvedValue(new Map()),
+            };
+            const mockMatrixClient = {
+                getCrypto: vi.fn(() => crypto),
+                getUserId: vi.fn(() => "@me:example.test"),
+            } as unknown as MatrixClient;
+
+            const matrixSecurity = new MatrixSecurity(undefined, undefined, openModal);
+            matrixSecurity.updateMatrixClientStore(mockMatrixClient);
+            // Simulate the shared re-entrancy flag being stuck true — left set by an aborted prior attempt, or
+            // flipped by a concurrent openChooseDeviceVerificationMethodModal during the Ready->ShowSas window.
+            matrixSecurity["isVerifyingDevice"] = true;
+
+            await matrixSecurity.verifyOwnDevice();
+
+            // DeviceVerificationPendingModal is opened first; the spinner closes only once its
+            // startVerificationPromise resolves (which opens the emoji dialog).
+            const pendingModalProps = openModal.mock.calls[0][1] as { startVerificationPromise: Promise<unknown> };
+            const startVerificationPromise = pendingModalProps.startVerificationPromise;
+
+            // Peer accepts -> Ready -> the fix downloads keys and calls startVerification.
+            request.phase = VerificationPhase.Ready;
+            request.emit(VerificationRequestEvent.Change);
+            await flush();
+            expect(request.startVerification).toHaveBeenCalledWith(VerificationMethod.Sas);
+
+            // startSas() advances to Started with a verifier (as the SDK would); drive the Started branch.
+            request.verifier = verifier;
+            request.chosenMethod = VerificationMethod.Sas;
+            request.phase = VerificationPhase.Started;
+            request.emit(VerificationRequestEvent.Change);
+
+            // SAS computed -> ShowSas. Before the fix, showSasHandler read this.isVerifyingDevice (true here)
+            // and silently returned, so the promise never resolved and the spinner hung forever.
+            verifier.emit(VerifierEvent.ShowSas, {
+                sas: {
+                    emoji: [
+                        ["🐶", "Dog"],
+                        ["🐱", "Cat"],
+                    ],
+                },
+                confirm: vi.fn(),
+                mismatch: vi.fn(),
+            });
+
+            await expect(startVerificationPromise).resolves.toMatchObject({
+                emojis: [
+                    ["🐶", "Dog"],
+                    ["🐱", "Cat"],
+                ],
+            });
         });
     });
 


### PR DESCRIPTION
Follow-up to #6308. That PR made WA↔Element emoji (SAS) verification *reach* the emoji step; this fixes it opening only **intermittently** — sometimes the method choice goes straight to the emojis, sometimes it sits on "Waiting for the other device" forever.

## Root cause

`verifyOwnDevice`'s `showSasHandler` gated the emoji-dialog resolution on the shared `this.isVerifyingDevice` singleton, which is reset **only** on the `Done`/`Cancelled` phases:

1. **Cross-attempt poison** — it's set `true` when the emojis show but never cleared on an *aborted* attempt (spinner/emoji modal closed, `verify()` rejects, timeout). It stays stuck `true`, so the **next** attempt's `showSasHandler` early-returns and never resolves the pending promise → `DeviceVerificationPendingModal`'s spinner never opens the emoji dialog.
2. **Concurrent-opener suppression** — a `openChooseDeviceVerificationMethodModal` fired from a store subscription (chat-visibility / room-change / `initEndToEndEncryption`) holds the same singleton `true` across its `await`s; if `ShowSas` lands in that window, `showSasHandler` bails the same way. Timing-dependent → exactly why it's intermittent.

## Fix

Gate the emoji-dialog resolution on a **closure-local `emojiDialogOpened` latch** instead of the shared singleton, so each `verifyOwnDevice` attempt is independent and immune to a prior attempt or a concurrent modal opener. The `this.isVerifyingDevice` write (its legitimate re-entrancy job) and the `Done`/`Cancelled` resets are **unchanged**, so re-entrancy semantics and the glare/ordering behaviour are untouched.

Also bound the start retry: on a transient `startVerification` reject (e.g. the other device's keys still propagating just after `getUserDeviceInfo`), reset `sasStartRequested` up to twice so it retries on the next `Change` instead of latching at `Ready`.

> Root cause found via a multi-agent race analysis + an adversarial review that rejected the naive "drop the flag" fix (it would relocate the stuck-flag bug); the shipped form only replaces the *read*, preserving re-entrancy.

## Tests

Added a `MatrixSecurity > verifyOwnDevice` unit test that drives `Ready → Started → ShowSas` with `isVerifyingDevice` **pre-set `true`** and asserts the emoji dialog still opens — it **times out on the current code** and passes with the fix.

- `typecheck` / `eslint` / `prettier` clean; `vitest` 15/15.
