### PR TITLE
fix(chat): don't send the composer draft when validating a message edit

### DIFF
--- a/play/src/front/Chat/Components/Room/MessageEdition.svelte
+++ b/play/src/front/Chat/Components/Room/MessageEdition.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { get } from "svelte/store";
+    import { onMount } from "svelte";
     import type { ChatMessage } from "../../Connection/ChatConnection";
     import { selectedChatMessageToEdit } from "../../Stores/ChatStore";
     import LL from "../../../../i18n/i18n-svelte";
@@ -27,12 +28,42 @@
             }, 2000);
         }
     }
+
+    function editMessageOrEscapeLine(keyDownEvent: KeyboardEvent) {
+        // Shift+Enter (or any other key) keeps the default behaviour, e.g. inserting a new line.
+        if (keyDownEvent.key !== "Enter" || keyDownEvent.shiftKey) {
+            return;
+        }
+        // Enter validates the edition instead of inserting a new line.
+        keyDownEvent.preventDefault();
+        editMessage(inputValue).catch((error) => console.error(error));
+    }
+
+    onMount(() => {
+        // Move the focus (and caret) into the edition input so that keystrokes - and especially the
+        // Enter used to validate the edition - are handled here and do not leak to the message
+        // composer, which would otherwise send the in-progress draft alongside the edition.
+        if (!messageInput) {
+            return;
+        }
+        messageInput.focus();
+        const selection = window.getSelection();
+        if (!selection) {
+            return;
+        }
+        const range = document.createRange();
+        range.selectNodeContents(messageInput);
+        range.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(range);
+    });
 </script>
 
 <div>
     <MessageInput
         bind:message={inputValue}
         bind:messageInput
+        onkeydown={editMessageOrEscapeLine}
         dataTestid="editMessageInput"
         inputClass=" p-1  !m-0 px-2 max-h-36 overflow-auto w-full h-full rounded-md !leading-6 block !text-sm !text-white !bg-white/20 placeholder:text-sm  !text-black border  resize-none  shadow-none focus:ring-0"
         dataText={$LL.chat.enter()}

--- a/play/src/front/Chat/Components/Room/MessageInputBar.svelte
+++ b/play/src/front/Chat/Components/Room/MessageInputBar.svelte
@@ -19,7 +19,7 @@
     import type { EmojiClickEvent } from "emoji-picker-element/shared";
     import { defaultNativeIntegrationAppName } from "@workadventure/shared-utils";
     import { hasChatRoomPollCreation, type ChatConversation } from "../../Connection/ChatConnection";
-    import { selectedChatMessageToReply } from "../../Stores/ChatStore";
+    import { selectedChatMessageToEdit, selectedChatMessageToReply } from "../../Stores/ChatStore";
     import { chatInputFocusStore } from "../../../Stores/ChatStore";
     import { warningMessageStore } from "../../../Stores/ErrorStore";
     import LL from "../../../../i18n/i18n-svelte";
@@ -134,7 +134,9 @@
             keyDownEvent.preventDefault();
         }
 
-        if (keyDownEvent.key === "Enter" && !isEmptyMessage) {
+        // When a message edition is in progress, the Enter key must only validate the edition. Never
+        // send the in-progress draft from the composer, even if it still holds the focus.
+        if (keyDownEvent.key === "Enter" && !isEmptyMessage && $selectedChatMessageToEdit === null) {
             // message contains HTML tags. Actually, the only tags we allow are for the new line, ie. <br> tags.
             // We can turn those back into carriage returns.
             const messageToSend = message.replace(/<br>/g, "\n");

--- a/tests/tests/chat/matrixChat.spec.ts
+++ b/tests/tests/chat/matrixChat.spec.ts
@@ -307,6 +307,35 @@ test.describe("Matrix chat tests @oidc @matrix @nowebkit", () => {
         await expect(page.getByText(chatMessageContent)).toBeAttached();
     });
 
+    test("Validating an edition with Enter does not send the in-progress draft", async ({ browser }) => {
+        await using page = await getPage(browser, "Alice", Map.url("empty"));
+        await oidcMatrixUserLogin(page);
+        await ChatUtils.openChat(page);
+        await ChatUtils.openCreateRoomDialog(page);
+        const publicChatRoomName = ChatUtils.getRandomName();
+        await page.getByTestId("createRoomName").fill(publicChatRoomName);
+        await page.getByPlaceholder("Users").click();
+        await page.getByPlaceholder("Users").press("Enter");
+        await page.getByTestId("createRoomButton").click();
+        await page.getByText(publicChatRoomName).click();
+        const chatMessageContent = "This is a test message";
+        const chatMessageEdited = "This is a test edited message";
+        const draftInProgress = "This draft must not be sent";
+        // Send a first message that we will edit later.
+        await page.getByTestId("messageInput").fill(chatMessageContent);
+        await page.getByTestId("sendMessageButton").click();
+        // Start writing a new message in the composer, but do NOT send it.
+        await page.getByTestId("messageInput").fill(draftInProgress);
+        // Edit the first message and validate the edition with Enter.
+        await page.getByTestId("editMessageButton").click();
+        await page.getByTestId("editMessageInput").fill(chatMessageEdited);
+        await page.getByTestId("editMessageInput").press("Enter");
+        // The edition is applied...
+        await expect(page.getByText(chatMessageEdited)).toBeAttached();
+        // ...and the in-progress draft is still in the composer (i.e. it was NOT sent: sending clears it).
+        await expect(page.getByTestId("messageInput")).toHaveText(draftInProgress);
+    });
+
     // test("Create a private chat room", async ({ browser }) => {
     //   await using page = await getPage(browser, 'Alice', Map.url("empty"));
     //   await oidcMatrixUserLogin(page);


### PR DESCRIPTION
Needs to be reproduced on master before merging.

## Problem

When a message is being typed in the composer (an unsent draft) and the user then edits **another** existing message, validating the edit with **Enter** also sends the in-progress draft. Both go out, instead of only the edit.

## Root cause

During an edit, two `contenteditable` inputs are alive at once: the composer (`MessageInputBar`, holds the draft) and the inline editor (`MessageEdition`). The inline editor never took focus on mount and had no Enter handling (the edit was only committed via the *Save* button). So focus stayed on the composer, whose `sendMessageOrEscapeLine` sends on Enter and had no awareness of edit mode — the Enter meant for the edit sent the draft.

## Fix

- **`MessageEdition.svelte`** — the edit box now takes focus (caret at end) on mount and validates on Enter (`Shift+Enter` still inserts a newline). Enter no longer leaks to the composer.
- **`MessageInputBar.svelte`** — safeguard: the composer refuses to send while an edit is in progress (`$selectedChatMessageToEdit === null`).

## Test

Added E2E `Validating an edition with Enter does not send the in-progress draft` in `tests/tests/chat/matrixChat.spec.ts`: types a draft, edits a prior message, validates with Enter, and asserts the edit is applied while the draft stays in the composer (i.e. it was not sent).

## Verification

- `eslint` passes on all changed files.
- `svelte-check` reports no diagnostics on the changed components (remaining errors are pre-existing Phaser/deps noise unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)