### PR TITLE
Fix Vivaldi minimized video rendering

### DIFF
--- a/play/src/front/Components/Video/CenteredVideo.svelte
+++ b/play/src/front/Components/Video/CenteredVideo.svelte
@@ -5,6 +5,7 @@
     import type { Streamable } from "../../Space/Streamable";
     import type { VideoBoxStatus } from "../../Space/VideoBox";
     import { activePictureInPictureStore } from "../../Stores/PeerStore";
+    import { visibilityStore } from "../../Stores/VisibilityStore";
     import WebRtcVideo from "./VideoTags/WebRtcVideo.svelte";
     import LivekitVideo from "./VideoTags/LivekitVideo.svelte";
     import ScriptingVideo from "./VideoTags/ScriptingVideo.svelte";
@@ -129,6 +130,9 @@
         }
     });
 
+    let hasVideoLayout = $derived(overlayWidth > 0 && overlayHeight > 0 && videoWidth > 0 && videoHeight > 0);
+    let shouldMountVideoElement = $derived(hasVideoLayout && ($visibilityStore || $activePictureInPictureStore));
+
     let displayNoVideoWarning = $state(false);
 </script>
 
@@ -185,7 +189,7 @@
                 </div>
             {/if}
 
-            {#if !isBlocked && videoEnabled && status === "connected"}
+            {#if !isBlocked && videoEnabled && status === "connected" && shouldMountVideoElement}
                 {#if media?.type === "webrtc"}
                     <WebRtcVideo
                         {media}


### PR DESCRIPTION
## What changed

- Avoid mounting remote video elements while the page is hidden or before the video layout has non-zero dimensions.
- Keep Picture-in-Picture active video rendering allowed while the main document is hidden.

## Why

In Vivaldi, a bubble started while the browser window is minimized can mount the remote video element with a 0x0 layout. The stream is received, but the video renderer never starts correctly after the window is restored.

## Validation

- npm exec --workspace=play eslint -- src/front/Components/Video/CenteredVideo.svelte
- npm run typecheck --workspace=play
- npm run svelte-check --workspace=play
- git diff --check
