### PR TITLE
fix(chat): give the chat a way out when the connection is OFFLINE

### DIFF
--- a/play/src/front/Chat/Components/ChatActionMenu.svelte
+++ b/play/src/front/Chat/Components/ChatActionMenu.svelte
@@ -146,6 +146,18 @@
             {/if}
         </button>
     </div>
+{:else if !hasSearch && hasCloseChat}
+    <!-- No search to offer, so there is no menu to hang the close on: show it on its own. Without
+         this, an OFFLINE chat (any anonymous user gets VoidChatConnection) has no way out at all,
+         since the action bar that owns the close is hidden whenever hasCloseChat is true. -->
+    <button
+        class="p-3 hover:bg-white/10 rounded aspect-square w-12 h-12 relative z-50"
+        data-testid="closeChatButton"
+        onclick={closeChat}
+        aria-label={$LL.chat.closeChat()}
+    >
+        <IconX font-size="20" />
+    </button>
 {/if}
 
 {#if menuOpen && !searchActive}

--- a/play/src/front/Chat/Components/ChatHeader.svelte
+++ b/play/src/front/Chat/Components/ChatHeader.svelte
@@ -25,6 +25,8 @@
     let searchLoader = $state(false);
     const DONE_TYPING_INTERVAL = 2000;
 
+    // ChatSidebar floats its own close button over this header as soon as a room is selected, so the
+    // menu must drop its close there or the two stack up.
     let isInSpecificDiscussion = $derived($selectedRoomStore !== undefined);
 
     function handleToggleSearch() {
@@ -123,7 +125,7 @@
     <div class="relative">
         <ChatActionMenu
             {searchActive}
-            hasCloseChat={$hideActionBarStoreBecauseOfChatBar}
+            hasCloseChat={$hideActionBarStoreBecauseOfChatBar && !isInSpecificDiscussion}
             hasSearch={$chatStatusStore !== "OFFLINE" && !isInSpecificDiscussion}
             matrixChatConnection={hasMatrixChatCapabilities(chat) ? chat : undefined}
             onToggleSearch={handleToggleSearch}


### PR DESCRIPTION
## Problem

On mobile, the chat and the user list cannot be closed when no conversation is selected. Inside a conversation, the close button is there.

## Root cause

On a phone the chat covers the whole screen, so `ActionBar.svelte:47` (`{#if !$hideActionBarStoreBecauseOfChatBar}`) hides itself and takes `CloseChatMenuItem` with it — the chat must then carry its own close button. It has two, and **outside a conversation both can vanish at once**:

- `ChatSidebar.svelte:111` guards the floating X with `isInSpecificDiscussion`, so it never shows in the room list or the user list.
- `ChatActionMenu`'s dropdown hangs off `hasSearch`, which is false when the chat connection is `OFFLINE` — `ChatActionMenu.svelte:50` and `:125` both require it, so nothing renders at all.

**Any anonymous user is OFFLINE**: `GameManager.ts:405` only builds a Matrix connection `if (matrixServerUrl && get(userIsConnected))`, otherwise it hands out a `VoidChatConnection` whose `connectionStatus` is pinned to `OFFLINE` (`VoidChatConnection.ts:18`).

So an anonymous user on a phone, in the room list, had **no way to close the chat at all** — and no search button either, since that is the same gate. Inside a conversation the floating X still showed, which is the asymmetry that got reported.

State table on mobile (`hideActionBarStoreBecauseOfChatBar` is always true there: 375 − 335 = 40 < 285):

| State | `hasSearch` | `ChatActionMenu` | Floating X | Way out |
|---|---|---|---|---|
| Room list / user list, online | true | chevron → dropdown | absent | dropdown |
| Room list / user list, **OFFLINE** | false | **nothing** | absent | **none** |
| In a conversation | — | header not rendered | present | direct X |

## Changes

Restore the `{:else if !hasSearch && hasCloseChat}` branch dropped by `9adb73ab1`: with no search to offer there is no menu to hang the close on, so the close shows on its own. **The dropdown and its two entries are untouched** — the chevron keeps offering Search and Close as before.

`9adb73ab1` dropped that branch to kill a double close button, and that was a real bug: in the user list with a room still selected, `ChatActionMenu`'s X and `ChatSidebar`'s floating X both showed. This narrows `hasCloseChat` with `!isInSpecificDiscussion`, which fixes it at the source — the header's close now stands down precisely when `ChatSidebar` floats its own — so the branch can come back safely.

`ChatSidebar` is left exactly as it is on master.

Net: **15 insertions, 1 deletion**, across `ChatActionMenu.svelte` and `ChatHeader.svelte`.

Resulting behaviour on mobile:

| State | `hasCloseChat` | `ChatActionMenu` | Floating X |
|---|---|---|---|
| Room list / user list, online | true | chevron → {Search, Close} | absent |
| Room list / user list, OFFLINE | true | **direct X** | absent |
| User list, room still selected | **false** | nothing | X |
| In a conversation | — | header not rendered | X |

Exactly one close affordance in every state; desktop is unaffected (`hasCloseChat` is false there, and `ActionBar` still owns the close).

## Verification

Prettier clean. The branch conditions were worked through by hand against every mobile state (table above); `svelte-check` could not be re-run at the end — it OOMs in the local container — but the change only restores a branch that shipped before `9adb73ab1`, using symbols that are all still declared (`closeChat`, the `hasCloseChat` prop, `IconX`), and `chat.closeChat` exists in all 15 locales.

**Not visually verified.** I could not render the chat: the local SaaS stack has an empty `rooms` table, so no map loads. Worth a look when running the app, in particular the OFFLINE room list on a phone.

## Why CI missed it

`matrixChatArea.spec.ts` is tagged `@nomobile` and skips on mobile at runtime; `matrixChat.spec.ts` runs on `mobilechromium` but only ever clicks `closeChatButton` from inside a conversation — the state that always worked. No test exercises `chatStatusStore === "OFFLINE"`. Follow-up coverage is worth adding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)