### PR TITLE
feat(chat): show link previews in the timeline

### DIFF
--- a/play/src/front/Chat/Components/Room/Message.svelte
+++ b/play/src/front/Chat/Components/Room/Message.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
     import { derived, readable } from "svelte/store";
     import type { Readable } from "svelte/store";
+    import { tick } from "svelte";
+    import type { WorkAdventureComponent } from "../../../../types/component";
     import type {
         ChatMessage,
         ChatMessageType,
         ChatRoomMember,
         ChatThreadSummary,
     } from "../../Connection/ChatConnection";
-    import type { WorkAdventureComponent } from "../../../../types/component";
     import LL, { locale } from "../../../../i18n/i18n-svelte";
+    import { localUserStore } from "../../../Connection/LocalUserStore";
+    import { findPreviewableLinks } from "../../Links/LinkExtractor";
+    import { shouldFetchUrlPreview } from "../../Links/UrlPreviewSettings";
     import Avatar from "../Avatar.svelte";
 
     import { resolveChatUserColor } from "../../Connection/Matrix/services/WaMatrixProfileService";
@@ -17,6 +21,7 @@
     import { selectedRoomStore } from "../../Stores/SelectRoomStore";
     import { isThreadPanelEnabledStore, selectedThreadStore } from "../../Stores/SelectedThreadStore";
     import { roomSidePanelStore } from "../../Stores/RoomSidePanelStore";
+    import LinkPreviewGroup from "./Message/LinkPreviewGroup.svelte";
     import MessageOptions from "./MessageOptions.svelte";
     import MessageImage from "./Message/MessageImage.svelte";
     import MessageText from "./Message/MessageText.svelte";
@@ -40,6 +45,11 @@
         /** Root message reply preview; hide inside an open thread timeline (main room only). */
         showThreadSummary?: boolean;
         updateMessageBody?: (event: { id: string }) => void;
+        /**
+         * Whether the room encrypts messages. Defaults to encrypted so that a caller which
+         * forgets to pass it gets no link previews rather than a privacy leak.
+         */
+        isEncrypted?: Readable<boolean>;
     }
 
     let {
@@ -49,9 +59,11 @@
         membersForMessageAvatars = undefined,
         showThreadSummary = true,
         updateMessageBody = () => {},
+        isEncrypted = readable(true),
     }: Props = $props();
 
     let messageRef: HTMLDivElement | undefined = $state();
+    let messageBodyRef: HTMLDivElement | undefined = $state();
 
     let {
         id,
@@ -67,7 +79,50 @@
         reactions,
     } = $derived(message);
 
+    let previewLinks: string[] = $state([]);
+
+    let mayPreviewLinks = $derived(
+        replyDepth === 0 &&
+            date !== null &&
+            shouldFetchUrlPreview({
+                isProximity: type === "proximity",
+                isEncrypted: $isEncrypted,
+                previewsInCleartextRooms: localUserStore.getChatUrlPreviews(),
+                previewsInPrivateMessages: localUserStore.getChatUrlPreviewsInPrivate(),
+            }),
+    );
+
+    let matrixClient = $derived(getMatrixClientForChatTint());
+
+    async function refreshPreviewLinks() {
+        if (!mayPreviewLinks) {
+            previewLinks = [];
+            return;
+        }
+        // MessageText signals us from a .finally(), which can land before Svelte has flushed
+        // the rendered markdown into the DOM.
+        await tick();
+        const root = messageBodyRef;
+        if (root === undefined) {
+            return;
+        }
+        const links = findPreviewableLinks(root);
+        // Only publish a real change, or every re-render would refetch.
+        if (links.length !== previewLinks.length || links.some((link, i) => link !== previewLinks[i])) {
+            previewLinks = links;
+        }
+    }
+
     const handleUpdateMessageBody = () => {
+        updateMessageBody({
+            id: message.id,
+        });
+        refreshPreviewLinks().catch((error) => console.error("Failed to collect links to preview", error));
+    };
+
+    // Preview cards grow the message after the fact; the timeline needs to re-anchor, but the
+    // links themselves have not changed, so this deliberately skips the extraction.
+    const handlePreviewResize = () => {
         updateMessageBody({
             id: message.id,
         });
@@ -213,7 +268,21 @@
                     {/if}
 
                     {@const MessageComponent = messageType[type]}
-                    <MessageComponent updateMessageBody={handleUpdateMessageBody} {content} />
+                    <!-- Scoped to this message's own body: the outer container also holds the
+                         quoted message, whose links are not ours to preview. -->
+                    <div bind:this={messageBodyRef}>
+                        <MessageComponent updateMessageBody={handleUpdateMessageBody} {content} />
+                    </div>
+
+                    {#if mayPreviewLinks && matrixClient && date && previewLinks.length > 0}
+                        <LinkPreviewGroup
+                            eventId={id}
+                            links={previewLinks}
+                            client={matrixClient}
+                            eventTimestamp={date.getTime()}
+                            onResize={handlePreviewResize}
+                        />
+                    {/if}
 
                     {#if $reactionsWithUsers.length > 0}
                         <MessageReactions

--- a/play/src/front/Chat/Components/Room/Message/LinkPreviewCard.svelte
+++ b/play/src/front/Chat/Components/Room/Message/LinkPreviewCard.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+    import type { UrlPreview } from "../../../Links/UrlPreviewFetcher";
+    import { openChatLinkAsCoWebsite } from "../../../Links/ChatLinkOpener";
+
+    interface Props {
+        preview: UrlPreview;
+        /** Called once the image has settled, so the timeline can re-anchor. */
+        onResize?: () => void;
+    }
+
+    let { preview, onResize = () => {} }: Props = $props();
+
+    // Same behaviour as clicking the bare link in the message body.
+    function open(event: MouseEvent) {
+        if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
+            return;
+        }
+        event.preventDefault();
+        openChatLinkAsCoWebsite(preview.link).catch((error) => console.error("Failed to open link preview", error));
+    }
+</script>
+
+<a
+    class="block no-underline rounded border border-solid border-white/10 bg-contrast/40 overflow-hidden hover:bg-contrast/60 transition-colors"
+    href={preview.link}
+    target="_blank"
+    rel="noopener noreferrer"
+    onclick={open}
+>
+    {#if preview.image}
+        <img
+            class="w-full object-cover max-h-40 block"
+            src={preview.image.src}
+            alt={preview.image.alt ?? ""}
+            loading="lazy"
+            draggable="false"
+            onload={onResize}
+            onerror={onResize}
+        />
+    {/if}
+    <div class="flex gap-2 items-start p-2">
+        {#if preview.siteIcon}
+            <img
+                class="w-8 h-8 rounded object-cover shrink-0"
+                src={preview.siteIcon}
+                alt=""
+                loading="lazy"
+                draggable="false"
+                onload={onResize}
+                onerror={onResize}
+            />
+        {/if}
+        <div class="min-w-0">
+            <div class="text-xs opacity-75 truncate">{preview.siteName}</div>
+            <div class="text-sm font-bold text-white line-clamp-2">{preview.title}</div>
+            {#if preview.description}
+                <div class="text-xs opacity-75 line-clamp-2 mt-0.5">{preview.description}</div>
+            {/if}
+        </div>
+    </div>
+</a>

--- a/play/src/front/Chat/Components/Room/Message/LinkPreviewGroup.svelte
+++ b/play/src/front/Chat/Components/Room/Message/LinkPreviewGroup.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+    import type { MatrixClient } from "matrix-js-sdk";
+    import { tick } from "svelte";
+    import LL from "../../../../../i18n/i18n-svelte";
+    import { UrlPreviewFetcher, type UrlPreview } from "../../../Links/UrlPreviewFetcher";
+    import LinkPreviewCard from "./LinkPreviewCard.svelte";
+
+    const MAX_PREVIEWS_WHEN_LIMITED = 2;
+
+    interface Props {
+        eventId: string;
+        links: string[];
+        client: MatrixClient;
+        eventTimestamp: number;
+        /** Lets the timeline re-anchor once cards change the height of the message. */
+        onResize?: () => void;
+    }
+
+    let { eventId, links, client, eventTimestamp, onResize = () => {} }: Props = $props();
+
+    let storageKey = $derived(`hide_preview_${eventId}`);
+    // Writable: reads back what the user chose for this message last time, and hide() overrides it.
+    let hidden = $derived(localStorage.getItem(storageKey) === "1");
+    let limited = $state(true);
+    let previews: UrlPreview[] = $state([]);
+
+    let fetcher = $derived(new UrlPreviewFetcher(client, eventTimestamp));
+
+    $effect(() => {
+        // Read every dependency before the first await. Anything read after one is not
+        // tracked, and this effect would then never run again.
+        const currentLinks = links;
+        const currentFetcher = fetcher;
+        const isHidden = hidden;
+        const isLimited = limited;
+
+        if (isHidden || currentLinks.length === 0) {
+            previews = [];
+            return;
+        }
+
+        const controller = new AbortController();
+        const wanted = isLimited ? currentLinks.slice(0, MAX_PREVIEWS_WHEN_LIMITED) : currentLinks;
+
+        (async () => {
+            const results = await Promise.all(wanted.map((link) => currentFetcher.fetchPreview(link, true)));
+            if (controller.signal.aborted) {
+                return;
+            }
+            previews = results.filter((preview): preview is UrlPreview => preview !== null);
+            // The message just got taller; let the timeline catch up before it measures.
+            await tick();
+            onResize();
+        })().catch((error) => console.error("Failed to load link previews", error));
+
+        return () => controller.abort();
+    });
+
+    function hide() {
+        localStorage.setItem(storageKey, "1");
+        hidden = true;
+    }
+
+    let remaining = $derived(links.length - previews.length);
+</script>
+
+{#if !hidden && previews.length > 0}
+    <div class="flex flex-col gap-1 px-3 pb-2 pt-1" aria-label={$LL.chat.urlPreview.label()}>
+        {#each previews as preview (preview.link)}
+            <LinkPreviewCard {preview} {onResize} />
+        {/each}
+
+        <div class="flex gap-2 items-center">
+            {#if links.length > MAX_PREVIEWS_WHEN_LIMITED}
+                <button
+                    class="text-xs underline opacity-75 hover:opacity-100 bg-transparent border-none p-0 cursor-pointer text-white"
+                    onclick={() => (limited = !limited)}
+                >
+                    {limited ? $LL.chat.showMore({ number: remaining }) : $LL.chat.showLess()}
+                </button>
+            {/if}
+            <button
+                class="text-xs underline opacity-75 hover:opacity-100 bg-transparent border-none p-0 cursor-pointer text-white ml-auto"
+                onclick={hide}
+            >
+                {$LL.chat.urlPreview.hide()}
+            </button>
+        </div>
+    </div>
+{/if}

--- a/play/src/front/Chat/Components/Room/RoomTimeline.svelte
+++ b/play/src/front/Chat/Components/Room/RoomTimeline.svelte
@@ -566,6 +566,7 @@
                                 showHeader={item.showHeader}
                                 membersForMessageAvatars={room.membersForMessageAvatars}
                                 showThreadSummary={room.conversationKind === "room"}
+                                isEncrypted={room.isEncrypted}
                             />
                         {/if}
                     </li>

--- a/play/src/front/Chat/Links/LinkExtractor.ts
+++ b/play/src/front/Chat/Links/LinkExtractor.ts
@@ -1,0 +1,71 @@
+// A link inside one of these is being shown, not shared: previewing it would be noise.
+const SKIPPED_TAGS = new Set(["PRE", "CODE", "BLOCKQUOTE"]);
+
+function parseUrl(href: string): URL | undefined {
+    try {
+        return new URL(href);
+    } catch {
+        return undefined;
+    }
+}
+
+function previewableHref(anchor: HTMLAnchorElement): string | undefined {
+    const href = anchor.getAttribute("href");
+    if (href === null) {
+        return undefined;
+    }
+
+    const url = parseUrl(href);
+    if (url === undefined || (url.protocol !== "http:" && url.protocol !== "https:")) {
+        return undefined;
+    }
+
+    // Previewing ourselves tells the user nothing they don't already see.
+    if (url.origin === window.location.origin) {
+        return undefined;
+    }
+
+    const text = anchor.textContent ?? "";
+
+    // "example.com/an-article": a deep link, worth previewing.
+    if (text.includes("/")) {
+        return href;
+    }
+    // A bare "example.com". Prose is full of things that autolink into a bare host
+    // ("foo.pl", "etc.io") and a card under each of them would be unbearable.
+    if (text.toLowerCase().trim().startsWith(url.host.toLowerCase())) {
+        return undefined;
+    }
+    // Anything else is a [labelled](link), which the sender wrote on purpose.
+    return href;
+}
+
+function collectLinks(nodes: Iterable<Element>, links: Set<string>): void {
+    for (const node of nodes) {
+        if (node.tagName === "A") {
+            const href = previewableHref(node as HTMLAnchorElement);
+            if (href !== undefined) {
+                links.add(href);
+            }
+        } else if (SKIPPED_TAGS.has(node.tagName)) {
+            continue;
+        } else if (node.children.length > 0) {
+            collectLinks(node.children, links);
+        }
+    }
+}
+
+/**
+ * Collects the links worth previewing out of an already rendered message.
+ *
+ * Reads the DOM rather than the message source on purpose: a reply is rendered from its
+ * formatted_body HTML, which never passes through our markdown renderer, so anything that
+ * inspects the source would silently miss every link in a reply.
+ *
+ * @returns unique hrefs, in the order they appear.
+ */
+export function findPreviewableLinks(root: Element): string[] {
+    const links = new Set<string>();
+    collectLinks([root], links);
+    return [...links];
+}

--- a/play/src/front/Chat/Links/UrlPreviewFetcher.ts
+++ b/play/src/front/Chat/Links/UrlPreviewFetcher.ts
@@ -149,7 +149,10 @@ export function previewFromResponse(
 export class UrlPreviewFetcher {
     private readonly cache = new Map<string, UrlPreview | null>();
 
-    public constructor(private readonly client: MatrixClient, private readonly eventTimestamp: number) {}
+    public constructor(
+        private readonly client: MatrixClient,
+        private readonly eventTimestamp: number,
+    ) {}
 
     public async fetchPreview(link: string, loadImage: boolean): Promise<UrlPreview | null> {
         const cached = this.cache.get(link);

--- a/play/src/front/Chat/Links/UrlPreviewFetcher.ts
+++ b/play/src/front/Chat/Links/UrlPreviewFetcher.ts
@@ -1,0 +1,173 @@
+import type { IPreviewUrlResponse, MatrixClient } from "matrix-js-sdk";
+
+export const PREVIEW_WIDTH_PX = 478;
+export const PREVIEW_HEIGHT_PX = 200;
+/** Below this, the image is a favicon rather than a thumbnail worth showing full width. */
+const MIN_PREVIEW_PX = 96;
+const MIN_IMAGE_SIZE_BYTES = 8192;
+
+export interface UrlPreviewImage {
+    src: string;
+    width?: number;
+    height?: number;
+    alt?: string;
+}
+
+export interface UrlPreview {
+    link: string;
+    title: string;
+    siteName: string;
+    description?: string;
+    /** A thumbnail worth showing full width. Mutually exclusive with siteIcon in practice. */
+    image?: UrlPreviewImage;
+    /** A favicon-sized image, for the compact card. */
+    siteIcon?: string;
+}
+
+/**
+ * OpenGraph declares every value a string, but Synapse hands some back as numbers.
+ */
+function numberFromOpenGraph(value: string | number | undefined): number | undefined {
+    if (typeof value === "number") {
+        return value;
+    }
+    if (typeof value === "string" && value !== "") {
+        const parsed = Number.parseInt(value, 10);
+        if (!Number.isNaN(parsed)) {
+            return parsed;
+        }
+    }
+    return undefined;
+}
+
+function trimmedString(value: string | number | undefined): string | undefined {
+    if (typeof value !== "string") {
+        return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed === "" ? undefined : trimmed;
+}
+
+function decodeEntities(value: string): string {
+    const element = document.createElement("textarea");
+    element.innerHTML = value;
+    return element.value;
+}
+
+/**
+ * Picks the best title/description/site name an OpenGraph response can support.
+ *
+ * Pages lie by omission constantly, hence the cascade: a card with a URL for a title and
+ * nothing else is worse than no card at all, which is what `null` from fetchPreview means.
+ */
+export function metadataFromResponse(
+    response: IPreviewUrlResponse,
+    link: string,
+): Pick<UrlPreview, "title" | "description" | "siteName"> {
+    let title = trimmedString(response["og:title"]);
+    let description = trimmedString(response["og:description"]);
+    const siteName = trimmedString(response["og:site_name"]) ?? new URL(link).hostname;
+
+    if (title === undefined && description !== undefined) {
+        title = description;
+        description = undefined;
+    } else if (title === undefined) {
+        title = siteName;
+    }
+
+    // A description that just repeats the site name is filler.
+    if (description !== undefined && description.toLowerCase() === siteName.toLowerCase()) {
+        description = undefined;
+    }
+
+    return { title, description: description === undefined ? undefined : decodeEntities(description), siteName };
+}
+
+function isThumbnail(width: number | undefined, height: number | undefined, bytes: number | undefined): boolean {
+    if (width !== undefined && width < MIN_PREVIEW_PX) {
+        return false;
+    }
+    if (height !== undefined && height < MIN_PREVIEW_PX) {
+        return false;
+    }
+    if (bytes !== undefined && bytes < MIN_IMAGE_SIZE_BYTES) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Turns an OpenGraph response into something renderable, or null when there is nothing
+ * worth showing.
+ */
+export function previewFromResponse(
+    client: Pick<MatrixClient, "mxcUrlToHttp">,
+    response: IPreviewUrlResponse,
+    link: string,
+    loadImage: boolean,
+): UrlPreview | null {
+    const { title, description, siteName } = metadataFromResponse(response, link);
+    const mxcImage = trimmedString(response["og:image"]);
+
+    // Nothing but the URL we already show as a link.
+    if (title === link && mxcImage === undefined) {
+        return null;
+    }
+
+    const preview: UrlPreview = { link, title, siteName, description };
+    if (mxcImage === undefined || !loadImage) {
+        return preview;
+    }
+
+    const width = numberFromOpenGraph(response["og:image:width"]);
+    const height = numberFromOpenGraph(response["og:image:height"]);
+    const bytes = numberFromOpenGraph(response["matrix:image:size"]);
+
+    if (isThumbnail(width, height, bytes)) {
+        const src = client.mxcUrlToHttp(mxcImage, PREVIEW_WIDTH_PX, PREVIEW_HEIGHT_PX, "scale");
+        if (src !== null) {
+            preview.image = {
+                src,
+                width: width === undefined ? undefined : Math.min(width, PREVIEW_WIDTH_PX),
+                height,
+                alt: trimmedString(response["og:image:alt"]),
+            };
+        }
+        return preview;
+    }
+
+    const icon = client.mxcUrlToHttp(mxcImage);
+    if (icon !== null) {
+        preview.siteIcon = icon;
+    }
+    return preview;
+}
+
+/**
+ * Fetches link previews from the homeserver, one per link, remembering what it already asked.
+ */
+export class UrlPreviewFetcher {
+    private readonly cache = new Map<string, UrlPreview | null>();
+
+    public constructor(private readonly client: MatrixClient, private readonly eventTimestamp: number) {}
+
+    public async fetchPreview(link: string, loadImage: boolean): Promise<UrlPreview | null> {
+        const cached = this.cache.get(link);
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        let response: IPreviewUrlResponse;
+        try {
+            response = await this.client.getUrlPreview(link, this.eventTimestamp);
+        } catch (error) {
+            // A page with no OpenGraph tags is the common case, not a fault worth shouting about.
+            console.debug("No URL preview available for", link, error);
+            return null;
+        }
+
+        const preview = previewFromResponse(this.client, response, link, loadImage);
+        this.cache.set(link, preview);
+        return preview;
+    }
+}

--- a/play/src/front/Chat/Links/UrlPreviewSettings.ts
+++ b/play/src/front/Chat/Links/UrlPreviewSettings.ts
@@ -1,0 +1,27 @@
+export interface UrlPreviewVisibility {
+    /**
+     * Proximity messages travel peer to peer and never reach the homeserver. Asking it to
+     * preview one would hand it a URL it was never meant to see.
+     */
+    isProximity: boolean;
+    /** Same reasoning for an encrypted room: a preview request undoes the encryption. */
+    isEncrypted: boolean;
+    /** User setting for rooms where the homeserver has already seen the message anyway. */
+    previewsInCleartextRooms: boolean;
+    /** User setting, per device, for the cases above. Off unless explicitly turned on. */
+    previewsInPrivateMessages: boolean;
+}
+
+/**
+ * Decides whether we may ask the homeserver to preview a link in a given message.
+ *
+ * Mirrors Element's split between `urlPreviewsEnabled` and `urlPreviewsEnabled_e2ee`, with
+ * proximity folded into the private case: Element defaults previews on in cleartext rooms
+ * because the server already has the message, which is not true of proximity chat.
+ */
+export function shouldFetchUrlPreview(visibility: UrlPreviewVisibility): boolean {
+    if (visibility.isProximity || visibility.isEncrypted) {
+        return visibility.previewsInPrivateMessages;
+    }
+    return visibility.previewsInCleartextRooms;
+}

--- a/play/src/front/Chat/Links/tests/LinkExtractor.test.ts
+++ b/play/src/front/Chat/Links/tests/LinkExtractor.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { findPreviewableLinks } from "../LinkExtractor";
+
+function render(html: string): Element {
+    const root = document.createElement("div");
+    root.innerHTML = html;
+    return root;
+}
+
+describe("findPreviewableLinks", () => {
+    it("previews a deep link", () => {
+        expect(findPreviewableLinks(render(`<a href="https://example.com/article">example.com/article</a>`))).toEqual([
+            "https://example.com/article",
+        ]);
+    });
+
+    it("previews a labelled link even when the label has no slash", () => {
+        expect(findPreviewableLinks(render(`<a href="https://example.com">Read this</a>`))).toEqual([
+            "https://example.com",
+        ]);
+    });
+
+    // Prose autolinks bare hosts constantly; a card under each would be unbearable.
+    it("skips a bare host that autolinked", () => {
+        expect(findPreviewableLinks(render(`<a href="https://example.com">example.com</a>`))).toEqual([]);
+        expect(findPreviewableLinks(render(`<a href="https://foo.pl">foo.pl</a>`))).toEqual([]);
+    });
+
+    it.each(["PRE", "CODE", "BLOCKQUOTE"])("skips links inside %s", (tag) => {
+        const html = `<${tag.toLowerCase()}><a href="https://example.com/x">example.com/x</a></${tag.toLowerCase()}>`;
+        expect(findPreviewableLinks(render(html))).toEqual([]);
+    });
+
+    it("finds links nested in other markup", () => {
+        expect(
+            findPreviewableLinks(
+                render(`<p><strong><em><a href="https://example.com/deep">example.com/deep</a></em></strong></p>`),
+            ),
+        ).toEqual(["https://example.com/deep"]);
+    });
+
+    it("deduplicates while keeping discovery order", () => {
+        const html = `
+            <a href="https://b.com/2">b.com/2</a>
+            <a href="https://a.com/1">a.com/1</a>
+            <a href="https://b.com/2">b.com/2 again</a>`;
+        expect(findPreviewableLinks(render(html))).toEqual(["https://b.com/2", "https://a.com/1"]);
+    });
+
+    it.each(["mailto:someone@example.com", "matrix:u/a:example.com", "/relative/path", "#anchor"])(
+        "skips the non-http(s) href %s",
+        (href) => {
+            expect(findPreviewableLinks(render(`<a href="${href}">something/here</a>`))).toEqual([]);
+        },
+    );
+
+    it("skips links back to our own origin", () => {
+        const html = `<a href="${window.location.origin}/@/world/room">${window.location.origin}/@/world/room</a>`;
+        expect(findPreviewableLinks(render(html))).toEqual([]);
+    });
+
+    it("returns nothing for a message without links", () => {
+        expect(findPreviewableLinks(render(`<p>just some words</p>`))).toEqual([]);
+    });
+
+    // A reply is rendered from formatted_body HTML, which never reaches our markdown
+    // renderer. Reading the DOM is what makes this case work at all.
+    it("finds links in already formed reply HTML", () => {
+        const html = `<p>agreed, see <a href="https://example.com/doc">example.com/doc</a></p>`;
+        expect(findPreviewableLinks(render(html))).toEqual(["https://example.com/doc"]);
+    });
+});

--- a/play/src/front/Chat/Links/tests/UrlPreviewFetcher.test.ts
+++ b/play/src/front/Chat/Links/tests/UrlPreviewFetcher.test.ts
@@ -102,7 +102,12 @@ describe("previewFromResponse", () => {
             link,
             true,
         );
-        expect(preview?.image).toEqual({ src: "https://media/mxc://x/y?w=478&h=200", width: 478, height: 630, alt: undefined });
+        expect(preview?.image).toEqual({
+            src: "https://media/mxc://x/y?w=478&h=200",
+            width: 478,
+            height: 630,
+            alt: undefined,
+        });
         expect(preview?.siteIcon).toBeUndefined();
     });
 

--- a/play/src/front/Chat/Links/tests/UrlPreviewFetcher.test.ts
+++ b/play/src/front/Chat/Links/tests/UrlPreviewFetcher.test.ts
@@ -1,0 +1,146 @@
+import type { IPreviewUrlResponse, MatrixClient } from "matrix-js-sdk";
+import { describe, expect, it } from "vitest";
+import { metadataFromResponse, previewFromResponse } from "../UrlPreviewFetcher";
+
+const client: Pick<MatrixClient, "mxcUrlToHttp"> = {
+    mxcUrlToHttp: (mxc: string, width?: number, height?: number) =>
+        width === undefined ? `https://media/${mxc}` : `https://media/${mxc}?w=${width}&h=${height}`,
+};
+
+// Loosely typed on purpose: the SDK types og:image:width as a number, but the OpenGraph spec
+// says string and real servers send both, which is the whole point of some of these cases.
+function response(overrides: Record<string, string | number | undefined>): IPreviewUrlResponse {
+    return { "og:title": "", "og:type": "website", "og:url": "", ...overrides };
+}
+
+describe("metadataFromResponse", () => {
+    it("keeps title, description and site name when the page provides them", () => {
+        expect(
+            metadataFromResponse(
+                response({ "og:title": "A title", "og:description": "A description", "og:site_name": "Example" }),
+                "https://example.com/a",
+            ),
+        ).toEqual({ title: "A title", description: "A description", siteName: "Example" });
+    });
+
+    it("falls back to the hostname when there is no site name", () => {
+        expect(metadataFromResponse(response({ "og:title": "T" }), "https://news.example.com/a").siteName).toBe(
+            "news.example.com",
+        );
+    });
+
+    it("promotes the description to title when there is no title", () => {
+        expect(metadataFromResponse(response({ "og:description": "Only this" }), "https://example.com/a")).toEqual({
+            title: "Only this",
+            description: undefined,
+            siteName: "example.com",
+        });
+    });
+
+    it("falls back to the site name when there is neither title nor description", () => {
+        expect(metadataFromResponse(response({ "og:site_name": "Example" }), "https://example.com/a").title).toBe(
+            "Example",
+        );
+    });
+
+    it("drops a description that merely repeats the site name", () => {
+        expect(
+            metadataFromResponse(
+                response({ "og:title": "T", "og:description": "example", "og:site_name": "Example" }),
+                "https://example.com/a",
+            ).description,
+        ).toBeUndefined();
+    });
+
+    it("decodes html entities in the description", () => {
+        expect(
+            metadataFromResponse(
+                response({ "og:title": "T", "og:description": "Ben &amp; Jerry&#39;s" }),
+                "https://example.com/a",
+            ).description,
+        ).toBe("Ben & Jerry's");
+    });
+
+    it("ignores blank values", () => {
+        expect(
+            metadataFromResponse(
+                response({ "og:title": "   ", "og:description": "  ", "og:site_name": "Example" }),
+                "https://example.com/a",
+            ),
+        ).toEqual({ title: "Example", description: undefined, siteName: "Example" });
+    });
+});
+
+describe("previewFromResponse", () => {
+    const link = "https://example.com/a";
+
+    // A card whose only content is the URL already shown as a link is worse than no card.
+    it("returns null when there is nothing but the link itself", () => {
+        expect(previewFromResponse(client, response({ "og:title": link }), link, true)).toBeNull();
+    });
+
+    it("keeps a link-titled response that at least has an image", () => {
+        const preview = previewFromResponse(
+            client,
+            response({ "og:title": link, "og:image": "mxc://x/y", "og:image:width": 800, "og:image:height": 400 }),
+            link,
+            true,
+        );
+        expect(preview?.image?.src).toBe("https://media/mxc://x/y?w=478&h=200");
+    });
+
+    it("renders a large image as a thumbnail", () => {
+        const preview = previewFromResponse(
+            client,
+            response({
+                "og:title": "T",
+                "og:image": "mxc://x/y",
+                "og:image:width": 1200,
+                "og:image:height": 630,
+                "matrix:image:size": 50000,
+            }),
+            link,
+            true,
+        );
+        expect(preview?.image).toEqual({ src: "https://media/mxc://x/y?w=478&h=200", width: 478, height: 630, alt: undefined });
+        expect(preview?.siteIcon).toBeUndefined();
+    });
+
+    it.each([
+        ["too narrow", { "og:image:width": 32, "og:image:height": 320 }],
+        ["too short", { "og:image:width": 320, "og:image:height": 32 }],
+        ["too few bytes", { "og:image:width": 320, "og:image:height": 320, "matrix:image:size": 512 }],
+    ])("treats a %s image as a site icon rather than a thumbnail", (_name, dims) => {
+        const preview = previewFromResponse(
+            client,
+            response({ "og:title": "T", "og:image": "mxc://x/y", ...dims }),
+            link,
+            true,
+        );
+        expect(preview?.siteIcon).toBe("https://media/mxc://x/y");
+        expect(preview?.image).toBeUndefined();
+    });
+
+    it("parses opengraph numbers given as strings", () => {
+        const preview = previewFromResponse(
+            client,
+            response({ "og:title": "T", "og:image": "mxc://x/y", "og:image:width": "1200", "og:image:height": "630" }),
+            link,
+            true,
+        );
+        expect(preview?.image?.width).toBe(478);
+    });
+
+    // Media is hidden: we still want the text card, just no image request.
+    it("omits the image when told not to load media", () => {
+        const preview = previewFromResponse(
+            client,
+            response({ "og:title": "T", "og:image": "mxc://x/y", "og:image:width": 1200, "og:image:height": 630 }),
+            link,
+            false,
+        );
+        expect(preview?.title).toBe("T");
+        expect(preview?.image).toBeUndefined();
+        expect(preview?.siteIcon).toBeUndefined();
+    });
+});

--- a/play/src/front/Chat/Links/tests/UrlPreviewSettings.test.ts
+++ b/play/src/front/Chat/Links/tests/UrlPreviewSettings.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { shouldFetchUrlPreview } from "../UrlPreviewSettings";
+
+const bothOn = { previewsInCleartextRooms: true, previewsInPrivateMessages: true };
+const cleartextOnly = { previewsInCleartextRooms: true, previewsInPrivateMessages: false };
+
+describe("shouldFetchUrlPreview", () => {
+    it("previews a cleartext room message when the setting is on", () => {
+        expect(shouldFetchUrlPreview({ isProximity: false, isEncrypted: false, ...cleartextOnly })).toBe(true);
+    });
+
+    it("does not preview a cleartext room message when the setting is off", () => {
+        expect(
+            shouldFetchUrlPreview({
+                isProximity: false,
+                isEncrypted: false,
+                previewsInCleartextRooms: false,
+                previewsInPrivateMessages: true,
+            }),
+        ).toBe(false);
+    });
+
+    // Asking the homeserver to preview a link out of an encrypted message hands it the
+    // very thing the encryption was hiding.
+    it("does not preview an encrypted room by default", () => {
+        expect(shouldFetchUrlPreview({ isProximity: false, isEncrypted: true, ...cleartextOnly })).toBe(false);
+    });
+
+    // Proximity messages are peer to peer; the homeserver never saw them. It must not be
+    // classed as "cleartext, so the server knows anyway".
+    it("does not preview proximity chat by default", () => {
+        expect(shouldFetchUrlPreview({ isProximity: true, isEncrypted: false, ...cleartextOnly })).toBe(false);
+    });
+
+    it("previews encrypted and proximity messages once explicitly opted in", () => {
+        expect(shouldFetchUrlPreview({ isProximity: false, isEncrypted: true, ...bothOn })).toBe(true);
+        expect(shouldFetchUrlPreview({ isProximity: true, isEncrypted: false, ...bothOn })).toBe(true);
+    });
+
+    it("treats proximity as private even if the cleartext setting is on and the private one is off", () => {
+        expect(shouldFetchUrlPreview({ isProximity: true, isEncrypted: true, ...cleartextOnly })).toBe(false);
+    });
+});

--- a/play/src/front/Components/Menu/ChatSubMenu.svelte
+++ b/play/src/front/Components/Menu/ChatSubMenu.svelte
@@ -9,10 +9,20 @@
     import { modals } from "@wa-modals";
 
     let chatSounds: boolean = $state(localUserStore.getChatSounds());
+    let chatUrlPreviews: boolean = $state(localUserStore.getChatUrlPreviews());
+    let chatUrlPreviewsInPrivate: boolean = $state(localUserStore.getChatUrlPreviewsInPrivate());
     let mychatID = localUserStore.getChatId();
 
     function changeChatSounds() {
         localUserStore.setChatSounds(chatSounds);
+    }
+
+    function changeChatUrlPreviews() {
+        localUserStore.setChatUrlPreviews(chatUrlPreviews);
+    }
+
+    function changeChatUrlPreviewsInPrivate() {
+        localUserStore.setChatUrlPreviewsInPrivate(chatUrlPreviewsInPrivate);
     }
 
     function openResetKeyStorage() {
@@ -37,6 +47,20 @@
                         bind:value={chatSounds}
                         onchange={changeChatSounds}
                         label={$LL.menu.settings.chatSounds()}
+                    />
+                    <InputCheckbox
+                        data-testid="chatUrlPreviews"
+                        bind:value={chatUrlPreviews}
+                        onchange={changeChatUrlPreviews}
+                        label={$LL.menu.settings.chatUrlPreviews()}
+                    />
+                    <!-- Fetching a preview tells the homeserver about the URL, which is exactly
+                         what encryption and proximity chat keep from it. Off unless asked for. -->
+                    <InputCheckbox
+                        data-testid="chatUrlPreviewsInPrivate"
+                        bind:value={chatUrlPreviewsInPrivate}
+                        onchange={changeChatUrlPreviewsInPrivate}
+                        label={$LL.menu.settings.chatUrlPreviewsInPrivate()}
                     />
                 </div>
                 <section class="centered-column resizing-width m-auto resizing-text">

--- a/play/src/front/Connection/LocalUserStore.ts
+++ b/play/src/front/Connection/LocalUserStore.ts
@@ -29,6 +29,8 @@ const authToken = "authToken";
 const notification = "notificationPermission";
 const allowPictureInPicture = "allowPictureInPicture";
 const chatSounds = "chatSounds";
+const chatUrlPreviews = "chatUrlPreviews";
+const chatUrlPreviewsInPrivate = "chatUrlPreviewsInPrivate";
 const preferredVideoInputDevice = "preferredVideoInputDevice";
 const preferredAudioInputDevice = "preferredAudioInputDevice";
 const cacheAPIIndex = "workavdenture-cache";
@@ -424,6 +426,28 @@ class LocalUserStore {
 
     getChatSounds(): boolean {
         return localStorage.getItem(chatSounds) !== "false";
+    }
+
+    setChatUrlPreviews(value: boolean): void {
+        localStorage.setItem(chatUrlPreviews, value.toString());
+    }
+
+    getChatUrlPreviews(): boolean {
+        return localStorage.getItem(chatUrlPreviews) !== "false";
+    }
+
+    setChatUrlPreviewsInPrivate(value: boolean): void {
+        localStorage.setItem(chatUrlPreviewsInPrivate, value.toString());
+    }
+
+    /**
+     * Previews for encrypted rooms and proximity chat, where fetching one tells the
+     * homeserver about a URL it would otherwise never see. Off unless asked for, and
+     * deliberately per device: no server or config should be able to answer this for
+     * the user.
+     */
+    getChatUrlPreviewsInPrivate(): boolean {
+        return localStorage.getItem(chatUrlPreviewsInPrivate) === "true";
     }
 
     private getFoldersOpened(): Set<string> {

--- a/play/src/i18n/ar-SA/chat.ts
+++ b/play/src/i18n/ar-SA/chat.ts
@@ -53,6 +53,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "الصورة غير متوفرة.",
         imageActions: "إجراءات الصورة",
     },
+    urlPreview: {
+        label: "معاينة الرابط",
+        hide: "إخفاء المعاينات",
+    },
     join: "انضمام",
     search: "بحث",
     closeSearch: "إغلاق البحث",

--- a/play/src/i18n/ar-SA/menu.ts
+++ b/play/src/i18n/ar-SA/menu.ts
@@ -80,6 +80,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "الإشعارات", // Notifications
         enablePictureInPicture: "تمكين صورة داخل صورة",
         chatSounds: "أصوات الدردشة", // Chat sounds
+        chatUrlPreviews: "إظهار معاينات الروابط في الدردشة",
+        chatUrlPreviewsInPrivate: "إظهار معاينات الروابط في الغرف المشفّرة ودردشة القرب",
         cowebsiteTrigger: "اسأل في كل مرة قبل فتح مواقع الويب أو غرف Jitsi-Meet", // Ask every time before opening websites or Jitsi-Meet rooms
         ignoreFollowRequest: "تجاهل طلبات المتابعة من المستخدمين الآخرين", // Ignore follow requests from other users
         proximityDiscussionVolume: "مستوى صوت النقاش القريب",

--- a/play/src/i18n/ca-ES/chat.ts
+++ b/play/src/i18n/ca-ES/chat.ts
@@ -54,6 +54,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "La imatge no està disponible.",
         imageActions: "Accions de la imatge",
     },
+    urlPreview: {
+        label: "Vista prèvia de l'enllaç",
+        hide: "Amaga les vistes prèvies",
+    },
     join: "Unir-se",
     search: "Cercar",
     closeSearch: "Tancar cerca",

--- a/play/src/i18n/ca-ES/menu.ts
+++ b/play/src/i18n/ca-ES/menu.ts
@@ -83,6 +83,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "Notificacions",
         enablePictureInPicture: "Activar picture-in-picture",
         chatSounds: "Sons del xat",
+        chatUrlPreviews: "Mostra les vistes prèvies dels enllaços al xat",
+        chatUrlPreviewsInPrivate: "Mostra les vistes prèvies a les sales xifrades i al xat de proximitat",
         cowebsiteTrigger: "Preguntar sempre abans d'obrir llocs web i habitacions Jitsi Meet",
         ignoreFollowRequest: "Ignorar peticions de seguir altres usuaris",
         proximityDiscussionVolume: "Volum de les bombolles de discussió",

--- a/play/src/i18n/de-DE/chat.ts
+++ b/play/src/i18n/de-DE/chat.ts
@@ -55,6 +55,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "Bild nicht verfügbar.",
         imageActions: "Bildaktionen",
     },
+    urlPreview: {
+        label: "Linkvorschau",
+        hide: "Vorschauen ausblenden",
+    },
     join: "Beitreten",
     search: "Suchen",
     closeSearch: "Suche schließen",

--- a/play/src/i18n/de-DE/menu.ts
+++ b/play/src/i18n/de-DE/menu.ts
@@ -83,6 +83,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "Benachrichtigungen",
         enablePictureInPicture: "Bild-in-Bild aktivieren",
         chatSounds: "Chat-Sounds",
+        chatUrlPreviews: "Linkvorschauen im Chat anzeigen",
+        chatUrlPreviewsInPrivate: "Linkvorschauen in verschlüsselten Räumen und im Nahbereichs-Chat anzeigen",
         cowebsiteTrigger: "Jedes Mal nachfragen, bevor Webseiten oder Jitsi-Meet-Räume geöffnet werden",
         ignoreFollowRequest: "Folgeanfragen anderer Benutzer ignorieren",
         blockAudio: "Musik und Hintergrund-Geräusche deaktivieren",

--- a/play/src/i18n/dsb-DE/chat.ts
+++ b/play/src/i18n/dsb-DE/chat.ts
@@ -55,6 +55,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "Wobraz njedajo se pokazaś.",
         imageActions: "Akcije wobraza",
     },
+    urlPreview: {
+        label: "Pśeglěd wótkaza",
+        hide: "Pśeglědy schowaś",
+    },
     join: "Pśizamknuś",
     search: "Pytaś",
     closeSearch: "Pytaś zacyniś",

--- a/play/src/i18n/dsb-DE/menu.ts
+++ b/play/src/i18n/dsb-DE/menu.ts
@@ -81,6 +81,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "Powěźeńki",
         enablePictureInPicture: "Wobraz-we-wobrazu aktiwěrowaś",
         chatSounds: "Zwuki chata",
+        chatUrlPreviews: "Pśeglědy wótkazow w chaśe pokazaś",
+        chatUrlPreviewsInPrivate: "Pśeglědy wótkazow w skoděrowanych rumnosćach a w chaśe bliskosći pokazaś",
         cowebsiteTrigger: "Kuždy raz se pšašaś, pjerwjej nježli webboki abo Jitsi-Meet-śpy se wótcyniju",
         ignoreFollowRequest: "Ignorěruj pšosby wó slědowanje wót drugich wužywarjow",
         proximityDiscussionVolume: "Głośnosć diskusijow w bliskosći",

--- a/play/src/i18n/en-US/chat.ts
+++ b/play/src/i18n/en-US/chat.ts
@@ -53,6 +53,10 @@ const chat: BaseTranslation = {
         notAvailable: "Image is not available.",
         imageActions: "Image actions",
     },
+    urlPreview: {
+        label: "Link preview",
+        hide: "Hide previews",
+    },
     join: "Join",
     search: "Search",
     closeSearch: "Close search",

--- a/play/src/i18n/en-US/menu.ts
+++ b/play/src/i18n/en-US/menu.ts
@@ -80,6 +80,8 @@ const menu: BaseTranslation = {
         notifications: "Notifications",
         enablePictureInPicture: "Enable picture-in-picture",
         chatSounds: "Chat sounds",
+        chatUrlPreviews: "Show link previews in chat",
+        chatUrlPreviewsInPrivate: "Show link previews in encrypted rooms and proximity chat",
         cowebsiteTrigger: "Always ask before opening websites and Jitsi Meet rooms",
         ignoreFollowRequest: "Ignore requests to follow other users",
         proximityDiscussionVolume: "Proximity discussion volume",

--- a/play/src/i18n/es-ES/chat.ts
+++ b/play/src/i18n/es-ES/chat.ts
@@ -54,6 +54,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "La imagen no está disponible.",
         imageActions: "Acciones de la imagen",
     },
+    urlPreview: {
+        label: "Vista previa del enlace",
+        hide: "Ocultar vistas previas",
+    },
     join: "Unirse",
     search: "Buscar",
     closeSearch: "Cerrar búsqueda",

--- a/play/src/i18n/es-ES/menu.ts
+++ b/play/src/i18n/es-ES/menu.ts
@@ -83,6 +83,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "Notificaciones",
         enablePictureInPicture: "Activar picture-in-picture",
         chatSounds: "Sonidos del chat",
+        chatUrlPreviews: "Mostrar vistas previas de enlaces en el chat",
+        chatUrlPreviewsInPrivate: "Mostrar vistas previas en salas cifradas y en el chat de proximidad",
         cowebsiteTrigger: "Preguntar siempre antes de abrir sitios web y habitaciones Jitsi Meet",
         ignoreFollowRequest: "Ignorar peticiones de seguir a otros usuarios",
         proximityDiscussionVolume: "Volumen de las burbujas de discusión",

--- a/play/src/i18n/fr-FR/chat.ts
+++ b/play/src/i18n/fr-FR/chat.ts
@@ -55,6 +55,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "Image indisponible.",
         imageActions: "Actions sur l’image",
     },
+    urlPreview: {
+        label: "Aperçu du lien",
+        hide: "Masquer les aperçus",
+    },
     join: "Rejoindre",
     search: "Rechercher",
     closeSearch: "Fermer la recherche",

--- a/play/src/i18n/fr-FR/menu.ts
+++ b/play/src/i18n/fr-FR/menu.ts
@@ -82,6 +82,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "Notifications",
         enablePictureInPicture: "Activer le picture-in-picture",
         chatSounds: "Sons du chat",
+        chatUrlPreviews: "Afficher les aperçus de liens dans le chat",
+        chatUrlPreviewsInPrivate: "Afficher les aperçus dans les salons chiffrés et le chat de proximité",
         cowebsiteTrigger: "Demander toujours avant d'ouvrir des sites web et des salles de conférence Jitsi",
         ignoreFollowRequest: "Ignorer les demandes de suivi des autres utilisateurs",
         proximityDiscussionVolume: "Volume des bulles de discussion",

--- a/play/src/i18n/hsb-DE/chat.ts
+++ b/play/src/i18n/hsb-DE/chat.ts
@@ -55,6 +55,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "Wobraz njeda so pokazać.",
         imageActions: "Akcije wobraza",
     },
+    urlPreview: {
+        label: "Přehlad wotkaza",
+        hide: "Přehlady schować",
+    },
     join: "Přizamknyć",
     search: "Pytać",
     closeSearch: "Pytać začinić",

--- a/play/src/i18n/hsb-DE/menu.ts
+++ b/play/src/i18n/hsb-DE/menu.ts
@@ -81,6 +81,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "powěsće",
         enablePictureInPicture: "wobraz-we-wobrazu aktiwěrować",
         chatSounds: "zwuki chata",
+        chatUrlPreviews: "Přehlady wotkazow w chaće pokazać",
+        chatUrlPreviewsInPrivate: "Přehlady wotkazow w zaklučowanych rumnosćach a w chaće bliskosće pokazać",
         cowebsiteTrigger: "Kóždy raz so naprašować, prjedy hač so webstrony abo Jitsi Meet rumy wotewrje",
         ignoreFollowRequest: "Ignoruj naprašowanja wo sćěhowanje wot druhich wužiwarjow",
         proximityDiscussionVolume: "hłošnosć diskusijow w bliskosći",

--- a/play/src/i18n/it-IT/chat.ts
+++ b/play/src/i18n/it-IT/chat.ts
@@ -55,6 +55,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "Immagine non disponibile.",
         imageActions: "Azioni sull’immagine",
     },
+    urlPreview: {
+        label: "Anteprima del link",
+        hide: "Nascondi anteprime",
+    },
     join: "Unisciti",
     search: "Cerca",
     closeSearch: "Chiudi ricerca",

--- a/play/src/i18n/it-IT/menu.ts
+++ b/play/src/i18n/it-IT/menu.ts
@@ -83,6 +83,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "Notifiche",
         enablePictureInPicture: "Abilita picture-in-picture",
         chatSounds: "Suoni chat",
+        chatUrlPreviews: "Mostra le anteprime dei link nella chat",
+        chatUrlPreviewsInPrivate: "Mostra le anteprime nelle stanze cifrate e nella chat di prossimità",
         cowebsiteTrigger: "Chiedi sempre prima di aprire siti web e stanze Jitsi Meet",
         ignoreFollowRequest: "Ignora richieste di seguire altri utenti",
         proximityDiscussionVolume: "Volume discussione di prossimità",

--- a/play/src/i18n/ja-JP/chat.ts
+++ b/play/src/i18n/ja-JP/chat.ts
@@ -55,6 +55,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "画像を利用できません。",
         imageActions: "画像の操作",
     },
+    urlPreview: {
+        label: "リンクのプレビュー",
+        hide: "プレビューを非表示",
+    },
     join: "参加",
     search: "検索",
     closeSearch: "検索を閉じる",

--- a/play/src/i18n/ja-JP/menu.ts
+++ b/play/src/i18n/ja-JP/menu.ts
@@ -81,6 +81,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "通知",
         enablePictureInPicture: "ピクチャーインピクチャーを有効にする",
         chatSounds: "チャットサウンド",
+        chatUrlPreviews: "チャットでリンクのプレビューを表示する",
+        chatUrlPreviewsInPrivate: "暗号化されたルームと近接チャットでもプレビューを表示する",
         cowebsiteTrigger: "ウェブサイトや Jitsi ルームを開く前に必ず確認する",
         ignoreFollowRequest: "他のユーザをフォローするリクエストを無視する",
         proximityDiscussionVolume: "近接ディスカッションの音量",

--- a/play/src/i18n/ko-KR/chat.ts
+++ b/play/src/i18n/ko-KR/chat.ts
@@ -54,6 +54,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "이미지를 사용할 수 없습니다.",
         imageActions: "이미지 작업",
     },
+    urlPreview: {
+        label: "링크 미리보기",
+        hide: "미리보기 숨기기",
+    },
     join: "참가",
     search: "검색",
     closeSearch: "검색 닫기",

--- a/play/src/i18n/ko-KR/menu.ts
+++ b/play/src/i18n/ko-KR/menu.ts
@@ -80,6 +80,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "알림",
         enablePictureInPicture: "PIP(화면 속 화면) 활성화",
         chatSounds: "채팅 소리",
+        chatUrlPreviews: "채팅에서 링크 미리보기 표시",
+        chatUrlPreviewsInPrivate: "암호화된 방과 근접 채팅에서도 미리보기 표시",
         cowebsiteTrigger: "웹사이트 및 Jitsi Meet 방을 열기 전에 항상 물어보기",
         ignoreFollowRequest: "다른 사용자를 따라가는 요청 무시",
         proximityDiscussionVolume: "근접 대화 볼륨",

--- a/play/src/i18n/nl-NL/chat.ts
+++ b/play/src/i18n/nl-NL/chat.ts
@@ -55,6 +55,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "Afbeelding is niet beschikbaar.",
         imageActions: "Afbeeldingsacties",
     },
+    urlPreview: {
+        label: "Linkvoorbeeld",
+        hide: "Voorbeelden verbergen",
+    },
     join: "Lid worden",
     search: "Zoeken",
     closeSearch: "Zoeken sluiten",

--- a/play/src/i18n/nl-NL/menu.ts
+++ b/play/src/i18n/nl-NL/menu.ts
@@ -82,6 +82,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "Meldingen",
         enablePictureInPicture: "Picture-in-picture inschakelen",
         chatSounds: "Geluiden van chat",
+        chatUrlPreviews: "Linkvoorbeelden in de chat tonen",
+        chatUrlPreviewsInPrivate: "Linkvoorbeelden tonen in versleutelde ruimtes en nabijheidschat",
         cowebsiteTrigger: "Altijd vragen voordat websites en Jitsi Meet-ruimtes worden geopend",
         ignoreFollowRequest: "Negeer verzoeken om andere gebruikers te volgen",
         proximityDiscussionVolume: "Volume van nabijheidsdiscussies",

--- a/play/src/i18n/pt-BR/chat.ts
+++ b/play/src/i18n/pt-BR/chat.ts
@@ -54,6 +54,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "Imagem não disponível.",
         imageActions: "Ações da imagem",
     },
+    urlPreview: {
+        label: "Pré-visualização do link",
+        hide: "Ocultar pré-visualizações",
+    },
     join: "Entrar",
     search: "Pesquisar",
     closeSearch: "Fechar pesquisa",

--- a/play/src/i18n/pt-BR/menu.ts
+++ b/play/src/i18n/pt-BR/menu.ts
@@ -82,6 +82,8 @@ const menu: BaseTranslation = {
         notifications: "Notificações",
         enablePictureInPicture: "Habilitar picture-in-picture",
         chatSounds: "Sons do chat",
+        chatUrlPreviews: "Mostrar pré-visualizações de links no chat",
+        chatUrlPreviewsInPrivate: "Mostrar pré-visualizações em salas criptografadas e no chat de proximidade",
         cowebsiteTrigger: "Sempre pergunte antes de abrir sites e salas do Jitsi Meet",
         ignoreFollowRequest: "Ignorar solicitações para seguir outros usuários",
         proximityDiscussionVolume: "Volume de discussão de proximidade",

--- a/play/src/i18n/zh-CN/chat.ts
+++ b/play/src/i18n/zh-CN/chat.ts
@@ -52,6 +52,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "图片不可用。",
         imageActions: "图片操作",
     },
+    urlPreview: {
+        label: "链接预览",
+        hide: "隐藏预览",
+    },
     join: "加入",
     search: "搜索",
     closeSearch: "关闭搜索",

--- a/play/src/i18n/zh-CN/menu.ts
+++ b/play/src/i18n/zh-CN/menu.ts
@@ -79,6 +79,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "通知",
         enablePictureInPicture: "启用画中画",
         chatSounds: "聊天声音",
+        chatUrlPreviews: "在聊天中显示链接预览",
+        chatUrlPreviewsInPrivate: "在加密房间和邻近聊天中显示链接预览",
         cowebsiteTrigger: "在打开网页和Jitsi Meet会议前总是询问",
         ignoreFollowRequest: "忽略跟随其他用户的请求",
         proximityDiscussionVolume: "邻近讨论音量",

--- a/play/src/i18n/zh-TW/chat.ts
+++ b/play/src/i18n/zh-TW/chat.ts
@@ -52,6 +52,10 @@ const chat: DeepPartial<Translation["chat"]> = {
         notAvailable: "圖片無法使用。",
         imageActions: "圖片操作",
     },
+    urlPreview: {
+        label: "連結預覽",
+        hide: "隱藏預覽",
+    },
     join: "加入",
     search: "搜尋",
     closeSearch: "關閉搜尋",

--- a/play/src/i18n/zh-TW/menu.ts
+++ b/play/src/i18n/zh-TW/menu.ts
@@ -79,6 +79,8 @@ const menu: DeepPartial<Translation["menu"]> = {
         notifications: "通知",
         enablePictureInPicture: "啟用子母畫面",
         chatSounds: "聊天音效",
+        chatUrlPreviews: "在聊天中顯示連結預覽",
+        chatUrlPreviewsInPrivate: "在加密房間和鄰近聊天中顯示連結預覽",
         cowebsiteTrigger: "在開啟網頁和 Jitsi Meet 會議前總是詢問",
         ignoreFollowRequest: "忽略跟隨其他使用者的請求",
         proximityDiscussionVolume: "鄰近討論音量",

--- a/synapse/homeserver.template.yaml
+++ b/synapse/homeserver.template.yaml
@@ -26,6 +26,35 @@ database:
     database: /data/homeserver.db
 log_config: "/data/matrix.workadventure.localhost.log.config"
 media_store_path: /data/media_store
+
+# Lets the chat show OpenGraph previews for links. Synapse defaults this off, and the
+# helm charts already turn it on, so without this dev is the odd one out and previews
+# only 404 here.
+url_preview_enabled: true
+# Synapse refuses to start with previews enabled and no blacklist, and rightly so: it
+# will fetch whatever URL a user pastes, so anything pointing inside the compose network
+# or at the host would otherwise be ours to fetch on the user's behalf.
+# Kept in sync with charts/synapse/values.yaml in the SaaS repo.
+url_preview_ip_range_blacklist:
+  - '127.0.0.0/8'
+  - '10.0.0.0/8'
+  - '172.16.0.0/12'
+  - '192.168.0.0/16'
+  - '100.64.0.0/10'
+  - '192.0.0.0/24'
+  - '169.254.0.0/16'
+  - '192.88.99.0/24'
+  - '198.18.0.0/15'
+  - '192.0.2.0/24'
+  - '198.51.100.0/24'
+  - '203.0.113.0/24'
+  - '224.0.0.0/4'
+  - '::1/128'
+  - 'fe80::/10'
+  - 'fc00::/7'
+  - '2001:db8::/32'
+  - 'ff00::/8'
+  - 'fec0::/10'
 report_stats: true
 registration_shared_secret: "XJx!`J-;J4Kx!'p>J%[C!G$u8=YP6_4eEV$~Je9#~c>9sPGcDz"
 macaroon_secret_key: "E@=9DoVJg.t:.k:p8uI9*hMOQl~^JF8,rs2ak-evN5eS*pv.jF"


### PR DESCRIPTION
> **Stacked on #6364** — review that one first; this PR's diff is against it, not master.

Links in chat were bare: no title, no description, nothing to say where they lead. This adds OpenGraph preview cards, modelled on Element Web's implementation.

## Matrix chat vs proximity chat — read this first

**Previews appear in Matrix rooms. They do not appear in proximity chat by default.** That difference is deliberate, and it is the main thing to review.

| | Matrix room (cleartext) | Matrix room (encrypted) | Proximity chat |
|---|---|---|---|
| Preview by default | **yes** | no | **no** |
| Can be turned on | yes (per device) | yes (per device) | yes (per device) |
| Works when logged out | n/a | n/a | **no — impossible** |

Two separate mechanisms produce that table, and they should not be conflated:

**1. A setting (a choice, one line to change).** Following Element, `shouldFetchUrlPreview` splits on whether the homeserver has already seen the message. Element's own split is `urlPreviewsEnabled` (default on) vs `urlPreviewsEnabled_e2ee` (default off, device-level only, so that "neither the homeserver nor client config can impact the user's choices"). We mirror it with `chatUrlPreviews` / `chatUrlPreviewsInPrivate` in `localUserStore`, and currently fold proximity in with the encrypted case.

**2. A hard constraint (not a choice).** `getUrlPreview()` is a method on the **Matrix client**, and `GameManager` only creates one `if (userIsConnected)`. An anonymous user has no client, so proximity previews are impossible for them regardless of the setting — and proximity chat is precisely where logged-out users are. Closing that gap would need a preview endpoint on the pusher (which is what the dead `EMBEDLY_KEY` config was for), not a flag.

### The rationale for folding proximity in is weaker than it looks

The gate was written on the premise that proximity messages are peer-to-peer and never reach a server. **That premise is wrong**, and the code comment and commit message still carry it. `ProximityChatRoom.sendMessage()` emits a `spaceMessage`, and `back/src/Model/EventProcessorInit.ts:5-24` reads `event.spaceMessage.message` — a plain string per `messages.proto:1249-1253` — and re-broadcasts it. Proximity chat transits the back in cleartext.

Element's reason for defaulting cleartext previews *on* is "the server already saw the message". For proximity, the WA back already saw it. So the honest argument for keeping the gate is narrower: the Matrix homeserver is a **different service** from the back, and in a self-hosted deployment pointing at a third-party homeserver, previewing a proximity URL does disclose it to a party that had not seen it. (Though `analyticsClient.openedWebsite(url)` already reports opened URLs anyway.)

Left as-is for now pending a product call. Treating proximity as cleartext — removing the inconsistency the table above shows — is a one-line change plus the setting's label. **The E2EE gate for encrypted rooms stays either way; that argument is untouched.**

## What is ported from Element

- **Links come from the rendered DOM**, not the message source — the same reason as #6364: a reply renders from `formatted_body` HTML and never passes through our markdown renderer.
- Links inside `PRE`/`CODE`/`BLOCKQUOTE` are skipped. A bare autolinked host is skipped too, or every "foo.pl" in a sentence would sprout a card; a `[labelled](link)` or a deep link is previewed.
- **Metadata cascade**: title ← `og:title` || description || site name || link; site name ← `og:site_name` || hostname; a description that merely repeats the site name is dropped. If the title is just the link and there is no image, **no card at all** — that is worse than nothing.
- **Image vs favicon**: below 96px or 8KB it is a site icon, not a thumbnail, and renders as a compact card. `og:image` is an `mxc://` URI resolved through `mxcUrlToHttp` at 478×200.
- Capped at 2 per message with a show-more toggle (reusing the existing `chat.showMore` / `chat.showLess` strings rather than adding machine-translated duplicates), dismissible per message via `localStorage`.

## Server config

`url_preview_enabled` is on in the helm charts but absent from the dev homeserver, so `getUrlPreview()` 404s locally while working in prod. This adds it to `synapse/homeserver.template.yaml` (`homeserver.yaml` itself is gitignored — `envsubst` regenerates it on boot) **with the charts' IP blacklist**: Synapse refuses to start without one, and it would otherwise fetch whatever URL a user pastes, including our own network. Verified against the dev homeserver: a real page returns OG data with an `mxc://` image, and `http://127.0.0.1:8008` returns `IP address blocked`.

## Known caveats

- **The SDK caches failures forever.** `client.js` stores the response unconditionally under `(url, minute)` with a literal `TODO: Expire the URL preview cache sometimes` above it, so a transient 429/5xx poisons that key for the client's lifetime. Accepted, not worked around.
- **Scroll.** Cards land after the message renders and change its height, so the group signals the timeline to re-anchor once the DOM has settled (`await tick()` before `updateMessageBody()`). This chat has a history of scroll-anchoring bugs — **worth exercising by hand**: sit at the bottom of the timeline and post a link.

## Testing

Testable logic is in plain `.ts` (no Svelte component tests exist in this repo): 36 tests over link extraction, the metadata/image rules, and the privacy gate. `Message` defaults `isEncrypted` to `readable(true)`, so a caller that forgets to pass it leaks nothing.

Verified: `tsc --noEmit` 0, `svelte-check` 0, eslint 0, 48/48 vitest across both PRs, `i18n:check` green on all 15 locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)