### PR TITLE
fix(livekit): display the sound meter (volume indicator) in video bubbles

### DIFF
--- a/play/src/front/Components/Video/VideoMediaBox.svelte
+++ b/play/src/front/Components/Video/VideoMediaBox.svelte
@@ -3,7 +3,7 @@
     import { getContext, onDestroy, onMount } from "svelte";
     import * as Sentry from "@sentry/svelte";
     import type { Subscription } from "rxjs";
-    import SoundMeterWidget from "../SoundMeterWidget.svelte";
+    import SoundMeterWidgetWrapper from "../SoundMeterWidgetWrapper.svelte";
     import { highlightedEmbedScreen } from "../../Stores/HighlightedEmbedScreenStore";
     import type { VideoBox } from "../../Space/VideoBox";
     import { LL } from "../../../i18n/i18n-svelte";
@@ -67,7 +67,6 @@
             : undefined,
     );
     let volumeStore = $derived(streamable?.volume);
-    let volumeMeter = $derived($volumeMeterStore);
     let webRtcStatsStore = $derived($displayVideoQualityStore ? streamable?.webrtcStats : undefined);
     let webRtcStats = $derived($webRtcStatsStore);
 
@@ -415,8 +414,10 @@
                                     class:opacity-20={$activePictureInPictureStore}
                                 >
                                     {#if $hasAudioStore && !audioStateMismatch}
-                                        <SoundMeterWidget
-                                            volume={volumeMeter}
+                                        <!-- The wrapper subscribes to the volume store itself, so the SoundMeter
+                                             (Web Audio analyser + polling) only runs while this block is rendered. -->
+                                        <SoundMeterWidgetWrapper
+                                            volume={volumeMeterStore}
                                             cssClass="voice-meter-cam-off relative mr-0 ml-auto translate-x-0 transition-transform"
                                             barColor="white"
                                         />

--- a/play/src/front/Livekit/LivekitParticipant.ts
+++ b/play/src/front/Livekit/LivekitParticipant.ts
@@ -14,7 +14,7 @@ import type { StreamableSubjects } from "../Space/SpacePeerManager/SpacePeerMana
 import { decrementLivekitConnectionsCount, incrementLivekitConnectionsCount } from "../Utils/E2EHooks";
 import { volumeProximityDiscussionStore } from "../Stores/PeerStore";
 import type { WebRtcStats } from "../Components/Video/WebRtcStats";
-import { videoQualityStore } from "../Stores/MediaStore";
+import { createVolumeStore, videoQualityStore } from "../Stores/MediaStore";
 import { screenShareQualityStore } from "../Stores/ScreenSharingStore";
 
 import { subscribeToVideoQualityAnalytics } from "../WebRtc/VideoQualityAnalytics";
@@ -35,6 +35,11 @@ export class LiveKitParticipant {
     private _audioScreenShareStreamStore: Writable<MediaStream | undefined> = writable<MediaStream | undefined>(
         undefined,
     );
+
+    // Volume meters (7-bar SoundMeter spectrum) derived from the LiveKit audio streams.
+    // Built once and shared, mirroring the WebRTC path (see RemotePeer.ts).
+    private readonly _videoVolumeStore: Readable<number[] | undefined>;
+    private readonly _screenShareVolumeStore: Readable<number[] | undefined>;
 
     private _nameStore: Writable<string>;
     private _hasVideo = writable<boolean>(false);
@@ -113,6 +118,16 @@ export class LiveKitParticipant {
         this._nameStore = writable(this.participant.name);
         this.videoWebrtcStats = this.getWebrtcStats("video");
         this.screenShareWebrtcStats = this.getWebrtcStats("screenShare");
+        this._videoVolumeStore = derived<Readable<MediaStream | undefined>, number[] | undefined>(
+            this._audioStreamStore,
+            ($audioStream, set) => createVolumeStore($audioStream, set),
+            undefined,
+        );
+        this._screenShareVolumeStore = derived<Readable<MediaStream | undefined>, number[] | undefined>(
+            this._audioScreenShareStreamStore,
+            ($audioStream, set) => createVolumeStore($audioStream, set),
+            undefined,
+        );
         for (const publication of this.participant.getTrackPublications()) {
             if (publication.isLocal) {
                 continue;
@@ -540,7 +555,7 @@ export class LiveKitParticipant {
                 ),
                 acquireVideoSubscription: () => this.acquireVideoSubscription("camera"),
             },
-            volumeStore: writable(undefined),
+            volumeStore: this._videoVolumeStore,
             volume: writable(this.defaultVolume),
             closeStreamable: () => {},
             canCloseStreamable: () => false,
@@ -573,7 +588,7 @@ export class LiveKitParticipant {
                 ),
                 acquireVideoSubscription: () => this.acquireVideoSubscription("screenShare"),
             },
-            volumeStore: writable(undefined),
+            volumeStore: this._screenShareVolumeStore,
             volume: writable(this.defaultVolume),
             closeStreamable: () => {},
             canCloseStreamable: () => false,

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -1189,7 +1189,7 @@ function isOverConstrainedError(e: unknown): e is OverconstrainedErrorInterface 
     return e instanceof Error && e.name === "OverconstrainedError";
 }
 
-function createVolumeStore(mediaStream: MediaStream | undefined, set: (value: number[] | undefined) => void) {
+export function createVolumeStore(mediaStream: MediaStream | undefined, set: (value: number[] | undefined) => void) {
     if (mediaStream === undefined || mediaStream.getAudioTracks().length <= 0) {
         set(undefined);
         return;


### PR DESCRIPTION
## Problem

In a proximity bubble, each video box shows a 7-bar **sound meter** that reflects how loudly the person is speaking. It works on the peer-to-peer (simple-peer) path but stays **frozen** for **LiveKit** participants.

## Root cause

The meter is driven by `Streamable.volumeStore`. In `LivekitParticipant`, both streamable builders hardcoded it:

```ts
// getVideoStream() and getScreenShareStream()
volumeStore: writable(undefined),
```

So `volumeStore` is permanently `undefined` → `SoundMeterWidget` renders static bars. The simple-peer path (`RemotePeer`) instead builds a `derived` store that runs a `SoundMeter` (Web Audio `AnalyserNode`) over the remote audio stream every 100 ms.

The audio `MediaStream` needed to feed a `SoundMeter` is **already available** on the LiveKit streamable (`_audioStreamStore` for the camera, `_audioScreenShareStreamStore` for screen share) — it was just never wired to an analyser.

## Fix

- Export the existing `createVolumeStore()` helper from `MediaStore.ts` (guards on an audio track, spins up a `SoundMeter`, polls `getVolume()` every 100 ms, cleans up).
- In `LivekitParticipant`, build two `derived` volume stores over the LiveKit audio streams (camera + screen share) and use them instead of `writable(undefined)`, mirroring the WebRTC path.

The `derived` store is lazy: the `SoundMeter` is created only when a `VideoMediaBox` subscribes (widget mounted), and is rebuilt/stopped when the audio stream changes (mute/unmute) or the widget unmounts. Since LiveKit already plays remote audio through its own `<audio>` elements, the audio track is live and the `AnalyserNode` receives real data.

No change to the WebRTC path, the local meter, or the UI components — they already consume `volumeStore` identically.

## Test plan

- [ ] Two clients in a **LiveKit**-backed world join the same bubble → the 7-bar meter animates on the remote participant's video box (as it does on WebRTC).
- [ ] Mute / unmute the mic → the meter stops, then resumes.
- [ ] Screen share **with audio** → the meter animates too.
- [ ] Non-regression: WebRTC (simple-peer) bubbles and the local meter behave as before.