### PR TITLE
Fix removeVariableListener adding the socket instead of removing it

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -999,12 +999,13 @@ export class GameRoom implements BrothersFinder {
     }
 
     public removeVariableListener(socket: VariableSocket) {
-        let listenersSet = this.variableListeners.get(socket.request.name);
-        if (!listenersSet) {
-            listenersSet = new Set<VariableSocket>();
-            this.variableListeners.set(socket.request.name, listenersSet);
+        const listenersSet = this.variableListeners.get(socket.request.name);
+        if (listenersSet) {
+            listenersSet.delete(socket);
+            if (listenersSet.size === 0) {
+                this.variableListeners.delete(socket.request.name);
+            }
         }
-        listenersSet.add(socket);
     }
 
     public addEventListener(socket: EventSocket) {

--- a/back/tests/GameRoom.test.ts
+++ b/back/tests/GameRoom.test.ts
@@ -1,11 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { describe, expect, it, vi } from "vitest";
 import { JoinRoomMessage, PositionMessage_Direction, RoomJoinedMessage } from "@workadventure/messages";
+import { LocalUrlError } from "@workadventure/map-editor/src/LocalUrlError";
+import { mapFetcher } from "@workadventure/map-editor/src/MapFetcher";
 import type { ConnectCallback, DisconnectCallback } from "../src/Model/GameRoom";
 import { GameRoom } from "../src/Model/GameRoom";
 import { Point } from "../src/Model/Websocket/MessageUserPosition";
 import type { Group } from "../src/Model/Group";
 import type { User, UserSocket } from "../src/Model/User";
+import type { VariableSocket } from "../src/RoomManager";
 import type { EmoteCallback } from "../src/Model/Zone";
 
 function createMockUser(userId: number): User {
@@ -64,6 +67,40 @@ function getWrittenMessageCases(socket: ReturnType<typeof createMockUserSocket>)
 }
 
 const emote: EmoteCallback = (emoteEventMessage, listener): void => {};
+
+const ROOM_URL = "https://play.workadventu.re/_/global/localhost/test.json";
+
+function createMockVariableSocket(name: string) {
+    const write = vi.fn().mockReturnValue(true);
+    const end = vi.fn();
+
+    return {
+        socket: {
+            request: { name, room: ROOM_URL },
+            write,
+            end,
+        } as unknown as VariableSocket,
+        write,
+        end,
+    };
+}
+
+function createWorld(): Promise<GameRoom> {
+    return GameRoom.create(
+        ROOM_URL,
+        () => {},
+        () => {},
+        160,
+        160,
+        () => {},
+        () => {},
+        () => {},
+        emote,
+        () => {},
+        () => {},
+        () => {}
+    );
+}
 
 describe("GameRoom", () => {
     it("should connect user1 and user2", async () => {
@@ -279,5 +316,46 @@ describe("GameRoom", () => {
         flushPendingMessages(secondUser);
 
         expect(getWrittenMessageCases(secondSocket)).toContain("duplicateUserConnectedMessage");
+    });
+
+    describe("variable listeners", () => {
+        it("should not write to a listener that was removed", async () => {
+            // Loading the map is irrelevant here: failing the fetch makes GameRoom fall back to a
+            // permission-less variable manager, which is enough to dispatch a variable change.
+            vi.spyOn(mapFetcher, "fetchMap").mockRejectedValue(new LocalUrlError("Local map"));
+
+            const world = await createWorld();
+
+            const removedListener = createMockVariableSocket("myVariable");
+            const remainingListener = createMockVariableSocket("myVariable");
+            world.addVariableListener(removedListener.socket);
+            world.addVariableListener(remainingListener.socket);
+
+            world.removeVariableListener(removedListener.socket);
+
+            await world.setVariable("myVariable", JSON.stringify("new value"), "RoomApi");
+
+            expect(removedListener.write).not.toHaveBeenCalled();
+            expect(remainingListener.write).toHaveBeenCalledWith("new value");
+        });
+
+        it("should forget the variable name once its last listener is removed", async () => {
+            const world = await createWorld();
+
+            const listener = createMockVariableSocket("myVariable");
+            world.addVariableListener(listener.socket);
+            world.removeVariableListener(listener.socket);
+
+            // isEmpty() drives cleanupRoomIfEmpty(): a leftover entry keeps the room alive forever.
+            expect(world.isEmpty()).toBe(true);
+        });
+
+        it("should not register a variable name when removing an unknown listener", async () => {
+            const world = await createWorld();
+
+            world.removeVariableListener(createMockVariableSocket("neverListenedTo").socket);
+
+            expect(world.isEmpty()).toBe(true);
+        });
     });
 });


### PR DESCRIPTION
## Problem

`GameRoom.removeVariableListener()` was a verbatim copy-paste of `addVariableListener()` — it ended with `listenersSet.add(socket)` where it must `delete` the socket:

```ts
public removeVariableListener(socket: VariableSocket) {
    let listenersSet = this.variableListeners.get(socket.request.name);
    if (!listenersSet) {
        listenersSet = new Set<VariableSocket>();
        this.variableListeners.set(socket.request.name, listenersSet);
    }
    listenersSet.add(socket);   // <-- adds the socket it was asked to remove
}
```

`SocketManager.removeVariableListener()` is called from `RoomManager.listenVariable()`'s `cancelled` / `close` / `error` handlers, so a cancelled or closed `listenVariable` gRPC stream (Room API) was **never unregistered** — the handler re-added the dead socket instead. The set grows without bound and `GameRoom` keeps calling `.write()` on dead streams on every variable change.

Removing a name that was never listened to also registered an empty set as a side effect of "removing".

## Room cleanup was affected too

`GameRoom.isEmpty()` tests `this.variableListeners.size` — the **Map's** size, not the sets'. The old code always left a map entry behind (and created one for an unknown name), so `isEmpty()` could never return true and `SocketManager.cleanupRoomIfEmpty()` never deleted the room. A room whose only remaining occupant was a variable listener leaked forever.

No change was needed in `SocketManager`: it already calls `cleanupRoomIfEmpty()` symmetrically with `removeEventListener()`. Dropping the map entry once its last listener is gone is what repairs the cleanup path.

## Fix

Mirror `removeEventListener()`, which sits right next to it and has always had the correct shape:

```ts
public removeVariableListener(socket: VariableSocket) {
    const listenersSet = this.variableListeners.get(socket.request.name);
    if (listenersSet) {
        listenersSet.delete(socket);
        if (listenersSet.size === 0) {
            this.variableListeners.delete(socket.request.name);
        }
    }
}
```

## Tests

Three regression tests in `back/tests/GameRoom.test.ts`. All three fail on the unpatched code and pass with the fix:

- `should not write to a listener that was removed` → `expected "vi.fn()" to not be called at all, but actually been called 1 times`
- `should forget the variable name once its last listener is removed` → `expected false to be true` (pins the room-cleanup regression via `isEmpty()`)
- `should not register a variable name when removing an unknown listener` → `expected false to be true`

To reach `setVariable()` offline, the first test stubs `mapFetcher.fetchMap` to reject, which sends `getVariableManager()` down its existing null-map fallback — no permission checks, no Redis, no network.

Full `back` suite green (216 passed, 2 skipped), `tsc --noEmit` clean, eslint clean, prettier clean on the changed source file.

This is pre-existing and unrelated to any feature branch — based on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)