### PR TITLE
Stop waiting for Matrix to be ready before starting the map

### DIFF
--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -1,7 +1,6 @@
 import * as Sentry from "@sentry/svelte";
 import * as Phaser from "phaser";
 import type { Subscription } from "rxjs";
-import { TimeoutError } from "@workadventure/shared-utils/src/Abort/TimeoutError";
 import { Queue } from "queue-typescript";
 import type { Readable, Unsubscriber } from "svelte/store";
 import { get } from "svelte/store";
@@ -193,7 +192,6 @@ import { ScriptLoadedError } from "../../Api/ScriptLoadedError";
 import { screenShareStreamStore, videoStreamStore } from "../../Stores/PeerStore";
 import type { ChatConnectionInterface, ChatUser } from "../../Chat/Connection/ChatConnection";
 import { selectedRoomStore } from "../../Chat/Stores/SelectRoomStore";
-import { raceTimeout } from "../../Utils/PromiseUtils";
 import { PLAYTEXT_NEW_MEDIA_DEVICE_PREFIX } from "../Entity/Character";
 import { type Avatar, ConversationBubble } from "../Entity/ConversationBubble";
 import { DarkenOutsideAreaEffect } from "../Components/DarkenOutsideArea/DarkenOutsideAreaEffect";
@@ -941,18 +939,6 @@ export class GameScene extends DirtyScene {
             this.gameMapFrontWrapper.initializedPromise.promise.then(() =>
                 debug("Loading process: Game map initialized"),
             ),
-            // Wait at most 5 seconds for the chat connection to be established
-            // If not, we can still proceed starting the scene without chat fully loaded
-            raceTimeout(gameManager.getChatConnection(), 5_000)
-                .then(() => debug("Loading process: Chat connection ready"))
-                .catch((e) => {
-                    if (e instanceof TimeoutError) {
-                        debug("Loading process: Chat connection timeout. Continuing loading while chat loads.");
-                        return;
-                    } else {
-                        throw e;
-                    }
-                }),
         ])
             .then((results) => {
                 const settledScriptLoadedResult = results[1];


### PR DESCRIPTION
Since Matrix is now using a worker for indexedDB, things are really smoother and Matrix no longer stalls the WorkAdventure main thread too much. Therefore, we can consider stopping waiting for Matrix to be initialized before starting the map.