### PR TITLE
fix(media): show the permission help modal on Safari and Firefox

### DIFF
--- a/play/src/front/Components/ActionBar/MediaSettingsList/MediaSettingsPanel.svelte
+++ b/play/src/front/Components/ActionBar/MediaSettingsList/MediaSettingsPanel.svelte
@@ -11,13 +11,17 @@
         silentStore,
         usedCameraDeviceIdStore,
         usedMicrophoneDeviceIdStore,
-        cameraAccessIssueStore,
-        microphoneAccessIssueStore,
         devicesNotLoaded,
         rawLocalStreamStore,
         mediaStreamConstraintsStore,
     } from "../../../Stores/MediaStore";
-    import { cameraPermissionStateStore, microphonePermissionStateStore } from "../../../Stores/MediaStatusStore";
+    import {
+        cameraAccessIssueStore,
+        cameraPermissionStateStore,
+        mediaPermissionDeniedStore,
+        microphoneAccessIssueStore,
+        microphonePermissionStateStore,
+    } from "../../../Stores/MediaStatusStore";
     import { analyticsClient } from "../../../Administration/AnalyticsClient";
     import { localUserStore } from "../../../Connection/LocalUserStore";
     import { noiseSuppressionEnabledStore, noiseSuppressionStateStore } from "../../../Stores/NoiseSuppressionStore";
@@ -85,14 +89,8 @@
         $noiseSuppressionStateStore.status === "error" || $noiseSuppressionStateStore.status === "unsupported",
     );
 
-    let cameraDenied = $derived(
-        $cameraPermissionStateStore === "denied" ||
-            ($cameraAccessIssueStore === "permission_denied" && $cameraPermissionStateStore !== "granted"),
-    );
-    let microphoneDenied = $derived(
-        $microphonePermissionStateStore === "denied" ||
-            ($microphoneAccessIssueStore === "permission_denied" && $microphonePermissionStateStore !== "granted"),
-    );
+    let cameraDenied = $derived($mediaPermissionDeniedStore.camera);
+    let microphoneDenied = $derived($mediaPermissionDeniedStore.microphone);
 
     let cameraLoaded = $derived(
         ($rawLocalStreamStore.type === "success" &&

--- a/play/src/front/Components/HelpSettings/HelpCameraSettingsPopup.svelte
+++ b/play/src/front/Components/HelpSettings/HelpCameraSettingsPopup.svelte
@@ -7,8 +7,17 @@
     import { IconInfoCircle } from "@wa-icons";
 
     let isAndroid = isAndroidFct();
-    let isFirefox = getNavigatorType() === NavigatorType.firefox;
-    let isChrome = getNavigatorType() === NavigatorType.chrome;
+    let navigatorType = (() => {
+        try {
+            return getNavigatorType();
+        } catch {
+            // getNavigatorType() throws on some embedded or uncommon browsers
+            return undefined;
+        }
+    })();
+    let isFirefox = navigatorType === NavigatorType.firefox;
+    let isChrome = navigatorType === NavigatorType.chrome;
+    let isSafari = navigatorType === NavigatorType.safari;
     let showDetails = $state(false);
 
     let cameraDenied = $derived($mediaPermissionDeniedStore.camera);
@@ -68,24 +77,30 @@
                 <p class="err">
                     {$LL.camera.help.firefoxContent()}
                 </p>
+            {:else if isSafari}
+                <p class="err">
+                    {$LL.camera.help.safariContent()}
+                </p>
             {/if}
-            <div class="h-72 overflow-hidden opacity-80 saturate-50">
-                {#if isFirefox}
-                    <img
-                        draggable="false"
-                        src={$LL.camera.help.screen.firefox()}
-                        alt="help media setup"
-                        class="w-full m-auto"
-                    />
-                {:else if isChrome && !isAndroid}
-                    <img
-                        draggable="false"
-                        src={$LL.camera.help.screen.chrome()}
-                        alt="help media setup"
-                        class="w-full m-auto"
-                    />
-                {/if}
-            </div>
+            {#if isFirefox || (isChrome && !isAndroid)}
+                <div class="h-72 overflow-hidden opacity-80 saturate-50">
+                    {#if isFirefox}
+                        <img
+                            draggable="false"
+                            src={$LL.camera.help.screen.firefox()}
+                            alt="help media setup"
+                            class="w-full m-auto"
+                        />
+                    {:else}
+                        <img
+                            draggable="false"
+                            src={$LL.camera.help.screen.chrome()}
+                            alt="help media setup"
+                            class="w-full m-auto"
+                        />
+                    {/if}
+                </div>
+            {/if}
         {/if}
     </section>
     <section class="flex row justify-center p-4 bg-contrast">

--- a/play/src/front/Stores/MediaStatusStore.test.ts
+++ b/play/src/front/Stores/MediaStatusStore.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { isPermissionDenied } from "./MediaStatusStore";
+
+// Chromium answers "denied" when the user blocks a device, so its permission state can be trusted.
+const CHROMIUM = true;
+// Safari always answers "prompt", even after a denial, and Firefox rejects the query (leaving the state null).
+const SAFARI_OR_FIREFOX = false;
+
+describe("isPermissionDenied", () => {
+    it("trusts the Permissions API when it reports a denial", () => {
+        expect(isPermissionDenied("denied", null, CHROMIUM)).toBe(true);
+    });
+
+    it("trusts the Permissions API when it reports a grant", () => {
+        expect(isPermissionDenied("granted", "permission_denied", CHROMIUM)).toBe(false);
+        expect(isPermissionDenied("granted", "permission_denied", SAFARI_OR_FIREFOX)).toBe(false);
+    });
+
+    it("does not report a denial on Chromium when the prompt was merely dismissed", () => {
+        // Chromium rejects getUserMedia with NotAllowedError when the user closes the prompt without choosing,
+        // while the permission state stays "prompt". That is not a denial.
+        expect(isPermissionDenied("prompt", "permission_denied", CHROMIUM)).toBe(false);
+    });
+
+    it("does not report a denial on Chromium while the permission query is still in flight", () => {
+        expect(isPermissionDenied(null, "permission_denied", CHROMIUM)).toBe(false);
+    });
+
+    it('reports a denial on Safari, which answers "prompt" even once the user has denied', () => {
+        expect(isPermissionDenied("prompt", "permission_denied", SAFARI_OR_FIREFOX)).toBe(true);
+    });
+
+    it("reports a denial on Firefox, which leaves the state unanswered", () => {
+        expect(isPermissionDenied(null, "permission_denied", SAFARI_OR_FIREFOX)).toBe(true);
+    });
+
+    it("does not confuse a missing device with a denial", () => {
+        expect(isPermissionDenied("prompt", "no_device", SAFARI_OR_FIREFOX)).toBe(false);
+    });
+
+    it("does not report a denial without a media access failure", () => {
+        expect(isPermissionDenied("prompt", null, SAFARI_OR_FIREFOX)).toBe(false);
+    });
+});

--- a/play/src/front/Stores/MediaStatusStore.ts
+++ b/play/src/front/Stores/MediaStatusStore.ts
@@ -1,6 +1,19 @@
-import { derived, readable } from "svelte/store";
+import { derived, readable, writable } from "svelte/store";
+import { getNavigatorType, NavigatorType } from "../WebRtc/DeviceUtils";
 
 export type BrowserMediaPermissionState = "granted" | "denied" | "prompt" | null;
+
+export type MediaAccessIssue = "permission_denied" | "no_device";
+
+/**
+ * Last camera access failure. Cleared whenever the camera is requested again.
+ */
+export const cameraAccessIssueStore = writable<MediaAccessIssue | null>(null);
+
+/**
+ * Last microphone access failure. Cleared whenever the microphone is requested again.
+ */
+export const microphoneAccessIssueStore = writable<MediaAccessIssue | null>(null);
 
 function createBrowserPermissionStateStore(name: "camera" | "microphone") {
     return readable<BrowserMediaPermissionState>(null, (set) => {
@@ -59,12 +72,62 @@ export interface MediaPermissionDeniedState {
     microphone: boolean;
 }
 
+/**
+ * Whether navigator.permissions.query() can be trusted to report a camera/microphone denial.
+ *
+ * Only Chromium ever answers "denied". Firefox rejects the query outright, and Safari answers "prompt" even once
+ * the user has denied, so on those a non-"denied" answer rules nothing out.
+ */
+const permissionStateIsReliable = ((): boolean => {
+    if (typeof navigator === "undefined" || !navigator.permissions?.query) {
+        return false;
+    }
+    try {
+        return getNavigatorType() === NavigatorType.chrome;
+    } catch {
+        // getNavigatorType() throws on some embedded or uncommon browsers
+        return false;
+    }
+})();
+
+/**
+ * Whether the browser is currently blocking a device.
+ *
+ * "denied" and "granted" are conclusive. Any other answer means the browser is not reporting a denial, which only
+ * rules one out where its answer is reliable: on Chromium a merely dismissed prompt also rejects getUserMedia with
+ * NotAllowedError, and that is not a denial. Everywhere else that failure is the only denial signal there is.
+ */
+export function isPermissionDenied(
+    permissionState: BrowserMediaPermissionState,
+    accessIssue: MediaAccessIssue | null,
+    stateIsReliable: boolean,
+): boolean {
+    if (permissionState === "denied") {
+        return true;
+    }
+
+    if (permissionState === "granted") {
+        return false;
+    }
+
+    return stateIsReliable ? false : accessIssue === "permission_denied";
+}
+
 export const mediaPermissionDeniedStore = derived(
-    [cameraPermissionStateStore, microphonePermissionStateStore],
-    ([$cameraPermissionStateStore, $microphonePermissionStateStore]): MediaPermissionDeniedState => {
+    [cameraPermissionStateStore, microphonePermissionStateStore, cameraAccessIssueStore, microphoneAccessIssueStore],
+    ([
+        $cameraPermissionStateStore,
+        $microphonePermissionStateStore,
+        $cameraAccessIssueStore,
+        $microphoneAccessIssueStore,
+    ]): MediaPermissionDeniedState => {
         return {
-            camera: $cameraPermissionStateStore === "denied",
-            microphone: $microphonePermissionStateStore === "denied",
+            camera: isPermissionDenied($cameraPermissionStateStore, $cameraAccessIssueStore, permissionStateIsReliable),
+            microphone: isPermissionDenied(
+                $microphonePermissionStateStore,
+                $microphoneAccessIssueStore,
+                permissionStateIsReliable,
+            ),
         };
     },
     {

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -51,22 +51,9 @@ import { NoiseSuppressionController } from "./NoiseSuppressionController";
 import { buildMicrophoneAudioConstraints } from "./MicrophoneSettings";
 import { audioPlaybackStore } from "./AudioPlaybackStore";
 import { browserNotificationStore } from "./BrowserNotificationStore";
+import { cameraAccessIssueStore, type MediaAccessIssue, microphoneAccessIssueStore } from "./MediaStatusStore";
 
 export const inBackgroundSettingsStore = writable<boolean>(false);
-
-export type MediaAccessIssue = "permission_denied" | "no_device";
-
-/**
- * Last camera access failure, or no videoinput reported by the browser.
- * Cleared when the user turns the camera off manually, when a video track is obtained, or when a camera appears.
- */
-export const cameraAccessIssueStore = writable<MediaAccessIssue | null>(null);
-
-/**
- * Last microphone access failure, or no audioinput reported by the browser.
- * Cleared when the user turns the microphone off manually, when an audio track is obtained, or when a microphone appears.
- */
-export const microphoneAccessIssueStore = writable<MediaAccessIssue | null>(null);
 
 /**
  * A store that contains the camera state requested by the user (on or off).
@@ -83,6 +70,14 @@ function createRequestedCameraState() {
         disableWebcam: () => {
             set(false);
             localUserStore.setRequestedCameraState(false);
+        },
+        /**
+         * Turns the webcam off for this session only, without recording it as a user choice.
+         * A browser refusal must not look like the user wanting the camera off: the persisted state would stop
+         * the next page load from calling getUserMedia at all, leaving the denial undetected.
+         */
+        forceDisableWebcam: () => {
+            set(false);
         },
     };
 }
@@ -102,6 +97,13 @@ function createRequestedMicrophoneState() {
         disableMicrophone: () => {
             set(false);
             localUserStore.setRequestedMicrophoneState(false);
+        },
+        /**
+         * Turns the microphone off for this session only, without recording it as a user choice.
+         * See forceDisableWebcam.
+         */
+        forceDisableMicrophone: () => {
+            set(false);
         },
     };
 }
@@ -662,6 +664,29 @@ function classifyMediaAccessError(error: unknown): MediaAccessIssue | null {
     return null;
 }
 
+/**
+ * Turns a device off after a failed access attempt.
+ *
+ * A denial is the browser's decision, not the user's, so it must not be persisted: otherwise the next page load
+ * skips getUserMedia entirely and the denial can never be detected again. Any other failure (no device...) keeps
+ * the regular persisting behaviour.
+ */
+function disableCameraAfterFailure(issue: MediaAccessIssue | null): void {
+    if (issue === "permission_denied") {
+        requestedCameraState.forceDisableWebcam();
+        return;
+    }
+    requestedCameraState.disableWebcam();
+}
+
+function disableMicrophoneAfterFailure(issue: MediaAccessIssue | null): void {
+    if (issue === "permission_denied") {
+        requestedMicrophoneState.forceDisableMicrophone();
+        return;
+    }
+    requestedMicrophoneState.disableMicrophone();
+}
+
 function emitCurrentStreamOrError(setIfCurrent: SetRawStreamIfCurrent, error: unknown) {
     if (currentStream) {
         setIfCurrent({
@@ -711,9 +736,6 @@ async function runRawStreamUpdate(
         });
     }
 
-    cameraAccessIssueStore.set(null);
-    microphoneAccessIssueStore.set(null);
-
     const nextConstraints = {
         video: constraints.video ?? false,
         audio: constraints.audio ?? false,
@@ -725,6 +747,16 @@ async function runRawStreamUpdate(
         constraints.video !== false && (!deepEqual(oldConstraints.video, constraints.video) || !hasLiveVideoTrack);
     const mustRequestNewAudio =
         constraints.audio !== false && (!deepEqual(oldConstraints.audio, constraints.audio) || !hasLiveAudioTrack);
+
+    // Only clear an issue for a device we are about to retry. Failing to access a device turns it off, which
+    // immediately triggers another update for the very same device with no request in it: clearing
+    // unconditionally would erase the failure we just recorded.
+    if (mustRequestNewVideo) {
+        cameraAccessIssueStore.set(null);
+    }
+    if (mustRequestNewAudio) {
+        microphoneAccessIssueStore.set(null);
+    }
 
     if (currentStream) {
         const oldStream = currentStream;
@@ -840,11 +872,11 @@ async function runRawStreamUpdate(
                 );
                 emitCurrentStreamOrError(setIfCurrent, e);
                 const classified = classifyMediaAccessError(e);
-                requestedCameraState.disableWebcam();
                 cameraAccessIssueStore.set(classified);
+                disableCameraAfterFailure(classified);
                 if (mustRequestNewAudio) {
-                    requestedMicrophoneState.disableMicrophone();
                     microphoneAccessIssueStore.set(classified);
+                    disableMicrophoneAfterFailure(classified);
                 }
             } else if (!constraints.video && !constraints.audio) {
                 console.error("Error. getUserMedia called with no audio and no video.");
@@ -856,8 +888,9 @@ async function runRawStreamUpdate(
                 console.info("Error. Unable to get microphone and/or camera access.", newConstraints, e);
                 emitCurrentStreamOrError(setIfCurrent, e);
                 if (mustRequestNewAudio) {
-                    requestedMicrophoneState.disableMicrophone();
-                    microphoneAccessIssueStore.set(classifyMediaAccessError(e));
+                    const classified = classifyMediaAccessError(e);
+                    microphoneAccessIssueStore.set(classified);
+                    disableMicrophoneAfterFailure(classified);
                 }
             }
         }

--- a/play/src/i18n/ar-SA/camera.ts
+++ b/play/src/i18n/ar-SA/camera.ts
@@ -23,6 +23,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         content: "يجب السماح بالوصول إلى الكاميرا والميكروفون في المتصفح.", // Access to camera and microphone must be allowed in the browser.
         cameraContent: "يجب السماح بالوصول إلى الكاميرا في المتصفح.",
         microphoneContent: "يجب السماح بالوصول إلى الميكروفون في المتصفح.",
+        safariContent:
+            'افتح Safari > الإعدادات لهذا الموقع… (أو Safari > الإعدادات > المواقع > الكاميرا / الميكروفون)، واضبط هذا الموقع على "السماح"، ثم أعد تحميل الصفحة.',
         firefoxContent: 'يرجى النقر على زر "حفظ هذا القرار" لمنع طلبات الإذن المتكررة في Firefox.', // Please click the "Save this decision" button to prevent repeated permission requests in Firefox.
         continue: "المتابعة بدون كاميرا", // Continue without camera
         continueWithoutMicrophone: "المتابعة بدون ميكروفون",

--- a/play/src/i18n/ca-ES/camera.ts
+++ b/play/src/i18n/ca-ES/camera.ts
@@ -23,6 +23,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         content: "Ha de permetre accés a la càmera i el micròfon al navegador.",
         cameraContent: "Ha de permetre accés a la càmera al navegador.",
         microphoneContent: "Ha de permetre accés al micròfon al navegador.",
+        safariContent:
+            'Obriu Safari > Configuració per a aquest lloc web… (o Safari > Configuració > Llocs web > Càmera / Micròfon), definiu aquest lloc com a "Permet" i actualitzeu la pàgina.',
         firefoxContent:
             'Si us plau, feu clic a la caixa "Recordar aquesta decisió", si no voleu que Firefox sigui demanant autorització.',
         allow: "Permetre la webcam",

--- a/play/src/i18n/de-DE/camera.ts
+++ b/play/src/i18n/de-DE/camera.ts
@@ -23,6 +23,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         content: "Der Zugriff auf Kamera und Mikrofon muss im Browser freigegeben werden.",
         cameraContent: "Der Zugriff auf die Kamera muss im Browser freigegeben werden.",
         microphoneContent: "Der Zugriff auf das Mikrofon muss im Browser freigegeben werden.",
+        safariContent:
+            'Öffne Safari > Einstellungen für diese Website… (oder Safari > Einstellungen > Websites > Kamera / Mikrofon), setze diese Website auf "Erlauben" und lade die Seite neu.',
         firefoxContent:
             'Bitte klicke auf die Schaltfläche "Diese Entscheidung speichern", um erneute Nachfragen nach der Freigabe in Firefox zu verhindern.',
         allow: "Webcam erlauben",

--- a/play/src/i18n/dsb-DE/camera.ts
+++ b/play/src/i18n/dsb-DE/camera.ts
@@ -23,6 +23,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         content: "Pśistup ku kamerje a mikrofonoju musy se zwóliś we browseru.",
         cameraContent: "Pśistup ku kamerje musy se zwóliś we browseru.",
         microphoneContent: "Pśistup ku mikrofonoju musy se zwóliś we browseru.",
+        safariContent:
+            'Wócyń Safari > Nastajenja za toś to websedło… (abo Safari > Nastajenja > Websedła > Kamera / Mikrofon), staj toś to sedło na "Zwóliś" a zacytaj bok znowa.',
         firefoxContent:
             'Klikni na bublin "Te nastajenja zachowaś", aby njemusali kuždy raz wótnowotki to zwólenje we Firefoxu aktiwěrowaś',
         allow: "Webcam zwóliś",

--- a/play/src/i18n/en-US/camera.ts
+++ b/play/src/i18n/en-US/camera.ts
@@ -24,6 +24,8 @@ const camera: BaseTranslation = {
         microphoneContent: "You must allow microphone access in your browser.",
         firefoxContent:
             'Please click the "Remember this decision" checkbox, if you don\'t want Firefox to keep asking you the authorization.',
+        safariContent:
+            'Open Safari > Settings for This Website… (or Safari > Settings > Websites > Camera / Microphone), set this site to "Allow", then refresh the page.',
         allow: "Allow webcam",
         allowMicrophone: "Allow microphone",
         allowCameraMicrophone: "Allow webcam and microphone",

--- a/play/src/i18n/es-ES/camera.ts
+++ b/play/src/i18n/es-ES/camera.ts
@@ -23,6 +23,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         content: "Debe permitir acceso a la cámara y el micrófono en el navegador.",
         cameraContent: "Debe permitir acceso a la cámara en el navegador.",
         microphoneContent: "Debe permitir acceso al micrófono en el navegador.",
+        safariContent:
+            'Abra Safari > Configuración para este sitio web… (o Safari > Configuración > Sitios web > Cámara / Micrófono), establezca este sitio en "Permitir" y actualice la página.',
         firefoxContent:
             'Por favor, haga clic en la caja "Recordar esta decisión", si no quiere que Firefox siga pidiéndole autorización.',
         allow: "Permitir webcam",

--- a/play/src/i18n/fr-FR/camera.ts
+++ b/play/src/i18n/fr-FR/camera.ts
@@ -25,6 +25,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         microphoneContent: "Vous devez autoriser l'accès au microphone dans votre navigateur.",
         firefoxContent:
             'Veuillez cocher la case "Se souvenir de cette décision" si vous ne voulez pas que Firefox vous demande sans cesse l\'autorisation.',
+        safariContent:
+            "Ouvrez Safari > Réglages pour ce site web… (ou Safari > Réglages > Sites web > Caméra / Microphone), passez ce site sur « Autoriser », puis rafraîchissez la page.",
         allow: "Autoriser la webcam",
         allowMicrophone: "Autoriser le microphone",
         allowCameraMicrophone: "Autoriser la webcam et le microphone",

--- a/play/src/i18n/hsb-DE/camera.ts
+++ b/play/src/i18n/hsb-DE/camera.ts
@@ -23,6 +23,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         content: "Přistup na kameru a mikrofon dyrbi so w browseru dopušćić dać.",
         cameraContent: "Přistup na kameru dyrbi so w browseru dopušćić dać.",
         microphoneContent: "Přistup na mikrofon dyrbi so w browseru dopušćić dać.",
+        safariContent:
+            'Wočiń Safari > Nastajenja za tute websydło… (abo Safari > Nastajenja > Websydła > Kamera / Mikrofon), staj tute sydło na "Dowolić" a začitaj stronu znowa.',
         firefoxContent:
             'Prošu zaklik na "Diese Entscheidungen speichern" šaltowanskej přestrjeni, zo by so wospjetnym naprašowanjam za dowolnosću w Firefox zadźěwało.',
         allow: "Webcam dowolić",

--- a/play/src/i18n/it-IT/camera.ts
+++ b/play/src/i18n/it-IT/camera.ts
@@ -23,6 +23,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         content: "Devi consentire l'accesso alla fotocamera e al microfono nel tuo browser.",
         cameraContent: "Devi consentire l'accesso alla fotocamera nel tuo browser.",
         microphoneContent: "Devi consentire l'accesso al microfono nel tuo browser.",
+        safariContent:
+            'Apri Safari > Impostazioni per questo sito web… (o Safari > Impostazioni > Siti web > Fotocamera / Microfono), imposta questo sito su "Consenti" e aggiorna la pagina.',
         firefoxContent:
             'Si prega di cliccare sulla casella "Ricorda questa decisione", se non vuoi che Firefox continui a chiederti l\'autorizzazione.',
         allow: "Consenti webcam",

--- a/play/src/i18n/ja-JP/camera.ts
+++ b/play/src/i18n/ja-JP/camera.ts
@@ -23,6 +23,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         content: "ブラウザからカメラとマイクへのアクセスを許可する必要があります。",
         cameraContent: "ブラウザからカメラへのアクセスを許可する必要があります。",
         microphoneContent: "ブラウザからマイクへのアクセスを許可する必要があります。",
+        safariContent:
+            "Safari >「このWebサイトの設定」（または Safari > 設定 > Webサイト > カメラ / マイク）を開き、このサイトを「許可」に設定してから、ページを再読み込みしてください。",
         firefoxContent:
             "今後 Firefox からの問い合わせを受けたくない場合は「今後も同様に処理する」にチェックを付けてください。",
         allow: "ウェブカメラを許可",

--- a/play/src/i18n/ko-KR/camera.ts
+++ b/play/src/i18n/ko-KR/camera.ts
@@ -23,6 +23,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         content: "브라우저에서 카메라와 마이크 사용을 허용해야 합니다.",
         cameraContent: "브라우저에서 카메라 사용을 허용해야 합니다.",
         microphoneContent: "브라우저에서 마이크 사용을 허용해야 합니다.",
+        safariContent:
+            'Safari > 이 웹사이트에 대한 설정…(또는 Safari > 설정 > 웹사이트 > 카메라 / 마이크)을 열고 이 사이트를 "허용"으로 설정한 다음 페이지를 새로 고치세요.',
         firefoxContent: 'Firefox가 계속해서 권한을 묻지 않도록 하려면 "이 결정을 기억" 체크박스를 클릭하세요.',
         allow: "웹캠 허용",
         allowMicrophone: "마이크 허용",

--- a/play/src/i18n/nl-NL/camera.ts
+++ b/play/src/i18n/nl-NL/camera.ts
@@ -23,6 +23,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         content: "Je moet toegang tot de camera en microfoon toestaan in je browser.",
         cameraContent: "Je moet toegang tot de camera toestaan in je browser.",
         microphoneContent: "Je moet toegang tot de microfoon toestaan in je browser.",
+        safariContent:
+            'Open Safari > Instellingen voor deze website… (of Safari > Instellingen > Websites > Camera / Microfoon), zet deze site op "Sta toe" en ververs de pagina.',
         firefoxContent:
             'Vink het vakje "Deze beslissing onthouden" aan als je niet wilt dat Firefox je steeds om toestemming vraagt.',
         allow: "Webcam toestaan",

--- a/play/src/i18n/pt-BR/camera.ts
+++ b/play/src/i18n/pt-BR/camera.ts
@@ -22,6 +22,8 @@ const camera: BaseTranslation = {
         content: "Você deve permitir o acesso à câmera e ao microfone em seu navegador.",
         cameraContent: "Você deve permitir o acesso à câmera em seu navegador.",
         microphoneContent: "Você deve permitir o acesso ao microfone em seu navegador.",
+        safariContent:
+            'Abra Safari > Configurações para este site… (ou Safari > Configurações > Sites > Câmera / Microfone), defina este site como "Permitir" e atualize a página.',
         firefoxContent:
             'Por favor, clique na caixa de seleção "Lembrar esta decisão", se você não quiser que o Firefox continue pedindo a autorização.',
         allow: "Permitir webcam",

--- a/play/src/i18n/zh-CN/camera.ts
+++ b/play/src/i18n/zh-CN/camera.ts
@@ -23,6 +23,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         content: "你必须在浏览器设置里允许摄像头和麦克风访问权限。",
         cameraContent: "你必须在浏览器设置里允许摄像头访问权限。",
         microphoneContent: "你必须在浏览器设置里允许麦克风访问权限。",
+        safariContent:
+            "打开 Safari >「此网站的设置」（或 Safari > 设置 > 网站 > 摄像头 / 麦克风），将本站设为「允许」，然后刷新页面。",
         firefoxContent: '如果你不希望Firefox反复要求授权，请选中"记住此决定"。',
         allow: "允许网络摄像头",
         allowMicrophone: "允许麦克风",

--- a/play/src/i18n/zh-TW/camera.ts
+++ b/play/src/i18n/zh-TW/camera.ts
@@ -23,6 +23,8 @@ const camera: DeepPartial<Translation["camera"]> = {
         content: "你必須在瀏覽器設定裡允許攝影機和麥克風的存取權限。",
         cameraContent: "你必須在瀏覽器設定裡允許攝影機的存取權限。",
         microphoneContent: "你必須在瀏覽器設定裡允許麥克風的存取權限。",
+        safariContent:
+            "打開 Safari >「此網站的設定」（或 Safari > 設定 > 網站 > 攝影機 / 麥克風），將本站設為「允許」，然後重新整理頁面。",
         firefoxContent: "如果你不希望 Firefox 反覆要求授權，請勾選「記住此決定」。",
         allow: "允許網路攝影機",
         allowMicrophone: "允許麥克風",


### PR DESCRIPTION
## Problem

When a user denies camera/microphone access and reloads the page, Chrome shows a modal explaining the denial and how to re-enable it. On Safari **nothing appears at all** — the modal is not broken there, it is unreachable. Firefox has the same root cause.

Everything gated on `navigator.permissions.query({name: "camera"})`:

- **Firefox** rejects the query outright.
- **Safari** answers — but always `"prompt"`, *even once the user has denied*. It never says `"denied"`.

So `mediaPermissionDeniedStore` reported "not denied" forever, `showHelpCameraSettings()` early-returned, and the subscription that actually opens the popup never fired.

Confirmed in Safari with permissions set to Deny:

```json
{ "perm_camera": "prompt", "perm_mic": "prompt", "gum": "REJECTS: NotAllowedError" }
```

## Approach

The `getUserMedia` failure is the one signal that does work everywhere, and it was already being classified into `cameraAccessIssueStore` / `microphoneAccessIssueStore` — but only used for tooltips. The same fallback was also already implemented, duplicated inline in `MediaSettingsPanel.svelte`.

So the predicate now asks **"can this browser's answer be trusted?"** rather than "does the API exist?":

- `"denied"` / `"granted"` are conclusive everywhere.
- Only Chromium ever answers `"denied"`, so it stays authoritative — a merely dismissed prompt (which also rejects `getUserMedia` with `NotAllowedError` while the state stays `"prompt"`) still does **not** open the modal.
- Everywhere else, the `getUserMedia` failure is the only denial signal that exists, so it is used.

Firefox needs no special case: its state stays `null`, which lands in the same branch as Safari.

## Three fixes were needed for a refresh to work

The trigger alone was not enough — the first two bugs silently defeated it:

1. **The signal was erased.** `cameraAccessIssueStore.set(null)` ran unconditionally at the top of every `runRawStreamUpdate`. Disabling a device after a failure immediately triggers another update, which wiped the failure microseconds after it was recorded. Now only cleared for a device about to be retried.
2. **`getUserMedia` was never called again.** `disableWebcam()` persisted "camera off" to localStorage. After a denial the device stayed off *across reloads*, so the next page load never called `getUserMedia`, and the denial became undetectable — exactly the reported scenario. Added `forceDisableWebcam()` / `forceDisableMicrophone()`: a browser refusal is not a user choice and must not be persisted.
3. **Import cycle.** `MediaStore → HelpSettingsStore → MediaStatusStore`, so the access-issue stores moved into `MediaStatusStore` (a leaf). `MediaSettingsPanel` now consumes the hoisted store instead of duplicating the logic.

## Making the modal usable once shown

- `getNavigatorType()` was called at component init with no `try`/`catch`, and it **throws** on unrecognised user agents — which the fallback now makes reachable. Guarded, reusing the pattern already in `CameraMenuItem.svelte`.
- Added Safari re-enable instructions (`camera.help.safariContent`, all 15 locales — `i18n:check` is a CI gate).
- The illustration container rendered an empty 288px grey box on Safari, which has no screenshot. It is now only rendered when an image exists.

## Behaviour change to note in review

On Chrome, dismissing the permission prompt without choosing no longer shows "open settings" in the media settings panel. Dismissing is not denying, and this now matches the modal. Previously the panel's inline logic disagreed with the store.

## Verification

- `npm run test -- MediaStatusStore` — **8 passed**, covering Chrome hard-block, Chrome dismissed-prompt (no false positive), Safari `"prompt"`+denial, Firefox, no-device, and query-in-flight.
- `npm run typecheck` — 0 errors. `svelte-check`, `eslint`, `prettier`, `i18n:check` — all green.
- Manual, Safari with Deny set: modal appears on load **and survives a refresh**; re-allowing in Safari settings + reload restores the camera with no modal.

## Known limitation

Users who denied *before* this ships still have `requestedCameraStateKey`/`requestedMicrophoneStateKey` persisted to `false` from the old code, so their device is not requested and the modal will not appear on load. It self-heals at the natural moment: clicking to turn the device on triggers `getUserMedia`, which fails and opens the modal.

No migration is proposed on purpose. The default for those keys is `true`, so clearing them would **turn cameras and microphones back on** for everyone who deliberately muted — a very common action in this app — and there is no way to distinguish a persisted denial from a deliberate mute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)