### PR TITLE
fix(chat): correct "Leaved" to "Left" for left-room membership badge

### DIFF
--- a/play/src/i18n/en-US/chat.ts
+++ b/play/src/i18n/en-US/chat.ts
@@ -378,7 +378,7 @@ const chat: BaseTranslation = {
         invite: "Invited",
         ban: "Banned",
         kick: "Kicked",
-        leave: "Leaved",
+        leave: "Left",
         roomID: "Room ID : {roomId}",
         membership: "Membership",
         permissionLevel: "Roles",

--- a/tests/tests/chat/matrixChatModeration.spec.ts
+++ b/tests/tests/chat/matrixChatModeration.spec.ts
@@ -106,7 +106,7 @@ test.describe("chat moderation @matrix @nowebkit", () => {
 
         await page.getByTestId("@admin:matrix.workadventure.localhost-unbanButton").click();
 
-        await expect(page.getByTestId("@admin:matrix.workadventure.localhost-membership")).toHaveText("Leaved");
+        await expect(page.getByTestId("@admin:matrix.workadventure.localhost-membership")).toHaveText("Left");
         await expect(page.getByTestId("@admin:matrix.workadventure.localhost-inviteButton")).toBeAttached();
         await page.getByTestId("@admin:matrix.workadventure.localhost-inviteButton").click();
 


### PR DESCRIPTION
The Matrix room membership badge for a member who left a room displayed the grammatically incorrect "Leaved". This corrects the English label to "Left".

## Change
- `play/src/i18n/en-US/chat.ts`: `manageRoomUsers.leave` `"Leaved"` → `"Left"`

This label is rendered in `play/src/front/Chat/Components/Room/RoomParticipant.svelte` (`getTranslatedMembership`, `$LL.chat.manageRoomUsers.leave()`).

## Notes
- Other locales already use properly localized values (de `Verlassen`, fr `Parti`, es `Salió`, etc.) — none used a literal English "Leaved", so no other locale needed updating.

## Validation
- `npm run typesafe-i18n` — regenerated cleanly (value-only change, no key/type change)
- `npm run i18n:check` — ✅ all translations complete
- `eslint` on the changed file + consuming component — passed