### PR TITLE
fix(chat): send Markdown as formatted_body instead of rendering it on read

### DIFF
--- a/play/src/front/Chat/Components/Room/Message/MessageText.svelte
+++ b/play/src/front/Chat/Components/Room/Message/MessageText.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import type { Readable, Unsubscriber } from "svelte/store";
-    import { Marked } from "marked";
     import { onDestroy, onMount } from "svelte";
     import type { ChatMessageContent } from "../../../Connection/ChatConnection";
+    import { renderMarkdown } from "../../../Services/MessageFormatter";
     import { sanitizeHTML } from "./WA-HTML-Sanitizer";
 
     interface Props {
@@ -13,58 +13,24 @@
 
     let { content, hasDepth, updateMessageBody = () => {} }: Props = $props();
 
-    async function getMarked(body: string): Promise<Marked> {
-        let marked: Marked;
-
-        // Let's lazy load hljs and markedHighlight if the message contains ```.
-        if (body.includes("```")) {
-            const hljsPromise = import("highlight.js");
-            const markedHighlightPromise = import("marked-highlight");
-            const [hljsModule, markedHighlightModule] = await Promise.all([hljsPromise, markedHighlightPromise]);
-
-            marked = new Marked(
-                markedHighlightModule.markedHighlight({
-                    langPrefix: "hljs language-",
-                    highlight(code, lang) {
-                        const language = hljsModule.default.getLanguage(lang) ? lang : "plaintext";
-                        return hljsModule.default.highlight(code, { language }).value;
-                    },
-                }),
-            );
-        } else {
-            marked = new Marked();
-        }
-
-        // Custom renderer for links
-        const renderer = new marked.Renderer();
-        renderer.link = function ({ href, title, tokens }) {
-            const titleAttr = title ? `title="${title}"` : "";
-            const text = this.parser.parseInline(tokens);
-            return `<a href="${href}" target="_blank" rel="noopener noreferrer" ${titleAttr} style="color: white;">${text}</a>`;
-        };
-
-        // Apply the custom renderer and enable line breaks
-        marked.use({
-            renderer,
-            breaks: true,
-        });
-
-        return marked;
-    }
-
     let html = $state("");
 
     let unsubscriber: Unsubscriber | undefined;
     onMount(() => {
         unsubscriber = content.subscribe((value) => {
-            let promiseHtml = getMarked(value.body).then((marked) => marked.parse(value.body));
+            // A formattedBody is already the HTML the sender rendered: display it as-is (sanitized below)
+            // rather than re-parsing it, which is what makes formatting from other Matrix clients survive.
+            // Without one, the message is plain text; parsing it as Markdown is what keeps the messages
+            // sent before WorkAdventure emitted a `formatted_body` rendering the way they always have.
+            const promiseHtml =
+                value.formattedBody !== undefined ? Promise.resolve(value.formattedBody) : renderMarkdown(value.body);
             promiseHtml
                 .then((result) => {
                     html = result;
                 })
                 .catch((error) => {
                     console.error("Failed to parse markdown content", error);
-                    html = $content.body;
+                    html = value.body;
                 })
                 .finally(() => {
                     updateMessageBody();

--- a/play/src/front/Chat/Components/Room/MessageInput.svelte
+++ b/play/src/front/Chat/Components/Room/MessageInput.svelte
@@ -64,7 +64,7 @@
         const text = event.clipboardData.getData("text");
 
         insertTextAtCursor(text);
-        message = messageInput?.innerHTML ?? "";
+        message = messageInput?.innerText ?? "";
         event.preventDefault();
     }
     function insertTextAtCursor(text: string) {
@@ -105,7 +105,7 @@
 {#if !disabled}
     <div
         data-testid={dataTestid}
-        bind:innerHTML={message}
+        bind:innerText={message}
         contenteditable="true"
         bind:this={messageInput}
         onkeydown={handleKeyDown}
@@ -125,7 +125,7 @@
 {:else}
     <div
         data-testid={dataTestid}
-        bind:innerHTML={message}
+        bind:innerText={message}
         contenteditable="false"
         bind:this={messageInput}
         class={`${inputClass} opacity-70/50 cursor-not-allowed`}

--- a/play/src/front/Chat/Components/Room/MessageInputBar.svelte
+++ b/play/src/front/Chat/Components/Room/MessageInputBar.svelte
@@ -126,7 +126,7 @@
         }
         if (stopTypingTimeOutID) clearTimeout(stopTypingTimeOutID);
 
-        const isEmptyMessage = message.replace(/<br>/g, "").trim() == "" || message == undefined;
+        const isEmptyMessage = message == undefined || message.trim() === "";
         if (keyDownEvent.key === "Enter" || isEmptyMessage) {
             room.stopTyping().catch((error) => console.error(error));
         } else {
@@ -148,10 +148,7 @@
         }
 
         if (keyDownEvent.key === "Enter" && !isEmptyMessage) {
-            // message contains HTML tags. Actually, the only tags we allow are for the new line, ie. <br> tags.
-            // We can turn those back into carriage returns.
-            const messageToSend = message.replace(/<br>/g, "\n");
-            sendMessage(messageToSend).catch((error) => console.error(error));
+            sendMessage(message).catch((error) => console.error(error));
         }
     }
 
@@ -207,9 +204,7 @@
     }
 
     function onInputHandler() {
-        // We remove the <br> tags and the whitespace to check if the message is empty
-        const messageToSend = message.replace(/<br>/g, "").trim();
-        if (messageToSend == "" || messageToSend == undefined) {
+        if (message == undefined || message.trim() === "") {
             if (stopTypingTimeOutID) clearTimeout(stopTypingTimeOutID);
             room.stopTyping().catch((error) => console.error(error));
         }

--- a/play/src/front/Chat/Connection/ChatConnection.ts
+++ b/play/src/front/Chat/Connection/ChatConnection.ts
@@ -419,9 +419,19 @@ export type ChatTimelineItem =
 export type ChatMessageType = "proximity" | "text" | "incoming" | "outcoming" | "image" | "file" | "audio" | "video";
 export type ChatMessageContent = {
     /**
-     * The body can contain HTML. It will be run against DOMPurify before being outputted to the user.
+     * The plain text of the message (the Matrix `body`). It is never HTML: it is the fallback shown by
+     * clients that cannot render `formattedBody`, so it must stay readable as-is.
      */
     body: string;
+    /**
+     * The HTML rendering of the message, from the Matrix `formatted_body` of a sender that advertised
+     * `format: "org.matrix.custom.html"`. It will be run against DOMPurify before being outputted to
+     * the user.
+     *
+     * Undefined for plain text messages, for non-Matrix (proximity) messages, and for messages sent
+     * before WorkAdventure emitted a `format`. Those are rendered by parsing `body` as Markdown.
+     */
+    formattedBody?: string;
     url: string | undefined;
     thumbnailUrl?: string;
     mediaState?: "ready" | "loading" | "error";

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatMessage.ts
@@ -12,11 +12,21 @@ import type {
     ChatThreadSummary,
     ChatUser,
 } from "../ChatConnection";
+import { htmlSerializeIfNeeded } from "../../Services/MessageFormatter";
 import { chatUserFactoryFromRoom } from "./MatrixChatUser";
 import { MatrixChatMessageReaction } from "./MatrixChatMessageReaction";
 import { MatrixChatRelation } from "./MatrixChatRelation";
 import { resolveAttachmentMediaFromEvent, resolveImageMediaFromEvent } from "./MatrixMediaResolver";
 import { shouldRenderQuotedReply } from "./MatrixThreadUtils";
+
+/**
+ * Strips the `<mx-reply>` block that senders prepend to the `formatted_body` of a reply as a fallback
+ * for clients that cannot resolve the quoted event. We render the quoted message ourselves, so the
+ * fallback would show up twice.
+ */
+function stripReplyFallback(formattedBody: string): string {
+    return formattedBody.replace(/^(<mx-reply>).*(<\/mx-reply>)/, "");
+}
 
 export class MatrixChatMessage implements ChatMessage {
     id: string;
@@ -127,10 +137,19 @@ export class MatrixChatMessage implements ChatMessage {
         const content = this.event.getContent();
         const quotedMessage = this.getQuotedMessage();
 
+        // `formatted_body` is only HTML when the sender advertises `format`. WorkAdventure used to mirror
+        // the Markdown source into `formatted_body` without any `format`, so messages sent by older
+        // clients must not be treated as HTML: leaving formattedBody undefined sends them down the
+        // Markdown-on-`body` path in MessageText, which is how they have always been rendered.
+        const isFormattedBody =
+            content.format === "org.matrix.custom.html" && typeof content.formatted_body === "string";
+        const formattedBody = isFormattedBody ? stripReplyFallback(content.formatted_body) : undefined;
+
         if (quotedMessage !== undefined && content.formatted_body) {
             this.quotedMessage = quotedMessage;
             return {
-                body: content.formatted_body.replace(/^(<mx-reply>).*(<\/mx-reply>)/, ""),
+                body: isFormattedBody ? content.body : stripReplyFallback(content.formatted_body),
+                formattedBody,
                 url: undefined,
             };
         }
@@ -152,7 +171,7 @@ export class MatrixChatMessage implements ChatMessage {
             };
         }
 
-        return { body: content.body, url: undefined };
+        return { body: content.body, formattedBody, url: undefined };
     }
 
     private loadImageMediaIfNeeded() {
@@ -348,11 +367,17 @@ export class MatrixChatMessage implements ChatMessage {
             throw new Error("Missing permission to edit this message");
         }
         try {
+            const formattedBody = await htmlSerializeIfNeeded(newContent);
+            const formatting =
+                formattedBody !== undefined
+                    ? { format: "org.matrix.custom.html" as const, formatted_body: formattedBody }
+                    : {};
             await this.room.client.sendEvent(this.room.roomId, EventType.RoomMessage, {
                 msgtype: MsgType.Text,
                 "m.relates_to": { rel_type: RelationType.Replace, event_id: this.id },
-                "m.new_content": { msgtype: MsgType.Text, body: newContent },
+                "m.new_content": { msgtype: MsgType.Text, body: newContent, ...formatting },
                 body: newContent,
+                ...formatting,
             });
         } catch (error) {
             console.error(error);

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatRoom.ts
@@ -83,6 +83,7 @@ import { chatVisibilityStore } from "../../../Stores/ChatStore";
 import type { UserProviderMerger } from "../../UserProviderMerger/UserProviderMerger";
 import { waitForGameSceneStore } from "../../../Stores/GameSceneStore";
 import { ProximityChatRoom } from "../Proximity/ProximityChatRoom";
+import { htmlSerializeIfNeeded } from "../../Services/MessageFormatter";
 import { MatrixChatMessage } from "./MatrixChatMessage";
 import { MatrixChatLightPoll } from "./MatrixChatLightPoll";
 import { MatrixChatPoll } from "./MatrixChatPoll";
@@ -1709,8 +1710,8 @@ export class MatrixChatRoom
     }
 
     sendMessage(message: string) {
-        this.matrixRoom.client
-            .sendMessage(this.matrixRoom.roomId, this.getMessageContent(message))
+        this.getMessageContent(message)
+            .then((content) => this.matrixRoom.client.sendMessage(this.matrixRoom.roomId, content))
             .then(() => {
                 selectedChatMessageToReply.set(null);
             })
@@ -1764,8 +1765,15 @@ export class MatrixChatRoom
         return threadConversation;
     }
 
-    private getMessageContent(message: string): RoomMessageEventContent {
-        const content: RoomMessageEventContent = { body: message, msgtype: MsgType.Text, formatted_body: message };
+    private async getMessageContent(message: string): Promise<RoomMessageEventContent> {
+        const formattedBody = await htmlSerializeIfNeeded(message);
+        const content: RoomMessageEventContent = {
+            body: message,
+            msgtype: MsgType.Text,
+            // `formatted_body` is only honoured by receiving clients when `format` comes along with it,
+            // and it is only worth sending when the Markdown rendering adds something to the body.
+            ...(formattedBody !== undefined ? { format: "org.matrix.custom.html", formatted_body: formattedBody } : {}),
+        };
         this.applyReplyContentIfReplyTo(content);
         return content;
     }

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatThread.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatThread.ts
@@ -26,6 +26,7 @@ import type {
 import LL from "../../../../i18n/i18n-svelte";
 import { selectedChatMessageToReply } from "../../Stores/ChatStore";
 import type { PictureStore } from "../../../Stores/PictureStore";
+import { htmlSerializeIfNeeded } from "../../Services/MessageFormatter";
 import type { MatrixChatMessage } from "./MatrixChatMessage";
 import { MatrixChatMessageReaction } from "./MatrixChatMessageReaction";
 import type { MatrixChatRoom } from "./MatrixChatRoom";
@@ -503,9 +504,8 @@ export class MatrixChatThread implements ChatThread {
         if (!get(this.canSendMessages)) {
             return;
         }
-        this.parentRoom
-            .getMatrixRoom()
-            .client.sendMessage(this.parentRoom.id, this.id, this.getMessageContent(message))
+        this.getMessageContent(message)
+            .then((content) => this.parentRoom.getMatrixRoom().client.sendMessage(this.parentRoom.id, this.id, content))
             .then(() => {
                 selectedChatMessageToReply.set(null);
             })
@@ -552,8 +552,15 @@ export class MatrixChatThread implements ChatThread {
         }
     }
 
-    private getMessageContent(message: string): RoomMessageEventContent {
-        const content: RoomMessageEventContent = { body: message, msgtype: MsgType.Text, formatted_body: message };
+    private async getMessageContent(message: string): Promise<RoomMessageEventContent> {
+        const formattedBody = await htmlSerializeIfNeeded(message);
+        const content: RoomMessageEventContent = {
+            body: message,
+            msgtype: MsgType.Text,
+            // `formatted_body` is only honoured by receiving clients when `format` comes along with it,
+            // and it is only worth sending when the Markdown rendering adds something to the body.
+            ...(formattedBody !== undefined ? { format: "org.matrix.custom.html", formatted_body: formattedBody } : {}),
+        };
         this.applyThreadRelationContent(content);
         return content;
     }

--- a/play/src/front/Chat/Services/MessageFormatter.ts
+++ b/play/src/front/Chat/Services/MessageFormatter.ts
@@ -1,0 +1,99 @@
+import { Marked, type Token } from "marked";
+
+/**
+ * Token types that carry no formatting of their own. A message built only out of those renders
+ * identically whether or not it goes through Markdown, so it needs no `formatted_body`.
+ *
+ * Mirrors the TEXT_NODES list of Element's `Markdown.isPlainText()`, which also treats line breaks
+ * as plain text.
+ */
+const PLAIN_TEXT_TOKEN_TYPES = new Set(["paragraph", "text", "space", "br"]);
+
+/**
+ * Builds the Marked instance used for every Markdown rendering of the chat, both when serializing an
+ * outgoing message and when displaying one. Both sides have to share it: otherwise a message could
+ * render differently for its sender and for its receiver.
+ */
+export async function getMarked(body: string): Promise<Marked> {
+    let marked: Marked;
+
+    // Let's lazy load hljs and markedHighlight if the message contains ```.
+    if (body.includes("```")) {
+        const hljsPromise = import("highlight.js");
+        const markedHighlightPromise = import("marked-highlight");
+        const [hljsModule, markedHighlightModule] = await Promise.all([hljsPromise, markedHighlightPromise]);
+
+        marked = new Marked(
+            markedHighlightModule.markedHighlight({
+                langPrefix: "hljs language-",
+                highlight(code, lang) {
+                    const language = hljsModule.default.getLanguage(lang) ? lang : "plaintext";
+                    return hljsModule.default.highlight(code, { language }).value;
+                },
+            }),
+        );
+    } else {
+        marked = new Marked();
+    }
+
+    // Custom renderer for links
+    const renderer = new marked.Renderer();
+    renderer.link = function ({ href, title, tokens }) {
+        const titleAttr = title ? `title="${title}"` : "";
+        const text = this.parser.parseInline(tokens);
+        return `<a href="${href}" target="_blank" rel="noopener noreferrer" ${titleAttr} style="color: white;">${text}</a>`;
+    };
+
+    // Apply the custom renderer and enable line breaks
+    marked.use({
+        renderer,
+        breaks: true,
+    });
+
+    return marked;
+}
+
+/**
+ * Renders Markdown to HTML.
+ *
+ * The result is NOT sanitized: every caller has to run it through DOMPurify before injecting it into
+ * the DOM.
+ */
+export async function renderMarkdown(body: string): Promise<string> {
+    const marked = await getMarked(body);
+    return marked.parse(body);
+}
+
+/**
+ * Descends into the inline tokens of each token. Block constructs (list, table, blockquote...) surface
+ * under their own token type, so finding one is enough to stop: there is no need to walk their items or
+ * rows.
+ */
+function containsOnlyPlainTextTokens(tokens: Token[]): boolean {
+    return tokens.every((token) => {
+        if (!PLAIN_TEXT_TOKEN_TYPES.has(token.type)) {
+            return false;
+        }
+        const nestedTokens = "tokens" in token ? token.tokens : undefined;
+        return nestedTokens === undefined || containsOnlyPlainTextTokens(nestedTokens);
+    });
+}
+
+function isPlainText(marked: Marked, body: string): boolean {
+    return containsOnlyPlainTextTokens(marked.lexer(body));
+}
+
+/**
+ * Returns the HTML to put in the `formatted_body` of an outgoing Matrix message, or undefined when
+ * `body` is plain text and a formatted body would carry nothing more than the body itself.
+ *
+ * Omitting it on plain messages is what Element does in `htmlSerializeIfNeeded`: a `formatted_body`
+ * that merely repeats the body pushes every receiving client into the HTML path for nothing.
+ */
+export async function htmlSerializeIfNeeded(body: string): Promise<string | undefined> {
+    const marked = await getMarked(body);
+    if (isPlainText(marked, body)) {
+        return undefined;
+    }
+    return marked.parse(body);
+}

--- a/play/src/front/Chat/Services/tests/MessageFormatter.test.ts
+++ b/play/src/front/Chat/Services/tests/MessageFormatter.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { htmlSerializeIfNeeded, renderMarkdown } from "../MessageFormatter";
+
+describe("htmlSerializeIfNeeded", () => {
+    it.each([
+        ["plain text", "hello"],
+        ["text holding HTML special characters", 'a < b & "c" > d'],
+        ["a single line break", "line1\nline2"],
+        ["a blank line", "line1\n\nline2"],
+    ])("returns no formatted body for %s", async (_case, body) => {
+        // A formatted_body that only repeats the body pushes every receiving client into the HTML path
+        // for nothing, so it must be omitted. Element omits it on the same inputs.
+        await expect(htmlSerializeIfNeeded(body)).resolves.toBeUndefined();
+    });
+
+    it.each([
+        ["bold", "**bold**", "<strong>bold</strong>"],
+        ["a heading", "# title", "<h1>title</h1>"],
+        ["a list", "- item", "<li>item</li>"],
+        ["inline code", "`code`", "<code>code</code>"],
+        ["a blockquote", "> quote", "<blockquote>"],
+    ])("renders %s to a formatted body", async (_case, body, expected) => {
+        await expect(htmlSerializeIfNeeded(body)).resolves.toContain(expected);
+    });
+
+    it("escapes HTML special characters it renders", async () => {
+        // The body is plain text straight from the composer. It must never be able to smuggle markup
+        // into the formatted body.
+        await expect(htmlSerializeIfNeeded("**bold** a < b & c")).resolves.toContain("a &lt; b &amp; c");
+    });
+
+    it("renders a fenced code block", async () => {
+        // Exercises the lazy highlight.js / marked-highlight path.
+        const formattedBody = await htmlSerializeIfNeeded("```js\nconst a = 1;\n```");
+        expect(formattedBody).toContain("<code");
+        expect(formattedBody).toContain("const");
+    });
+});
+
+describe("renderMarkdown", () => {
+    it("escapes HTML special characters coming from a plain text body", async () => {
+        await expect(renderMarkdown("a < b & c")).resolves.toContain("a &lt; b &amp; c");
+    });
+
+    it("turns a line break into a <br>", async () => {
+        await expect(renderMarkdown("line1\nline2")).resolves.toContain("<br>");
+    });
+});


### PR DESCRIPTION
Supersedes #4463, following @moufmouf's review there:

> The underlying problem is that we should send a "formatted_body" along the "body" in the message. Which means Markdown transformations should happen when sending a message (and not when reading it).

## The problem

The composer was bound to the contenteditable's `innerHTML` (`MessageInput.svelte`), so the string it produced was HTML: a typed `<` came out as `&lt;`, `&` as `&amp;`, and newlines as `<br>`. That string was sent as the Matrix `body` — the plain text fallback every other client displays — so Element showed the raw entities.

Three consequences, all from the same root:

- `formatted_body` was set to that same string and **no `format` was ever emitted anywhere in the repo**. The spec only honours `formatted_body` alongside `format: "org.matrix.custom.html"`, so the field was inert for interop *and* wrong, since it was never HTML.
- Incoming messages from Element carry a real `formatted_body`; we ignored it and parsed their `body` as Markdown instead, losing the sender's formatting.
- The send button passed the raw `message` and skipped the `<br>` → newline replacement the Enter key did, so the two paths disagreed.

#4463 decoded the HTML entities just before sending. That fixes the wire format but leaves the pipeline HTML-typed, and it decodes via `div.innerHTML`, which fires `<img onerror>` handlers even on a detached node.

## The fix

Mirrors Element's `createMessageContent` / `htmlSerializeIfNeeded`:

- the composer yields **plain text** (`bind:innerText`), which removes the entity escaping and the `<br>` juggling at the source — both `<br>` replacements are gone, and Enter and the send button now take the same path;
- `body` carries that text as-is;
- Markdown is rendered to HTML **at send time** into `formatted_body`, together with its `format`;
- `formatted_body` is **omitted for plain text messages** — a body-identical formatted body only pushes receivers into the HTML path for nothing. Like Element, line breaks still count as plain text.

Applied to the room, thread and edit paths (the edit path previously emitted no `formatted_body` at all).

On read, a `formatted_body` is displayed as the HTML it is (sanitized), instead of being re-parsed as Markdown.

### Backward compatibility

Messages sent before this change carry no `format`, so they are still rendered by parsing `body` as Markdown and look **exactly as they always have**. The Markdown instance is shared between serializing and displaying, so a message cannot render differently for its sender and its receiver.

## Verification

- `tsc --noEmit`, `eslint`, `svelte-check`: clean
- `vitest`: 161 tests pass (27 files), including 13 new ones on `MessageFormatter` — there was no coverage at all on this path before
- The plain-text detection was diffed against `marked`'s own `walkTokens` over 35 inputs: 0 mismatches

Not verified at runtime: I could not drive the real app from a worktree, so **the composer change (`bind:innerText`) deserves a click-through on the deploy environment** — typing, pasting multi-line text, the emoji picker, and IME composition all read back through that binding.

## Left out on purpose

`WA-HTML-Sanitizer.ts` calls `DOMPurify.sanitize(html)` with the default config, which is considerably more permissive than the allowlist the Matrix spec recommends and that Element implements. Worth tightening, but it carries its own display-regression risk and belongs in a separate PR.