### PR TITLE
fix(play): copy patches/ into the Docker builder so the phaser patch applies

### DIFF
--- a/play/Dockerfile
+++ b/play/Dockerfile
@@ -14,6 +14,10 @@ ARG NODE_OPTIONS="--max-old-space-size=16384"
 WORKDIR /usr/src
 RUN apt-get update && apt-get install -y git
 COPY package.json package-lock.json ./
+# The root postinstall runs patch-package during the npm ci below; it needs the
+# patch files present in the build context, otherwise the play build bundles an
+# unpatched phaser (patches/phaser+4.2.0.patch fixes TilemapGPULayer rendering).
+COPY patches ./patches
 COPY play/package.json play/package.json
 COPY play/packages/iframe-api-typings/package.json play/packages/iframe-api-typings/package.json
 COPY libs/messages/package.json libs/messages/package.json


### PR DESCRIPTION
## Problem

The deployed `play` build ships **pristine, unpatched Phaser** — none of the fixes in `patches/phaser+4.2.0.patch` (tile rotation, transparent empty GPU-layer cells, animated-tile frames) reach staging/prod. Confirmed on staging by fetching the served tilemap-shader JS chunk: it has the baseline shader but none of the patch markers (`mod(flags, 4.0)`, `if (tile.empty) { discard; }`, `animations.length * 2`).

## Cause

In `play/Dockerfile`, the `builder` stage copies `package.json` / `package-lock.json` but **never copies the root `patches/` directory** into the image. The root `postinstall` runs `patch-package` during that stage's `npm ci`, but with no `patches/` present it finds nothing to apply and exits 0 — so `npm run build` bundles unpatched Phaser and the build stays green.

Local dev is unaffected: the play container mounts host `node_modules`, which a full root `npm install` has already patched.

## Fix

`COPY patches ./patches` in the builder stage before `npm ci`, so `patch-package` has the patch files to apply. One line; `patch-package` is already installed there and the postinstall already runs.

The runtime stage (`--omit=dev`) doesn't rebuild — it copies the already-built `play/` from the builder — so it needs nothing.

## Verify after deploy

Grep the served tilemap-shader chunk for `mod(flags, 4.0)` (rotation) or `if (tile.empty) { discard; }`; shader string literals survive minification.

Related: upstream Phaser fix phaserjs/phaser#7338.