### PR TITLE
Fix Tasks Vision timestamp recovery

### DIFF
--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -1032,7 +1032,20 @@ async function runLocalVideoTrackUpdate(
 
     if (!backgroundTransformer) {
         const currentConfig = get(backgroundConfigStore);
-        backgroundTransformer = createBackgroundTransformer(currentConfig);
+        const transformer = createBackgroundTransformer(currentConfig, (error) => {
+            if (backgroundTransformer !== transformer) {
+                return;
+            }
+
+            console.warn("[MediaStore] Background transformer stopped after a terminal failure:", error);
+            Sentry.captureException(error);
+            warningMessageStore.addWarningMessage(get(LL).warning.backgroundProcessing.failedToApply());
+            transformer.close();
+            backgroundTransformer = undefined;
+            lastBackgroundConfig = undefined;
+            backgroundConfigStore.reset();
+        });
+        backgroundTransformer = transformer;
     }
 
     if (!backgroundTransformer) {

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
@@ -2,7 +2,11 @@ import type { MPMask } from "@mediapipe/tasks-vision";
 import { ImageSegmenter, FilesetResolver, DrawingUtils } from "@mediapipe/tasks-vision";
 import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
-import type { BackgroundConfig, BackgroundTransformer } from "./createBackgroundTransformer";
+import type {
+    BackgroundConfig,
+    BackgroundTransformer,
+    BackgroundTransformerFailureHandler,
+} from "./createBackgroundTransformer";
 
 const DEFAULT_FRAME_RATE = 30;
 const MAX_CONSECUTIVE_RECOVERY_ATTEMPTS = 2;
@@ -53,7 +57,10 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
     private foregroundCanvas: HTMLCanvasElement | null = null;
     private foregroundCtx: CanvasRenderingContext2D | null = null;
 
-    constructor(private config: BackgroundConfig) {
+    constructor(
+        private config: BackgroundConfig,
+        private readonly onTerminalFailure?: BackgroundTransformerFailureHandler,
+    ) {
         // Create WebGL canvas for MediaPipe (shared with ImageSegmenter and DrawingUtils)
         this.glCanvas = this.createGlCanvas();
 
@@ -288,6 +295,16 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
                         ? `${recoveryError.name}: ${recoveryError.message}`
                         : String(recoveryError);
                 console.error(`[MediaPipe Tasks Vision] Recovery failed: ${recoveryErrorMessage}`);
+
+                const terminalError = new Error("MediaPipe Tasks Vision recovery failed", {
+                    cause: recoveryError,
+                });
+                this.close();
+                try {
+                    this.onTerminalFailure?.(terminalError);
+                } catch (callbackError) {
+                    console.error("[MediaPipe Tasks Vision] Terminal failure handler failed:", callbackError);
+                }
             })
             .finally(() => {
                 this.recoveryPromise = null;

--- a/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts
@@ -4,6 +4,10 @@ import { AbortError } from "@workadventure/shared-utils/src/Abort/AbortError";
 import { raceAbort } from "@workadventure/shared-utils/src/Abort/raceAbort";
 import type { BackgroundConfig, BackgroundTransformer } from "./createBackgroundTransformer";
 
+const DEFAULT_FRAME_RATE = 30;
+const MAX_CONSECUTIVE_RECOVERY_ATTEMPTS = 2;
+const SUCCESSFUL_FRAMES_BEFORE_RECOVERY_RESET = 30;
+
 /**
  * MediaPipe Tasks Vision-based background transformer for video streams
  * Uses the modern @mediapipe/tasks-vision API with ImageSegmenter and DrawingUtils
@@ -30,11 +34,12 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
     private frameCount = 0;
     private startTime = performance.now();
     private initPromise: Promise<void>;
-    private frameRate = 33;
-    // Use a global timestamp that never resets to ensure monotonic timestamps for MediaPipe
-    private globalStartTime = performance.now();
-    // Track the last timestamp to guarantee strict monotonic increase
-    private lastTimestampMicroseconds = 0;
+    private frameRate = DEFAULT_FRAME_RATE;
+    private frameIntervalMs = 1000 / DEFAULT_FRAME_RATE;
+    private lastTimestampMs = -1;
+    private recoveryPromise: Promise<void> | null = null;
+    private consecutiveRecoveryAttempts = 0;
+    private successfulFramesSinceRecovery = 0;
 
     // Canvas for blurred background (used as texture source for DrawingUtils)
     private blurredCanvas: HTMLCanvasElement | null = null;
@@ -50,7 +55,7 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
 
     constructor(private config: BackgroundConfig) {
         // Create WebGL canvas for MediaPipe (shared with ImageSegmenter and DrawingUtils)
-        this.glCanvas = document.createElement("canvas");
+        this.glCanvas = this.createGlCanvas();
 
         // Create output canvas for stream capture (2D context for captureStream compatibility)
         this.outputCanvas = document.createElement("canvas");
@@ -135,6 +140,10 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
         this.drawingUtils = new DrawingUtils(this.gl);
     }
 
+    private createGlCanvas(): HTMLCanvasElement {
+        return document.createElement("canvas");
+    }
+
     private initializeBlurredCanvas(): void {
         this.blurredCanvas = document.createElement("canvas");
         this.blurredCtx = this.blurredCanvas.getContext("2d")!;
@@ -185,10 +194,7 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
 
         // Skip processing if canvas has invalid dimensions
         if (!width || !height || width === 0 || height === 0) {
-            if (this.timeoutId) {
-                clearTimeout(this.timeoutId);
-            }
-            this.timeoutId = setTimeout(() => this.processFrame(), this.frameRate);
+            this.scheduleNextFrame();
             return;
         }
 
@@ -197,59 +203,135 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
         const videoHeight = this.inputVideo.videoHeight;
 
         if (!videoWidth || !videoHeight || videoWidth === 0 || videoHeight === 0) {
-            if (this.timeoutId) {
-                clearTimeout(this.timeoutId);
-            }
-            this.timeoutId = setTimeout(() => this.processFrame(), this.frameRate);
+            this.scheduleNextFrame();
             return;
         }
 
         if (this.inputVideo.readyState < 2) {
             // Video not ready yet, retry
-            if (this.timeoutId) {
-                clearTimeout(this.timeoutId);
-            }
-            this.timeoutId = setTimeout(() => this.processFrame(), this.frameRate);
+            this.scheduleNextFrame();
             return;
         }
 
         try {
-            // Calculate timestamp in microseconds (MediaPipe requires microseconds)
-            // Use a global timestamp that never resets to ensure strict monotonic increase
-            // This is critical: MediaPipe requires timestamps to be STRICTLY increasing
-            const currentTime = performance.now();
-            let timestampMicroseconds = Math.floor((currentTime - this.globalStartTime) * 1000);
-
-            // Ensure timestamp is strictly greater than the last one
-            // performance.now() can return the same value on rapid calls, causing MediaPipe errors
-            if (timestampMicroseconds <= this.lastTimestampMicroseconds) {
-                timestampMicroseconds = this.lastTimestampMicroseconds + 1;
-            }
-            this.lastTimestampMicroseconds = timestampMicroseconds;
+            // The Tasks Vision API expects milliseconds and requires monotonically increasing values.
+            const timestampMs = Math.max(performance.now(), this.lastTimestampMs + 1);
+            this.lastTimestampMs = timestampMs;
 
             // Segment the current video frame
-            const result = this.imageSegmenter.segmentForVideo(this.inputVideo, timestampMicroseconds);
-
-            if (result.confidenceMasks && result.confidenceMasks.length > 0) {
-                this.processResults(result.confidenceMasks[0]);
+            const result = this.imageSegmenter.segmentForVideo(this.inputVideo, timestampMs);
+            try {
+                if (result.confidenceMasks && result.confidenceMasks.length > 0) {
+                    this.processResults(result.confidenceMasks[0]);
+                }
+                // Silently skip if no mask - this can happen occasionally and is not critical
+            } finally {
+                result.close();
             }
-            // Silently skip if no mask - this can happen occasionally and is not critical
 
-            // Schedule next frame
-            if (this.timeoutId) {
-                clearTimeout(this.timeoutId);
-            }
-            this.timeoutId = setTimeout(() => this.processFrame(), this.frameRate);
+            this.markSuccessfulFrame();
+            this.scheduleNextFrame();
         } catch (error) {
-            console.error("[MediaPipe Tasks Vision] : ", error);
-            this.timeoutId = setTimeout(() => this.processFrame(), this.frameRate);
+            this.startRecovery(error);
+        }
+    }
+
+    private scheduleNextFrame(): void {
+        this.cancelScheduledFrame();
+        if (this.closed || !this.outputStream || this.config.mode === "none") {
             return;
         }
+        this.timeoutId = setTimeout(() => this.processFrame(), this.frameIntervalMs);
+    }
+
+    private cancelScheduledFrame(): void {
+        if (this.timeoutId) {
+            clearTimeout(this.timeoutId);
+            this.timeoutId = null;
+        }
+    }
+
+    private markSuccessfulFrame(): void {
+        if (this.consecutiveRecoveryAttempts === 0) {
+            return;
+        }
+
+        this.successfulFramesSinceRecovery++;
+        if (this.successfulFramesSinceRecovery >= SUCCESSFUL_FRAMES_BEFORE_RECOVERY_RESET) {
+            this.consecutiveRecoveryAttempts = 0;
+            this.successfulFramesSinceRecovery = 0;
+        }
+    }
+
+    private startRecovery(error: unknown): void {
+        if (this.closed || this.recoveryPromise) {
+            return;
+        }
+
+        this.cancelScheduledFrame();
+        const errorMessage = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+        const inputTrack =
+            this.inputVideo.srcObject instanceof MediaStream
+                ? this.inputVideo.srcObject.getVideoTracks()[0]
+                : undefined;
+        console.error(
+            `[MediaPipe Tasks Vision] Frame processing failed: ${errorMessage}; ` +
+                `timestampMs=${this.lastTimestampMs}; videoTime=${this.inputVideo.currentTime}; ` +
+                `readyState=${this.inputVideo.readyState}; trackState=${inputTrack?.readyState ?? "unavailable"}; ` +
+                `visibility=${document.visibilityState}; webGlContextLost=${this.gl?.isContextLost() ?? true}`,
+        );
+
+        this.recoveryPromise = this.recoverMediaPipe()
+            .catch((recoveryError: unknown) => {
+                const recoveryErrorMessage =
+                    recoveryError instanceof Error
+                        ? `${recoveryError.name}: ${recoveryError.message}`
+                        : String(recoveryError);
+                console.error(`[MediaPipe Tasks Vision] Recovery failed: ${recoveryErrorMessage}`);
+            })
+            .finally(() => {
+                this.recoveryPromise = null;
+            });
+    }
+
+    private async recoverMediaPipe(): Promise<void> {
+        if (this.closed || this.consecutiveRecoveryAttempts >= MAX_CONSECUTIVE_RECOVERY_ATTEMPTS) {
+            throw new Error("MediaPipe recovery attempts exhausted");
+        }
+
+        this.consecutiveRecoveryAttempts++;
+        this.successfulFramesSinceRecovery = 0;
+
+        this.disposeMediaPipeResources();
+        this.glCanvas = this.createGlCanvas();
+        this.glCanvas.width = this.outputCanvas.width;
+        this.glCanvas.height = this.outputCanvas.height;
+
+        try {
+            await this.initializeMediaPipe();
+        } catch (error) {
+            if (this.consecutiveRecoveryAttempts >= MAX_CONSECUTIVE_RECOVERY_ATTEMPTS) {
+                throw error;
+            }
+            return this.recoverMediaPipe();
+        }
+
+        if (this.closed) {
+            this.disposeMediaPipeResources();
+            return;
+        }
+        if (!this.outputStream || this.config.mode === "none") {
+            return;
+        }
+
+        console.info(
+            `[MediaPipe Tasks Vision] Recovered after attempt ${this.consecutiveRecoveryAttempts}/${MAX_CONSECUTIVE_RECOVERY_ATTEMPTS}`,
+        );
+        this.scheduleNextFrame();
     }
 
     private processResults(mask: MPMask): void {
         if (this.closed) {
-            mask.close();
             return;
         }
 
@@ -257,7 +339,6 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
 
         // Skip processing if canvas has invalid dimensions
         if (!width || !height || width === 0 || height === 0) {
-            mask.close();
             console.warn(
                 `[MediaPipe Tasks Vision] Skipping frame processing: canvas dimensions are ${width}x${height}`,
             );
@@ -269,20 +350,14 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
         } else if (this.config.mode === "image" || this.config.mode === "video") {
             this.processReplaceMode(mask);
         } else {
-            mask.close();
             throw new Error(`[MediaPipe Tasks Vision] Unknown mode: ${this.config.mode}`);
         }
 
-        // Clean up mask resources
-        mask.close();
-
-        // Copy from WebGL canvas to output canvas for stream capture
-        this.outputCtx.drawImage(this.glCanvas, 0, 0, width, height);
-
-        // Ensure WebGL operations are flushed for captureStream
+        // Ensure WebGL operations are submitted before copying to the capture canvas.
         if (this.gl) {
             this.gl.flush();
         }
+        this.outputCtx.drawImage(this.glCanvas, 0, 0, width, height);
 
         this.frameCount++;
     }
@@ -470,21 +545,13 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
     }
 
     public stop(): void {
-        // Stop timeout
-        if (this.timeoutId) {
-            clearTimeout(this.timeoutId);
-            this.timeoutId = null;
-        }
+        this.cancelScheduledFrame();
     }
 
     public close(): void {
         this.closed = true;
 
-        // Stop timeout
-        if (this.timeoutId) {
-            clearTimeout(this.timeoutId);
-            this.timeoutId = null;
-        }
+        this.cancelScheduledFrame();
 
         // Stop output stream
         if (this.outputStream) {
@@ -492,27 +559,7 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
             this.outputStream = null;
         }
 
-        // Close DrawingUtils (frees WebGL resources)
-        if (this.drawingUtils) {
-            try {
-                this.drawingUtils.close();
-            } catch (error) {
-                console.warn("[MediaPipe Tasks Vision] Error closing DrawingUtils:", error);
-            }
-            this.drawingUtils = null;
-        }
-
-        // Close MediaPipe
-        if (this.imageSegmenter) {
-            try {
-                this.imageSegmenter.close();
-            } catch (error) {
-                console.warn("[MediaPipe Tasks Vision] Error closing segmenter:", error);
-            }
-            this.imageSegmenter = null;
-        }
-
-        this.gl = null;
+        this.disposeMediaPipeResources();
 
         // Clean up resources
         if (this.backgroundVideo) {
@@ -533,11 +580,44 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
         // Clean up foreground canvas
         this.foregroundCanvas = null;
         this.foregroundCtx = null;
+
+        this.inputVideo.pause();
+        this.inputVideo.srcObject = null;
+    }
+
+    private disposeMediaPipeResources(): void {
+        if (this.drawingUtils) {
+            try {
+                this.drawingUtils.close();
+            } catch (error) {
+                console.warn("[MediaPipe Tasks Vision] Error closing DrawingUtils:", error);
+            }
+            this.drawingUtils = null;
+        }
+
+        if (this.imageSegmenter) {
+            try {
+                this.imageSegmenter.close();
+            } catch (error) {
+                console.warn("[MediaPipe Tasks Vision] Error closing segmenter:", error);
+            }
+            this.imageSegmenter = null;
+        }
+
+        if (this.gl) {
+            // This extension only releases the transformer's context; Phaser uses a different canvas/context.
+            this.gl.getExtension("WEBGL_lose_context")?.loseContext();
+        }
+        this.gl = null;
     }
 
     public async transform(inputStream: MediaStream, signal?: AbortSignal): Promise<MediaStream> {
-        this.frameRate = inputStream.getVideoTracks()[0]?.getSettings().frameRate || 33;
+        this.frameRate = inputStream.getVideoTracks()[0]?.getSettings().frameRate || DEFAULT_FRAME_RATE;
+        this.frameIntervalMs = 1000 / this.frameRate;
         await this.initPromise;
+        if (this.recoveryPromise) {
+            await raceAbort(this.recoveryPromise, signal);
+        }
         if (signal?.aborted) {
             throw signal.reason ?? new AbortError("Transform aborted after initialization");
         }
@@ -601,16 +681,9 @@ export class MediaPipeTasksVisionTransformer implements BackgroundTransformer {
             this.outputStream.addTrack(audioTrack);
         }
 
-        // Don't reset timestamp - keep it monotonic across stream changes
-        // MediaPipe requires strictly increasing timestamps, so we use a global timestamp
-        // that never resets
-
         // Stop any existing processing loop before starting a new one
         // This prevents race conditions when transform() is called multiple times
-        if (this.timeoutId) {
-            clearTimeout(this.timeoutId);
-            this.timeoutId = null;
-        }
+        this.cancelScheduledFrame();
 
         // Start processing loop
         this.processFrame();

--- a/play/src/front/WebRtc/BackgroundProcessor/createBackgroundTransformer.ts
+++ b/play/src/front/WebRtc/BackgroundProcessor/createBackgroundTransformer.ts
@@ -21,6 +21,8 @@ export interface BackgroundTransformer {
     stop(): void;
 }
 
+export type BackgroundTransformerFailureHandler = (error: Error) => void;
+
 /**
  * Create a MediaPipe-based background transformer with fallback support
  * Supports both the new Tasks Vision API (GPU-accelerated) and legacy Selfie Segmentation (CPU)
@@ -29,13 +31,16 @@ export interface BackgroundTransformer {
  * @param config Background configuration
  * @returns A MediaPipe transformer instance or fallback
  */
-export function createBackgroundTransformer(config: BackgroundConfig): BackgroundTransformer {
+export function createBackgroundTransformer(
+    config: BackgroundConfig,
+    onTerminalFailure?: BackgroundTransformerFailureHandler,
+): BackgroundTransformer {
     const engine = BACKGROUND_TRANSFORMER_ENGINE || "tasks-vision";
     console.info(`[BackgroundProcessor] Using transformer engine: ${engine}`);
 
     if (engine === "tasks-vision") {
         try {
-            const transformer = new MediaPipeTasksVisionTransformer(config);
+            const transformer = new MediaPipeTasksVisionTransformer(config, onTerminalFailure);
             return transformer;
         } catch (error) {
             console.error("[BackgroundTransformer] Failed to create Tasks Vision transformer, using fallback:", error);

--- a/play/tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.test.ts
+++ b/play/tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.test.ts
@@ -30,7 +30,7 @@ interface SegmenterMock {
 interface TestDom {
     contextLoss: ReturnType<typeof vi.fn>;
     inputTrack: MediaStreamTrack;
-    outputTrack: MediaStreamTrack;
+    outputTrackStop: ReturnType<typeof vi.fn>;
 }
 
 function createSegmenter(): SegmenterMock {
@@ -51,10 +51,11 @@ function installTestDom(frameRate = 25): TestDom {
         getSettings: () => ({ frameRate }),
         stop: vi.fn(),
     } as unknown as MediaStreamTrack;
+    const outputTrackStop = vi.fn();
     const outputTrack = {
         kind: "video",
         readyState: "live",
-        stop: vi.fn(),
+        stop: outputTrackStop,
     } as unknown as MediaStreamTrack;
     const inputVideo = {
         autoplay: false,
@@ -95,7 +96,7 @@ function installTestDom(frameRate = 25): TestDom {
         throw new Error(`Unexpected element requested by test: ${tagName}`);
     });
 
-    return { contextLoss, inputTrack, outputTrack };
+    return { contextLoss, inputTrack, outputTrackStop };
 }
 
 async function flushPromises(): Promise<void> {
@@ -167,5 +168,35 @@ describe("MediaPipeTasksVisionTransformer", () => {
 
         await vi.advanceTimersByTimeAsync(40);
         expect(recoveredSegmenter.segmentForVideo).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes the output and surfaces a terminal recovery failure", async () => {
+        const { inputTrack, outputTrackStop } = installTestDom();
+        const segmenters = [createSegmenter(), createSegmenter(), createSegmenter()];
+        for (const segmenter of segmenters) {
+            segmenter.segmentForVideo.mockImplementation(() => {
+                throw new Error("Packet timestamp mismatch on free_memory");
+            });
+        }
+        mediaPipeMocks.createFromOptions
+            .mockResolvedValueOnce(segmenters[0])
+            .mockResolvedValueOnce(segmenters[1])
+            .mockResolvedValueOnce(segmenters[2]);
+        const onTerminalFailure = vi.fn();
+        transformer = new MediaPipeTasksVisionTransformer({ mode: "blur" }, onTerminalFailure);
+
+        await transformer.transform(new MediaStream([inputTrack]));
+        await flushPromises();
+        await vi.advanceTimersByTimeAsync(40);
+        await flushPromises();
+        await vi.advanceTimersByTimeAsync(40);
+        await flushPromises();
+
+        expect(mediaPipeMocks.createFromOptions).toHaveBeenCalledTimes(3);
+        expect(onTerminalFailure).toHaveBeenCalledOnce();
+        expect(onTerminalFailure.mock.calls[0][0]).toMatchObject({
+            message: "MediaPipe Tasks Vision recovery failed",
+        });
+        expect(outputTrackStop).toHaveBeenCalledOnce();
     });
 });

--- a/play/tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.test.ts
+++ b/play/tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mediaPipeMocks = vi.hoisted(() => ({
+    createFromOptions: vi.fn(),
+    forVisionTasks: vi.fn(),
+    drawingUtilsClose: vi.fn(),
+    drawConfidenceMask: vi.fn(),
+}));
+
+vi.mock("@mediapipe/tasks-vision", () => ({
+    FilesetResolver: {
+        forVisionTasks: mediaPipeMocks.forVisionTasks,
+    },
+    ImageSegmenter: {
+        createFromOptions: mediaPipeMocks.createFromOptions,
+    },
+    DrawingUtils: class {
+        public close = mediaPipeMocks.drawingUtilsClose;
+        public drawConfidenceMask = mediaPipeMocks.drawConfidenceMask;
+    },
+}));
+
+import { MediaPipeTasksVisionTransformer } from "../../../../src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer";
+
+interface SegmenterMock {
+    close: ReturnType<typeof vi.fn>;
+    segmentForVideo: ReturnType<typeof vi.fn>;
+}
+
+interface TestDom {
+    contextLoss: ReturnType<typeof vi.fn>;
+    inputTrack: MediaStreamTrack;
+    outputTrack: MediaStreamTrack;
+}
+
+function createSegmenter(): SegmenterMock {
+    return {
+        close: vi.fn(),
+        segmentForVideo: vi.fn(() => ({
+            confidenceMasks: [],
+            close: vi.fn(),
+        })),
+    };
+}
+
+function installTestDom(frameRate = 25): TestDom {
+    const contextLoss = vi.fn();
+    const inputTrack = {
+        kind: "video",
+        readyState: "live",
+        getSettings: () => ({ frameRate }),
+        stop: vi.fn(),
+    } as unknown as MediaStreamTrack;
+    const outputTrack = {
+        kind: "video",
+        readyState: "live",
+        stop: vi.fn(),
+    } as unknown as MediaStreamTrack;
+    const inputVideo = {
+        autoplay: false,
+        muted: false,
+        playsInline: false,
+        srcObject: null,
+        readyState: 2,
+        videoWidth: 640,
+        videoHeight: 360,
+        currentTime: 1,
+        play: vi.fn().mockResolvedValue(undefined),
+        pause: vi.fn(),
+    } as unknown as HTMLVideoElement;
+
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+        if (tagName === "video") {
+            return inputVideo;
+        }
+
+        if (tagName === "canvas") {
+            const context2d = {
+                drawImage: vi.fn(),
+                filter: "none",
+            } as unknown as CanvasRenderingContext2D;
+            const webGl = {
+                flush: vi.fn(),
+                getExtension: vi.fn(() => ({ loseContext: contextLoss })),
+                isContextLost: vi.fn(() => false),
+            } as unknown as WebGL2RenderingContext;
+            return {
+                width: 300,
+                height: 150,
+                getContext: vi.fn((contextId: string) => (contextId === "webgl2" ? webGl : context2d)),
+                captureStream: vi.fn(() => new MediaStream([outputTrack])),
+            } as unknown as HTMLCanvasElement;
+        }
+
+        throw new Error(`Unexpected element requested by test: ${tagName}`);
+    });
+
+    return { contextLoss, inputTrack, outputTrack };
+}
+
+async function flushPromises(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe("MediaPipeTasksVisionTransformer", () => {
+    let transformer: MediaPipeTasksVisionTransformer | undefined;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.spyOn(performance, "now").mockReturnValue(42_000);
+        vi.spyOn(console, "error").mockImplementation(() => undefined);
+        vi.spyOn(console, "info").mockImplementation(() => undefined);
+        mediaPipeMocks.forVisionTasks.mockResolvedValue({});
+    });
+
+    afterEach(() => {
+        transformer?.close();
+        transformer = undefined;
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+        mediaPipeMocks.createFromOptions.mockReset();
+        mediaPipeMocks.forVisionTasks.mockReset();
+        mediaPipeMocks.drawingUtilsClose.mockReset();
+        mediaPipeMocks.drawConfidenceMask.mockReset();
+    });
+
+    it("uses monotonic millisecond timestamps and schedules frames from the input frame rate", async () => {
+        const { inputTrack } = installTestDom(25);
+        const segmenter = createSegmenter();
+        mediaPipeMocks.createFromOptions.mockResolvedValue(segmenter);
+        transformer = new MediaPipeTasksVisionTransformer({ mode: "blur" });
+
+        await transformer.transform(new MediaStream([inputTrack]));
+
+        expect(segmenter.segmentForVideo).toHaveBeenCalledTimes(1);
+        expect(segmenter.segmentForVideo.mock.calls[0][1]).toBe(42_000);
+
+        await vi.advanceTimersByTimeAsync(39);
+        expect(segmenter.segmentForVideo).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(segmenter.segmentForVideo).toHaveBeenCalledTimes(2);
+        expect(segmenter.segmentForVideo.mock.calls[1][1]).toBe(42_001);
+    });
+
+    it("replaces a failed segmenter and releases its WebGL context", async () => {
+        const { contextLoss, inputTrack } = installTestDom();
+        const failedSegmenter = createSegmenter();
+        failedSegmenter.segmentForVideo.mockImplementationOnce(() => {
+            throw new Error("Packet timestamp mismatch on free_memory");
+        });
+        const recoveredSegmenter = createSegmenter();
+        mediaPipeMocks.createFromOptions
+            .mockResolvedValueOnce(failedSegmenter)
+            .mockResolvedValueOnce(recoveredSegmenter);
+        transformer = new MediaPipeTasksVisionTransformer({ mode: "blur" });
+
+        await transformer.transform(new MediaStream([inputTrack]));
+        await flushPromises();
+
+        expect(failedSegmenter.segmentForVideo).toHaveBeenCalledTimes(1);
+        expect(failedSegmenter.close).toHaveBeenCalledTimes(1);
+        expect(contextLoss).toHaveBeenCalledTimes(1);
+        expect(mediaPipeMocks.createFromOptions).toHaveBeenCalledTimes(2);
+
+        await vi.advanceTimersByTimeAsync(40);
+        expect(recoveredSegmenter.segmentForVideo).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## What changed

- pass MediaPipe Tasks Vision frame timestamps in milliseconds and keep them monotonic
- schedule processing from the camera frame rate using the correct millisecond interval
- close segmentation results reliably after drawing
- replace a failed ImageSegmenter and its WebGL context instead of retrying a poisoned graph forever
- bound consecutive recovery attempts and add first-failure diagnostics
- add regression coverage for timestamp cadence and segmenter recovery

## Why

Long-running virtual-background sessions could become permanently black after MediaPipe reported a `Packet timestamp mismatch` on its internal `free_memory` stream. The transformer retried the same failed graph every frame, but that graph does not recover. The previous timestamp calculation also passed microseconds to an API that expects milliseconds.

The recovery path closes the old segmenter and explicitly releases only the transformer's WebGL context before creating a replacement. Phaser continues using its separate canvas and WebGL context.

## Validation

- `npm test -- --run tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.test.ts --reporter=verbose`
- `npx eslint src/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.ts tests/front/WebRtc/BackgroundProcessor/MediaPipeTasksVisionTransformer.test.ts`
- Prettier check
- `git diff --check`
- pre-commit hooks, including i18n validation and generated documentation checks

The full `play` typecheck remains blocked by existing Matrix SDK and Phaser typing errors unrelated to this change.