### PR TITLE
perf(chat): lazy-load Matrix room members to bound the sync blob

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -814,6 +814,12 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             threadSupport: true,
             //Detached to prevent using listener on localIdReplaced for each event
             pendingEventOrdering: PendingEventOrdering.Detached,
+            // Lazy-load room members instead of pulling every m.room.member event on initial sync.
+            // For accounts in many/large rooms, member state is the dominant part of the accumulated
+            // /sync blob that gets structured-cloned to IndexedDB on persist; loading members on
+            // demand (loadOutOfBandMembers, done transparently by the SDK when a room needs them)
+            // keeps that blob — and the persist cost — small.
+            lazyLoadMembers: true,
         });
 
         try {


### PR DESCRIPTION
## Why

The matrix-js-sdk sync accumulator persists the full accumulated `/sync` `roomsData` blob to IndexedDB. For accounts in many/large rooms, the `m.room.member` state is the **dominant** part of that blob, and persisting it is a synchronous structured-clone that showed up as a multi-second main-thread cost in a profile of a laggy session.

This is optimization #2 from the lag investigation. #6334 moved the persist **off** the main thread; this reduces **how much** is persisted in the first place (smaller blob → cheaper clone, less GC, faster load).

## What

Pass `lazyLoadMembers: true` to `startClient` (`MatrixChatConnection.ts`). Initial sync no longer pulls every membership event; members are loaded on demand via `loadOutOfBandMembers`, which the SDK does transparently when a room needs the member list. This is the same lazy-loading Element uses.

`initialSyncLimit` is intentionally **left at the SDK default (8)** — member state, not timeline depth, is what dominates the blob, and lowering the timeline limit would trade blob size for a worse first-open experience.

## Behaviour change to validate

With lazy loading, a room's full member list isn't present in memory until something requests it. matrix-js-sdk loads out-of-band members on demand (opening a room, encrypting a message, etc.), so this is transparent for the common paths — but **please sanity-check any chat feature that reads the full membership eagerly** (member counts/lists, mentions/autocomplete, permissions checks) to confirm they still trigger the on-demand load. Requires a homeserver with lazy-loading support (Synapse — yes).

## Validation

On a Matrix account with a large accumulated store, compare the `persistSyncData` / `store.put` cost (and the `workadventure-matrix` IndexedDB `sync` size) before/after — the blob and the persist time should drop substantially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)