### PR TITLE
fix(pusher): don't report space-destroyed query cancellations to Sentry

### DIFF
--- a/play/src/pusher/controllers/IoSocketController.ts
+++ b/play/src/pusher/controllers/IoSocketController.ts
@@ -24,7 +24,11 @@ import { isAdminMessageInterface } from "../models/Websocket/Admin/AdminMessages
 import { adminService } from "../services/AdminService";
 import type { ConnectingSocketData, SpaceName } from "../models/Websocket/SocketData";
 import { ClientAbortError } from "../models/ClientAbortError";
-import { ClientNotPartOfSpaceError, UserAlreadyAddedInSpaceError } from "../models/SpaceValidationErrors";
+import {
+    ClientNotPartOfSpaceError,
+    SpaceDestroyedError,
+    UserAlreadyAddedInSpaceError,
+} from "../models/SpaceValidationErrors";
 import { videoQualityAnalyticsQueue } from "../services/VideoQualityAnalyticsQueue";
 import { PusherRoomSocketController } from "../services/PusherRoomSocketController";
 import { AdminWebSocketBackpressureWriter } from "../services/AdminWebSocketBackpressureWriter";
@@ -998,8 +1002,12 @@ export class IoSocketController {
                                             error,
                                         );
 
-                                        // Expected join-space validation error: do not send to Sentry.
-                                        if (!(err instanceof UserAlreadyAddedInSpaceError)) {
+                                        // Expected join-space validation errors and space-destroyed cancellations:
+                                        // do not send to Sentry (already logged above).
+                                        if (
+                                            !(err instanceof UserAlreadyAddedInSpaceError) &&
+                                            !(err instanceof SpaceDestroyedError)
+                                        ) {
                                             Sentry.captureException(err, {
                                                 extra: {
                                                     queryType,

--- a/play/src/pusher/models/SpaceQuery.ts
+++ b/play/src/pusher/models/SpaceQuery.ts
@@ -1,6 +1,7 @@
 import type { SpaceAnswerMessage, SpaceQueryMessage } from "@workadventure/messages";
 import { asError } from "catch-unknown";
 import type { Space } from "./Space";
+import { SpaceDestroyedError } from "./SpaceValidationErrors";
 
 export class Query {
     private readonly _queries = new Map<
@@ -107,7 +108,7 @@ export class Query {
         for (const query of this._queries.values()) {
             const durationMs = Date.now() - query.createdAt;
             query.reject(
-                new Error(
+                new SpaceDestroyedError(
                     `Query "${query.answerType}" cancelled because the space is being destroyed (pending for ${durationMs}ms)`,
                 ),
             );

--- a/play/src/pusher/models/SpaceValidationErrors.ts
+++ b/play/src/pusher/models/SpaceValidationErrors.ts
@@ -50,6 +50,17 @@ export class UserAlreadyInSpaceError extends Error {
 }
 
 /**
+ * Thrown to reject pending queries when the space they belong to is being destroyed.
+ * This is an expected lifecycle event, so it is logged but not sent to Sentry.
+ */
+export class SpaceDestroyedError extends Error {
+    constructor(message: string, options?: { cause?: Error }) {
+        super(message, options);
+        this.name = "SpaceDestroyedError";
+    }
+}
+
+/**
  * Thrown when a client attempts an operation on a space they are not part of.
  * Used to avoid sending expected validation errors to Sentry.
  */

--- a/play/src/pusher/services/SocketManager.ts
+++ b/play/src/pusher/services/SocketManager.ts
@@ -62,7 +62,7 @@ import { EMBEDDED_DOMAINS_WHITELIST, GRPC_MAX_MESSAGE_SIZE, SECRET_KEY } from ".
 import type { SpaceInterface } from "../models/Space";
 import { Space } from "../models/Space";
 import { SpaceConnection } from "../models/SpaceConnection";
-import { ClientNotPartOfSpaceError } from "../models/SpaceValidationErrors";
+import { ClientNotPartOfSpaceError, SpaceDestroyedError } from "../models/SpaceValidationErrors";
 import type { UpgradeFailedData } from "../controllers/IoSocketController";
 import { eventProcessor } from "../models/eventProcessorInit";
 import { clientEventsEmitter } from "./ClientEventsEmitter";
@@ -538,7 +538,10 @@ export class SocketManager implements ZoneEventListener {
             }
             space.forwarder.unregisterUser(client).catch((error) => {
                 console.error("Error while unregistering user from space after abort", error);
-                Sentry.captureException(error);
+                // The space being destroyed is an expected lifecycle event: log it but don't report to Sentry.
+                if (!(error instanceof SpaceDestroyedError)) {
+                    Sentry.captureException(error);
+                }
             });
         });
     }
@@ -797,7 +800,10 @@ export class SocketManager implements ZoneEventListener {
                     return { space, spaceName, success: true };
                 } catch (error) {
                     console.error(`Error unregistering user from space ${spaceName}:`, error);
-                    Sentry.captureException(error);
+                    // The space being destroyed is an expected lifecycle event: log it but don't report to Sentry.
+                    if (!(error instanceof SpaceDestroyedError)) {
+                        Sentry.captureException(error);
+                    }
                     return { space, spaceName, success: false };
                 }
             } else {


### PR DESCRIPTION
## Problem

When a `Space` is destroyed (e.g. the connection to the back is cut), its pending queries are rejected so callers stop waiting on them. This is an expected lifecycle event, but the generic `Error` thrown by `Query.destroy()` was being caught downstream and reported to Sentry, adding noise.

## Change

- Add a typed `SpaceDestroyedError` in `SpaceValidationErrors.ts`, alongside the other errors already used to skip Sentry reporting.
- `Query.destroy()` now throws `SpaceDestroyedError` instead of a plain `Error` (same message).
- Skip Sentry reporting for `SpaceDestroyedError` at the catch sites that await space register/unregister queries:
  - `IoSocketController` query handler — mirrors the existing `UserAlreadyAddedInSpaceError` skip.
  - `SocketManager.leaveSpaces`.
  - `SocketManager` post-abort `unregisterUser` handler.

The error is still logged via `console.error` in every case; only the Sentry report is suppressed.

Part of the ongoing effort to trim Sentry noise.

## Testing

- `npm run typecheck` ✅
- `eslint` on changed files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)