### PR TITLE
fix(chat): keep the timeline live after accepting an invitation

### DIFF
--- a/play/src/front/Chat/Components/Room/RoomInvitation.svelte
+++ b/play/src/front/Chat/Components/Room/RoomInvitation.svelte
@@ -3,6 +3,7 @@
     import type { ChatRoomMembershipManagement, ChatRoom } from "../../Connection/ChatConnection";
     import { warningMessageStore } from "../../../Stores/ErrorStore";
     import { selectedRoomStore } from "../../Stores/SelectRoomStore";
+    import { gameManager } from "../../../Phaser/Game/GameManager";
     import Avatar from "../Avatar.svelte";
     import { LL } from "../../../../i18n/i18n-svelte";
     import { IconLoader } from "@wa-icons";
@@ -12,6 +13,7 @@
     }
 
     let { room }: Props = $props();
+    const chat = gameManager.chatConnection;
     let roomType = $derived(room.type);
     let roomName = $derived(room.name);
     let loadingInvitation = $state(false);
@@ -20,9 +22,15 @@
     function joinRoom() {
         loadingInvitation = true;
 
-        room.joinRoom()
-            .then(() => {
-                if (!room.isRoomFolder) selectedRoomStore.set(room);
+        // Accepting the invitation flips the room to "join", which destroys THIS component's `room` wrapper —
+        // a fresh one is rebuilt during placement reconciliation. Selecting `room` here would bind the open
+        // timeline to that destroyed wrapper (its live RoomEvent.Timeline listener is gone), so messages sent
+        // right after joining are delivered to the server but never render until the room is re-opened. Route
+        // through the connection's joinRoom, which resolves with the live wrapper now in the room list, and
+        // select that instead (same pattern as JoignableRooms/RoomSuggested).
+        chat.joinRoom(room.id)
+            .then((joinedRoom) => {
+                if (joinedRoom && !joinedRoom.isRoomFolder) selectedRoomStore.set(joinedRoom);
             })
             .catch(() => {
                 warningMessageStore.addWarningMessage($LL.chat.failedToJoinRoom());

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -47,7 +47,7 @@ import type {
     MatrixPeerProfileDiagnostics,
     MatrixUserSettingsDiagnostics,
 } from "../ChatConnection";
-import { selectedRoomStore } from "../../Stores/SelectRoomStore";
+import { retargetSelectedRoomIfReplaced, selectedRoomStore } from "../../Stores/SelectRoomStore";
 import { chatNotificationStore } from "../../../Stores/ProximityNotificationStore";
 import { currentPlayerWokaStore } from "../../../Stores/CurrentPlayerWokaStore";
 import LL from "../../../../i18n/i18n-svelte";
@@ -1490,17 +1490,8 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
         return newRoom;
     }
 
-    /**
-     * A membership change (e.g. accepting an invitation) destroys the room's previous MatrixChatRoom
-     * wrapper and rebuilds a fresh one during placement reconciliation. Any UI still bound to the old,
-     * now-destroyed wrapper would stop receiving live timeline events — a message the user sends is
-     * delivered to the server but never renders until the room is re-opened. Keep `selectedRoomStore`
-     * pointing at the live wrapper so the open timeline keeps updating.
-     */
     private retargetSelectedRoomIfReplaced(newRoom: MatrixChatRoom): void {
-        if (get(selectedRoomStore)?.id === newRoom.id) {
-            selectedRoomStore.set(newRoom);
-        }
+        retargetSelectedRoomIfReplaced(newRoom);
     }
     private onClientEventDeleteRoom(roomId: string) {
         this.untrackRawUnreadRoom(roomId);

--- a/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixRoomFolder.ts
@@ -10,6 +10,7 @@ import { Deferred } from "@workadventure/shared-utils";
 import { matrixRateLimiter } from "../../Services/MatrixRateLimiter";
 import { ignoredSuggestedRoomIdsStore } from "../../Stores/ChatStore";
 import type { RoomFolder } from "../ChatConnection";
+import { retargetSelectedRoomIfReplaced } from "../../Stores/SelectRoomStore";
 import { MatrixChatRoom } from "./MatrixChatRoom";
 import { hasValidViaEntries } from "./MatrixSpaceRelations";
 
@@ -431,7 +432,13 @@ export class MatrixRoomFolder extends MatrixChatRoom implements RoomFolder {
                 }
                 spaceFolder.init();
             } else if (!this.roomList.has(child.roomId)) {
-                this.roomList.set(child.roomId, new MatrixChatRoom(child));
+                const newRoom = new MatrixChatRoom(child);
+                this.roomList.set(child.roomId, newRoom);
+                // Accepting an invitation rebuilds the room's wrapper here (the previous one was destroyed when
+                // the room was detached from its old placement). If it is the open room, keep selectedRoomStore
+                // on this live wrapper — otherwise the timeline stays bound to the destroyed wrapper and messages
+                // sent right after joining never render until the room is re-opened.
+                retargetSelectedRoomIfReplaced(newRoom);
             }
         });
     }

--- a/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
+++ b/play/src/front/Chat/Connection/Matrix/tests/MatrixChatConnection.test.ts
@@ -9,6 +9,8 @@ import { MatrixChatConnection } from "../MatrixChatConnection";
 import { MatrixRoomFolder } from "../MatrixRoomFolder";
 import type { CreateRoomOptions } from "../../ChatConnection";
 import type { MatrixChatRoom } from "../MatrixChatRoom";
+import { MatrixChatRoom as MatrixChatRoomClass } from "../MatrixChatRoom";
+import { selectedRoomStore } from "../../../Stores/SelectRoomStore";
 import type { MatrixSecurity } from "../MatrixSecurity";
 import type { RequestedStatus } from "../../../../Rules/StatusRules/statusRules";
 
@@ -995,6 +997,65 @@ describe("MatrixChatConnection", () => {
 
             expect(folder.roomList.has(roomId)).toBeFalsy();
             expect(staleRoom.destroy).toHaveBeenCalledOnce();
+        });
+
+        it("should repoint selectedRoomStore to the rebuilt wrapper when folder getChildren re-adds the open room", () => {
+            // Reproduces the invite-accept regression: the open room's previous wrapper was destroyed when the
+            // room was detached from its old placement, leaving selectedRoomStore on a dead wrapper. getChildren
+            // rebuilds the wrapper for the same room id and must re-point selectedRoomStore at the live one,
+            // otherwise messages sent right after joining never render until the room is re-opened.
+            const roomId = "!child:server";
+            const childRoom = {
+                roomId,
+                getMyMembership: vi.fn().mockReturnValue(KnownMembership.Join),
+                isSpaceRoom: vi.fn().mockReturnValue(false),
+            };
+            const parentRoom = {
+                client: {
+                    getRoomUpgradeHistory: vi.fn().mockReturnValue([childRoom]),
+                },
+                getLiveTimeline: vi.fn().mockReturnValue({
+                    getState: vi.fn().mockReturnValue({
+                        getStateEvents: vi.fn().mockReturnValue([
+                            {
+                                getStateKey: vi.fn().mockReturnValue(roomId),
+                                getContent: vi.fn().mockReturnValue({ via: ["server"] }),
+                            },
+                        ]),
+                    }),
+                }),
+            };
+
+            vi.mocked(MatrixChatRoomClass).mockImplementation(function (this: unknown, room: { roomId: string }) {
+                return {
+                    id: room.roomId,
+                    conversationKind: "room",
+                    isEncrypted: writable(false),
+                    destroy: vi.fn(),
+                } as unknown as MatrixChatRoom;
+            });
+
+            const destroyedWrapper = {
+                id: roomId,
+                conversationKind: "room",
+                isEncrypted: writable(false),
+                destroy: vi.fn(),
+            } as unknown as MatrixChatRoom;
+            selectedRoomStore.set(destroyedWrapper);
+
+            const folder = Object.create(MatrixRoomFolder.prototype) as MatrixRoomFolder;
+            folder["room"] = parentRoom as never;
+            folder.roomList = new Map() as never;
+            folder.folderList = new Map() as never;
+
+            folder.getChildren();
+
+            const rebuiltWrapper = folder.roomList.get(roomId);
+            expect(rebuiltWrapper).toBeDefined();
+            expect(get(selectedRoomStore)).toBe(rebuiltWrapper);
+            expect(get(selectedRoomStore)).not.toBe(destroyedWrapper);
+
+            selectedRoomStore.set(undefined);
         });
 
         it("should ignore a parent relation when the parent has no matching m.space.child", () => {

--- a/play/src/front/Chat/Stores/SelectRoomStore.ts
+++ b/play/src/front/Chat/Stores/SelectRoomStore.ts
@@ -39,3 +39,17 @@ const createSelectedRoomStore = () => {
 };
 
 export const selectedRoomStore = createSelectedRoomStore();
+
+/**
+ * A membership change (e.g. accepting an invitation) destroys the room's previous wrapper and rebuilds a
+ * fresh one during placement reconciliation — in the connection lists (root/folder placement) or inside a
+ * space folder's own children rebuild ({@link MatrixRoomFolder.getChildren}). Any UI still bound to the old,
+ * now-destroyed wrapper stops receiving live timeline events: a message the user sends is delivered to the
+ * server but never renders until the room is re-opened. Whenever a replacement wrapper for the selected room
+ * is created, repoint `selectedRoomStore` at it so the open timeline keeps updating.
+ */
+export function retargetSelectedRoomIfReplaced(newRoom: ChatConversation): void {
+    if (get(selectedRoomStore)?.id === newRoom.id) {
+        selectedRoomStore.set(newRoom);
+    }
+}


### PR DESCRIPTION
## Symptom

After accepting a room invitation, the messages the other person sent *before* the invite are visible, but **no new message renders** — neither the ones you send nor the ones the other person sends afterwards. The timeline is frozen. Closing and re-opening the conversation makes everything appear. (Reproduced with a direct message at the root of the chat list.)

## Root cause

The **Accept** button in `RoomInvitation.svelte` did:

```ts
room.joinRoom().then(() => {
    if (!room.isRoomFolder) selectedRoomStore.set(room); // room = the invited wrapper
});
```

Accepting flips the room's membership to `join`, which **destroys** that `room` wrapper and rebuilds a fresh one during placement reconciliation (its `RoomEvent.Timeline` listener is removed on destroy). By the time the promise resolves, `room` is the *destroyed* wrapper, so re-selecting it binds the open timeline to a dead wrapper: the history already loaded stays visible, but every new live event (incoming **and** outgoing) is delivered to the server yet never rendered — until the room is re-opened, which selects the live wrapper from the room list.

This is also why the earlier `selectedRoomStore` retarget (#6322) never took effect for this flow: reconciliation *did* repoint the store at the live wrapper, and then this `.then()` immediately clobbered it back to the destroyed `room`.

## Fix

**Primary** — `RoomInvitation.svelte`: route the accept through the connection's `joinRoom(roomId)`, which resolves with the **live** wrapper registered in the room list, and select that. This mirrors the pattern already used by `JoignableRooms.svelte` and `RoomSuggested.svelte`.

**Hardening** — extract the retarget guard into a shared `retargetSelectedRoomIfReplaced()` helper (`SelectRoomStore`) and also call it from the space folder's own children rebuild (`MatrixRoomFolder.getChildren()`), which previously rebuilt a room's wrapper without repointing `selectedRoomStore` — the folder-placed variant of the same class of bug. `MatrixChatConnection` now delegates to the shared helper.

## Verification

- `tsc --noEmit`: no type errors in the changed files.
- `svelte-check`: 0 errors / 0 warnings.
- `vitest` `MatrixChatConnection.test.ts`: 48/48 pass (includes a regression test for the folder `getChildren` retarget).
- The primary fix is behavioural (two-user Matrix flow) and mirrors existing proven code; it removes the stale-wrapper selection that matches every observed symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)