### PR TITLE
fix(status): split browser-imposed SOUND_BLOCKED from BACK_IN_A_MOMENT

### DIFF
--- a/back/src/Model/User.ts
+++ b/back/src/Model/User.ts
@@ -195,7 +195,8 @@ export class User implements Movable, CustomJsonReplacerInterface {
             this.availabilityStatus === AvailabilityStatus.DO_NOT_DISTURB ||
             this.availabilityStatus === AvailabilityStatus.BACK_IN_A_MOMENT ||
             this.availabilityStatus === AvailabilityStatus.LIVEKIT ||
-            this.availabilityStatus === AvailabilityStatus.LISTENER
+            this.availabilityStatus === AvailabilityStatus.LISTENER ||
+            this.availabilityStatus === AvailabilityStatus.SOUND_BLOCKED
         );
     }
 

--- a/messages/protos/messages.proto
+++ b/messages/protos/messages.proto
@@ -21,6 +21,10 @@ enum AvailabilityStatus {
   BACK_IN_A_MOMENT = 10;
   LIVEKIT = 11;
   LISTENER = 12;
+  // Set automatically when the browser refuses to play audio for lack of a user
+  // gesture. Unlike BACK_IN_A_MOMENT, which the user picks, this one is imposed and
+  // clears on the next click.
+  SOUND_BLOCKED = 13;
 }
 
 message PositionMessage {

--- a/play/src/front/Chat/Components/UserList/User.svelte
+++ b/play/src/front/Chat/Components/UserList/User.svelte
@@ -69,6 +69,8 @@
                 return $LL.chat.status.do_not_disturb();
             case AvailabilityStatus.BACK_IN_A_MOMENT:
                 return $LL.chat.status.back_in_a_moment();
+            case AvailabilityStatus.SOUND_BLOCKED:
+                return $LL.chat.status.sound_blocked();
             case AvailabilityStatus.JITSI:
             case AvailabilityStatus.BBB:
             case AvailabilityStatus.LIVEKIT:

--- a/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
+++ b/play/src/front/Chat/Connection/Matrix/MatrixChatConnection.ts
@@ -157,6 +157,7 @@ export class MatrixChatConnection implements ChatConnectionInterface, MatrixChat
             | AvailabilityStatus.SPEAKER
             | AvailabilityStatus.LIVEKIT
             | AvailabilityStatus.LISTENER
+            | AvailabilityStatus.SOUND_BLOCKED
             | RequestedStatus
         >,
         private matrixSecurity: MatrixSecurity = defaultMatrixSecurity,

--- a/play/src/front/Components/ActionBar/AvailabilityStatus/AvailabilityStatusList.svelte
+++ b/play/src/front/Components/ActionBar/AvailabilityStatus/AvailabilityStatusList.svelte
@@ -38,7 +38,7 @@
 
     <HeaderMenuItem label={$LL.actionbar.listStatusTitle.enable()} />
     <!-- Some status (silent, in a meeting...) are locking the status bar to only one option -->
-    {#if [AvailabilityStatus.LISTENER, AvailabilityStatus.SPEAKER, AvailabilityStatus.JITSI, AvailabilityStatus.LIVEKIT, AvailabilityStatus.BBB, AvailabilityStatus.DENY_PROXIMITY_MEETING, AvailabilityStatus.SILENT].includes($availabilityStatusStore)}
+    {#if [AvailabilityStatus.LISTENER, AvailabilityStatus.SPEAKER, AvailabilityStatus.JITSI, AvailabilityStatus.LIVEKIT, AvailabilityStatus.BBB, AvailabilityStatus.DENY_PROXIMITY_MEETING, AvailabilityStatus.SILENT, AvailabilityStatus.SOUND_BLOCKED].includes($availabilityStatusStore)}
         <button
             class="status-button group flex px-2 py-1 gap-2 items-center transition-all cursor-pointer text-sm text-neutral-100 w-full pointer-events-auto text-start rounded active:outline-none focus:outline-none"
         >

--- a/play/src/front/Components/ActionBar/AvailabilityStatus/statusChanger.ts
+++ b/play/src/front/Components/ActionBar/AvailabilityStatus/statusChanger.ts
@@ -1,5 +1,4 @@
 import { StatusChanger } from "../../../Rules/StatusRules/StatusChanger";
-import { StatusRules } from "../../../Rules/StatusRules/statusRules";
 import { StatusStrategyFactory } from "../../../Rules/StatusRules/StatusFactory/StatusStrategyFactory";
 
-export const statusChanger = new StatusChanger(StatusRules, StatusStrategyFactory);
+export const statusChanger = new StatusChanger(StatusStrategyFactory);

--- a/play/src/front/Components/ActionBar/MenuIcons/CameraMenuItem.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/CameraMenuItem.svelte
@@ -26,6 +26,7 @@
                 $availabilityStatusStore === AvailabilityStatus.BUSY ||
                 $availabilityStatusStore === AvailabilityStatus.AWAY ||
                 $availabilityStatusStore === AvailabilityStatus.BACK_IN_A_MOMENT ||
+                $availabilityStatusStore === AvailabilityStatus.SOUND_BLOCKED ||
                 $availabilityStatusStore === AvailabilityStatus.DO_NOT_DISTURB ||
                 $silentStore === true ||
                 ($cameraListStore !== undefined && $cameraListStore.length === 0)

--- a/play/src/front/Components/ActionBar/MenuIcons/MicrophoneMenuItem.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/MicrophoneMenuItem.svelte
@@ -25,6 +25,7 @@
                 $availabilityStatusStore === AvailabilityStatus.BUSY ||
                 $availabilityStatusStore === AvailabilityStatus.AWAY ||
                 $availabilityStatusStore === AvailabilityStatus.BACK_IN_A_MOMENT ||
+                $availabilityStatusStore === AvailabilityStatus.SOUND_BLOCKED ||
                 $availabilityStatusStore === AvailabilityStatus.DO_NOT_DISTURB ||
                 $silentStore === true ||
                 ($microphoneListStore !== undefined && $microphoneListStore.length === 0)

--- a/play/src/front/Components/PopUp/SayPopUp.svelte
+++ b/play/src/front/Components/PopUp/SayPopUp.svelte
@@ -44,6 +44,7 @@
             case AvailabilityStatus.AWAY:
             case AvailabilityStatus.DO_NOT_DISTURB:
             case AvailabilityStatus.BACK_IN_A_MOMENT:
+            case AvailabilityStatus.SOUND_BLOCKED:
             case AvailabilityStatus.BUSY: {
                 type = "think";
                 break;

--- a/play/src/front/Rules/StatusRules/Errors/InvalidStatusTransitionError.ts
+++ b/play/src/front/Rules/StatusRules/Errors/InvalidStatusTransitionError.ts
@@ -1,5 +1,0 @@
-export class InvalidStatusTransitionError extends Error {
-    constructor(msg: string) {
-        super(msg);
-    }
-}

--- a/play/src/front/Rules/StatusRules/StatusChanger.ts
+++ b/play/src/front/Rules/StatusRules/StatusChanger.ts
@@ -1,16 +1,22 @@
 import type { AvailabilityStatus } from "@workadventure/messages";
 import type { StatusStrategyInterface } from "./StatusStrategyInterface";
 import { BasicStatusStrategy } from "./StatusStrategy/BasicStatusStrategy";
-import type { StatusRulesVerificationInterface } from "./statusRules";
-import { InvalidStatusTransitionError } from "./Errors/InvalidStatusTransitionError";
 
 export interface StatusStrategyFactoryInterface {
     createStrategy: (newStatus: AvailabilityStatus) => StatusStrategyInterface;
 }
 
+/**
+ * Applies the side rules that come with a status (timed rules, notification sound policy).
+ *
+ * It only ever *observes* availabilityStatusStore, which already decided the status by
+ * priority — so it deliberately vets nothing. It used to reject "impossible" transitions,
+ * but the store emits them routinely (a BUSY user walking into a silent zone) and
+ * GameScene sends the status to the back off its own subscription regardless. The
+ * rejection could not undo a status, only skip these rules and leave the strategy behind.
+ */
 export class StatusChanger {
     constructor(
-        private _rulesVerification: StatusRulesVerificationInterface,
         private _StatusStrategyFactory: StatusStrategyFactoryInterface,
         private _statusStrategy: StatusStrategyInterface = new BasicStatusStrategy(),
     ) {
@@ -20,11 +26,6 @@ export class StatusChanger {
         return this._statusStrategy.getActualStatus();
     }
     changeStatusTo(newStatus: AvailabilityStatus) {
-        if (!this._rulesVerification.canChangeStatus(this._statusStrategy.getActualStatus()).to(newStatus)) {
-            throw new InvalidStatusTransitionError(
-                `Cannot change status from ${this._statusStrategy.getActualStatus()} to ${newStatus}`,
-            );
-        }
         this._statusStrategy.cleanTimedRules();
         this.setStrategy(newStatus);
         this._statusStrategy.applyAllRules();

--- a/play/src/front/Rules/StatusRules/StatusStrategy/BasicStatusStrategy.ts
+++ b/play/src/front/Rules/StatusRules/StatusStrategy/BasicStatusStrategy.ts
@@ -14,6 +14,9 @@ export class BasicStatusStrategy extends StatusStrategy {
 
     allowNotificationSound(): boolean {
         switch (this.status) {
+            // Sound being blocked, the notification could not play anyway, and trying
+            // would signal the block again.
+            case AvailabilityStatus.SOUND_BLOCKED:
             case AvailabilityStatus.SILENT:
             case AvailabilityStatus.JITSI:
             case AvailabilityStatus.BBB:

--- a/play/src/front/Rules/StatusRules/statusRules.ts
+++ b/play/src/front/Rules/StatusRules/statusRules.ts
@@ -1,57 +1,11 @@
-import { AvailabilityStatus } from "@workadventure/messages";
-
-export interface StatusRulesVerificationInterface {
-    canChangeStatus: (actualStatus: AvailabilityStatus) => { to: (futureStatus: AvailabilityStatus) => boolean };
-}
+import type { AvailabilityStatus } from "@workadventure/messages";
 
 export type TimedRules = {
     applyIn: number;
     rule: () => void;
 };
 
-const basicStatus: Array<AvailabilityStatus> = [
-    AvailabilityStatus.SPEAKER,
-    AvailabilityStatus.UNCHANGED,
-    AvailabilityStatus.SILENT,
-    AvailabilityStatus.AWAY,
-    AvailabilityStatus.UNRECOGNIZED,
-    AvailabilityStatus.DENY_PROXIMITY_MEETING,
-];
-
 export type RequestedStatus =
     | AvailabilityStatus.DO_NOT_DISTURB
     | AvailabilityStatus.BACK_IN_A_MOMENT
     | AvailabilityStatus.BUSY;
-
-export const setableStatus: Array<AvailabilityStatus> = [
-    AvailabilityStatus.BUSY,
-    AvailabilityStatus.DO_NOT_DISTURB,
-    AvailabilityStatus.BACK_IN_A_MOMENT,
-];
-
-const invalidTransition: Map<AvailabilityStatus, Array<AvailabilityStatus>> = new Map([
-    [AvailabilityStatus.UNCHANGED, [...setableStatus]],
-    [AvailabilityStatus.ONLINE, []],
-    [AvailabilityStatus.SILENT, [...setableStatus]],
-    [AvailabilityStatus.AWAY, [...setableStatus]],
-    [AvailabilityStatus.JITSI, []],
-    [AvailabilityStatus.BBB, []],
-    [AvailabilityStatus.DENY_PROXIMITY_MEETING, [...setableStatus]],
-    [AvailabilityStatus.SPEAKER, [...setableStatus]],
-    [AvailabilityStatus.BUSY, [...basicStatus]],
-    [AvailabilityStatus.DO_NOT_DISTURB, [...basicStatus]],
-    [AvailabilityStatus.BACK_IN_A_MOMENT, [...basicStatus]],
-    [AvailabilityStatus.UNRECOGNIZED, []],
-    [AvailabilityStatus.LIVEKIT, []],
-]);
-
-export const StatusRules = {
-    canChangeStatus: (actualStatus: AvailabilityStatus) => {
-        const listOfInvalidTransition: Array<AvailabilityStatus> = invalidTransition.get(actualStatus) || [];
-        return {
-            to: (futureStatus: AvailabilityStatus): boolean => {
-                return !listOfInvalidTransition.includes(futureStatus);
-            },
-        };
-    },
-};

--- a/play/src/front/Rules/StatusRules/tests/status.test.ts
+++ b/play/src/front/Rules/StatusRules/tests/status.test.ts
@@ -1,76 +1,53 @@
-import { beforeEach, describe, expect, it, test, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AvailabilityStatus } from "@workadventure/messages";
-import type { StatusRulesVerificationInterface, TimedRules } from "../statusRules";
-import { StatusRules } from "../statusRules";
+import type { TimedRules } from "../statusRules";
 import { BasicStatusStrategy } from "../StatusStrategy/BasicStatusStrategy";
-import { InvalidStatusTransitionError } from "../Errors/InvalidStatusTransitionError";
+import { BackInAMomentStatusStrategy } from "../StatusStrategy/BackInAMomentStatusStrategy";
+import { StatusStrategyFactory } from "../StatusFactory/StatusStrategyFactory";
 import type { StatusStrategyFactoryInterface } from "../StatusChanger";
 import { StatusChanger } from "../StatusChanger";
 import type { StatusStrategyInterface } from "../StatusStrategyInterface";
 
-describe("Verify Rules Transition", () => {
-    test.each([
-        { actualStatus: AvailabilityStatus.ONLINE, futureStatus: AvailabilityStatus.BUSY, result: true },
-        { actualStatus: AvailabilityStatus.ONLINE, futureStatus: AvailabilityStatus.DO_NOT_DISTURB, result: true },
-        { actualStatus: AvailabilityStatus.ONLINE, futureStatus: AvailabilityStatus.BACK_IN_A_MOMENT, result: true },
-        { actualStatus: AvailabilityStatus.ONLINE, futureStatus: AvailabilityStatus.ONLINE, result: true },
-        { actualStatus: AvailabilityStatus.BUSY, futureStatus: AvailabilityStatus.DO_NOT_DISTURB, result: true },
-        { actualStatus: AvailabilityStatus.BUSY, futureStatus: AvailabilityStatus.JITSI, result: true },
-        { actualStatus: AvailabilityStatus.JITSI, futureStatus: AvailabilityStatus.BUSY, result: true },
-    ])(
-        "change status $actualStatus to status $futureStatus to be $result  ",
-        ({
-            actualStatus,
-            futureStatus,
-            result,
-        }: {
-            actualStatus: AvailabilityStatus;
-            futureStatus: AvailabilityStatus;
-            result: boolean;
-        }) => {
-            //Arrange
-            //Act
-            const isValid: boolean = StatusRules.canChangeStatus(actualStatus).to(futureStatus);
-            //Assert
-            expect(isValid).toBe(result);
-        },
-    );
-});
+// The real strategies reach popups and MediaStore, whose module graph cycles back through
+// MediaManager -> ScreenSharingStore and dies on import. Stub the leaves so the factory
+// itself stays under test.
+vi.mock("../statusChangerFunctions", () => ({
+    askToChangeStatus: vi.fn(),
+    askIfUserWantToJoinBubbleOf: vi.fn(),
+    resetAllStatusStoreExcept: vi.fn(),
+    passStatusToOnline: vi.fn(),
+    closeChangeStatusConfirmationModal: vi.fn(),
+    closeBubbleConfirmationModal: vi.fn(),
+    hideBubbleConfirmationModal: vi.fn(),
+}));
+vi.mock("../../../Stores/PopupStore", () => ({
+    popupStore: { addPopup: vi.fn(), removePopup: vi.fn() },
+}));
+vi.mock("../../../Connection/LocalUserStore", () => ({
+    localUserStore: {
+        getLastNotificationPermissionRequest: vi.fn(),
+        setLastNotificationPermissionRequest: vi.fn(),
+    },
+}));
 
 describe("Status Rules", () => {
     describe("StatusChanger", () => {
         it("should create an instance of statusStrategy with online Status by default", () => {
             //Arrange
-            const mockRulesVerification: StatusRulesVerificationInterface = {
-                canChangeStatus: (actualStatus: AvailabilityStatus) => {
-                    return {
-                        to: vi.fn().mockReturnValueOnce(true),
-                    };
-                },
-            };
-
             const mockCreateStrategy = vi.fn().mockReturnValueOnce(new BasicStatusStrategy(AvailabilityStatus.BUSY));
 
             const mockStatusStrategyFactory: StatusStrategyFactoryInterface = {
                 createStrategy: mockCreateStrategy,
             };
 
-            const statusStrategy: StatusChanger = new StatusChanger(mockRulesVerification, mockStatusStrategyFactory);
+            const statusStrategy: StatusChanger = new StatusChanger(mockStatusStrategyFactory);
             //Act
             const actualStatus = statusStrategy.getActualStatus();
             //Assert
             expect(actualStatus).toBe(AvailabilityStatus.ONLINE);
         });
-        it("should set the status when statusVerification return true", () => {
+        it("should set the status", () => {
             //Arrange
-            const mockRulesVerification: StatusRulesVerificationInterface = {
-                canChangeStatus: (actualStatus: AvailabilityStatus) => {
-                    return {
-                        to: vi.fn().mockReturnValueOnce(true),
-                    };
-                },
-            };
-
             const actualStatus = AvailabilityStatus.ONLINE;
             const actualStrategy = new BasicStatusStrategy(actualStatus, [], []);
             const newStatus = AvailabilityStatus.BBB;
@@ -81,11 +58,7 @@ describe("Status Rules", () => {
                 createStrategy: mockCreateStrategy,
             };
 
-            const statusStrategy: StatusChanger = new StatusChanger(
-                mockRulesVerification,
-                mockStatusStrategyFactory,
-                actualStrategy,
-            );
+            const statusStrategy: StatusChanger = new StatusChanger(mockStatusStrategyFactory, actualStrategy);
             expect(statusStrategy.getActualStatus()).toBe(actualStatus);
 
             //Act
@@ -96,58 +69,35 @@ describe("Status Rules", () => {
             //Assert
             expect(result).toBe(newStatus);
         });
-        it("should return InvalidStatusTransitionError and leave the actual status when statusVerificator return false", () => {
-            //Arrange
-            const mockTo = vi.fn().mockReturnValueOnce(false);
-            const mockRulesVerificator: StatusRulesVerificationInterface = {
-                canChangeStatus: (actualStatus: AvailabilityStatus) => {
-                    return {
-                        to: mockTo,
-                    };
-                },
-            };
-
-            const actualStatus = AvailabilityStatus.ONLINE;
-            const actualStrategy = new BasicStatusStrategy(actualStatus, [], []);
-            const newStatus = AvailabilityStatus.BBB;
-
-            const mockCreateStrategy = vi.fn().mockReturnValueOnce(new BasicStatusStrategy(newStatus));
-
-            const mockStatusStrategyFactory: StatusStrategyFactoryInterface = {
-                createStrategy: mockCreateStrategy,
-            };
-
-            const statusStrategy: StatusChanger = new StatusChanger(
-                mockRulesVerificator,
-                mockStatusStrategyFactory,
-                actualStrategy,
+        // The derived availabilityStatusStore routinely preempts a requested status with an
+        // automatic one (BUSY -> SILENT on entering a silent zone, and back out again). Those
+        // used to throw. Nothing may reject a status here: the store has already emitted it.
+        it("should accept a transition between an automatic and a requested status", () => {
+            const statusStrategy = new StatusChanger(
+                StatusStrategyFactory,
+                new BasicStatusStrategy(AvailabilityStatus.BUSY),
             );
-            expect(statusStrategy.getActualStatus()).toBe(actualStatus);
+
+            statusStrategy.changeStatusTo(AvailabilityStatus.SILENT);
+            expect(statusStrategy.getActualStatus()).toBe(AvailabilityStatus.SILENT);
+
+            statusStrategy.changeStatusTo(AvailabilityStatus.BUSY);
+            expect(statusStrategy.getActualStatus()).toBe(AvailabilityStatus.BUSY);
+        });
+        it("should accept the status the browser imposes when sound is blocked while away", () => {
+            const statusStrategy = new StatusChanger(
+                StatusStrategyFactory,
+                new BasicStatusStrategy(AvailabilityStatus.AWAY),
+            );
 
             //Act
-            expect(() => {
-                statusStrategy.changeStatusTo(newStatus);
-            }).toThrow(InvalidStatusTransitionError);
-
-            const result = statusStrategy.getActualStatus();
+            statusStrategy.changeStatusTo(AvailabilityStatus.SOUND_BLOCKED);
 
             //Assert
-            expect(mockTo).toHaveBeenCalledOnce();
-
-            expect(result).toBe(actualStatus);
+            expect(statusStrategy.getActualStatus()).toBe(AvailabilityStatus.SOUND_BLOCKED);
         });
-        it("should apply rules of new status and delete rules of old status when you change status and statusVerificator return true", () => {
+        it("should apply rules of new status and delete rules of old status when you change status", () => {
             //Arrange
-
-            const mockTo = vi.fn().mockName("to").mockReturnValueOnce(true);
-            const mockRulesVerification: StatusRulesVerificationInterface = {
-                canChangeStatus: (actualStatus: AvailabilityStatus) => {
-                    return {
-                        to: mockTo,
-                    };
-                },
-            };
-
             const applyAllRulesOld = vi.fn();
             const cleanTimedRulesOld = vi.fn();
 
@@ -182,7 +132,6 @@ describe("Status Rules", () => {
             };
 
             const statusStrategy: StatusChanger = new StatusChanger(
-                mockRulesVerification,
                 mockStatusStrategyFactory,
                 mockOldBasicStatusStrategy,
             );
@@ -198,6 +147,39 @@ describe("Status Rules", () => {
             //Assert
             expect(result).toBe(newStatus);
             expect(applyAllRulesNew).toHaveBeenCalledOnce();
+        });
+    });
+    // SOUND_BLOCKED and BACK_IN_A_MOMENT both mean "cannot take part right now", but only
+    // BACK_IN_A_MOMENT is a deliberate choice. Handing the imposed one the requested one's
+    // strategy is what made a blocked <audio> element eventually prompt "still back in a
+    // moment?" at users who never asked for the status.
+    describe("SOUND_BLOCKED is not a requested BACK_IN_A_MOMENT", () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        it("should not give it the BACK_IN_A_MOMENT strategy", () => {
+            const strategy = StatusStrategyFactory.createStrategy(AvailabilityStatus.SOUND_BLOCKED);
+
+            expect(strategy).not.toBeInstanceOf(BackInAMomentStatusStrategy);
+        });
+
+        it("should not arm the timed rule that asks the user to change status", () => {
+            const backInAMoment = StatusStrategyFactory.createStrategy(AvailabilityStatus.BACK_IN_A_MOMENT);
+            backInAMoment.applyAllRules();
+            expect(vi.getTimerCount()).toBe(1);
+
+            vi.clearAllTimers();
+
+            const soundBlocked = StatusStrategyFactory.createStrategy(AvailabilityStatus.SOUND_BLOCKED);
+            soundBlocked.applyAllRules();
+            expect(vi.getTimerCount()).toBe(0);
+        });
+
+        it("should still mute notification sounds, which could not play anyway", () => {
+            const strategy = StatusStrategyFactory.createStrategy(AvailabilityStatus.SOUND_BLOCKED);
+
+            expect(strategy.allowNotificationSound()).toBe(false);
         });
     });
     describe("StatusStrategy", () => {

--- a/play/src/front/Stores/MediaStore.ts
+++ b/play/src/front/Stores/MediaStore.ts
@@ -435,7 +435,7 @@ export const availabilityStatusStore = derived(
     ]) => {
         // Important: Statuses that should not switch to BUSY
         // must be checked BEFORE privacyShutdownStore to prevent switching to BUSY when privacy is enabled.
-        if ($audioPlaybackStore.size > 0 && !$browserNotificationStore) return AvailabilityStatus.BACK_IN_A_MOMENT;
+        if ($audioPlaybackStore.size > 0 && !$browserNotificationStore) return AvailabilityStatus.SOUND_BLOCKED;
         if ($inJitsiStore) return AvailabilityStatus.JITSI;
         if ($inBbbStore) return AvailabilityStatus.BBB;
         if (!$proximityMeetingStore) return AvailabilityStatus.DENY_PROXIMITY_MEETING;
@@ -518,6 +518,7 @@ export const mediaStreamConstraintsStore = derived(
             $availabilityStatusStore === AvailabilityStatus.SILENT ||
             $availabilityStatusStore === AvailabilityStatus.DO_NOT_DISTURB ||
             $availabilityStatusStore === AvailabilityStatus.BACK_IN_A_MOMENT ||
+            $availabilityStatusStore === AvailabilityStatus.SOUND_BLOCKED ||
             $availabilityStatusStore === AvailabilityStatus.BUSY;
         const shouldDisableMicrophoneForPrivacy =
             $privacyShutdownStore === true && !localUserStore.getMicrophonePrivacySettings();
@@ -1174,6 +1175,7 @@ export const localStreamStoreForPublishing = derived<
             $availabilityStatusStore === AvailabilityStatus.SILENT ||
             $availabilityStatusStore === AvailabilityStatus.DO_NOT_DISTURB ||
             $availabilityStatusStore === AvailabilityStatus.BACK_IN_A_MOMENT ||
+            $availabilityStatusStore === AvailabilityStatus.SOUND_BLOCKED ||
             $availabilityStatusStore === AvailabilityStatus.BUSY;
         const shouldMaskVideoForPublishing = isUnavailableStatus && $inBackgroundSettingsStore;
 

--- a/play/src/front/Stores/StreamableCollectionRules.ts
+++ b/play/src/front/Stores/StreamableCollectionRules.ts
@@ -36,6 +36,7 @@ export function shouldDisplayLocalCameraPeer({
         availabilityStatus === AvailabilityStatus.SILENT ||
         availabilityStatus === AvailabilityStatus.DO_NOT_DISTURB ||
         availabilityStatus === AvailabilityStatus.BACK_IN_A_MOMENT ||
+        availabilityStatus === AvailabilityStatus.SOUND_BLOCKED ||
         availabilityStatus === AvailabilityStatus.BUSY;
 
     if (isUnavailableStatus) {

--- a/play/src/front/Utils/AvailabilityStatus.ts
+++ b/play/src/front/Utils/AvailabilityStatus.ts
@@ -20,14 +20,19 @@ const COLORS: Record<AvailabilityStatus, { filling: number; outline: number }> =
     [AvailabilityStatus.BUSY]: { filling: 0xe9c84e, outline: 0xd3873b },
     [AvailabilityStatus.LIVEKIT]: { filling: 0x68e97a, outline: 0x44d45a },
     [AvailabilityStatus.LISTENER]: { filling: 0x68e97a, outline: 0x44d45a },
+    [AvailabilityStatus.SOUND_BLOCKED]: { filling: 0x7382e2, outline: 0x4156f6 },
 };
 
+// A peer running an older build sends statuses this one has no colour for, and the
+// protobuf reader hands them over as raw ints rather than UNRECOGNIZED.
+const UNKNOWN_STATUS_COLOR = { filling: 0xffffff, outline: 0xffffff };
+
 export const getColorOfStatus = (status: AvailabilityStatus): { filling: number; outline: number } => {
-    return COLORS[status];
+    return COLORS[status] ?? UNKNOWN_STATUS_COLOR;
 };
 
 export const getColorHexOfStatus = (status: AvailabilityStatus): string => {
-    return `#${COLORS[status].filling.toString(16)}`;
+    return `#${getColorOfStatus(status).filling.toString(16)}`;
 };
 
 export const getStatusLabel = (status: AvailabilityStatus): string => {

--- a/play/src/i18n/ar-SA/actionbar.ts
+++ b/play/src/i18n/ar-SA/actionbar.ts
@@ -72,6 +72,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "في اجتماع",
         LIVEKIT: "في اجتماع",
         LISTENER: "في اجتماع",
+        SOUND_BLOCKED: "الصوت محجوب",
     },
     subtitle: {
         camera: "الكاميرا",

--- a/play/src/i18n/ar-SA/chat.ts
+++ b/play/src/i18n/ar-SA/chat.ts
@@ -92,6 +92,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         busy: "مشغول",
         meeting: "في اجتماع",
         megaphone: "يستخدم مكبر الصوت",
+        sound_blocked: "الصوت محجوب",
     },
     logIn: "تسجيل الدخول",
     signIn: "سجل أو قم بتسجيل الدخول للاستمتاع بجميع ميزات الدردشة!",

--- a/play/src/i18n/ca-ES/actionbar.ts
+++ b/play/src/i18n/ca-ES/actionbar.ts
@@ -74,6 +74,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "En una reunió",
         LIVEKIT: "En una reunió",
         LISTENER: "En una reunió",
+        SOUND_BLOCKED: "So bloquejat",
     },
     subtitle: {
         camera: "Càmera",

--- a/play/src/i18n/ca-ES/chat.ts
+++ b/play/src/i18n/ca-ES/chat.ts
@@ -93,6 +93,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "No disponible",
         meeting: "En reunió",
         megaphone: "Utilitza el megàfon",
+        sound_blocked: "So bloquejat",
     },
     logIn: "Iniciar sessió",
     signIn: "Registreu-vos o inicieu sessió per gaudir de totes les funcionalitats del xat!",

--- a/play/src/i18n/de-DE/actionbar.ts
+++ b/play/src/i18n/de-DE/actionbar.ts
@@ -76,6 +76,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "In einer Besprechung",
         LIVEKIT: "In einer Besprechung",
         LISTENER: "In einer Besprechung",
+        SOUND_BLOCKED: "Ton blockiert",
     },
     subtitle: {
         camera: "Kamera",

--- a/play/src/i18n/de-DE/chat.ts
+++ b/play/src/i18n/de-DE/chat.ts
@@ -94,6 +94,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "Nicht verfügbar",
         meeting: "In Besprechung",
         megaphone: "Nutzt das Megaphon",
+        sound_blocked: "Ton blockiert",
     },
     logIn: "Anmelden",
     signIn: "Registrieren oder anmelden, um alle Funktionen des Chats zu nutzen!",

--- a/play/src/i18n/dsb-DE/actionbar.ts
+++ b/play/src/i18n/dsb-DE/actionbar.ts
@@ -74,6 +74,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "W zetkanju",
         LIVEKIT: "W zetkanju",
         LISTENER: "W zetkanju",
+        SOUND_BLOCKED: "Zuk zablokěrowany",
     },
     subtitle: {
         camera: "Kamara",

--- a/play/src/i18n/dsb-DE/chat.ts
+++ b/play/src/i18n/dsb-DE/chat.ts
@@ -94,6 +94,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "njestoj k dipoziciji",
         meeting: "W zasedańu",
         megaphone: "Wužywa megafon",
+        sound_blocked: "Zuk zablokěrowany",
     },
     logIn: "Zalogowaś se",
     signIn: "Registrěruj se abo zaloguj se, aby wšykne funkcije chata se wužywali!",

--- a/play/src/i18n/en-US/actionbar.ts
+++ b/play/src/i18n/en-US/actionbar.ts
@@ -73,6 +73,7 @@ const actionbar: BaseTranslation = {
         SPEAKER: "In a meeting",
         LIVEKIT: "In a meeting",
         LISTENER: "In a meeting",
+        SOUND_BLOCKED: "Sound blocked",
     },
     subtitle: {
         camera: "Camera",

--- a/play/src/i18n/en-US/chat.ts
+++ b/play/src/i18n/en-US/chat.ts
@@ -92,6 +92,7 @@ const chat: BaseTranslation = {
         busy: "Busy",
         meeting: "In a meeting",
         megaphone: "Using the megaphone",
+        sound_blocked: "Sound blocked",
     },
     logIn: "Log in",
     signIn: "Register or log in to enjoy all the features of the chat !",

--- a/play/src/i18n/es-ES/actionbar.ts
+++ b/play/src/i18n/es-ES/actionbar.ts
@@ -74,6 +74,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "En una reunión",
         LIVEKIT: "En una reunión",
         LISTENER: "En una reunión",
+        SOUND_BLOCKED: "Sonido bloqueado",
     },
     subtitle: {
         camera: "Cámara",

--- a/play/src/i18n/es-ES/chat.ts
+++ b/play/src/i18n/es-ES/chat.ts
@@ -93,6 +93,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "No disponible",
         meeting: "En reunión",
         megaphone: "Usa el megáfono",
+        sound_blocked: "Sonido bloqueado",
     },
     logIn: "Iniciar sesión",
     signIn: "¡Regístrese o inicie sesión para disfrutar de todas las funciones del chat!",

--- a/play/src/i18n/fr-FR/actionbar.ts
+++ b/play/src/i18n/fr-FR/actionbar.ts
@@ -76,6 +76,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "En réunion",
         LIVEKIT: "En réunion",
         LISTENER: "En réunion",
+        SOUND_BLOCKED: "Son bloqué",
     },
     subtitle: {
         camera: "Caméra",

--- a/play/src/i18n/fr-FR/chat.ts
+++ b/play/src/i18n/fr-FR/chat.ts
@@ -93,6 +93,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "Non disponible",
         meeting: "En réunion",
         megaphone: "Utilise le mégaphone",
+        sound_blocked: "Son bloqué",
     },
     logIn: "Se connecter",
     signIn: "Inscrivez-vous ou connectez-vous pour profiter de toutes les fonctionnalités du chat !",

--- a/play/src/i18n/hsb-DE/actionbar.ts
+++ b/play/src/i18n/hsb-DE/actionbar.ts
@@ -74,6 +74,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "W zetkanju",
         LIVEKIT: "W zetkanju",
         LISTENER: "W zetkanju",
+        SOUND_BLOCKED: "Zwuk zablokowany",
     },
     subtitle: {
         camera: "Kamera",

--- a/play/src/i18n/hsb-DE/chat.ts
+++ b/play/src/i18n/hsb-DE/chat.ts
@@ -94,6 +94,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "njesteji k dispoziciji",
         meeting: "W zasedanju",
         megaphone: "Wužiwa megafon",
+        sound_blocked: "Zwuk zablokowany",
     },
     logIn: "přizjewić",
     signIn: "Registrować abo přizjewić, zo hodźa so wšitke funkcije chata wužiwać!",

--- a/play/src/i18n/it-IT/actionbar.ts
+++ b/play/src/i18n/it-IT/actionbar.ts
@@ -74,6 +74,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "In una riunione",
         LIVEKIT: "In una riunione",
         LISTENER: "In una riunione",
+        SOUND_BLOCKED: "Audio bloccato",
     },
     subtitle: {
         camera: "Fotocamera",

--- a/play/src/i18n/it-IT/chat.ts
+++ b/play/src/i18n/it-IT/chat.ts
@@ -94,6 +94,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "Non disponibile",
         meeting: "In riunione",
         megaphone: "Usando il megafono",
+        sound_blocked: "Audio bloccato",
     },
     logIn: "Accedi",
     signIn: "Registrati o accedi per godere di tutte le funzionalità della chat!",

--- a/play/src/i18n/ja-JP/actionbar.ts
+++ b/play/src/i18n/ja-JP/actionbar.ts
@@ -73,6 +73,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "会議中",
         LIVEKIT: "会議中",
         LISTENER: "会議中",
+        SOUND_BLOCKED: "音声がブロックされています",
     },
     subtitle: {
         camera: "カメラ",

--- a/play/src/i18n/ja-JP/chat.ts
+++ b/play/src/i18n/ja-JP/chat.ts
@@ -94,6 +94,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "利用不可",
         meeting: "ミーティング中",
         megaphone: "メガホン使用中",
+        sound_blocked: "音声がブロックされています",
     },
     logIn: "ログイン",
     signIn: "登録またはログインして、チャットのすべての機能をお楽しみください！",

--- a/play/src/i18n/ko-KR/actionbar.ts
+++ b/play/src/i18n/ko-KR/actionbar.ts
@@ -74,6 +74,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "회의 중",
         LIVEKIT: "회의 중",
         LISTENER: "회의 중",
+        SOUND_BLOCKED: "소리 차단됨",
     },
     subtitle: {
         camera: "카메라",

--- a/play/src/i18n/ko-KR/chat.ts
+++ b/play/src/i18n/ko-KR/chat.ts
@@ -93,6 +93,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         busy: "바쁨",
         meeting: "회의 중",
         megaphone: "확성기 사용 중",
+        sound_blocked: "소리 차단됨",
     },
     logIn: "로그인",
     signIn: "채팅의 모든 기능을 이용하려면 회원가입 또는 로그인을 해 주세요!",

--- a/play/src/i18n/nl-NL/actionbar.ts
+++ b/play/src/i18n/nl-NL/actionbar.ts
@@ -75,6 +75,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "In een vergadering",
         LIVEKIT: "In een vergadering",
         LISTENER: "In een vergadering",
+        SOUND_BLOCKED: "Geluid geblokkeerd",
     },
     subtitle: {
         camera: "Camera",

--- a/play/src/i18n/nl-NL/chat.ts
+++ b/play/src/i18n/nl-NL/chat.ts
@@ -94,6 +94,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "Niet beschikbaar",
         meeting: "In vergadering",
         megaphone: "Gebruikt de megafoon",
+        sound_blocked: "Geluid geblokkeerd",
     },
     logIn: "Inloggen",
     signIn: "Registreer of log in om van alle functies van de chat te genieten!",

--- a/play/src/i18n/pt-BR/actionbar.ts
+++ b/play/src/i18n/pt-BR/actionbar.ts
@@ -78,6 +78,7 @@ const actionbar: BaseTranslation = {
         SPEAKER: "Em uma reunião",
         LIVEKIT: "Em uma reunião",
         LISTENER: "Em uma reunião",
+        SOUND_BLOCKED: "Som bloqueado",
     },
     subtitle: {
         camera: "Câmera",

--- a/play/src/i18n/pt-BR/chat.ts
+++ b/play/src/i18n/pt-BR/chat.ts
@@ -93,6 +93,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         busy: "Ocupado",
         meeting: "Em uma reunião",
         megaphone: "Usando o megafone",
+        sound_blocked: "Som bloqueado",
     },
     logIn: "Entrar",
     signIn: "Registre-se ou faça login para aproveitar todos os recursos do chat!",

--- a/play/src/i18n/zh-CN/actionbar.ts
+++ b/play/src/i18n/zh-CN/actionbar.ts
@@ -72,6 +72,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "会议中",
         LIVEKIT: "会议中",
         LISTENER: "会议中",
+        SOUND_BLOCKED: "声音被阻止",
     },
     subtitle: {
         camera: "摄像头",

--- a/play/src/i18n/zh-CN/chat.ts
+++ b/play/src/i18n/zh-CN/chat.ts
@@ -91,6 +91,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "不可用",
         meeting: "会议中",
         megaphone: "使用扩音器",
+        sound_blocked: "声音被阻止",
     },
     logIn: "登录",
     signIn: "注册或登录以享受聊天的所有功能！",

--- a/play/src/i18n/zh-TW/actionbar.ts
+++ b/play/src/i18n/zh-TW/actionbar.ts
@@ -72,6 +72,7 @@ const actionbar: DeepPartial<Translation["actionbar"]> = {
         SPEAKER: "會議中",
         LIVEKIT: "會議中",
         LISTENER: "會議中",
+        SOUND_BLOCKED: "聲音被封鎖",
     },
     subtitle: {
         camera: "攝影機",

--- a/play/src/i18n/zh-TW/chat.ts
+++ b/play/src/i18n/zh-TW/chat.ts
@@ -91,6 +91,7 @@ const chat: DeepPartial<Translation["chat"]> = {
         unavailable: "無法使用",
         meeting: "會議中",
         megaphone: "使用擴音器",
+        sound_blocked: "聲音被封鎖",
     },
     logIn: "登入",
     signIn: "註冊或登入以享受聊天的所有功能！",


### PR DESCRIPTION
## Problem

Sentry: `Cannot change status from 3 to 10` (`AWAY` → `BACK_IN_A_MOMENT`).

`BACK_IN_A_MOMENT` was doing two unrelated jobs:

1. **Requested** — the user picks "Back in a moment" from the profile menu. Persisted, carries a 1h "do you still want this status?" timed rule, belongs to `setableStatus`.
2. **Imposed** — the browser blocked audio playback for lack of a user gesture, so `MediaStore` forced `BACK_IN_A_MOMENT` to pull the user out of the bubble (they can't hear). Transient, not persisted, clears on the next click.

The derived `availabilityStatusStore` ranks the imposed case **above** requested statuses, but the `invalidTransition` table forbids exactly those cross-family transitions. So the store routinely emitted transitions the table rejects and `StatusChanger` threw. `3 → 10` is the most frequent instance of a whole family (`BUSY → SILENT`, `BUSY → SPEAKER`, and the reverse as the automatic status clears) — 25 reachable illegal pairs in total, of which the enum split alone fixes 4.

## Changes

Two independent fixes, shipped together (each is incomplete without the other):

**1. New `AvailabilityStatus.SOUND_BLOCKED` (13)** for the audio-blocked case. It joins every **behavioural** list, to preserve today's behaviour exactly:
- `back` `User.silent` — so the proximity bubble still closes server-side;
- `isUnavailableStatus` (×2 in `MediaStore`) + `StreamableCollectionRules` — media stays unpublished;
- `allowNotificationSound() → false` — playing a sound would fail and re-signal the block;
- `SayPopUp` "think" group, mic/camera "disabled", the locked status-picker row.

It joins **no intent list**: not user-requestable, no persistence, and crucially it keeps the default `BasicStatusStrategy` — so **no 1h timed rule** fires at a user who never chose the status. Same dot colour as `BACK_IN_A_MOMENT`, its own text label.

**2. Remove the transition veto.** `StatusChanger` only *observes* a status the store already decided and `GameScene` already sent to the back off its own subscription — so rejecting a transition could never undo it, only skip the side rules and leave the strategy desynced. Deletes `invalidTransition` / `basicStatus` / `setableStatus` / `StatusRules` / `InvalidStatusTransitionError`.

**Bonus hardening:** `getColorOfStatus` now has a fallback, so an older client receiving an unknown status value during a rolling deploy no longer crashes in the WOKA status dot.

## Test plan

Static checks, all green (run in capped throwaway containers):

- [x] `vitest src/front/Rules/StatusRules` — 12/12; the new tests were confirmed to go red under a mutation that routes `SOUND_BLOCKED` to the `BACK_IN_A_MOMENT` strategy
- [x] `typecheck` (`play` + `back`)
- [x] `svelte-check` — 0 errors, 0 warnings
- [x] `i18n:check` — all translations complete (2 keys × 15 locales)
- [x] `eslint` + `prettier` on changed files

**Not yet done — needs a reviewer with a running stack:**

- [ ] Browser end-to-end. Repro the blocked state with Chrome `--autoplay-policy=document-user-activation-required`, open the room **without clicking**, bring a second user into proximity. Expect: the `BrowserNoSoundInfoToast` appears; the status picker shows a read-only "Sound blocked" row (not "Back in a moment" checked); the bubble closes for the second user; the chat user list reads "Sound blocked"; clicking resolves it back to `ONLINE`. Also check the requested `BACK_IN_A_MOMENT` still persists across reload.

## Caveats

- The **Sorbian** (`dsb-DE`, `hsb-DE`) and **Arabic** (`ar-SA`) labels are best-effort and would benefit from a native review.
- Worth watching Sentry after merge for the sibling pairs (`8 → 2`, `2 → 8`, `8 → 7`): removing the veto should silence them too. If one survives, the reachability analysis missed a case.
