### PR TITLE
fix(play): correct Phaser TilemapGPULayer rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "workadventure",
+      "hasInstallScript": true,
       "workspaces": [
         "play",
         "back",
@@ -19,6 +20,7 @@
       ],
       "devDependencies": {
         "husky": "^9.1.7",
+        "patch-package": "^8.0.1",
         "typescript": "^5.9.3"
       }
     },
@@ -6298,6 +6300,13 @@
       "license": "Apache-2.0",
       "peer": true
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -8113,6 +8122,22 @@
       "peer": true,
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cipher-base": {
@@ -10572,6 +10597,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -11765,6 +11800,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -12096,6 +12147,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -12373,6 +12437,26 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -12404,6 +12488,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/jwt-decode": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
@@ -12420,6 +12514,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/known-css-properties": {
@@ -14316,6 +14420,23 @@
         "protobufjs": "^7.2.4"
       }
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openapi-types": {
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
@@ -14631,6 +14752,64 @@
       "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/path-browserify": {
@@ -16478,6 +16657,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/slice-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20226,6 +20226,7 @@
         "globals": "^17.6.0",
         "jsdom": "^29.1.1",
         "lint-staged": "^17.0.5",
+        "patch-package": "^8.0.1",
         "prettier": "^3.8.3",
         "prettier-plugin-svelte": "^4.0.1",
         "svelte": "^5.55.9",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "private": true,
   "devDependencies": {
     "husky": "^9.1.7",
+    "patch-package": "^8.0.1",
     "typescript": "^5.9.3"
   },
   "scripts": {
+    "postinstall": "patch-package",
     "prepare": "husky install || echo 'Husky not found. Maybe you are installing only a subproject.'",
     "generate-env-docs": "npm run generate --workspace=contrib/tools/generate-env-docs",
     "check-env-docs": "npm run check --workspace=contrib/tools/generate-env-docs",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "typescript": "^5.9.3"
   },
   "scripts": {
-    "postinstall": "patch-package",
+    "postinstall": "patch-package || echo 'patch-package not found. Maybe you are installing only a subproject without it (e.g. a scoped `npm ci --workspace`); patches are only needed for the play build.'",
     "prepare": "husky install || echo 'Husky not found. Maybe you are installing only a subproject.'",
     "generate-env-docs": "npm run generate --workspace=contrib/tools/generate-env-docs",
     "check-env-docs": "npm run check --workspace=contrib/tools/generate-env-docs",

--- a/patches/phaser+4.2.0.patch
+++ b/patches/phaser+4.2.0.patch
@@ -1,0 +1,58 @@
+diff --git a/node_modules/phaser/dist/phaser.esm.js b/node_modules/phaser/dist/phaser.esm.js
+index 07a961e..07bdd4f 100644
+--- a/node_modules/phaser/dist/phaser.esm.js
++++ b/node_modules/phaser/dist/phaser.esm.js
+@@ -208488,6 +208488,9 @@ module.exports = [
+     '{',
+     '    vec2 layerTexCoord = outTexCoord;',
+     '    Tile tile = getLayerData(layerTexCoord);',
++    '    // WA patch: empty cells must be transparent. Without this, empty tiles sample tile 0 of the',
++    '    // tileset (opaque for most tilesets) and paint over whatever is drawn beneath the layer.',
++    '    if (tile.empty) { discard; }',
+     '    Samples samples = getFinalSamples(tile, layerTexCoord);',
+     '    vec4 fragColor = samples.color;',
+     '    #pragma phaserTemplate(declareSamples)',
+@@ -246698,7 +246701,11 @@ var Tileset = new Class({
+                 var animationDuration = tileDatum.animationDuration;
+ 
+                 // This index maps to an animation, not a single tile.
+-                indexToAnimMap.set(i, animations.length);
++                // WA patch: each animation header occupies 2 texels ([duration, frameOffset]) at
++                // texel 2*ordinal, but the shader's animationIndex() reads the header at texel `index`.
++                // Storing the raw ordinal only worked for ordinal 0; store 2*ordinal so every animated
++                // tile past the first resolves to the correct frames instead of a wrong tile.
++                indexToAnimMap.set(i, animations.length * 2);
+ 
+                 // This animation points to a run of frames.
+                 animations.push([ animationDuration, animFrames.length ]);
+diff --git a/node_modules/phaser/src/renderer/webgl/shaders/TilemapGPULayer-frag.js b/node_modules/phaser/src/renderer/webgl/shaders/TilemapGPULayer-frag.js
+index 8f3f66c..e1ce878 100644
+--- a/node_modules/phaser/src/renderer/webgl/shaders/TilemapGPULayer-frag.js
++++ b/node_modules/phaser/src/renderer/webgl/shaders/TilemapGPULayer-frag.js
+@@ -227,6 +227,9 @@ module.exports = [
+     '{',
+     '    vec2 layerTexCoord = outTexCoord;',
+     '    Tile tile = getLayerData(layerTexCoord);',
++    '    // WA patch: empty cells must be transparent. Without this, empty tiles sample tile 0 of the',
++    '    // tileset (opaque for most tilesets) and paint over whatever is drawn beneath the layer.',
++    '    if (tile.empty) { discard; }',
+     '    Samples samples = getFinalSamples(tile, layerTexCoord);',
+     '    vec4 fragColor = samples.color;',
+     '    #pragma phaserTemplate(declareSamples)',
+diff --git a/node_modules/phaser/src/tilemaps/Tileset.js b/node_modules/phaser/src/tilemaps/Tileset.js
+index 5447865..cea245f 100644
+--- a/node_modules/phaser/src/tilemaps/Tileset.js
++++ b/node_modules/phaser/src/tilemaps/Tileset.js
+@@ -614,7 +614,11 @@ var Tileset = new Class({
+                 var animationDuration = tileDatum.animationDuration;
+ 
+                 // This index maps to an animation, not a single tile.
+-                indexToAnimMap.set(i, animations.length);
++                // WA patch: each animation header occupies 2 texels ([duration, frameOffset]) at
++                // texel 2*ordinal, but the shader's animationIndex() reads the header at texel `index`.
++                // Storing the raw ordinal only worked for ordinal 0; store 2*ordinal so every animated
++                // tile past the first resolves to the correct frames instead of a wrong tile.
++                indexToAnimMap.set(i, animations.length * 2);
+ 
+                 // This animation points to a run of frames.
+                 animations.push([ animationDuration, animFrames.length ]);

--- a/play/package.json
+++ b/play/package.json
@@ -79,6 +79,7 @@
     "globals": "^17.6.0",
     "jsdom": "^29.1.1",
     "lint-staged": "^17.0.5",
+    "patch-package": "^8.0.1",
     "prettier": "^3.8.3",
     "prettier-plugin-svelte": "^4.0.1",
     "svelte": "^5.55.9",

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -259,7 +259,6 @@ export class GameMapFrontWrapper {
         }
 
         let layerTileset: Tileset | undefined;
-        let hasAnimatedTile = false;
         for (const tileIndex of tileIndices) {
             const tileset = terrains.find((terrain) => terrain.containsTileIndex(tileIndex));
             if (!tileset) {
@@ -272,10 +271,9 @@ export class GameMapFrontWrapper {
                 return undefined;
             }
             layerTileset = tileset;
-            hasAnimatedTile ||= this.tileHasAnimation(tileset, tileIndex);
         }
 
-        return hasAnimatedTile ? layerTileset : undefined;
+        return layerTileset;
     }
 
     private getLayerTileIndices(layer: ITiledMapTileLayer): Set<number> | undefined {
@@ -343,11 +341,6 @@ export class GameMapFrontWrapper {
         }
 
         return refreshDelay;
-    }
-
-    private tileHasAnimation(tileset: Tileset, tileIndex: number): boolean {
-        const tileData = tileset.tileData as Record<string, TileAnimationData | undefined>;
-        return tileData[tileIndex - tileset.firstgid]?.animation !== undefined;
     }
 
     private isGpuTilemapLayer(layer: RenderableTilemapLayer): layer is TilemapGPULayer {


### PR DESCRIPTION
## Problem

Since the Phaser 4 migration we use the native `TilemapGPULayer` for animated tilesets. It has two rendering bugs that corrupt animated tiles and layered maps. On the `smallOffice` preset map this showed up as: the animated **sea** rendered the wrong tiles (grass in the water), the **sea layer was invisible** when another animated GPU layer existed, and the static **beach sand** rendered as green.

Both are upstream Phaser 4.2.0 bugs, root-caused and fixed here via a vendored `patch-package` patch:

- **Empty GPU-layer cells were opaque.** The shader flags empty cells but never discards them, so they sample tile 0 of the tileset (opaque for most tilesets) and paint over whatever is drawn beneath the layer. This is also what made stacked GPU layers hide one another (the upper layer's empty cells covered the lower one).
- **The GPU animation frame lookup was off by a factor of 2.** Animation headers are packed 2 texels apart (`2*ordinal`), but `_animationDataIndexMap` stored the raw ordinal while the shader reads the header at texel `index`. Only the first animated tile of a tileset resolved correctly; the rest resolved to wrong tiles.

## Changes

- Add `patches/phaser+4.2.0.patch` (via `patch-package`, wired through a root `postinstall`) with the two one-line fixes:
  - `TilemapGPULayer.frag`: `if (tile.empty) { discard; }`
  - `Tileset.js`: store the animation index as a texel offset (`animations.length * 2`)
- Now that the GPU path renders correctly, drop the animated-tile gate in `getGpuTilesetForLayer` so all single-tileset layers use the GPU layer (and remove the now-unused `tileHasAnimation` helper).

## Verification

Tested live against the `smallOffice` preset map: the sea renders and animates correctly, the sandy beach is back, and multiple animated GPU layers (sea + river) render simultaneously. `npm run typecheck` and ESLint pass.

Upstream issue/PRs to `photonstorm/phaser` will follow (each fix is a one-liner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)