### PR TITLE
Fixing centering of CamerasContainer

### DIFF
--- a/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
+++ b/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
@@ -447,7 +447,7 @@
     }
 
     // Re-run scroll indicator check when layout or content changes
-    $effect(() => {
+    $effect.pre(() => {
         if (camerasContainer) {
             const _exhaustiveCheck = [
                 $oneLineStreamableCollectionStore,

--- a/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
+++ b/play/src/front/Components/EmbedScreens/CamerasContainer.svelte
@@ -422,32 +422,28 @@
         if (!camerasContainer) return;
         const step = camerasContainer.clientWidth * scrollStepRatio;
         camerasContainer.scrollBy({ left: -step, behavior: "smooth" });
-        setTimeout(updateScrollIndicators, 300);
     }
 
     function scrollCamerasRight() {
         if (!camerasContainer) return;
         const step = camerasContainer.clientWidth * scrollStepRatio;
         camerasContainer.scrollBy({ left: step, behavior: "smooth" });
-        setTimeout(updateScrollIndicators, 300);
     }
 
     function scrollCamerasUp() {
         if (!camerasContainer) return;
         const step = camerasContainer.clientHeight * scrollStepRatio;
         camerasContainer.scrollBy({ top: -step, behavior: "smooth" });
-        setTimeout(updateScrollIndicators, 300);
     }
 
     function scrollCamerasDown() {
         if (!camerasContainer) return;
         const step = camerasContainer.clientHeight * scrollStepRatio;
         camerasContainer.scrollBy({ top: step, behavior: "smooth" });
-        setTimeout(updateScrollIndicators, 300);
     }
 
     // Re-run scroll indicator check when layout or content changes
-    $effect.pre(() => {
+    $effect(() => {
         if (camerasContainer) {
             const _exhaustiveCheck = [
                 $oneLineStreamableCollectionStore,
@@ -470,7 +466,9 @@
         bind:clientWidth={containerWidth}
         bind:clientHeight={camerasContainerHeight}
         bind:this={camerasContainer}
-        class="no-scroll-bar mx-1 justify-center"
+        class="no-scroll-bar mx-1"
+        class:justify-center-safe={isOnOneLine && oneLineMode === "horizontal"}
+        class:justify-center={!isOnOneLine || oneLineMode !== "horizontal"}
         class:pointer-events-none={!grabPointerEvents}
         class:pointer-events-auto={grabPointerEvents}
         class:hidden={$highlightFullScreen && $highlightedEmbedScreen && oneLineMode !== "vertical"}
@@ -487,7 +485,6 @@
         class:flex-col={isOnOneLine && oneLineMode === "vertical" && !isPictureInPictureGridMode}
         class:flex-wrap={!isOnOneLine}
         class:content-start={!isOnOneLine}
-        class:!justify-start={canScrollLeft || canScrollRight}
         class:whitespace-nowrap={isOnOneLine}
         class:relative={true}
         class:overflow-x-auto={isOnOneLine && oneLineMode === "horizontal" && !isPictureInPictureGridMode}
@@ -507,6 +504,7 @@
         class:m-2={$activePictureInPictureStore}
         id="cameras-container"
         data-testid="cameras-container"
+        onscroll={updateScrollIndicators}
     >
         {#each pipVideoBoxes as videoBox, i (videoBox.uniqueId)}
             <div


### PR DESCRIPTION
## What changed

- Use CSS overflow-safe centering for the horizontal one-line camera layout.
- Keep fitting camera rows centered while aligning overflowing rows to the start, where the highest-priority speakers are located.
- Remove the alignment dependency on `canScrollLeft` and `canScrollRight`.
- Update scroll indicators from the native `scroll` event and remove the delayed timer updates after programmatic scrolling.

## Why

The previous layout initially centered the camera row, measured whether it overflowed in JavaScript, and then switched it to start alignment. That made camera positioning depend on scroll-indicator state and could cause a second layout shift that changed which camera boxes intersected the viewport.

`justify-content: safe center` expresses the intended behavior directly in CSS: center the row when it fits and fall back to start alignment when centering would overflow. JavaScript remains responsible only for showing the optional scroll controls.

## User impact

Camera rows remain centered when there is enough room. When the row overflows, scrolling starts from the left so the most important speakers remain visible first, without an intermediate alignment change.

## Validation

- `npx prettier --check src/front/Components/EmbedScreens/CamerasContainer.svelte`
- `npx eslint src/front/Components/EmbedScreens/CamerasContainer.svelte`
- `npm run svelte-check` (0 errors and 0 warnings)
- Repository pre-commit hooks, including i18n validation
