### PR TITLE
fix(map-storage): release S3 sockets on client disconnect to prevent agent pool exhaustion

### DIFF
--- a/map-storage/src/Upload/S3FileSystem.ts
+++ b/map-storage/src/Upload/S3FileSystem.ts
@@ -397,21 +397,26 @@ export class S3FileSystem implements FileSystemInterface {
                     }
 
                     await new Promise<void>((resolve, reject) => {
-                        // If the archive is destroyed while this entry is being written (client
-                        // disconnect mid-file), archive.entry()'s callback may never fire. Settle
-                        // on archive teardown and destroy the body so it does not leak its socket.
-                        const onArchiveGone = () => {
-                            archive.removeListener("close", onArchiveGone);
-                            archive.removeListener("error", onArchiveGone);
+                        // archive.entry()'s callback may never fire if the archive is torn down
+                        // while this entry is being written. Watch the archive so we always settle
+                        // and release the S3 body's socket:
+                        //  - "close": teardown (archive.destroy(), e.g. the client disconnected) —
+                        //    stop cleanly; the outer `if (archive.destroyed)` check ends the loop.
+                        //  - "error": a real archiving error — propagate it (do not swallow).
+                        const onClose = () => {
                             body.destroy();
                             resolve();
                         };
-                        archive.once("close", onArchiveGone);
-                        archive.once("error", onArchiveGone);
+                        const onError = (err: Error) => {
+                            body.destroy();
+                            reject(err);
+                        };
+                        archive.once("close", onClose);
+                        archive.once("error", onError);
 
                         archive.entry(body, { name: key.substring(virtualPath.length) }, (err) => {
-                            archive.removeListener("close", onArchiveGone);
-                            archive.removeListener("error", onArchiveGone);
+                            archive.removeListener("close", onClose);
+                            archive.removeListener("error", onError);
                             if (err) {
                                 body.destroy();
                                 reject(err);

--- a/map-storage/src/Upload/S3FileSystem.ts
+++ b/map-storage/src/Upload/S3FileSystem.ts
@@ -245,6 +245,16 @@ export class S3FileSystem implements FileSystemInterface {
         this.s3
             .getObject({ Bucket: this.bucketName, Key: virtualPath })
             .then((result) => {
+                // The client may have disconnected while we were fetching the object from S3.
+                // If the response is already gone, stream.pipeline() below would throw
+                // ERR_STREAM_UNABLE_TO_PIPE and leave the S3 body (and its socket) dangling.
+                // Destroy the body explicitly so its socket is returned to the S3 connection
+                // pool instead of leaking it.
+                if (res.destroyed) {
+                    (result.Body as Readable | undefined)?.destroy();
+                    return;
+                }
+
                 // Set the content type and content length headers
                 res.set("Content-Type", result.ContentType);
 
@@ -360,6 +370,14 @@ export class S3FileSystem implements FileSystemInterface {
                         continue;
                     }
 
+                    // The archive is piped to the HTTP response. When the client disconnects
+                    // the archive is destroyed. Stop here instead of opening another S3
+                    // GetObject stream that would never be consumed, leaking its socket from
+                    // the S3 connection pool.
+                    if (archive.destroyed) {
+                        return;
+                    }
+
                     const { Body } = await this.s3.send(
                         new GetObjectCommand({
                             Bucket: this.bucketName,
@@ -369,10 +387,33 @@ export class S3FileSystem implements FileSystemInterface {
                     if (!Body) {
                         throw new Error("Failed to get file from S3");
                     }
+                    const body = Body as Readable;
+
+                    // The client may have disconnected while the object was being fetched.
+                    // Destroy the body so its socket is released rather than leaked.
+                    if (archive.destroyed) {
+                        body.destroy();
+                        return;
+                    }
 
                     await new Promise<void>((resolve, reject) => {
-                        archive.entry(Body as Readable, { name: key.substring(virtualPath.length) }, (err) => {
+                        // If the archive is destroyed while this entry is being written (client
+                        // disconnect mid-file), archive.entry()'s callback may never fire. Settle
+                        // on archive teardown and destroy the body so it does not leak its socket.
+                        const onArchiveGone = () => {
+                            archive.removeListener("close", onArchiveGone);
+                            archive.removeListener("error", onArchiveGone);
+                            body.destroy();
+                            resolve();
+                        };
+                        archive.once("close", onArchiveGone);
+                        archive.once("error", onArchiveGone);
+
+                        archive.entry(body, { name: key.substring(virtualPath.length) }, (err) => {
+                            archive.removeListener("close", onArchiveGone);
+                            archive.removeListener("error", onArchiveGone);
                             if (err) {
+                                body.destroy();
                                 reject(err);
                                 return;
                             }

--- a/map-storage/src/Upload/UploadController.ts
+++ b/map-storage/src/Upload/UploadController.ts
@@ -650,6 +650,16 @@ export class UploadController {
                 // pipe archive data to the file
                 archive.pipe(res);
 
+                // If the client disconnects before the archive is fully sent, destroy the
+                // archive so archiveDirectory() stops fetching S3 objects and releases any
+                // in-flight S3 response streams. Otherwise their sockets leak from the S3
+                // connection pool and eventually exhaust it (maxSockets).
+                res.on("close", () => {
+                    if (!res.writableFinished) {
+                        archive.destroy();
+                    }
+                });
+
                 await this.fileSystem.archiveDirectory(archive, virtualDirectory);
 
                 archive.finalize();

--- a/map-storage/src/Upload/UploadController.ts
+++ b/map-storage/src/Upload/UploadController.ts
@@ -662,7 +662,11 @@ export class UploadController {
 
                 await this.fileSystem.archiveDirectory(archive, virtualDirectory);
 
-                archive.finalize();
+                // If the client disconnected, the archive was already destroyed above; calling
+                // finalize() on it would write to a destroyed stream and emit a spurious error.
+                if (!archive.destroyed) {
+                    archive.finalize();
+                }
             })().catch((e) => {
                 console.error(`[${new Date().toISOString()}]`, e);
                 Sentry.captureException(e);

--- a/map-storage/src/Upload/tests/S3FileSystem.test.ts
+++ b/map-storage/src/Upload/tests/S3FileSystem.test.ts
@@ -132,5 +132,28 @@ describe("S3FileSystem", () => {
             await promise;
             expect(body.destroyed).toBe(true);
         });
+
+        it("rejects and destroys the S3 body when the archive emits a real error mid-entry", async () => {
+            const body = new PassThrough();
+            const archive = new PassThrough();
+            // entry() never calls back; the failure surfaces via the archive "error" event.
+            const entry = vi.fn();
+            (archive as unknown as { entry: unknown }).entry = entry;
+
+            const send = vi
+                .fn()
+                .mockResolvedValueOnce({ Contents: [{ Key: "map/a.png" }], IsTruncated: false })
+                .mockResolvedValueOnce({ Body: body });
+            const fileSystem = new S3FileSystem({ send } as unknown as S3, "bucket");
+
+            const promise = fileSystem.archiveDirectory(archive as unknown as ZipStream, "map");
+            await vi.waitFor(() => expect(entry).toHaveBeenCalledOnce());
+
+            // A genuine archiving error (not a teardown) must be propagated, not swallowed.
+            archive.emit("error", new Error("zip boom"));
+
+            await expect(promise).rejects.toThrow("zip boom");
+            expect(body.destroyed).toBe(true);
+        });
     });
 });

--- a/map-storage/src/Upload/tests/S3FileSystem.test.ts
+++ b/map-storage/src/Upload/tests/S3FileSystem.test.ts
@@ -30,6 +30,23 @@ describe("S3FileSystem", () => {
             await vi.waitFor(() => expect(body.destroyed).toBe(true));
             expect(next).not.toHaveBeenCalled();
         });
+
+        it("destroys the S3 response body when the client already disconnected before it was fetched", async () => {
+            const body = new PassThrough();
+            const getObject = vi.fn().mockResolvedValue({ Body: body });
+            const fileSystem = new S3FileSystem({ getObject } as unknown as S3, "bucket");
+            const set = vi.fn();
+            const response = Object.assign(new PassThrough(), { set }) as unknown as Response;
+            const next = vi.fn();
+
+            // The client is already gone by the time getObject resolves.
+            response.destroy();
+            fileSystem.serveStaticFile("map/file.png", response, next);
+
+            await vi.waitFor(() => expect(body.destroyed).toBe(true));
+            expect(next).not.toHaveBeenCalled();
+            expect(set).not.toHaveBeenCalled();
+        });
     });
 
     describe("archiveDirectory", () => {
@@ -45,6 +62,75 @@ describe("S3FileSystem", () => {
             expect(send).toHaveBeenCalledOnce();
             expect(send.mock.calls[0]?.[0]).toBeInstanceOf(ListObjectsV2Command);
             expect(send.mock.calls.some(([command]) => command instanceof GetObjectCommand)).toBe(false);
+        });
+
+        it("destroys the fetched body and stops when the archive is destroyed during the fetch", async () => {
+            const body = new PassThrough();
+            const archive = new PassThrough();
+            const entry = vi.fn();
+            (archive as unknown as { entry: unknown }).entry = entry;
+
+            const send = vi
+                .fn()
+                .mockResolvedValueOnce({ Contents: [{ Key: "map/a.png" }, { Key: "map/b.png" }], IsTruncated: false })
+                // While the first object is being fetched, the client disconnects and the
+                // archive is destroyed.
+                .mockImplementationOnce(() => {
+                    archive.destroy();
+                    return Promise.resolve({ Body: body });
+                });
+            const fileSystem = new S3FileSystem({ send } as unknown as S3, "bucket");
+
+            await fileSystem.archiveDirectory(archive as unknown as ZipStream, "map");
+
+            expect(body.destroyed).toBe(true);
+            expect(entry).not.toHaveBeenCalled();
+            // ListObjectsV2 + a single GetObject: the second object is never fetched.
+            expect(send).toHaveBeenCalledTimes(2);
+        });
+
+        it("destroys the S3 body when writing the archive entry fails", async () => {
+            const body = new PassThrough();
+            const archive = new PassThrough();
+            (archive as unknown as { entry: unknown }).entry = vi.fn(
+                (_source: unknown, _data: unknown, cb: (err: Error | null) => void) => {
+                    cb(new Error("boom"));
+                    return archive;
+                },
+            );
+
+            const send = vi
+                .fn()
+                .mockResolvedValueOnce({ Contents: [{ Key: "map/a.png" }], IsTruncated: false })
+                .mockResolvedValueOnce({ Body: body });
+            const fileSystem = new S3FileSystem({ send } as unknown as S3, "bucket");
+
+            await expect(fileSystem.archiveDirectory(archive as unknown as ZipStream, "map")).rejects.toThrow("boom");
+            expect(body.destroyed).toBe(true);
+        });
+
+        it("destroys the S3 body and resolves when the archive is torn down mid-entry", async () => {
+            const body = new PassThrough();
+            const archive = new PassThrough();
+            // entry() never calls back (archiver stalled because its output was destroyed).
+            const entry = vi.fn();
+            (archive as unknown as { entry: unknown }).entry = entry;
+
+            const send = vi
+                .fn()
+                .mockResolvedValueOnce({ Contents: [{ Key: "map/a.png" }], IsTruncated: false })
+                .mockResolvedValueOnce({ Body: body });
+            const fileSystem = new S3FileSystem({ send } as unknown as S3, "bucket");
+
+            const promise = fileSystem.archiveDirectory(archive as unknown as ZipStream, "map");
+            await vi.waitFor(() => expect(entry).toHaveBeenCalledOnce());
+
+            // Client disconnects: the archive (piped to the response) is destroyed.
+            archive.destroy();
+
+            // archiveDirectory must not hang, and must release the in-flight S3 body.
+            await promise;
+            expect(body.destroyed).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## What changed

Two S3 streaming paths in map-storage now release their `GetObject` response body (and its socket) when the client disconnects, instead of leaking it into the S3 client's `https.Agent` connection pool:

- **`serveStaticFile`** (`S3FileSystem.ts`): if the client is already gone when `getObject` resolves (`res.destroyed`), destroy the S3 body and return. Previously `stream.pipeline()` threw `ERR_STREAM_UNABLE_TO_PIPE` in this case and left the body — and its socket — dangling.
- **Archive download** (`UploadController.ts` + `archiveDirectory` in `S3FileSystem.ts`): wire the response `close` event to `archive.destroy()`; stop opening new `GetObject` streams once the archive is destroyed; settle the pending `archive.entry()` promise on archive teardown; and destroy the body on entry error. Previously a mid-download disconnect stalled the archiver, the awaited `archive.entry()` callback never fired, and in-flight/subsequent S3 bodies were never consumed or destroyed.

Adds regression tests for both paths (mirroring #6258's disconnect test), plus an incident report at the repo root documenting the production diagnosis. *(Drop `INCIDENT_map-storage_s3_agent_exhaustion_2026-07-07.md` from the branch if you'd rather not track it.)*

## Why

A prod map-storage replica (`v1.32.6`) wedged after ~3.5 days of uptime: **every** S3 request began failing with the 5000 ms `connectionTimeout` (`@smithy/node-http-handler ... did not establish a connection ... within 5000 ms`), ~4650 errors and zero successful S3 ops. Meanwhile:

- CPU (5m), memory, fds (98), libuv thread pool (all idle) and node egress were healthy;
- a fresh `dns.lookup` + `net.connect` to S3 **from inside the pod** succeeded in ~24 ms;
- the sibling replica had **0** timeouts;
- the process owned **no S3 sockets and zero `SYN_SENT`** — requests were queued in the agent, never assigned a socket.

That is a wedged `https.Agent`: its per-origin socket count had leaked up to `maxSockets` (`S3_MAX_PARALLEL_REQUESTS = 50`), so every request queued forever and timed out at the connect phase. This is the **same failure class as #6258** (already present in this build); the leaks above are paths that fix did not cover. The earlier prod signal was `ERR_STREAM_UNABLE_TO_PIPE at S3FileSystem.ts:272` (the `serveStaticFile` case).

A pod restart clears the in-memory agent state and restores service; this PR removes the underlying leaks.

## Validation

- `npm test --workspace=map-storage -- --run src/Upload/tests/S3FileSystem.test.ts` — 6 passed
- `npm run typecheck --workspace=map-storage`
- `npx eslint` on the changed files
- `npx prettier --check` on the changed files

## Follow-ups (not in this PR)

- Alert on per-replica S3 connect-timeout rate (this failure is invisible until catastrophic).
- Consider `throwOnRequestTimeout: true` so stuck requests surface as errors rather than a single silent WARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)