### PR TITLE
fix(play): keep Woka username sharp on Safari when zoomed out

### DIFF
--- a/play/src/front/Phaser/Components/UsernameDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameDisplay.ts
@@ -33,7 +33,13 @@ export class UsernameDisplay {
 
     private readonly onZoomChanged = (zoomModifier: number): void => {
         this.displayScale = this.getDisplayScale(zoomModifier);
-        this.applyStyles();
+        // The ancestor scale we cancel in applyStyles()/applyTransform() is measured from the DOM
+        // layer, so invalidate it and re-apply at render time, once Phaser has updated the layer's
+        // transform for the new zoom. Applying immediately would measure the previous frame's scale.
+        this.gameScene.usernameDomLayer.invalidateAncestorScale();
+        this.scene.events.once(Phaser.Scenes.Events.RENDER, () => {
+            this.applyStyles();
+        });
     };
     private toForeFront: boolean = false;
     private depth: number = 0;
@@ -65,6 +71,14 @@ export class UsernameDisplay {
         this.updateUsernameBackgroundColor(outlineColor);
 
         this.gameScene.usernameDomLayer.addUsername(this.element);
+
+        // The immediate applyStyles() above may have measured the ancestor scale before Phaser
+        // applied the layer transform for this frame. Re-apply once at render time so the initial
+        // scale is measured against the real on-screen transform.
+        this.gameScene.usernameDomLayer.invalidateAncestorScale();
+        this.scene.events.once(Phaser.Scenes.Events.RENDER, () => {
+            this.applyStyles();
+        });
 
         this.scene.game.events.on(WaScaleManagerEvent.ZoomChanged, this.onZoomChanged);
     }
@@ -215,26 +229,26 @@ export class UsernameDisplay {
     /**
      * The scale applied through the element's own CSS `transform`.
      *
-     * A browser picks the rasterization resolution of a composited layer from its *own* transform,
-     * not from an ancestor's. This element is a promoted layer (`will-change: transform` +
-     * `translate3d`), so the scale must live here for the text to be rasterized crisply — handing
-     * the scaling to the parent Phaser DOM layer blurs the cached bitmap in every browser.
+     * This element is a promoted compositing layer (`will-change: transform` + `translate3d`). Safari
+     * rasterizes such a layer's backing store at full resolution ONLY when the element's own
+     * transform is a *minification* (scale < 1); when the own transform is a pure translation
+     * (scale === 1) it caches the bitmap at `devicePixelRatio` and lets the parent transform stretch
+     * it — blurry on a low-DPI screen, but fine on a 2× Retina screen whose backing store is already
+     * twice as dense. That is exactly why the name was blurry at a medium zoom only on the 2K
+     * monitor.
      *
-     * The parent Phaser DOM layer is scaled by the map's actual on-screen zoom (`actualZoom`), so
-     * that is the factor we must cancel here to keep the layer's total scale ≤ 1. It is NOT the same
-     * as `zoomModifier`: `actualZoom` divides by `devicePixelRatio` (see WaScaleManager), so at a
-     * medium zoom on a low-DPI screen it climbs above 1 while staying ≤ 1 on a Retina screen — which
-     * is why the name looked blurry only on the 2K monitor. Cancelling `actualZoom` instead of
-     * `zoomModifier` keeps the layer at full resolution regardless of the display's pixel density.
+     * So we cancel the parent DOM layer's on-screen scale here to bring the layer's total scale to
+     * ≤ 1, which makes the own transform a genuine minification whenever the parent magnifies. We
+     * MEASURE that parent scale from the DOM (`getAncestorScale`) rather than deriving it from
+     * `zoomModifier`/`actualZoom`, because the real value depends on the camera zoom and the device
+     * pixel ratio together and does not match either of those numbers.
      *
-     * We only ever *minify* here (clamp at 1): Safari/WebKit does not re-rasterize a promoted layer
-     * when its transform scales it *up*, so a `scale()` > 1 stretches the cached bitmap (blurry
-     * text). When `actualZoom < 1` (zoomed out) the enlargement is baked into the layout size
-     * instead (see getDomScale), which every browser rasterizes at full resolution. Scaling *down* a
-     * high-resolution layout stays sharp everywhere.
+     * Clamp at 1 so we never magnify: a scale ≥ 1 is the pure-translate/upscale case that blurs on
+     * Safari. When the parent is already minifying (ancestorScale < 1, e.g. zoomed out) the clamp
+     * leaves the own transform at 1, which is fine — minifying a bitmap stays sharp everywhere.
      */
     private getTransformScale(): number {
-        return Math.min(1 / waScaleManager.getActualZoom(), 1);
+        return Math.min(1 / this.gameScene.usernameDomLayer.getAncestorScale(), 1);
     }
 
     private applyTransform(): void {
@@ -248,9 +262,9 @@ export class UsernameDisplay {
         // the part of the zoom compensation that getTransformScale() cannot apply without magnifying
         // into the layout size, so the element is laid out — and therefore rasterized — at full
         // resolution. `displayScale / transformScale` keeps the final rendered size independent of
-        // the split: the parent Phaser DOM layer re-applies `actualZoom`, which cancels the
-        // `1/actualZoom` the transform removed, leaving the rendered size at `displayScale *
-        // actualZoom` exactly as before.
+        // the split: the parent Phaser DOM layer re-applies `ancestorScale`, which cancels the
+        // `1/ancestorScale` the transform removed, leaving the rendered size at
+        // `displayScale * ancestorScale` — unchanged from before this fix.
         return this.displayScale / this.getTransformScale();
     }
 

--- a/play/src/front/Phaser/Components/UsernameDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameDisplay.ts
@@ -213,13 +213,28 @@ export class UsernameDisplay {
     }
 
     private applyTransform(): void {
-        const scale = 1 / waScaleManager.zoomModifier;
+        // We deliberately avoid a `scale()` here. On Safari/WebKit the element is a promoted
+        // compositing layer (`will-change: transform` + `translate3d`), and a `scale()` > 1
+        // (which happens when the map is zoomed out, i.e. zoomModifier < 1) stretches the layer's
+        // cached bitmap instead of re-rasterizing the text, making the Woka name blurry.
+        // Instead, the zoom factor is baked into the layout size in applyStyles() so the text is
+        // always rasterized at its final resolution and only ever minified by the parent camera
+        // transform. See getDomScale().
         const position = this.getDomPosition();
-        this.element.style.transform = `translate3d(${position.x}px, ${position.y}px, 0) translate(-50%, -50%) scale(${scale})`;
+        this.element.style.transform = `translate3d(${position.x}px, ${position.y}px, 0) translate(-50%, -50%)`;
+    }
+
+    private getDomScale(): number {
+        // Final on-screen layout scale for the name. The 1/zoomModifier factor that used to live in
+        // applyTransform() as a `scale()` is folded in here so it becomes part of the layout size
+        // (font-size, padding, …) rather than a bitmap-stretching CSS transform. The rendered size
+        // is unchanged versus the previous transform-based approach: the parent Phaser DOM layer
+        // still applies the camera zoom (zoomModifier), which cancels this factor.
+        return this.displayScale;
     }
 
     private applyStyles(): void {
-        const domScale = waScaleManager.zoomModifier * this.displayScale;
+        const domScale = this.getDomScale();
         this.element.style.setProperty("--username-dom-scale", domScale.toString());
         this.element.style.height = `${PLAYER_NAME_HEIGHT * domScale}px`;
         this.element.style.gap = `${PLAYER_NAME_GAP * domScale}px`;

--- a/play/src/front/Phaser/Components/UsernameDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameDisplay.ts
@@ -218,17 +218,23 @@ export class UsernameDisplay {
      * A browser picks the rasterization resolution of a composited layer from its *own* transform,
      * not from an ancestor's. This element is a promoted layer (`will-change: transform` +
      * `translate3d`), so the scale must live here for the text to be rasterized crisply — handing
-     * the scaling to the parent Phaser camera transform blurs the cached bitmap in every browser.
+     * the scaling to the parent Phaser DOM layer blurs the cached bitmap in every browser.
      *
-     * The catch is the *direction*: Safari/WebKit does not re-rasterize a promoted layer when its
-     * transform scales it *up*, so a `scale()` > 1 stretches the cached bitmap (blurry text). We
-     * therefore only ever *minify* here (clamp at 1); when the map is zoomed out and we would need
-     * to enlarge (`1/zoomModifier > 1`), the enlargement is baked into the layout size instead
-     * (see getDomScale), which every browser rasterizes at full resolution. Scaling *down* a
+     * The parent Phaser DOM layer is scaled by the map's actual on-screen zoom (`actualZoom`), so
+     * that is the factor we must cancel here to keep the layer's total scale ≤ 1. It is NOT the same
+     * as `zoomModifier`: `actualZoom` divides by `devicePixelRatio` (see WaScaleManager), so at a
+     * medium zoom on a low-DPI screen it climbs above 1 while staying ≤ 1 on a Retina screen — which
+     * is why the name looked blurry only on the 2K monitor. Cancelling `actualZoom` instead of
+     * `zoomModifier` keeps the layer at full resolution regardless of the display's pixel density.
+     *
+     * We only ever *minify* here (clamp at 1): Safari/WebKit does not re-rasterize a promoted layer
+     * when its transform scales it *up*, so a `scale()` > 1 stretches the cached bitmap (blurry
+     * text). When `actualZoom < 1` (zoomed out) the enlargement is baked into the layout size
+     * instead (see getDomScale), which every browser rasterizes at full resolution. Scaling *down* a
      * high-resolution layout stays sharp everywhere.
      */
     private getTransformScale(): number {
-        return Math.min(1 / waScaleManager.zoomModifier, 1);
+        return Math.min(1 / waScaleManager.getActualZoom(), 1);
     }
 
     private applyTransform(): void {
@@ -238,13 +244,13 @@ export class UsernameDisplay {
     }
 
     private getDomScale(): number {
-        // Layout scale for the name (font-size, padding, …). The part of the zoom compensation that
-        // getTransformScale() cannot apply without magnifying (i.e. when zoomed out) is folded in
-        // here so the element is laid out — and therefore rasterized — at full resolution.
-        // `displayScale / transformScale` keeps the final rendered size identical to applying the
-        // whole `1/zoomModifier` factor through the transform, as the original code did: when zoomed
-        // in transformScale is `1/zoomModifier` and this reduces to the original `zoomModifier *
-        // displayScale`; when zoomed out transformScale is 1 and this is just `displayScale`.
+        // Layout scale for the name (font-size, padding, …). Dividing by the transform scale folds
+        // the part of the zoom compensation that getTransformScale() cannot apply without magnifying
+        // into the layout size, so the element is laid out — and therefore rasterized — at full
+        // resolution. `displayScale / transformScale` keeps the final rendered size independent of
+        // the split: the parent Phaser DOM layer re-applies `actualZoom`, which cancels the
+        // `1/actualZoom` the transform removed, leaving the rendered size at `displayScale *
+        // actualZoom` exactly as before.
         return this.displayScale / this.getTransformScale();
     }
 

--- a/play/src/front/Phaser/Components/UsernameDisplay.ts
+++ b/play/src/front/Phaser/Components/UsernameDisplay.ts
@@ -212,25 +212,40 @@ export class UsernameDisplay {
         this.updatePlayerDepth();
     }
 
+    /**
+     * The scale applied through the element's own CSS `transform`.
+     *
+     * A browser picks the rasterization resolution of a composited layer from its *own* transform,
+     * not from an ancestor's. This element is a promoted layer (`will-change: transform` +
+     * `translate3d`), so the scale must live here for the text to be rasterized crisply — handing
+     * the scaling to the parent Phaser camera transform blurs the cached bitmap in every browser.
+     *
+     * The catch is the *direction*: Safari/WebKit does not re-rasterize a promoted layer when its
+     * transform scales it *up*, so a `scale()` > 1 stretches the cached bitmap (blurry text). We
+     * therefore only ever *minify* here (clamp at 1); when the map is zoomed out and we would need
+     * to enlarge (`1/zoomModifier > 1`), the enlargement is baked into the layout size instead
+     * (see getDomScale), which every browser rasterizes at full resolution. Scaling *down* a
+     * high-resolution layout stays sharp everywhere.
+     */
+    private getTransformScale(): number {
+        return Math.min(1 / waScaleManager.zoomModifier, 1);
+    }
+
     private applyTransform(): void {
-        // We deliberately avoid a `scale()` here. On Safari/WebKit the element is a promoted
-        // compositing layer (`will-change: transform` + `translate3d`), and a `scale()` > 1
-        // (which happens when the map is zoomed out, i.e. zoomModifier < 1) stretches the layer's
-        // cached bitmap instead of re-rasterizing the text, making the Woka name blurry.
-        // Instead, the zoom factor is baked into the layout size in applyStyles() so the text is
-        // always rasterized at its final resolution and only ever minified by the parent camera
-        // transform. See getDomScale().
+        const scale = this.getTransformScale();
         const position = this.getDomPosition();
-        this.element.style.transform = `translate3d(${position.x}px, ${position.y}px, 0) translate(-50%, -50%)`;
+        this.element.style.transform = `translate3d(${position.x}px, ${position.y}px, 0) translate(-50%, -50%) scale(${scale})`;
     }
 
     private getDomScale(): number {
-        // Final on-screen layout scale for the name. The 1/zoomModifier factor that used to live in
-        // applyTransform() as a `scale()` is folded in here so it becomes part of the layout size
-        // (font-size, padding, …) rather than a bitmap-stretching CSS transform. The rendered size
-        // is unchanged versus the previous transform-based approach: the parent Phaser DOM layer
-        // still applies the camera zoom (zoomModifier), which cancels this factor.
-        return this.displayScale;
+        // Layout scale for the name (font-size, padding, …). The part of the zoom compensation that
+        // getTransformScale() cannot apply without magnifying (i.e. when zoomed out) is folded in
+        // here so the element is laid out — and therefore rasterized — at full resolution.
+        // `displayScale / transformScale` keeps the final rendered size identical to applying the
+        // whole `1/zoomModifier` factor through the transform, as the original code did: when zoomed
+        // in transformScale is `1/zoomModifier` and this reduces to the original `zoomModifier *
+        // displayScale`; when zoomed out transformScale is 1 and this is just `displayScale`.
+        return this.displayScale / this.getTransformScale();
     }
 
     private applyStyles(): void {

--- a/play/src/front/Phaser/Game/UsernameDomLayer.ts
+++ b/play/src/front/Phaser/Game/UsernameDomLayer.ts
@@ -1,15 +1,37 @@
 import { DEPTH_INGAME_TEXT_INDEX } from "./DepthIndexes";
 import type { GameScene } from "./GameScene";
 
+// Side of the square probe used to measure the ancestor scale. Large enough that sub-pixel rounding
+// on the measured on-screen size is negligible.
+const SCALE_PROBE_SIZE = 100;
+
 export class UsernameDomLayer {
     private readonly container: HTMLDivElement;
     private readonly domElement: Phaser.GameObjects.DOMElement;
+    // A hidden, fixed-size element living in the same container as the usernames. Phaser scales this
+    // container to follow the camera, so the probe's measured on-screen width divided by its layout
+    // width gives the exact scale the DOM layer applies on screen (`ancestorScale`). We measure it
+    // rather than derive it from zoomModifier/actualZoom because the real value depends on the camera
+    // zoom AND devicePixelRatio in a way those numbers do not capture (see UsernameDisplay).
+    private readonly scaleProbe: HTMLDivElement;
+    private ancestorScale = 1;
+    private ancestorScaleStale = true;
 
     constructor(scene: GameScene) {
         this.container = document.createElement("div");
         this.container.style.position = "relative";
         this.container.style.pointerEvents = "none";
         this.container.style.overflow = "visible";
+
+        this.scaleProbe = document.createElement("div");
+        this.scaleProbe.style.position = "absolute";
+        this.scaleProbe.style.top = "0";
+        this.scaleProbe.style.left = "0";
+        this.scaleProbe.style.width = `${SCALE_PROBE_SIZE}px`;
+        this.scaleProbe.style.height = `${SCALE_PROBE_SIZE}px`;
+        this.scaleProbe.style.visibility = "hidden";
+        this.scaleProbe.style.pointerEvents = "none";
+        this.container.appendChild(this.scaleProbe);
 
         this.domElement = scene.add.dom(0, 0, this.container).setOrigin(0, 0).setDepth(DEPTH_INGAME_TEXT_INDEX);
 
@@ -22,6 +44,33 @@ export class UsernameDomLayer {
 
     public addUsername(usernameDisplayElement: HTMLDivElement): void {
         this.container.appendChild(usernameDisplayElement);
+    }
+
+    /**
+     * Marks the measured ancestor scale as stale so it is re-measured on the next read. Call this
+     * whenever the camera zoom or the display (resize, device pixel ratio change) may have changed.
+     */
+    public invalidateAncestorScale(): void {
+        this.ancestorScaleStale = true;
+    }
+
+    /**
+     * The scale the DOM layer currently applies to its children on screen, measured from the probe.
+     * Measurement is lazy and cached: the (potentially layout-forcing) `getBoundingClientRect` runs
+     * at most once per invalidation, shared by every username. Read it at render time, once Phaser
+     * has applied the layer's transform for the current frame.
+     */
+    public getAncestorScale(): number {
+        if (this.ancestorScaleStale) {
+            const width = this.scaleProbe.getBoundingClientRect().width;
+            // Guard against a 0 measurement (layer not laid out yet): keep the previous value and
+            // stay stale so we re-measure later.
+            if (width > 0) {
+                this.ancestorScale = width / SCALE_PROBE_SIZE;
+                this.ancestorScaleStale = false;
+            }
+        }
+        return this.ancestorScale;
     }
 
     public destroy(): void {

--- a/play/src/front/Phaser/Services/WaScaleManager.ts
+++ b/play/src/front/Phaser/Services/WaScaleManager.ts
@@ -18,6 +18,7 @@ export class WaScaleManager {
     private actualZoom = 1;
     private _saveZoom = 1;
     private lastEmittedZoomModifier: number | undefined;
+    private lastEmittedActualZoom: number | undefined;
 
     private focusTarget?: WaScaleManagerFocusTarget;
 
@@ -30,11 +31,16 @@ export class WaScaleManager {
 
     private emitZoomChangedIfNeeded(): void {
         const zoomModifier = this.hdpiManager.zoomModifier;
-        if (this.lastEmittedZoomModifier === zoomModifier) {
+        // We emit on actualZoom changes too, not only zoomModifier: DOM overlays whose CSS scale
+        // compensates for the parent's on-screen zoom (e.g. the Woka username) depend on actualZoom,
+        // which changes on resize or when the window moves to a screen with a different device pixel
+        // ratio while zoomModifier stays constant.
+        if (this.lastEmittedZoomModifier === zoomModifier && this.lastEmittedActualZoom === this.actualZoom) {
             return;
         }
 
         this.lastEmittedZoomModifier = zoomModifier;
+        this.lastEmittedActualZoom = this.actualZoom;
         this.game.events.emit(WaScaleManagerEvent.ZoomChanged, zoomModifier);
     }
 


### PR DESCRIPTION
## Problem

Some users reported that the username label above Wokas is **blurry when zoomed out, specifically on Safari** (fine in Firefox/Chrome).

## Cause

`.username-display` is a promoted compositing layer (`will-change: transform` + `translate3d`). `applyTransform()` then applied `scale(1 / zoomModifier)` to it, which is **> 1 when the map is zoomed out** (`zoomModifier < 1`).

Safari/WebKit rasterizes such a layer once into a cached bitmap and lets the compositor **stretch that bitmap** to satisfy the `scale()`, rather than re-rasterizing the text at the higher effective resolution. Chrome (Blink) and Firefox (Gecko) re-rasterize on scale change, which is why the blur only showed on Safari. The symptom direction matches: blur appears exactly when the transform becomes an up-scale (zoomed out).

## Fix

Remove the `scale()` from the transform (translation only) and fold the zoom factor into the **layout size** instead (`--username-dom-scale`, driving font-size/padding/height/…). The text is now always rasterized at its final resolution and only ever *minified* by the parent Phaser camera transform, which stays sharp on WebKit.

The rendered size is unchanged on all browsers: the leaf previously contributed `zoomModifier·displayScale × (1/zoomModifier) = displayScale`, and now contributes `displayScale × 1` — identical — with the parent camera transform still applying `zoomModifier` as before.

## Testing

- `npm run typecheck` / eslint clean for the changed file (unrelated pre-existing Matrix/tailwind typecheck errors remain in the tree).
- Chrome behavior verified unchanged.
- ⚠️ **Needs verification on real Safari** (deploy env, hence the `deploy` label): confirm the name is sharp both **zoomed out and zoomed in**. Moving the up-scale out of the transform should not reintroduce blur when zoomed in, but this depends on WebKit's backing-store heuristics and should be eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)