### PR TITLE
feat(play): demote GPU tile layers to CPU layers on scripting mutations

### DIFF
--- a/maps/tests/Metadata/setTilesGpuDemotion.json
+++ b/maps/tests/Metadata/setTilesGpuDemotion.json
@@ -1,0 +1,793 @@
+{
+ "compressionlevel": -1,
+ "height": 10,
+ "infinite": false,
+ "layers": [
+  {
+   "data": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    52,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+   ],
+   "height": 10,
+   "id": 1,
+   "name": "start",
+   "opacity": 1,
+   "type": "tilelayer",
+   "visible": true,
+   "width": 10,
+   "x": 0,
+   "y": 0
+  },
+  {
+   "data": [
+    33,
+    34,
+    34,
+    34,
+    34,
+    34,
+    34,
+    34,
+    34,
+    35,
+    41,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    43,
+    41,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    43,
+    41,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    43,
+    41,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    43,
+    41,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    43,
+    41,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    43,
+    41,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    43,
+    41,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    42,
+    43,
+    49,
+    50,
+    50,
+    50,
+    50,
+    50,
+    50,
+    50,
+    50,
+    51
+   ],
+   "height": 10,
+   "id": 2,
+   "name": "bottom",
+   "opacity": 1,
+   "type": "tilelayer",
+   "visible": true,
+   "width": 10,
+   "x": 0,
+   "y": 0
+  },
+  {
+   "data": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    128,
+    128,
+    128,
+    128,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    128,
+    128,
+    128,
+    128,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    128,
+    128,
+    128,
+    128,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    128,
+    128,
+    128,
+    128,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+   ],
+   "height": 10,
+   "id": 4,
+   "name": "metadata",
+   "opacity": 1,
+   "properties": [
+    {
+     "name": "openWebsite",
+     "type": "string",
+     "value": "setTiles.php"
+    },
+    {
+     "name": "openWebsiteAllowApi",
+     "type": "bool",
+     "value": true
+    }
+   ],
+   "type": "tilelayer",
+   "visible": true,
+   "width": 10,
+   "x": 0,
+   "y": 0
+  },
+  {
+   "data": [
+    65,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    65,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    65,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    65,
+    65,
+    65,
+    65,
+    65,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    65,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    65,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+   ],
+   "height": 10,
+   "id": 8,
+   "name": "setTiles",
+   "opacity": 1,
+   "type": "tilelayer",
+   "visible": true,
+   "width": 10,
+   "x": 0,
+   "y": 0
+  },
+  {
+   "draworder": "topdown",
+   "id": 5,
+   "name": "floorLayer",
+   "objects": [
+    {
+     "class": "",
+     "height": 191.866671635267,
+     "id": 1,
+     "name": "",
+     "rotation": 0,
+     "text": {
+      "fontfamily": "Sans Serif",
+      "pixelsize": 9,
+      "text": "Test : \nWalk on the grass\n\nResult : \nThe Yellow Tile opens a Jitsi with Trigger.\n\nThe Red Flashy Tile opens cowebsite Wikipedia. The highest Red Tile is found by 'name' property index, the lowest by 'number' index.\n\nThe White Tiles are silent tiles. You cannot open a bubble in it. (Even if the other player didn't activate the script.)\n\nThe Pale Tile (Lowest) is an exitUrl tile to customMenu.json.\n\nThe Blue Tile are 'collides' tile. The two tiles in the center are 'number' index. The others are 'name' property index.\n",
+      "wrap": true
+     },
+     "visible": true,
+     "width": 274.674838251912,
+     "x": 32.5473600365393,
+     "y": 128.305680721763
+    }
+   ],
+   "opacity": 1,
+   "type": "objectgroup",
+   "visible": true,
+   "x": 0,
+   "y": 0
+  }
+ ],
+ "nextlayerid": 9,
+ "nextobjectid": 2,
+ "orientation": "orthogonal",
+ "renderorder": "right-down",
+ "tiledversion": "1.9.2",
+ "tileheight": 32,
+ "tilesets": [
+  {
+   "columns": 8,
+   "firstgid": 1,
+   "image": "tileset_dungeon.png",
+   "imageheight": 256,
+   "imagewidth": 256,
+   "margin": 0,
+   "name": "TDungeon",
+   "spacing": 0,
+   "tilecount": 64,
+   "tileheight": 32,
+   "tiles": [
+    {
+     "id": 0,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 1,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 2,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 3,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 4,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 8,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 9,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 10,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 11,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 12,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 16,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 17,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 18,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 19,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    },
+    {
+     "id": 20,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    }
+   ],
+   "tilewidth": 32
+  },
+  {
+   "columns": 8,
+   "firstgid": 65,
+   "image": "floortileset.png",
+   "imageheight": 288,
+   "imagewidth": 256,
+   "margin": 0,
+   "name": "Floor",
+   "spacing": 0,
+   "tilecount": 72,
+   "tileheight": 32,
+   "tiles": [
+    {
+     "id": 9,
+     "properties": [
+      {
+       "name": "exitUrl",
+       "type": "string",
+       "value": "customMenu.json"
+      }
+     ]
+    },
+    {
+     "id": 27,
+     "properties": [
+      {
+       "name": "jitsiRoom",
+       "type": "string",
+       "value": "TEST"
+      },
+      {
+       "name": "jitsiTrigger",
+       "type": "string",
+       "value": "onaction"
+      }
+     ]
+    },
+    {
+     "animation": [
+      {
+       "duration": 100,
+       "tileid": 34
+      },
+      {
+       "duration": 100,
+       "tileid": 35
+      },
+      {
+       "duration": 100,
+       "tileid": 36
+      }
+     ],
+     "id": 34,
+     "properties": [
+      {
+       "name": "name",
+       "type": "string",
+       "value": "Red"
+      },
+      {
+       "name": "openWebsite",
+       "type": "string",
+       "value": "https://fr.wikipedia.org/wiki/Wikip%C3%A9dia:Accueil_principal"
+      }
+     ]
+    },
+    {
+     "id": 40,
+     "properties": [
+      {
+       "name": "name",
+       "type": "string",
+       "value": ""
+      }
+     ]
+    },
+    {
+     "id": 44,
+     "properties": [
+      {
+       "name": "collides",
+       "type": "bool",
+       "value": true
+      },
+      {
+       "name": "name",
+       "type": "string",
+       "value": "blue"
+      }
+     ]
+    },
+    {
+     "id": 52,
+     "properties": [
+      {
+       "name": "silent",
+       "type": "bool",
+       "value": true
+      }
+     ]
+    }
+   ],
+   "tilewidth": 32
+  }
+ ],
+ "tilewidth": 32,
+ "type": "map",
+ "version": "1.9",
+ "width": 10,
+ "properties": [
+  {
+   "name": "script",
+   "type": "string",
+   "value": "../E2E/empty.js"
+  },
+  {
+   "name": "scriptDisableModuleSupport",
+   "type": "bool",
+   "value": true
+  }
+ ]
+}

--- a/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
+++ b/play/src/front/Phaser/Game/GameMap/GameMapFrontWrapper.ts
@@ -34,7 +34,7 @@ import Tilemap = Phaser.Tilemaps.Tilemap;
 import Tileset = Phaser.Tilemaps.Tileset;
 import WebGLRenderer = Phaser.Renderer.WebGL.WebGLRenderer;
 
-type RenderableTilemapLayer = TilemapLayer | TilemapGPULayer;
+export type RenderableTilemapLayer = TilemapLayer | TilemapGPULayer;
 type TileAnimationData = {
     animation?: Array<{ duration?: number }>;
 };
@@ -75,6 +75,7 @@ export type PropertyChangeCallback = (
 export class GameMapFrontWrapper {
     private scene: GameScene;
     private gameMap: GameMap;
+    private readonly terrains: Array<Tileset>;
 
     private oldKey: number | undefined;
     /**
@@ -156,6 +157,7 @@ export class GameMapFrontWrapper {
         this.scene = scene;
         this.gameMap = gameMap;
         this.phaserMap = phaserMap;
+        this.terrains = terrains;
 
         this.existingTileIndex = terrains.length > 0 ? terrains[0].firstgid : -1;
 
@@ -894,20 +896,23 @@ export class GameMapFrontWrapper {
     }
 
     public putTile(tile: string | number | null, x: number, y: number, layer: string): void {
-        const phaserLayer = this.findPhaserLayer(layer);
+        let phaserLayer = this.findPhaserLayer(layer);
         if (phaserLayer) {
+            // A layer modified by the scripting API loses its GPU eligibility: scripts may place
+            // tiles from any tileset of the map, but a GPU layer can only render a single one.
+            if (this.isGpuTilemapLayer(phaserLayer)) {
+                const demotedLayer = this.demoteGpuLayerToCpu(phaserLayer);
+                if (!demotedLayer) {
+                    return;
+                }
+                phaserLayer = demotedLayer;
+            }
             if (tile === null) {
                 phaserLayer.putTileAt(-1, x, y);
             } else {
                 const tileIndex = this.gameMap.getIndexForTileType(tile);
                 if (tileIndex === undefined) {
                     console.error("The tile '" + tile + "' that you want to place doesn't exist.");
-                    return;
-                }
-                if (this.isGpuTilemapLayer(phaserLayer) && !phaserLayer.tileset.containsTileIndex(tileIndex)) {
-                    console.warn(
-                        `Cannot place tile ${tileIndex} on GPU tile layer "${layer}" because it belongs to another tileset.`,
-                    );
                     return;
                 }
                 this.gameMap.putTileInFlatLayer(tileIndex, x, y, layer);
@@ -920,13 +925,47 @@ export class GameMapFrontWrapper {
                     }
                 }
             }
-            if (this.isGpuTilemapLayer(phaserLayer)) {
-                phaserLayer.generateLayerDataTexture();
-            }
             this.invalidateCollisionGrid({ modifiedLayer: phaserLayer });
         } else {
             console.error("The layer '" + layer + "' does not exist (or is not a tilelaye).");
         }
+    }
+
+    /**
+     * Replaces a GPU tile layer with a classic CPU tile layer rendering the same LayerData.
+     * The CPU layer receives every tileset of the map, so tiles from any tileset can be
+     * placed on it afterwards.
+     */
+    private demoteGpuLayerToCpu(gpuLayer: TilemapGPULayer): TilemapLayer | undefined {
+        const arrayIndex = this.phaserLayers.indexOf(gpuLayer);
+        const layerName = gpuLayer.layer.name;
+        const { layerIndex, x, y, depth, alpha, visible, scrollFactorX, scrollFactorY, timePaused } = gpuLayer;
+        const layerDataTexture = gpuLayer.layerDataTexture;
+
+        // destroy(false) detaches the game object but keeps the LayerData in the Tilemap,
+        // so a new layer can be created on top of the same data.
+        gpuLayer.destroy(false);
+        // The GPU layer does not release its tile data texture on destroy.
+        layerDataTexture?.destroy();
+
+        const cpuLayer = this.phaserMap.createLayer(layerIndex, this.terrains, x, y, false);
+        if (!cpuLayer || this.isGpuTilemapLayer(cpuLayer)) {
+            console.error(`Could not demote GPU tile layer "${layerName}" to a CPU tile layer.`);
+            return undefined;
+        }
+        cpuLayer
+            .setDepth(depth)
+            .setScrollFactor(scrollFactorX, scrollFactorY)
+            .setAlpha(alpha)
+            .setVisible(visible)
+            .setTimerPaused(timePaused);
+        if (arrayIndex !== -1) {
+            this.phaserLayers[arrayIndex] = cpuLayer;
+        }
+        this.scene.onTileLayerReplaced(gpuLayer, cpuLayer);
+        this.scene.markDirty();
+        console.info(`Tile layer "${layerName}" was modified by a script: switching it to the CPU rendering path.`);
+        return cpuLayer;
     }
 
     public canEntityBePlacedOnMap(

--- a/play/src/front/Phaser/Game/GameScene.ts
+++ b/play/src/front/Phaser/Game/GameScene.ts
@@ -204,6 +204,7 @@ import { audioPlaybackStore } from "../../Stores/AudioPlaybackStore";
 import { requestedScreenSharingState } from "../../Stores/ScreenSharingStore";
 import { EnterLeaveScriptingService } from "../Helpers/EnterLeaveScriptingService";
 import { GameMapFrontWrapper } from "./GameMap/GameMapFrontWrapper";
+import type { RenderableTilemapLayer } from "./GameMap/GameMapFrontWrapper";
 import { gameManager } from "./GameManager";
 import { EmoteManager } from "./EmoteManager";
 import { OutlineManager } from "./UI/OutlineManager";
@@ -348,6 +349,11 @@ export class GameScene extends DirtyScene {
     private entityPermissions: EntityPermissions | undefined;
     private entityPermissionsDeferred: Deferred<EntityPermissions> = new Deferred();
     private gameMapFrontWrapper!: GameMapFrontWrapper;
+    /**
+     * Player-vs-tile Arcade colliders, per tile layer, so that the collision can follow a layer
+     * when its game object is replaced (GPU layer demoted to a CPU layer).
+     */
+    private layerColliders = new Map<RenderableTilemapLayer, Phaser.Physics.Arcade.Collider>();
     private actionableItems: Map<number, ActionableItem> = new Map<number, ActionableItem>();
     private isReconnecting: boolean | undefined = undefined;
     private playerName!: string;
@@ -1171,6 +1177,7 @@ export class GameScene extends DirtyScene {
 
         this.connection?.closeConnection();
         this.outlineManager?.clear();
+        this.layerColliders.clear();
         this.tileAnimationRefreshEvent?.remove(false);
         this.tileAnimationRefreshEvent = undefined;
         this.userInputManager?.destroy();
@@ -3999,6 +4006,7 @@ ${escapedMessage}
     }
 
     private createCollisionWithPlayer() {
+        this.layerColliders.clear();
         //add collision layer
         for (const phaserLayer of this.gameMapFrontWrapper.phaserLayers) {
             // Area blocking is handled by Area game objects/colliders.
@@ -4007,25 +4015,45 @@ ${escapedMessage}
                 continue;
             }
 
-            this.physics.add.collider(
-                this.CurrentPlayer,
-                phaserLayer,
-                (
-                    object1: Body | StaticBody | Tile | Phaser.Types.Physics.Arcade.GameObjectWithBody,
-                    object2: Body | StaticBody | Tile | Phaser.Types.Physics.Arcade.GameObjectWithBody,
-                ) => {},
-            );
-            phaserLayer.setCollisionByProperty({ collides: true });
-            if (DEBUG_MODE) {
-                //debug code to see the collision hitbox of the object in the top layer
-                phaserLayer.renderDebug(this.add.graphics(), {
-                    tileColor: null, //non-colliding tiles
-                    collidingTileColor: new Color(243, 134, 48, 200), // Colliding tiles,
-                    faceColor: new Color(40, 39, 37, 255), // Colliding face edges
-                });
-            }
-            //});
+            this.addLayerCollider(phaserLayer);
         }
+    }
+
+    private addLayerCollider(phaserLayer: RenderableTilemapLayer): void {
+        const collider = this.physics.add.collider(
+            this.CurrentPlayer,
+            phaserLayer,
+            (
+                object1: Body | StaticBody | Tile | Phaser.Types.Physics.Arcade.GameObjectWithBody,
+                object2: Body | StaticBody | Tile | Phaser.Types.Physics.Arcade.GameObjectWithBody,
+            ) => {},
+        );
+        this.layerColliders.set(phaserLayer, collider);
+        phaserLayer.setCollisionByProperty({ collides: true });
+        if (DEBUG_MODE) {
+            //debug code to see the collision hitbox of the object in the top layer
+            phaserLayer.renderDebug(this.add.graphics(), {
+                tileColor: null, //non-colliding tiles
+                collidingTileColor: new Color(243, 134, 48, 200), // Colliding tiles,
+                faceColor: new Color(40, 39, 37, 255), // Colliding face edges
+            });
+        }
+    }
+
+    /**
+     * Called when a tile layer game object has been replaced by another one rendering the same
+     * LayerData (a GPU layer demoted to a CPU layer after a scripting mutation). Moves the
+     * player collision from the old (destroyed) layer to the new one.
+     */
+    public onTileLayerReplaced(oldLayer: RenderableTilemapLayer, newLayer: RenderableTilemapLayer): void {
+        const collider = this.layerColliders.get(oldLayer);
+        if (collider === undefined) {
+            // Colliders have not been created yet; createCollisionWithPlayer will pick up the new layer.
+            return;
+        }
+        collider.destroy();
+        this.layerColliders.delete(oldLayer);
+        this.addLayerCollider(newLayer);
     }
 
     private createCurrentPlayer(startPosition: PositionInterface) {

--- a/tests/tests/gpu_tile_layer.spec.ts
+++ b/tests/tests/gpu_tile_layer.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+import { evaluateScript } from "./utils/scripting";
+import { publicTestMapUrl } from "./utils/urls";
+import { getPage } from "./utils/auth";
+import { isMobile } from "./utils/isMobile";
+
+test.describe("GPU tile layer demotion @nowebkit", () => {
+    test.beforeEach(async ({ page }) => {
+        test.skip(isMobile(page), "Skip on mobile devices");
+    });
+
+    test("setTiles demotes a GPU layer and renders tiles from another tileset", async ({ browser }) => {
+        // The "setTiles" layer of this map only uses tiles from the "Floor" tileset,
+        // so it is rendered with a TilemapGPULayer. The first setTiles call must demote
+        // it to a classic CPU layer, which can then display tiles from any tileset.
+        await using page = await getPage(
+            browser,
+            "Alice",
+            publicTestMapUrl("tests/Metadata/setTilesGpuDemotion.json", "gpu_tile_layer"),
+        );
+
+        const consoleTexts: string[] = [];
+        const pageErrors: string[] = [];
+        page.on("console", (msg) => consoleTexts.push(msg.text()));
+        page.on("pageerror", (err) => pageErrors.push(err.message));
+
+        await evaluateScript(page, async () => {
+            await WA.onInit();
+            WA.room.setTiles([
+                // Named tile from the Floor tileset (the layer's own tileset)
+                { x: 2, y: 2, tile: "Red", layer: "setTiles" },
+                // Cross-tileset tiles: gids 33 and 34 belong to the TDungeon tileset
+                { x: 3, y: 2, tile: 33, layer: "setTiles" },
+                { x: 4, y: 2, tile: 34, layer: "setTiles" },
+                { x: 5, y: 2, tile: "blue", layer: "setTiles" },
+            ]);
+        });
+
+        await expect
+            .poll(() => consoleTexts.some((t) => t.includes('Tile layer "setTiles" was modified by a script')), {
+                timeout: 15000,
+            })
+            .toBe(true);
+
+        // Let a few frames render to make sure nothing blew up
+        // (e.g. a stale player collider still pointing to the destroyed GPU layer).
+        await page.evaluate(
+            () =>
+                new Promise((resolve) => {
+                    let frames = 0;
+                    const step = () => (++frames >= 30 ? resolve(undefined) : requestAnimationFrame(step));
+                    requestAnimationFrame(step);
+                }),
+        );
+        expect(pageErrors).toEqual([]);
+    });
+});


### PR DESCRIPTION
## What

Follow-up to the Phaser 4 `TilemapGPULayer` work: now that every single-tileset layer is rendered on the GPU path, the scripting API could no longer freely edit those layers — `WA.room.setTiles` refused tiles belonging to another tileset, because a `TilemapGPULayer` can only render a single tileset.

Per the design decision taken with the wa-map-optimizer refactor, a **layer mutated by a script loses its GPU eligibility** instead of constraining the optimizer to duplicate every named tile into every tileset:

- On the first `putTile` targeting a GPU layer, the layer is demoted to a classic CPU `TilemapLayer` rendering the same `LayerData`, carrying over depth, scroll factor, alpha, visibility and animation-timer pause state. The CPU layer receives **every tileset of the map**, so tiles from any tileset (including named tiles) can then be placed on it. Demotion is per-layer: all other layers keep their GPU path.
- Player-vs-tile Arcade colliders are now tracked per layer (`GameScene.layerColliders`) so the collision follows the layer when its game object is replaced — previously the collider would have kept pointing at the destroyed GPU layer and thrown every frame.
- The GPU layer's tile data texture is explicitly released on demotion (Phaser 4.2 does not free it in `destroy()`).
- A `console.info` is emitted on demotion so map authors can tell why a layer left the fast path.

## Test coverage

New e2e test `tests/gpu_tile_layer.spec.ts` with map `maps/tests/Metadata/setTilesGpuDemotion.json` (the existing setTiles test map + a script property): the `setTiles` layer starts GPU-eligible (Floor tileset only), the test mutates it with a named Floor tile and two TDungeon tiles (cross-tileset), asserts the demotion happened and that 30 further rendered frames produce no page error (exercising the collider swap).

Also verified manually against the local dev stack: the mutated tiles render correctly after demotion, the other layers stay GPU-rendered, and the visual result is unchanged elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)