### PR TITLE
fix(chat): show messages sent right after accepting an invitation

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -1304,7 +1304,9 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             roomFolder.init();
         } else {
             if (!parentFolder.roomList.has(roomId)) {
-                parentFolder.roomList.set(roomId, new MatrixChatRoom(room));
+                const newRoom = new MatrixChatRoom(room);
+                parentFolder.roomList.set(roomId, newRoom);
+                this.retargetSelectedRoomIfReplaced(newRoom);
             }
         }
 
@@ -1323,7 +1325,9 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             return;
         }
         if (!this.roomList.has(roomId)) {
-            this.roomList.set(roomId, new MatrixChatRoom(room));
+            const newRoom = new MatrixChatRoom(room);
+            this.roomList.set(roomId, newRoom);
+            this.retargetSelectedRoomIfReplaced(newRoom);
         }
     }
 
@@ -1482,10 +1486,21 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
     private createAndAddNewRootRoom(room: Room): MatrixChatRoom {
         const newRoom = new MatrixChatRoom(room);
         this.roomList.set(newRoom.id, newRoom);
+        this.retargetSelectedRoomIfReplaced(newRoom);
+        return newRoom;
+    }
+
+    /**
+     * A membership change (e.g. accepting an invitation) destroys the room's previous MatrixChatRoom
+     * wrapper and rebuilds a fresh one during placement reconciliation. Any UI still bound to the old,
+     * now-destroyed wrapper would stop receiving live timeline events — a message the user sends is
+     * delivered to the server but never renders until the room is re-opened. Keep `selectedRoomStore`
+     * pointing at the live wrapper so the open timeline keeps updating.
+     */
+    private retargetSelectedRoomIfReplaced(newRoom: MatrixChatRoom): void {
         if (get(selectedRoomStore)?.id === newRoom.id) {
             selectedRoomStore.set(newRoom);
         }
-        return newRoom;
     }
     private onClientEventDeleteRoom(roomId: string) {
         this.untrackRawUnreadRoom(roomId);


### PR DESCRIPTION
## Problem

When a user accepts a chat invitation to a room and types a message **right away**, the message is sent (the server receives it) but it never appears in the open timeline until the room is closed and re-opened.

## Root cause

Accepting an invitation flips the room's membership to `join`. `onRoomEventMembership` then **destroys** the room's previous `MatrixChatRoom` wrapper (`detachRoomFromRootLists` → `AutoDestroyingMapStore.delete()` → `destroy()`, which removes the `RoomEvent.Timeline` listener) and **rebuilds** a fresh wrapper during placement reconciliation.

`selectedRoomStore` (what the open timeline is bound to) kept pointing at the **destroyed** wrapper. `createAndAddNewRootRoom` already re-pointed it to the rebuilt wrapper, but the folder path (`addRoomToParentFolder`, used for rooms nested under a space) did **not** — so for those rooms the UI stayed bound to a dead wrapper whose timeline listener was gone. The message reaches the server (and the *new* wrapper), but the displayed timeline never receives the live event.

This is deterministic for rooms under a space/folder (e.g. area/tag rooms); root-level invitations were unaffected because their path already re-pointed.

## Fix

Re-point `selectedRoomStore` to the rebuilt wrapper in **every** placement path (root and folder), via a shared `retargetSelectedRoomIfReplaced()` helper.

## Verification

Driven end-to-end against a live stack (real Matrix + browser), accepting an invitation via the UI then sending a message immediately:

- **Root-room invitation** → message appears (works with and without the fix).
- **Space-child (folder) invitation** → message appears **with the fix**.
- **Negative control**: removing only the folder-path re-point reproduces the bug exactly (message sent but never rendered), confirming the fix addresses it.

`tsc --noEmit` passes; the 47 `MatrixChatConnection` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
