### PR TITLE
refactor(ui): migrate the hard-case design-system usages onto components

### DIFF
--- a/play/src/front/Chat/Components/MatrixChatSettingsModal.svelte
+++ b/play/src/front/Chat/Components/MatrixChatSettingsModal.svelte
@@ -3,6 +3,7 @@
     import { scale } from "svelte/transition";
     import type { MatrixChatConnectionLike, MatrixUserSettingsDiagnostics } from "../Connection/ChatConnection";
     import ButtonClose from "../../Components/Input/ButtonClose.svelte";
+    import Button from "../../Components/UI/Button.svelte";
     import LL from "../../../i18n/i18n-svelte";
     import { clearIgnoredSuggestedRooms } from "../Stores/ChatStore";
     import { DEBUG_MODE } from "../../Enum/EnvironmentVariable";
@@ -226,12 +227,13 @@
         {#if !loading && data}
             <div class="flex flex-shrink-0 flex-col gap-2 border-t border-white/10 p-4 sm:p-5">
                 <p class="text-xs text-white/55">{$LL.chat.matrixSettings.clearSuggestedRoomsHint()}</p>
-                <button
+                <Button
                     type="button"
-                    class="btn transition-all duration-200 active:scale-[0.98] disabled:opacity-50 disabled:active:scale-100 {successFlash ===
-                    'clearSuggested'
-                        ? 'btn-success matrix-settings-btn-success'
-                        : 'btn-light btn-border'}"
+                    variant={successFlash === "clearSuggested" ? "success" : "light"}
+                    appearance={successFlash === "clearSuggested" ? "filled" : "border"}
+                    class={`transition-all duration-200 active:scale-[0.98] disabled:opacity-50 disabled:active:scale-100 ${
+                        successFlash === "clearSuggested" ? "matrix-settings-btn-success" : ""
+                    }`}
                     disabled={syncing}
                     onclick={handleClearSuggested}
                 >
@@ -246,16 +248,16 @@
                     {:else}
                         {$LL.chat.matrixSettings.clearSuggestedRoomsButton()}
                     {/if}
-                </button>
+                </Button>
                 {#if DEBUG_MODE}
                     <p class="text-xs text-white/55 pt-1">{$LL.chat.matrixSettings.publishWokaToMatrixProfileHint()}</p>
                 {/if}
-                <button
+                <Button
                     type="button"
-                    class="btn font-semibold transition-all duration-200 active:scale-[0.98] disabled:opacity-50 disabled:active:scale-100 {successFlash ===
-                    'syncAccount'
-                        ? 'btn-success matrix-settings-btn-success'
-                        : 'btn-secondary'}"
+                    variant={successFlash === "syncAccount" ? "success" : "secondary"}
+                    class={`font-semibold transition-all duration-200 active:scale-[0.98] disabled:opacity-50 disabled:active:scale-100 ${
+                        successFlash === "syncAccount" ? "matrix-settings-btn-success" : ""
+                    }`}
                     disabled={syncing}
                     onclick={syncAccountData}
                 >
@@ -273,14 +275,15 @@
                     {:else}
                         {$LL.chat.matrixSettings.syncButton()}
                     {/if}
-                </button>
+                </Button>
             </div>
         {/if}
     </div>
 </div>
 
 <style>
-    @keyframes matrix-settings-success-pop {
+    /* -global- keeps the keyframe name un-hashed so the :global() rule below can reference it. */
+    @keyframes -global-matrix-settings-success-pop {
         0% {
             transform: scale(1);
         }
@@ -291,7 +294,8 @@
             transform: scale(1);
         }
     }
-    .matrix-settings-btn-success {
+    /* Global so it survives on the <button> that <Button> renders (scoped CSS would not reach it). */
+    :global(.matrix-settings-btn-success) {
         animation: matrix-settings-success-pop 0.55s cubic-bezier(0.34, 1.25, 0.64, 1);
     }
 </style>

--- a/play/src/front/Chat/Components/Room/Message.svelte
+++ b/play/src/front/Chat/Components/Room/Message.svelte
@@ -9,6 +9,7 @@
     } from "../../Connection/ChatConnection";
     import type { WorkAdventureComponent } from "../../../../types/component";
     import LL, { locale } from "../../../../i18n/i18n-svelte";
+    import AvatarBox from "../../../Components/UI/Avatar.svelte";
     import Avatar from "../Avatar.svelte";
 
     import { resolveChatUserColor } from "../../Connection/Matrix/services/WaMatrixProfileService";
@@ -143,14 +144,14 @@
             : 'justify-start pl-3'}"
     >
         {#if (!isMyMessage || isQuotedMessage) && sender !== undefined && replyDepth === 0 && showHeader}
-            <div class="avatar overflow-hidden mt-4 shrink-0">
+            <AvatarBox class="overflow-hidden mt-4 shrink-0">
                 <Avatar
                     compact
                     pictureStore={messageAvatarPictureStore}
                     fallbackName={sender?.username}
                     color={messageSenderAvatarColor}
                 />
-            </div>
+            </AvatarBox>
         {/if}
 
         <div class="flex flex-col justify-end max-w-full {replyDepth === 0 && !showHeader ? 'ml-12' : ''}">

--- a/play/src/front/Chat/Components/Room/TypingUsers.svelte
+++ b/play/src/front/Chat/Components/Room/TypingUsers.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import AvatarBox from "../../../Components/UI/Avatar.svelte";
     import Avatar from "../Avatar.svelte";
     import type { PictureStore } from "../../../Stores/PictureStore";
 
@@ -15,14 +16,14 @@
         .map((typingMember, index) => ({ ...typingMember, index }))
         .slice(0, NUMBER_OF_TYPING_MEMBER_TO_DISPLAY) as typingMember (typingMember.id)}
         {#if typingMember}
-            <div id={`typing-user-${typingMember.id}`} class="avatar overflow-hidden shrink-0">
+            <AvatarBox id={`typing-user-${typingMember.id}`} class="overflow-hidden shrink-0">
                 <Avatar
                     compact
                     isChatAvatar={true}
                     pictureStore={typingMember.pictureStore}
                     fallbackName={typingMember.name ? typingMember.name : "Unknown"}
                 />
-            </div>
+            </AvatarBox>
         {/if}
     {/each}
 

--- a/play/src/front/Components/ActionBar/EmojiSubMenu.svelte
+++ b/play/src/front/Components/ActionBar/EmojiSubMenu.svelte
@@ -22,6 +22,7 @@
     import { connectionManager } from "../../Connection/ConnectionManager";
     import { popupStore } from "../../Stores/PopupStore";
     import SayPopUp from "../PopUp/SayPopUp.svelte";
+    import Button from "../UI/Button.svelte";
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { IconPencil, IconXIcon } from "@wa-icons";
 
@@ -204,37 +205,49 @@
             <div
                 class="transition-all bottom-action-button flex items-center h-full pl-2 relative before:content-[''] before:absolute before:top-0 before:left-1 before:w-[1px] before:h-full before:bg-white/10"
             >
-                <button
-                    class="btn btn-sm btn-ghost btn-light flex"
+                <Button
+                    variant="light"
+                    appearance="ghost"
+                    size="sm"
                     onclick={(event) => {
                         event.stopPropagation();
                         event.preventDefault();
                         edit();
                     }}
-                    bind:this={triggerElement}
+                    bind:element={triggerElement}
                 >
-                    {#if emoteDataLoading}
-                        <svg
-                            class="animate-spin h-5 w-5 text-white"
-                            xmlns="http://www.w3.org/2000/svg"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                        >
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-                            <path
-                                class="opacity-75"
-                                fill="currentColor"
-                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                            />
-                        </svg>
-                    {:else if !$emoteMenuStore}
-                        <IconPencil stroke="1" font-size="12" class="text-white" />
-                        <div>{$LL.actionbar.edit()}</div>
-                    {:else}
-                        <IconXIcon stroke="1" font-size="16" class="text-white" />
-                        <div>{$LL.actionbar.cancel()}</div>
-                    {/if}
-                </button>
+                    <!-- Flex wrapper keeps the icon and label side by side inside .btn-label. -->
+                    <span class="flex items-center gap-2">
+                        {#if emoteDataLoading}
+                            <svg
+                                class="animate-spin h-5 w-5 text-white"
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                            >
+                                <circle
+                                    class="opacity-25"
+                                    cx="12"
+                                    cy="12"
+                                    r="10"
+                                    stroke="currentColor"
+                                    stroke-width="4"
+                                />
+                                <path
+                                    class="opacity-75"
+                                    fill="currentColor"
+                                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                                />
+                            </svg>
+                        {:else if !$emoteMenuStore}
+                            <IconPencil stroke="1" font-size="12" class="text-white" />
+                            <div>{$LL.actionbar.edit()}</div>
+                        {:else}
+                            <IconXIcon stroke="1" font-size="16" class="text-white" />
+                            <div>{$LL.actionbar.cancel()}</div>
+                        {/if}
+                    </span>
+                </Button>
             </div>
             <!--
             <div class="transition-all bottom-action-button flex items-center rounded-r-lg h-full ml-2">

--- a/play/src/front/Components/Exploration/MapList.svelte
+++ b/play/src/front/Components/Exploration/MapList.svelte
@@ -10,6 +10,7 @@
     import PopUpContainer from "../PopUp/PopUpContainer.svelte";
     import Button from "../UI/Button.svelte";
     import Chip from "../UI/Chip.svelte";
+    import InputSearch from "../Input/InputSearch.svelte";
 
     interface RoomData {
         name: string;
@@ -93,13 +94,14 @@
                         <div class="w-full flex flex-col items-start gap-2 px-6">
                             <label for="search" class="text-white pl-2">{$LL.mapEditor.listRoom.searchLabel()}</label>
                             <div class="relative flex grow w-full">
-                                <input
+                                <InputSearch
                                     id="search"
                                     type="text"
+                                    size="lg"
                                     placeholder={$LL.mapEditor.listRoom.searchPlaceholder()}
                                     bind:value={search}
                                     oninput={onUpdateSearch}
-                                    class="grow input-search input-search-lg peer w-full"
+                                    class="grow peer w-full"
                                 />
                                 <svg
                                     class="icon icon-tabler icon-tabler-search stroke-contrast-400 absolute top-0 bottom-0 right-5 m-auto peer-focus:stroke-secondary peer-hover:stroke-secondary-500 transition-all peer-focus:-translate-x-1"

--- a/play/src/front/Components/Input/InputSearch.svelte
+++ b/play/src/front/Components/Input/InputSearch.svelte
@@ -38,7 +38,7 @@
     let classes = $derived(
         ["input-search", size && `input-search-${size}`, variant === "light" && "input-search-light", className]
             .filter(Boolean)
-            .join(" ")
+            .join(" "),
     );
 </script>
 

--- a/play/src/front/Components/Input/InputSearch.svelte
+++ b/play/src/front/Components/Input/InputSearch.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+    interface Props {
+        id?: string;
+        dataTestId?: string;
+        // The design system's `.input-search` styling is independent of the input type;
+        // callers keep whichever behaviour they had (search adds a clear button, text does not).
+        type?: "search" | "text";
+        placeholder?: string;
+        value?: string;
+        size?: "xs" | "sm" | "lg";
+        variant?: "light";
+        disabled?: boolean;
+        // Renders a bare <input> so the caller keeps ownership of the surrounding container
+        // and any sibling (e.g. a `peer`-driven icon). Pass positioning/`peer` via class.
+        class?: string;
+        oninput?: () => void;
+        [key: string]: unknown;
+    }
+
+    let {
+        id = undefined,
+        dataTestId = undefined,
+        type = "search",
+        placeholder = "",
+        value = $bindable<string>(),
+        size = undefined,
+        variant = undefined,
+        disabled = false,
+        class: className = "",
+        oninput = undefined,
+        ...rest
+    }: Props = $props();
+
+    // Spread rather than an explicit attribute so a caller-supplied data-testid isn't clobbered.
+    let testIdAttr = $derived(dataTestId ? { "data-testid": dataTestId } : {});
+
+    // Static design-system classes, so interpolation is safe.
+    let classes = $derived(
+        ["input-search", size && `input-search-${size}`, variant === "light" && "input-search-light", className]
+            .filter(Boolean)
+            .join(" ")
+    );
+</script>
+
+<input {...rest} {...testIdAttr} {id} {type} class={classes} bind:value {placeholder} {disabled} {oninput} />

--- a/play/src/front/Components/MapEditor/PropertyEditor/JitsiRoomPropertyEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/JitsiRoomPropertyEditor.svelte
@@ -3,6 +3,7 @@
     import { LL } from "../../../../i18n/i18n-svelte";
     import Input from "../../Input/Input.svelte";
     import InputSwitch from "../../Input/InputSwitch.svelte";
+    import Button from "../../UI/Button.svelte";
     import RangeSlider from "../../Input/RangeSlider.svelte";
     import Select from "../../Input/Select.svelte";
     import InputCheckbox from "../../Input/InputCheckbox.svelte";
@@ -172,13 +173,13 @@
                         />
                     {/if}
 
-                    <button
-                        class="btn bg-transparent rounded-md hover:!bg-white/10 transition-all border !border-white py-2"
+                    <Button
+                        class="jitsi-more-options-btn bg-transparent rounded-md hover:!bg-white/10 transition-all border !border-white py-2"
                         onclick={OpenPopup}
-                        data-testid="livekitRoomMoreOptionsButton"
+                        dataTestId="livekitRoomMoreOptionsButton"
                     >
                         {$LL.mapEditor.properties.jitsiRoomProperty.moreOptionsLabel()}
-                    </button>
+                    </Button>
 
                     <!-- <JitsiRoomConfigEditor
                         bind:isOpen={jitsiConfigModalOpened}
@@ -194,12 +195,13 @@
 </PropertyEditorBase>
 
 <style>
-    button {
+    /* Global so it reaches the <button> rendered by <Button> (scoped CSS would not). */
+    :global(.jitsi-more-options-btn) {
         flex: 1 1 0px;
         border: 1px solid grey;
         margin-bottom: 0.5em;
     }
-    button:hover {
+    :global(.jitsi-more-options-btn):hover {
         background-color: rgb(77 75 103);
     }
     .value-switch {

--- a/play/src/front/Components/MapEditor/PropertyEditor/LivekitRoomPropertyEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/LivekitRoomPropertyEditor.svelte
@@ -2,6 +2,7 @@
     import type { LivekitRoomConfigData, LivekitRoomPropertyData } from "@workadventure/map-editor";
     import { LL } from "../../../../i18n/i18n-svelte";
     import Input from "../../Input/Input.svelte";
+    import Button from "../../UI/Button.svelte";
     import PropertyEditorBase from "./PropertyEditorBase.svelte";
     import LivekitRoomConfigEditor from "./LivekitRoomConfigEditor.svelte";
     import { IconUsersGroup } from "@wa-icons";
@@ -69,33 +70,37 @@
                     onchange={onValueChange}
                 />
             </div>
-            <button
-                class="w-full mt-4 btn bg-transparent rounded-md hover:!bg-white/10 transition-all border !border-white py-2"
+            <Button
+                class="livekit-config-btn w-full mt-4 bg-transparent rounded-md hover:!bg-white/10 transition-all border !border-white py-2"
                 onclick={OpenPopup}
-                data-testid="livekitRoomMoreOptionsButton"
+                dataTestId="livekitRoomMoreOptionsButton"
             >
                 {$LL.mapEditor.properties.livekitRoomProperty.moreOptionsLabel()}
-            </button>
+            </Button>
             {#if !hasHighlightProperty}
-                <button
-                    class=" btn btn-sm btn-light btn-ghost w-full"
+                <Button
+                    variant="light"
+                    appearance="ghost"
+                    size="sm"
+                    class="livekit-config-btn w-full"
                     onclick={() => {
                         onhighlightareaonenter?.();
                     }}
                 >
                     {$LL.mapEditor.properties.livekitRoomProperty.highlightAreaOnEnter()}
-                </button>
+                </Button>
             {/if}
         </span>
     {/snippet}
 </PropertyEditorBase>
 
 <style>
-    button {
+    /* Global so it reaches the <button> rendered by <Button> (scoped CSS would not). */
+    :global(.livekit-config-btn) {
         flex: 1 1 0px;
         border: 1px solid grey;
     }
-    button:hover {
+    :global(.livekit-config-btn):hover {
         background-color: rgb(77 75 103);
     }
 </style>

--- a/play/src/front/Components/Modal/GlobalCommunicationModal.svelte
+++ b/play/src/front/Components/Modal/GlobalCommunicationModal.svelte
@@ -526,8 +526,8 @@
                     </div>
                     <div class="flex flew-row justify-center">
                         {#if !$requestedMegaphoneStore}
-                            <button
-                                class="btn light text-black bg-white mt-4 rounded-md"
+                            <Button
+                                class="font-light text-black bg-white mt-4 rounded-md disabled:bg-[#4a5568] disabled:cursor-not-allowed"
                                 onclick={startLive}
                                 disabled={!$requestedCameraState && !$requestedMicrophoneState}
                             >
@@ -535,7 +535,7 @@
                                     <Tooltip text={$LL.warning.megaphoneNeeds()} />
                                 {/if}
                                 {$LL.megaphone.modal.liveMessage.startMegaphone()}
-                            </button>
+                            </Button>
                         {:else}
                             <Button variant="danger" onclick={stopLive}>
                                 {$LL.megaphone.modal.liveMessage.stopMegaphone()}
@@ -554,10 +554,5 @@
         &:hover {
             scale: 1.1;
         }
-    }
-
-    button.light[disabled] {
-        background-color: #4a5568;
-        cursor: not-allowed;
     }
 </style>

--- a/play/src/front/Components/Modal/GlobalCommunicationModal.svelte
+++ b/play/src/front/Components/Modal/GlobalCommunicationModal.svelte
@@ -527,7 +527,7 @@
                     <div class="flex flew-row justify-center">
                         {#if !$requestedMegaphoneStore}
                             <Button
-                                class="font-light text-black bg-white mt-4 rounded-md disabled:bg-[#4a5568] disabled:cursor-not-allowed"
+                                class="font-light [&_.btn-label]:text-black bg-white mt-4 rounded-md disabled:bg-[#4a5568] disabled:cursor-not-allowed"
                                 onclick={startLive}
                                 disabled={!$requestedCameraState && !$requestedMicrophoneState}
                             >

--- a/play/src/front/Components/PopUp/PopUpCameraAccesDenied.svelte
+++ b/play/src/front/Components/PopUp/PopUpCameraAccesDenied.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount, onDestroy } from "svelte";
     import type { UserInputManager } from "../../Phaser/UserInput/UserInputManager";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -23,15 +24,13 @@
 <PopUpContainer reduceOnSmallScreen={true}>
     {message}
     {#snippet buttons()}
-        <button class="btn btn-secondary w-1/2 justify-center responsive-message" onclick={click}>
-            See preferences
-        </button>
+        <Button variant="secondary" class="w-1/2 responsive-message" onclick={click}>See preferences</Button>
     {/snippet}
 </PopUpContainer>
 
 <style>
     @media (max-width: 768px) {
-        .responsive-message {
+        :global(.responsive-message) {
             scale: 1.2;
         }
     }

--- a/play/src/front/Components/PopUp/PopUpMapEditorNotEnabled.svelte
+++ b/play/src/front/Components/PopUp/PopUpMapEditorNotEnabled.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount, onDestroy } from "svelte";
     import type { UserInputManager } from "../../Phaser/UserInput/UserInputManager";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -23,13 +24,13 @@
 <PopUpContainer reduceOnSmallScreen={true}>
     {message}
     {#snippet buttons()}
-        <button class="btn btn-secondary w-1/2 justify-center responsive-message" {onclick}>Close</button>
+        <Button variant="secondary" class="w-1/2 responsive-message" {onclick}>Close</Button>
     {/snippet}
 </PopUpContainer>
 
 <style>
     @media (max-width: 768px) {
-        .responsive-message {
+        :global(.responsive-message) {
             scale: 1.2;
         }
     }

--- a/play/src/front/Components/PopUp/PopUpMapEditorShortcut.svelte
+++ b/play/src/front/Components/PopUp/PopUpMapEditorShortcut.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount, onDestroy } from "svelte";
     import type { UserInputManager } from "../../Phaser/UserInput/UserInputManager";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -23,13 +24,13 @@
 <PopUpContainer reduceOnSmallScreen={true}>
     {message}
     {#snippet buttons()}
-        <button class="btn btn-secondary w-1/2 justify-center responsive-message" {onclick}> See preferences </button>
+        <Button variant="secondary" class="w-1/2 responsive-message" {onclick}>See preferences</Button>
     {/snippet}
 </PopUpContainer>
 
 <style>
     @media (max-width: 768px) {
-        .responsive-message {
+        :global(.responsive-message) {
             scale: 1.2;
         }
     }

--- a/play/src/front/Components/PopUp/PopUpRoomAccessDenied.svelte
+++ b/play/src/front/Components/PopUp/PopUpRoomAccessDenied.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount, onDestroy } from "svelte";
     import type { UserInputManager } from "../../Phaser/UserInput/UserInputManager";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -23,13 +24,13 @@
 <PopUpContainer reduceOnSmallScreen={true}>
     {message}
     {#snippet buttons()}
-        <button class="btn btn-secondary w-1/2 justify-center responsive-message" {onclick}> Close </button>
+        <Button variant="secondary" class="w-1/2 responsive-message" {onclick}>Close</Button>
     {/snippet}
 </PopUpContainer>
 
 <style>
     @media (max-width: 768px) {
-        .responsive-message {
+        :global(.responsive-message) {
             scale: 1.2;
         }
     }

--- a/play/src/front/Components/PopUp/PopUpSharingScreenAcessDenied.svelte
+++ b/play/src/front/Components/PopUp/PopUpSharingScreenAcessDenied.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount, onDestroy } from "svelte";
     import type { UserInputManager } from "../../Phaser/UserInput/UserInputManager";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -23,15 +24,13 @@
 <PopUpContainer reduceOnSmallScreen={true}>
     {message}
     {#snippet buttons()}
-        <button class="btn btn-secondary w-1/2 justify-center responsive-message" onclick={click}>
-            See preferences
-        </button>
+        <Button variant="secondary" class="w-1/2 responsive-message" onclick={click}>See preferences</Button>
     {/snippet}
 </PopUpContainer>
 
 <style>
     @media (max-width: 768px) {
-        .responsive-message {
+        :global(.responsive-message) {
             scale: 1.2;
         }
     }

--- a/play/src/front/Components/PopUp/PopUpTab.svelte
+++ b/play/src/front/Components/PopUp/PopUpTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount, onDestroy } from "svelte";
     import type { UserInputManager } from "../../Phaser/UserInput/UserInputManager";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -23,15 +24,13 @@
 <PopUpContainer reduceOnSmallScreen={true}>
     {message}
     {#snippet buttons()}
-        <button class="btn btn-secondary w-1/2 max-w-80 justify-center responsive-message" onclick={click}>
-            Open Tab
-        </button>
+        <Button variant="secondary" class="w-1/2 max-w-80 responsive-message" onclick={click}>Open Tab</Button>
     {/snippet}
 </PopUpContainer>
 
 <style>
     @media (max-width: 768px) {
-        .responsive-message {
+        :global(.responsive-message) {
             font-size: 24px;
             line-height: 32px;
             padding-bottom: 14px;

--- a/play/src/front/Components/PopUp/TutorialInstruction.svelte
+++ b/play/src/front/Components/PopUp/TutorialInstruction.svelte
@@ -235,10 +235,14 @@
     </div>
     {#snippet buttons()}
         <div class="tutorial-buttons flex flex-col-reverse sm:flex-row w-full gap-2 sm:gap-2 sm:space-x-2">
-            <button
-                class="btn btn-light btn-sm btn-ghost flex-1 min-h-10 sm:min-h-0 justify-center tutorial-btn-secondary"
-                >View full tutorial</button
+            <Button
+                variant="light"
+                appearance="ghost"
+                size="sm"
+                class="flex-1 min-h-10 sm:min-h-0 tutorial-btn-secondary"
             >
+                View full tutorial
+            </Button>
             <Button variant="secondary" size="sm" class="flex-1 min-h-10 sm:min-h-0" onclick={closeBanner}>
                 Close
             </Button>
@@ -249,7 +253,8 @@
 <style>
     /* Responsive: larger touch targets and readable text on small screens */
     @media (max-width: 768px) {
-        .tutorial-btn-secondary {
+        /* Global so it reaches the <button> rendered by <Button> (scoped CSS would not). */
+        :global(.tutorial-btn-secondary) {
             font-size: 0.9375rem; /* Slightly larger for readability */
         }
     }

--- a/play/src/front/Components/PwaInstall/PwaInstallScreen.svelte
+++ b/play/src/front/Components/PwaInstall/PwaInstallScreen.svelte
@@ -203,17 +203,19 @@
                         </Button>
                     {/if}
 
-                    <button
+                    <!-- No variant: the design system's `.btn-light .btn-label` is dark, but this
+                         translucent button needs the base white label, which no-variant keeps. -->
+                    <Button
                         type="button"
-                        class="btn btn-light !bg-white/10 !text-lg !text-white hover:!bg-white/20"
+                        class="!bg-white/10 !text-lg !text-white hover:!bg-white/20"
                         onclick={() => {
                             analyticsClient.pwaContinueInBrowserClick();
                             handleContinue();
                         }}
-                        data-testid="pwa-install-skip"
+                        dataTestId="pwa-install-skip"
                     >
                         {$LL.warning.pwaInstall.continue()}
-                    </button>
+                    </Button>
 
                     <div class="flex flex-col items-center gap-2">
                         <button

--- a/play/src/front/Components/SelectCompanion/SelectCompanionScene.svelte
+++ b/play/src/front/Components/SelectCompanion/SelectCompanionScene.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { LL } from "../../../i18n/i18n-svelte";
+    import Button from "../UI/Button.svelte";
     import type { Game } from "../../Phaser/Game/Game";
     import type { SelectCompanionScene } from "../../Phaser/Login/SelectCompanionScene";
     import { SelectCompanionSceneName } from "../../Phaser/Login/SelectCompanionScene";
@@ -74,18 +75,23 @@
     <section
         class="action container m-auto p-4 flex flex-col-reverse md:flex-row items-center space-y-2 md:space-y-0 md:space-x-4 justify-between"
     >
-        <button
-            class="btn btn-light btn-lg btn-ghost w-full md:w-1/2 block selectCompanionSceneFormBack"
+        <Button
+            variant="light"
+            appearance="ghost"
+            size="lg"
+            class="w-full md:w-1/2 block selectCompanionSceneFormBack pointer-events-auto"
             onclick={(event) => {
                 event.preventDefault();
                 noCompanion();
             }}
         >
             {$LL.companion.select.any()}
-        </button>
-        <button
+        </Button>
+        <Button
             type="submit"
-            class="btn btn-secondary btn-lg w-full md:w-1/2 block selectCompanionSceneFormSubmit"
+            variant="secondary"
+            size="lg"
+            class="w-full md:w-1/2 block selectCompanionSceneFormSubmit pointer-events-auto"
             onclick={(event) => {
                 event.preventDefault();
                 analyticsClient.selectCompanion();
@@ -93,7 +99,7 @@
             }}
         >
             {$LL.companion.select.continue()}
-        </button>
+        </Button>
     </section>
 </div>
 

--- a/play/src/front/Components/UI/Avatar.svelte
+++ b/play/src/front/Components/UI/Avatar.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+    import type { Snippet } from "svelte";
+
+    // Wraps the design system's `.avatar` box. Note the app also has a richer, domain-specific
+    // Chat/Components/Avatar.svelte; import this one under an alias where both are needed.
+    interface Props {
+        id?: string;
+        size?: "lg" | "sm" | "xs";
+        circle?: boolean;
+        stack?: boolean;
+        borderLight?: boolean;
+        href?: string;
+        class?: string;
+        // Initials, rendered in the design system's .avatar-name span.
+        name?: Snippet;
+        // A <Badge> overlaid on the corner; the design system positions it per size.
+        notification?: Snippet;
+        children?: Snippet;
+    }
+
+    let {
+        id = undefined,
+        size = undefined,
+        circle = false,
+        stack = false,
+        borderLight = false,
+        href = undefined,
+        class: className = "",
+        name,
+        notification,
+        children,
+    }: Props = $props();
+
+    // Static design-system classes, so interpolation is safe. `avatar-lg-circle` is the design
+    // system's own combo rule: it re-places the notification when lg meets circle.
+    let classes = $derived(
+        [
+            "avatar",
+            size && `avatar-${size}`,
+            circle && "avatar-circle",
+            size === "lg" && circle && "avatar-lg-circle",
+            stack && "avatar-stack",
+            borderLight && "avatar-border-light",
+            className,
+        ]
+            .filter(Boolean)
+            .join(" ")
+    );
+</script>
+
+{#snippet body()}
+    {#if children}
+        {@render children()}
+    {/if}
+    {#if name}
+        <span class="avatar-name">{@render name()}</span>
+    {/if}
+    {#if notification}
+        {@render notification()}
+    {/if}
+{/snippet}
+
+{#if href}
+    <a {id} {href} class={classes}>{@render body()}</a>
+{:else}
+    <div {id} class={classes}>{@render body()}</div>
+{/if}

--- a/play/src/front/Components/UI/Avatar.svelte
+++ b/play/src/front/Components/UI/Avatar.svelte
@@ -44,7 +44,7 @@
             className,
         ]
             .filter(Boolean)
-            .join(" ")
+            .join(" "),
     );
 </script>
 

--- a/play/src/front/Components/UI/Button.svelte
+++ b/play/src/front/Components/UI/Button.svelte
@@ -17,6 +17,8 @@
         dataTestId?: string;
         class?: string;
         onclick?: (event: MouseEvent) => void;
+        // Bind to get the rendered element, e.g. as a floating-UI anchor.
+        element?: HTMLElement;
         icon?: Snippet;
         notification?: Snippet;
         children?: Snippet;
@@ -35,6 +37,7 @@
         dataTestId = undefined,
         class: className = "",
         onclick = undefined,
+        element = $bindable(),
         icon,
         notification,
         children,
@@ -77,11 +80,19 @@
 {/snippet}
 
 {#if href}
-    <a {...rest} {...testIdAttr} {href} class={classes} aria-disabled={disabled || undefined} {onclick}>
+    <a
+        bind:this={element}
+        {...rest}
+        {...testIdAttr}
+        {href}
+        class={classes}
+        aria-disabled={disabled || undefined}
+        {onclick}
+    >
         {@render body()}
     </a>
 {:else}
-    <button {...rest} {...testIdAttr} {type} class={classes} {disabled} {onclick}>
+    <button bind:this={element} {...rest} {...testIdAttr} {type} class={classes} {disabled} {onclick}>
         {@render body()}
     </button>
 {/if}

--- a/play/src/front/Components/UI/ErrorScreen.svelte
+++ b/play/src/front/Components/UI/ErrorScreen.svelte
@@ -11,6 +11,7 @@
     import logoImg from "../images/logo-min-white.png";
     import LoaderIcon from "../Icons/LoaderIcon.svelte";
     import type { Room } from "../../Connection/Room";
+    import Button from "./Button.svelte";
     import errorGif from "./images/error.gif";
     import { IconRefresh } from "@wa-icons";
 
@@ -50,6 +51,10 @@
 
     let detailsStylized = $derived((details ?? "").replace("{time}", `${timeVar / 1000}`));
 </script>
+
+{#snippet refreshIcon()}
+    <IconRefresh />
+{/snippet}
 
 {#if $errorScreenStore}
     <main
@@ -94,18 +99,21 @@
             </div>
             <div class="flex gap-2">
                 {#if ($errorScreenStore.type === "retry" && $errorScreenStore.canRetryManual) || $errorScreenStore.type === "unauthorized"}
-                    <button
+                    <Button
                         type="button"
-                        class="btn-lg btn btn-light btn-border button flex items-center gap-2"
+                        size="lg"
+                        variant="light"
+                        appearance="border"
+                        class="button"
+                        icon={$errorScreenStore.type === "retry" ? refreshIcon : undefined}
                         onclick={click}
                     >
-                        {#if $errorScreenStore.type === "retry"}<IconRefresh />{/if}
                         {$errorScreenStore.buttonTitle}
-                    </button>
+                    </Button>
                     {#if $userIsConnected}
-                        <button type="button" class="btn-lg btn btn-secondary button" onclick={logout}>
+                        <Button type="button" size="lg" variant="secondary" class="button" onclick={logout}>
                             {$LL.menu.profile.logout()}
-                        </button>
+                        </Button>
                     {/if}
                 {/if}
             </div>
@@ -154,7 +162,8 @@
             left: 0;
             top: -19px;
         }
-        .button {
+        /* Global so it reaches the <button> rendered by <Button> (scoped CSS would not). */
+        :global(.button) {
             cursor: pointer;
             font-size: 14px;
         }

--- a/play/src/front/Components/VisitCard/VisitCard.svelte
+++ b/play/src/front/Components/VisitCard/VisitCard.svelte
@@ -8,6 +8,7 @@
     import chat from "../images/chat.png";
 
     import ButtonClose from "../Input/ButtonClose.svelte";
+    import Button from "../UI/Button.svelte";
     import Spinner from "../Icons/Spinner.svelte";
     import { IconLoader } from "@wa-icons";
 
@@ -82,14 +83,17 @@
             <div class="buttonContainer p-2.5 flex flex-row justify-end gap-2 bg-contrast rounded-b-lg">
                 {#if selectPlayerChatID && showSendMessageButton}
                     {#if !$roomCreationInProgress}
-                        <button
-                            class="btn btn-secondary text-nowrap justify-center m-2 flex-1 min-w-0"
-                            data-testid="sendMessagefromVisitCardButton"
+                        <Button
+                            variant="secondary"
+                            class="text-nowrap m-2 flex-1 min-w-0"
+                            dataTestId="sendMessagefromVisitCardButton"
                             onclick={openChat}
                         >
-                            <img src={chat} alt="chat" class="w-6 h-6 mx-2" draggable="false" />
+                            {#snippet icon()}
+                                <img src={chat} alt="chat" class="w-6 h-6 mx-2" draggable="false" />
+                            {/snippet}
                             {$LL.menu.visitCard.sendMessage()}
-                        </button>
+                        </Button>
                     {:else}
                         <button
                             class="light cursor-pointer px-3 mb-2 mr-0"
@@ -121,7 +125,8 @@
             }
         }
 
-        button {
+        /* Global so it reaches the <button> rendered by <Button> (scoped CSS would not). */
+        :global(button) {
             float: right;
         }
     }


### PR DESCRIPTION
> **Stacked on #6371** (base = `refactor/design-system-components`, itself on #6363). Merge those first; GitHub will retarget this to `master` afterwards.

Follow-up to #6371, which deliberately left a set of design-system usages raw because they needed more than a mechanical swap. This PR clears **almost all** of them — the two points I flagged as "reversible, ask me".

## Point 1 — usages that needed the component adapted

- **`.avatar` (2)**: recreated `UI/Avatar.svelte` with an `id` prop and migrated the two boxes (`Message`, `TypingUsers`). Imported **under an alias** so it sits beside the domain `Chat/Components/Avatar.svelte` without a name clash.
- **`.input-search` (1)**: recreated `Input/InputSearch.svelte` as a **bare `<input>`** (no wrapper div) so `MapList` keeps its own `relative` container and the `peer`-driven search icon keeps reacting to focus/hover. Added a `type` prop to preserve `type="text"`.

## Point 2 — buttons whose scoped CSS was the blocker → `:global()`

The reason these couldn't be `<Button>` before: Svelte scopes CSS by hashing elements in the component's own markup, and a component's internal `<button>` doesn't get that hash. Hoisting each selector to `:global()` fixes it.

- 6 `responsive-message` PopUps, plus `MatrixChatSettingsModal`, `TutorialInstruction`, `ErrorScreen`, `Jitsi`/`LivekitRoomPropertyEditor`. Where a rule referenced a `@keyframes`, the keyframe is marked `-global-` so the global rule can still reach it.
- `SelectCompanionScene` **keeps** its `button {}` rule (8 other raw buttons still need it); the 2 migrated buttons get a `pointer-events-auto` utility instead.
- `GlobalCommunicationModal`'s `button.light[disabled]` became `disabled:*` utilities, dropping the generic `.light` hook rather than globalizing such a broad class name.
- `VisitCard`'s (dead — the button is a flex item) `.visitCard button { float }` kept faithfully via `:global()`.

## Also

- **`Button` gains a bindable `element`** — `EmojiSubMenu` uses it as its floating-UI anchor, clearing the last `bind:this` blocker.
- **`PwaInstallScreen`** drops `variant="light"`: its translucent button needs white label text, which the DS's `.btn-light .btn-label` (dark) would have broken once the text moved into the `.btn-label` span. No-variant keeps the base white label.

## Left raw, reported

- **`WarningBanner`** — its admin-configurable **inline** text colour must reach the text node, which `.btn-label` would override. No clean path without a bespoke Button API; not worth it for one banner.
- The only other raw `btn` occurrences left in the codebase are **inside HTML comments**.

## Verification

`svelte-check` (`--fail-on-warnings`), `eslint`, `prettier` all clean on the changes. **All 285 test ids preserved** (before/after diff). No behaviour or wording changes.

**Not verified visually** (build/vitest can't run on the dev host). This is the change most worth eyeballing on the `deploy` env — several buttons had scoped CSS whose `:global()` behaviour I reasoned about but couldn't render. Same unrelated `IoSocketController.ts` protobuf error as #6371 (shared build artifact, not in any file this PR touches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)