### PR TITLE
fix(chat): persist Matrix sync data on a web worker to avoid main-thread freeze

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/MatrixClientWrapper.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixClientWrapper.ts
@@ -9,6 +9,9 @@ import type { LocalUser } from "../../../Connection/LocalUser";
 import AccessSecretStorageDialog from "./AccessSecretStorageDialog.svelte";
 import { matrixSecurity } from "./MatrixSecurity";
 import { customMatrixLogger } from "./CustomMatrixLogger";
+// Inline worker (bundled as a same-origin blob) that drives matrix-js-sdk's IndexedDB store off the
+// main thread. See matrixIndexedDbWorker.ts for why the entry script and `?worker&inline` are needed.
+import MatrixIndexedDbWorker from "./matrixIndexedDbWorker?worker&inline";
 import { modals } from "@wa-modals";
 
 window.Buffer = Buffer;
@@ -177,6 +180,11 @@ export class MatrixClientWrapper implements MatrixClientWrapperInterface {
             indexedDB: globalThis.indexedDB,
             localStorage: globalThis.localStorage,
             dbName: "workadventure-matrix",
+            // Run sync persistence on a dedicated web worker so the structured-clone of the
+            // accumulated /sync blob (persistSyncData -> store.put) does not block the main
+            // thread. Without this, matrix-js-sdk falls back to the main-thread backend and can
+            // freeze the UI for several seconds on large stores.
+            workerFactory: typeof Worker !== "undefined" ? () => new MatrixIndexedDbWorker() : undefined,
         });
 
         const indexDbCryptoStore = new IndexedDBCryptoStore(

--- a/play/src/front/Chat/Connection/Matrix/matrixIndexedDbWorker.ts
+++ b/play/src/front/Chat/Connection/Matrix/matrixIndexedDbWorker.ts
@@ -1,0 +1,28 @@
+import { IndexedDBStoreWorker } from "matrix-js-sdk/lib/indexeddb-worker";
+
+/**
+ * Worker entry point for matrix-js-sdk's IndexedDB store.
+ *
+ * matrix-js-sdk's shipped `indexeddb-worker.js` only re-exports the
+ * {@link IndexedDBStoreWorker} class — it does NOT wire up the worker message
+ * handlers. The application is expected to provide this tiny entry script (see the
+ * class doc-comment in matrix-js-sdk). It is loaded via `?worker&inline` from
+ * {@link MatrixClientWrapper} so it is bundled as a same-origin blob worker, which
+ * avoids the cross-origin `SecurityError` in the dev setup where Vite serves assets
+ * from a different sub-domain than the app.
+ */
+
+// The dedicated worker global scope, typed minimally to avoid pulling in the
+// "webworker" lib (which conflicts with the project's DOM lib).
+interface WorkerScope {
+    postMessage(message: unknown): void;
+    onmessage: ((event: MessageEvent) => void) | null;
+}
+const workerScope = self as unknown as WorkerScope;
+
+// The SDK invokes the passed function as `postMessage.call(null, message)`; passing the
+// bare `self.postMessage` would rebind `this` and make the worker's postMessage throw
+// "Illegal invocation", so wrap it in an arrow function.
+const remoteWorker = new IndexedDBStoreWorker((message: unknown) => workerScope.postMessage(message));
+
+workerScope.onmessage = remoteWorker.onMessage;


### PR DESCRIPTION
## Problem

WorkAdventure is sometimes laggy. A Chrome performance trace of a laggy staging session showed the main thread frozen for **~7.3 seconds** in a single task. Reconstructing the CPU profile, that freeze is dominated by **matrix-js-sdk persisting `/sync` data to IndexedDB on the main thread**:

- **55.6%** — `matrix-js-sdk/lib/store/indexeddb-local-backend.js` `persistSyncData()` → `store.put({ … roomsData })` (the synchronous structured-clone of the whole accumulated `roomsData` blob)
- **18.9%** — garbage collector (churn from building/serializing that object graph)
- **9.3%** — `recursiveMapToObject` (converting the SDK's internal `Map`s to plain objects before persisting)

Root cause: `IndexedDBStore` was constructed **without a `workerFactory`**, so matrix-js-sdk falls back to `LocalIndexedDBStoreBackend`, which runs persistence on the main thread.

## Fix

Pass a `workerFactory` to `IndexedDBStore` so matrix-js-sdk uses `RemoteIndexedDBStoreBackend` and performs persistence on a **dedicated web worker** instead of the main thread.

- matrix-js-sdk's shipped `indexeddb-worker.js` only *re-exports* the `IndexedDBStoreWorker` class, so this adds a small worker entry (`matrixIndexedDbWorker.ts`) that instantiates it and wires up `postMessage`/`onmessage` (per the SDK's own doc comment).
- The worker is imported via `?worker&inline` so it is bundled as a **same-origin blob**, avoiding a cross-origin `SecurityError` when Vite serves assets from a different sub-domain than the app.

## Notes

- **Production** (single origin): the inline blob is self-contained and same-origin, so the worker runs off the main thread as intended.
- **Local dev**: the `play.*` (app) vs `front.*` (Vite) origin split means the worker's module graph is `303`-redirected cross-origin, so matrix-js-sdk currently still falls back to the main-thread backend in dev. A follow-up change to serve `/src`, `/node_modules`, `/@fs` same-origin under `play.*` (Traefik routing) is needed to exercise the worker in dev. This does not affect production.
- When validating, watch the console: the `IndexedDB worker failed to connect` / `Falling back to local indexeddb backend` lines should be **absent** — their presence means the worker didn't start and persistence is back on the main thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)