### PR TITLE
fix(map-storage): raise response max-listeners for the disconnect handler

### DIFF
--- a/map-storage/src/Upload/S3FileSystem.ts
+++ b/map-storage/src/Upload/S3FileSystem.ts
@@ -275,6 +275,12 @@ export class S3FileSystem implements FileSystemInterface {
                 controller.abort(new ClientDisconnectedError());
             }
         };
+        // `stream.pipeline` below already registers several "close" listeners on the response, and the
+        // Express/Sentry stack adds more, leaving a served file right at Node's default limit of 10.
+        // Our disconnect listener is one more on top, which would trip a (harmless but noisy)
+        // MaxListenersExceededWarning. The set is bounded and removed in `finally`, so account for our
+        // one extra listener instead of masking leaks with an unlimited (0) budget.
+        res.setMaxListeners(res.getMaxListeners() + 1);
         res.on("close", onClose);
 
         this.s3


### PR DESCRIPTION
## Problem

After deploying #6346, map-storage logs this on every file download:

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
11 close listeners added to [ServerResponse]. MaxListeners is 10.
```

## Diagnosis (it is NOT a leak)

The disconnect handler added in #6346 — `res.on("close", onClose)`, which aborts the in-flight S3 read so its socket is released cleanly — is **one** `close` listener on the response. But:

| Source | `close` listeners on the `ServerResponse` |
|---|---|
| `stream.pipeline(body, res, …)` (already there) | ~6 |
| Express `on-finished` + Sentry HTTP integration | a few more |
| our `onClose` (#6346) | +1 |

A served file was already sitting right at Node's default limit of **10**, so our `+1` tipped it to **11** and tripped the warning.

The listener set is **bounded and cleaned up** — reproduced in isolation, the count stays flat at 6 across 15 back-to-back keep-alive requests, and every listener is removed in `.finally`. So this is a threshold artifact, not a growing EventEmitter leak.

We can't drop the listener: it is what releases the S3 socket on disconnect. Removing it would let `pipeline` destroy the *undrained* S3 body instead — the exact socket leak (aws-sdk-js-v3#6691) that wedges the connection pool.

## Fix

Account for the one extra listener where we add it:

```ts
res.setMaxListeners(res.getMaxListeners() + 1);
res.on("close", onClose);
```

`+1` rather than `setMaxListeners(0)` (unlimited) on purpose — it silences this known, bounded case while still catching any genuine unbounded leak later.

## Verification

- Reproduced the exact `11 close listeners` warning in isolation; confirmed it fires without the fix and is gone with it.
- `npm run typecheck` clean, `eslint` clean, all 8 `S3FileSystem` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)