### PR TITLE
fix(mobile): stop a long press from selecting the whole map

### DIFF
--- a/play/src/front/Chat/Connection/Matrix/CreateRecoveryKeyDialog.svelte
+++ b/play/src/front/Chat/Connection/Matrix/CreateRecoveryKeyDialog.svelte
@@ -85,7 +85,9 @@
             {#if generatedSecretStorageKey?.encodedPrivateKey}
                 <p>{$LL.chat.e2ee.createRecoveryKey.privateKeyDescription()}</p>
                 <div class="flex justify-between">
-                    <p class="text-green-500 m-0 content-center">{generatedSecretStorageKey.encodedPrivateKey}</p>
+                    <p class="text-green-500 m-0 content-center select-text">
+                        {generatedSecretStorageKey.encodedPrivateKey}
+                    </p>
                     <button data-testid="downloadRecoveryKeyButton" onclick={downloadPrivateKeyFile}>
                         <IconFileDownload />
                     </button>

--- a/play/src/front/Components/UI/ErrorScreen.svelte
+++ b/play/src/front/Components/UI/ErrorScreen.svelte
@@ -130,6 +130,8 @@
         p.code {
             font-size: 12px;
             opacity: 0.6;
+            /* Prefixed too, or WebKit ignores the opt-in and `body` keeps this unselectable. */
+            -webkit-user-select: text;
             user-select: text;
         }
         .loading {

--- a/play/src/front/style/style.css
+++ b/play/src/front/style/style.css
@@ -7,6 +7,28 @@ body {
     overflow: hidden;
 }
 
+/* Nothing is selectable except real text, so a long press on a control cannot start a
+ * selection that spills over the map. Opt back in with the `select-text` utility.
+ *
+ * Anchor on `body`, never `*`: `user-select` propagates, so a direct declaration on a
+ * descendant beats the propagated value. `*` would match every element directly and,
+ * this file being unlayered, would override `select-text` in @layer utilities.
+ *
+ * `-webkit-user-select` is load-bearing: WebKit ignores the unprefixed property before
+ * Safari 17.4. */
+body {
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+/* Guard for older iOS, where an inherited `user-select: none` could block typing. */
+input,
+textarea,
+[contenteditable]:not([contenteditable="false"]) {
+    -webkit-user-select: text;
+    user-select: text;
+}
+
 body button:focus,
 body img:focus,
 body input:focus {

--- a/play/src/front/style/style.css
+++ b/play/src/front/style/style.css
@@ -551,40 +551,6 @@ div.action.danger p.action-body {
     }
 }
 
-#game-overlay {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    user-select: none;
-
-    & + div {
-        pointer-events: none;
-        z-index: 2;
-    }
-
-    & + div > div {
-        pointer-events: auto;
-    }
-
-    & > div {
-        position: relative;
-        width: 100%;
-        height: 100%;
-
-        & > div.scrollable {
-            overflow-y: auto;
-            -webkit-overflow-scrolling: touch;
-            pointer-events: auto;
-        }
-    }
-
-    &.hide {
-        visibility: hidden;
-    }
-}
-
-
 .active-discussion div.emoji-picker {
     transform: translateX(-188px);
 }


### PR DESCRIPTION
## Problem

On mobile, long-pressing a UI control — typically the zoom `+`/`−` buttons of the map explorer — starts a native text selection that spills over and highlights the whole map and UI.

## Root cause

`style.css` defined `#game-overlay { … user-select: none; … }`, but **no element bears that id** — the only occurrence of `game-overlay` in the repo was the rule itself. The guard was dead, so nothing covered `body`, `#game` or the canvas.

`ExplorerMenu.svelte:51` already calls `preventDefault()` on `pointerdown`, which is enough on Android Chrome but not on iOS Safari — hence a CSS fix.

The policy was already half in place: `select-text` opt-ins exist on the chat messages, the stats box, the calendar and the todo list.

## Changes

1. **`style.css`** — anchor the policy on `body`, keep `select-text` as the opt-in. Two details are load-bearing and are commented in place:
   - **`body`, never `*`.** `user-select` propagates, so a direct declaration on a descendant beats the propagated value. `*` would match every element directly and, this file being unlayered, would override `select-text` in `@layer utilities` — breaking every opt-in. Verified: with `*`, `select-text` selects 0 chars on all three engines.
   - **`-webkit-user-select` is not decorative.** WebKit ignores the unprefixed property before Safari 17.4, so an unprefixed-only rule fixes nothing on Safari — precisely the platform of the bug.
2. **`CreateRecoveryKeyDialog.svelte`** — opt the E2EE recovery key back in; it is the one string a user may legitimately copy by hand.
3. **`ErrorScreen.svelte`** — add the `-webkit-` prefix to the existing error-code opt-in. It was the only hand-written opt-in in the codebase, and it was inert on WebKit; once `body` carried the rule, Safari users could no longer select the code they need to report a problem. The `select-text` utility emits both spellings, so every other opt-in was already safe.
4. **`style.css`** — drop the dead `#game-overlay` block (separate commit, behavioural no-op).

## Deliberately not done

- **No `-webkit-touch-callout: none`.** Not needed: `-webkit-user-select: none` already suppresses the long-press selection, and the zoom buttons are `<div>` + `<svg>` — no `href`, no `<img>`, so no callout to suppress. On `body` it would cost the long-press menus on chat links and images ("Copy link", "Save image").
- Existing `.noselect` / `select-none` usages are left alone: redundant now, harmless.

## Verification

Driving the real app (real Tailwind/Vite CSS chain), on **Chromium and WebKit**: dragging over UI text selects nothing, while the error code stays selectable. Negative control against the pre-patch stylesheet: UI text selected 30 chars before, 0 after, on all three engines. Chat, invitation link, chat composer and inputs are unchanged.

The WebKit regression in point 3 was caught this way — the error code came back empty on WebKit and populated on Chromium.

**Still needs a real device:** the iOS long-press gesture itself. Playwright emulates touch but not Safari's selection gesture recognizer, so it cannot reproduce the original bug. Please check on an iPhone: long-press the zoom buttons (no selection, no magnifier); long-press a chat message (selection works); long-press a chat link ("Copy link" still offered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)