### PR TITLE
Improving global perfs in Livekit meeting

### DIFF
--- a/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
+++ b/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
@@ -456,7 +456,7 @@
                 isOnOneLine,
                 oneLineMode,
             ];
-            setTimeout(updateScrollIndicators, 100);
+            updateScrollIndicators();
         }
     });
 </script>


### PR DESCRIPTION
Walking in a crowded Livekit meeting would cause WorkAdventure to slow down a lot.
The reason: the switch from CamerasContainer from multi-line to one-line was causing a storm of visibility changes because we waited 100ms before scrolling the cameras container to the left.

Fix: Removing the setTimeout before calling updateScrollIndicators.

updateScrollIndicators updates the canScrollLeft and canScrollRight. If all are false, the CamerasContainer is centered. So before, doing 100ms, the camera container was centered before aligned left. This caused the Visibility observers to trigger and was causing Livekit connection churn.
