### PR TITLE
perf(livekit): disable wasted per-frame time-sync monitor

### DIFF
--- a/play/src/front/Livekit/LiveKitRoom.ts
+++ b/play/src/front/Livekit/LiveKitRoom.ts
@@ -1,3 +1,6 @@
+// Side-effect import: disables livekit-client's wasted per-frame time-sync monitor before any
+// Room/track is created. See patchLivekitTimeSync.ts for the rationale.
+import "./patchLivekitTimeSync";
 import { z } from "zod";
 import { MapStore } from "@workadventure/store-utils";
 import type { LocalParticipant, Participant, RemoteParticipant, TrackPublishOptions } from "livekit-client";

--- a/play/src/front/Livekit/patchLivekitTimeSync.test.ts
+++ b/play/src/front/Livekit/patchLivekitTimeSync.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RemoteTrack } from "livekit-client";
+// Importing the module applies the patch as a side effect.
+import "./patchLivekitTimeSync";
+
+describe("patchLivekitTimeSync", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("replaces registerTimeSyncUpdate with a no-op that never starts the per-frame monitor", () => {
+        const proto = RemoteTrack.prototype as { registerTimeSyncUpdate: () => void };
+
+        expect(typeof proto.registerTimeSyncUpdate).toBe("function");
+
+        const rafSpy = vi.fn<(cb: FrameRequestCallback) => number>(() => 1);
+        vi.stubGlobal("requestAnimationFrame", rafSpy);
+
+        const getSynchronizationSources = vi.fn(() => []);
+        const fakeTrack = {
+            receiver: { getSynchronizationSources },
+            timeSyncHandle: undefined as number | undefined,
+        };
+
+        // Invoking the patched method must do nothing: no rAF loop, no getSynchronizationSources call.
+        const result = proto.registerTimeSyncUpdate.call(fakeTrack);
+
+        expect(result).toBeUndefined();
+        expect(rafSpy).not.toHaveBeenCalled();
+        expect(getSynchronizationSources).not.toHaveBeenCalled();
+        expect(fakeTrack.timeSyncHandle).toBeUndefined();
+    });
+});

--- a/play/src/front/Livekit/patchLivekitTimeSync.ts
+++ b/play/src/front/Livekit/patchLivekitTimeSync.ts
@@ -1,0 +1,48 @@
+import { RemoteTrack } from "livekit-client";
+import * as Sentry from "@sentry/svelte";
+
+/**
+ * [INTERNAL ACCESS WARNING]
+ * This module disables livekit-client's per-track "time sync" monitor by overriding the
+ * non-abstract `RemoteTrack.prototype.registerTimeSyncUpdate` method with a no-op.
+ *
+ * Why:
+ * `registerTimeSyncUpdate()` starts a `requestAnimationFrame` loop (livekit-client
+ * `src/room/track/RemoteTrack.ts`) that calls the native `RTCRtpReceiver.getSynchronizationSources()`
+ * once per frame, per subscribed remote track (audio AND video). Its only output is the
+ * `TrackEvent.TimeSyncUpdate` event, which livekit consumes solely for the video "packet trailer"
+ * feature. WorkAdventure never subscribes to `TimeSyncUpdate` anywhere, so for us this loop is pure
+ * wasted main-thread work. In a large meeting (~50 subscribed tracks) it runs ~50×/frame and was
+ * measured at ~8% of the main thread in a staging performance trace, causing choppy Woka movement.
+ *
+ * Safety:
+ * - We only neutralize the rAF time-sync loop. The separate 2s stats interval (`monitorReceiver`,
+ *   used for bitrate/quality analytics) is on `startMonitor()` and is left untouched.
+ * - Active-speaker / isSpeaking state is server-pushed and does not depend on this loop.
+ *
+ * Fragility:
+ * This reaches into a livekit-client internal method and may break on upgrade. If the method ever
+ * disappears (rename/removal), the guard below reports it so the patch does not silently stop
+ * applying. Re-verify against livekit-client on every upgrade. Current target: livekit-client 2.19.x.
+ */
+function patchLivekitTimeSync(): void {
+    const proto = RemoteTrack.prototype as { registerTimeSyncUpdate?: () => void };
+
+    if (typeof proto.registerTimeSyncUpdate !== "function") {
+        // The internal method we intended to disable no longer exists. The per-frame monitor may be
+        // back (and hurting performance) under a different name. Surface it loudly rather than fail silently.
+        const message =
+            "patchLivekitTimeSync: RemoteTrack.prototype.registerTimeSyncUpdate is not a function. " +
+            "livekit-client internals changed; the time-sync monitor patch no longer applies and must be revisited.";
+        console.error(message);
+        Sentry.captureMessage(message, { level: "warning" });
+        return;
+    }
+
+    // Replace with a no-op: never start the per-frame getSynchronizationSources() loop.
+    proto.registerTimeSyncUpdate = function registerTimeSyncUpdate(): void {
+        // Intentionally does nothing. See file header for rationale.
+    };
+}
+
+patchLivekitTimeSync();


### PR DESCRIPTION
## Problem

At ~50 participants in a LiveKit meeting, the main thread saturates and Woka movement becomes choppy. A staging Chrome performance trace showed **~8% of the main thread** (≈945 ms over 12 s, and growing with participant count) spent in a per-animation-frame call to native `RTCRtpReceiver.getSynchronizationSources()`.

That loop is livekit-client's `RemoteTrack.registerTimeSyncUpdate()` — a `requestAnimationFrame` loop, started **per subscribed remote track** (audio *and* video), whose only output is the `TrackEvent.TimeSyncUpdate` event (used solely by livekit's video "packet trailer" feature). **WorkAdventure never subscribes to `TimeSyncUpdate` anywhere**, so with ~50 subscribed tracks this ran ~50×/frame for nothing.

## Fix

Override `RemoteTrack.prototype.registerTimeSyncUpdate` with a no-op at bootstrap, via a side-effect import at the top of `LiveKitRoom.ts` (before any `Room`/track is created). `RemoteTrack` is a public export and the method is inherited by both `RemoteAudioTrack` and `RemoteVideoTrack`, so one override covers all remote tracks.

- The separate 2 s `monitorReceiver` bitrate-stats interval (used by WA analytics) is **untouched**.
- Active-speaker / `isSpeaking` state is server-pushed and does not depend on this loop.
- A guard reports via `console.error` + Sentry if the internal method disappears on a future livekit-client upgrade, so the patch can't silently stop applying. Current target: livekit-client 2.19.x.

## Changes

- `play/src/front/Livekit/patchLivekitTimeSync.ts` — the override + rationale + upgrade guard.
- `play/src/front/Livekit/LiveKitRoom.ts` — side-effect import.
- `play/src/front/Livekit/patchLivekitTimeSync.test.ts` — asserts the method is a no-op that never calls `getSynchronizationSources` nor schedules `requestAnimationFrame`.

## Verification

- Unit test passes; ESLint clean; `tsc` clean (pre-existing `vite.config.ts` error unrelated).
- **To validate on staging (deploy):** join a populated meeting, capture a Chrome performance trace, and confirm `getSynchronizationSources` self-time drops to ~0 and dropped-frame count decreases. Confirm audio, active-speaker highlighting, and bitrate/quality analytics still work.

> Follow-up (separate PR): the ~23% main-thread renegotiation churn is publisher-side and driven by the ~50 always-on audio subscriptions — analysis and next steps captured separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)