### PR TITLE
refactor(ui): migrate raw design-system markup onto reusable components

### DIFF
--- a/play/src/front/Chat/Components/ChatHeader.svelte
+++ b/play/src/front/Chat/Components/ChatHeader.svelte
@@ -139,7 +139,7 @@
             <div class="absolute w-full h-full z-40 right-0 top-0 bg-contrast/30">
                 <input
                     autocomplete="new-password"
-                    class="wa-searchbar block text-white placeholder:text-white/50 w-full placeholder:text-sm border-none pl-6 pr-20 bg-transparent py-3 text-base h-full"
+                    class="block text-white placeholder:text-white/50 w-full placeholder:text-sm border-none pl-6 pr-20 bg-transparent py-3 text-base h-full"
                     placeholder={$navChat.key === "users" ? $LL.chat.searchUser() : $LL.chat.searchChat()}
                     onkeydown={handleKeyDown}
                     onkeyup={() => handleKeyUp(userProviderMerger)}

--- a/play/src/front/Chat/Components/RequiresLoginForChatModal.svelte
+++ b/play/src/front/Chat/Components/RequiresLoginForChatModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import Popup from "../../Components/Modal/Popup.svelte";
+    import Button from "../../Components/UI/Button.svelte";
     import LL from "../../../i18n/i18n-svelte";
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import { modals } from "@wa-modals";
@@ -29,14 +30,11 @@
     {/snippet}
 
     {#snippet action()}
-        <button
-            class="btn border border-solid border-white/10 hover:bg-white/10 flex-1 justify-center"
-            onclick={() => modals.close()}>{$LL.chat.createFolder.buttons.cancel()}</button
+        <Button class="border border-solid border-white/10 hover:bg-white/10 flex-1" onclick={() => modals.close()}
+            >{$LL.chat.createFolder.buttons.cancel()}</Button
         >
-        <button
-            class="btn disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
-            onclick={goToLoginPage}
+        <Button class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1" onclick={goToLoginPage}
             >{$LL.menu.profile.login()}
-        </button>
+        </Button>
     {/snippet}
 </Popup>

--- a/play/src/front/Chat/Components/Room/CreateFolderModal.svelte
+++ b/play/src/front/Chat/Components/Room/CreateFolderModal.svelte
@@ -10,6 +10,8 @@
     import SelectMatrixUser from "../SelectMatrixUser.svelte";
     import { analyticsClient } from "../../../Administration/AnalyticsClient";
     import Input from "../../../Components/Input/Input.svelte";
+    import InputGroupLabel from "../../../Components/Input/InputGroupLabel.svelte";
+    import Button from "../../../Components/UI/Button.svelte";
     import { modals } from "@wa-modals";
 
     interface Props {
@@ -122,9 +124,9 @@
                 ></textarea>
                 {#if createFolderOptions.visibility === "private"}
                     <div class="flex flex-col items-start gap-1">
-                        <div class="input-label">
+                        <InputGroupLabel id="createFolderUsersLabel">
                             <span>{$LL.chat.createFolder.users()}</span>
-                        </div>
+                        </InputGroupLabel>
                         <SelectMatrixUser
                             onerror={handleSelectMatrixUserError}
                             bind:value={createFolderOptions.invite}
@@ -140,16 +142,17 @@
         {#if loadingFolderCreation}
             <p>{$LL.chat.createFolder.loadingCreation()}</p>
         {:else}
-            <button class="btn btn-contrast flex-1 justify-center" onclick={() => modals.close()}
-                >{$LL.chat.createFolder.buttons.cancel()}</button
+            <Button variant="contrast" class="flex-1" onclick={() => modals.close()}
+                >{$LL.chat.createFolder.buttons.cancel()}</Button
             >
-            <button
-                data-testid="createFolderButton"
-                class="btn btn-secondary disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
+            <Button
+                dataTestId="createFolderButton"
+                variant="secondary"
+                class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1"
                 disabled={createFolderOptions.name === undefined || createFolderOptions.name?.trim().length === 0}
                 onclick={() => createNewFolder(createFolderOptions)}
                 >{$LL.chat.createFolder.buttons.create()}
-            </button>
+            </Button>
         {/if}
     {/snippet}
 </Popup>

--- a/play/src/front/Chat/Components/Room/CreateRoomModal.svelte
+++ b/play/src/front/Chat/Components/Room/CreateRoomModal.svelte
@@ -11,8 +11,10 @@
     import SelectMatrixUser from "../SelectMatrixUser.svelte";
     import Input from "../../../Components/Input/Input.svelte";
     import InputCheckbox from "../../../Components/Input/InputCheckbox.svelte";
+    import InputGroupLabel from "../../../Components/Input/InputGroupLabel.svelte";
     import InputRadio from "../../../Components/Input/InputRadio.svelte";
     import Spinner from "../../../Components/Icons/Spinner.svelte";
+    import Button from "../../../Components/UI/Button.svelte";
     import { modals } from "@wa-modals";
 
     interface Props {
@@ -166,9 +168,9 @@
                 </div>
                 {#if !parentID}
                     <div class="flex flex-col items-start gap-1">
-                        <div class="input-label">
+                        <InputGroupLabel id="createRoomUsersLabel">
                             <span>{$LL.chat.createRoom.users()}</span>
-                        </div>
+                        </InputGroupLabel>
                         <SelectMatrixUser
                             onerror={handleSelectMatrixUserError}
                             bind:value={createRoomOptions.invite}
@@ -199,16 +201,17 @@
         {#if loadingRoomCreation}
             <p>{$LL.chat.createRoom.loadingCreation()}</p>
         {:else}
-            <button class="flex-1 justify-cente btn btn-contrast m-1" onclick={() => modals.close()}
-                >{$LL.chat.createRoom.buttons.cancel()}</button
+            <Button variant="contrast" class="flex-1 m-1" onclick={() => modals.close()}
+                >{$LL.chat.createRoom.buttons.cancel()}</Button
             >
-            <button
-                data-testid="createRoomButton"
-                class="disabled:text-gray-400 btn btn-secondary disabled:bg-gray-500 bg-secondary flex-1 justify-center m-1"
+            <Button
+                dataTestId="createRoomButton"
+                variant="secondary"
+                class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 m-1"
                 disabled={createRoomOptions.name === undefined || createRoomOptions.name?.trim().length === 0}
                 onclick={() => createNewRoom(createRoomOptions)}
                 >{$LL.chat.createRoom.buttons.create()}
-            </button>
+            </Button>
         {/if}
     {/snippet}
 </Popup>

--- a/play/src/front/Chat/Components/Room/ManageParticipantsModal.svelte
+++ b/play/src/front/Chat/Components/Room/ManageParticipantsModal.svelte
@@ -7,6 +7,7 @@
     import LL from "../../../../i18n/i18n-svelte";
     import { notificationPlayingStore } from "../../../Stores/NotificationStore";
     import SelectMatrixUser from "../SelectMatrixUser.svelte";
+    import Button from "../../../Components/UI/Button.svelte";
     import RoomParticipant from "./RoomParticipant.svelte";
     import { IconLoader, IconLink } from "@wa-icons";
     import { modals } from "@wa-modals";
@@ -95,9 +96,9 @@
             {:else if membersLoadingError}
                 <div class="flex flex-col items-center justify-center gap-3 py-8">
                     <p class="text-sm text-red-100">{$LL.chat.manageRoomUsers.error()} : {membersLoadingError}</p>
-                    <button type="button" class="btn btn-secondary" onclick={loadMembers}>
+                    <Button variant="secondary" onclick={loadMembers}>
                         {$LL.chat.load()}
-                    </button>
+                    </Button>
                 </div>
             {:else if sendingInvitationsToRoom}
                 <div class="flex flex-col items-center justify-center gap-3 py-10">
@@ -153,18 +154,17 @@
         {#if sendingInvitationsToRoom}
             <p class="text-sm text-white/70">{$LL.chat.createRoom.loadingCreation()}</p>
         {:else}
-            <button type="button" class="btn btn-secondary flex-1 justify-center" onclick={() => modals.close()}>
+            <Button variant="secondary" class="flex-1" onclick={() => modals.close()}>
                 {$LL.chat.manageRoomUsers.buttons.cancel()}
-            </button>
+            </Button>
             {#if $isRoomAdmin}
-                <button
-                    type="button"
-                    data-testid="createRoomButton"
-                    class="btn disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
+                <Button
+                    dataTestId="createRoomButton"
+                    class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1"
                     disabled={invitations === undefined || invitations.length === 0 || !$hasPermissionToInvite}
                     onclick={inviteUsersAndCloseModalOnSuccess}
                     >{$LL.chat.manageRoomUsers.buttons.sendInvitations()}
-                </button>
+                </Button>
             {/if}
         {/if}
     {/snippet}

--- a/play/src/front/Chat/Components/Room/MessageInputBar.svelte
+++ b/play/src/front/Chat/Components/Room/MessageInputBar.svelte
@@ -838,7 +838,7 @@
         bind:message
         bind:messageInput
         disabled={messageInputDisabled}
-        inputClass="message-input flex-grow !m-0 px-4 py-2.5 max-h-36 overflow-auto h-full rounded-lg wa-searchbar block text-sm text-white placeholder:text-white/50 placeholder:text-sm border border-white/10 !bg-white/5 resize-none outline-none shadow-none focus:ring-0 focus:border-white/20"
+        inputClass="message-input flex-grow !m-0 px-4 py-2.5 max-h-36 overflow-auto h-full rounded-lg block text-sm text-white placeholder:text-white/50 placeholder:text-sm border border-white/10 !bg-white/5 resize-none outline-none shadow-none focus:ring-0 focus:border-white/20"
         dataText={$LL.chat.enter()}
         dataTestid="messageInput"
     />

--- a/play/src/front/Chat/Components/Room/RoomSidePanelParticipants.svelte
+++ b/play/src/front/Chat/Components/Room/RoomSidePanelParticipants.svelte
@@ -3,6 +3,7 @@
     import { get } from "svelte/store";
     import LL from "../../../../i18n/i18n-svelte";
     import type { ChatRoom, ChatRoomMembershipManagement, ChatRoomModeration } from "../../Connection/ChatConnection";
+    import Button from "../../../Components/UI/Button.svelte";
     import ManageParticipantsModal from "./ManageParticipantsModal.svelte";
     import RoomSidePanelParticipantRow from "./RoomSidePanelParticipantRow.svelte";
     import { IconLoader } from "@wa-icons";
@@ -82,13 +83,9 @@
         {:else if membersLoadingError}
             <div class="flex flex-col items-center justify-center gap-3 py-8 px-2 text-center">
                 <p class="text-sm text-red-100">{$LL.chat.manageRoomUsers.error()} : {membersLoadingError}</p>
-                <button
-                    type="button"
-                    class="btn btn-secondary"
-                    onclick={() => loadMembers().catch((e) => console.error(e))}
-                >
+                <Button variant="secondary" onclick={() => loadMembers().catch((e) => console.error(e))}>
                     {$LL.chat.load()}
-                </button>
+                </Button>
             </div>
         {:else if joinedMembers.length === 0}
             <div

--- a/play/src/front/Chat/Components/Room/RoomSidePanelSettings.svelte
+++ b/play/src/front/Chat/Components/Room/RoomSidePanelSettings.svelte
@@ -3,6 +3,7 @@
     import { readable } from "svelte/store";
     import LL from "../../../../i18n/i18n-svelte";
     import { notificationPlayingStore } from "../../../Stores/NotificationStore";
+    import Button from "../../../Components/UI/Button.svelte";
     import type {
         ChatRoom,
         ChatRoomMembershipManagement,
@@ -414,17 +415,17 @@
                     {saveError}
                 </div>
             {/if}
-            <button
-                type="button"
-                class="btn btn-secondary m-0 w-full justify-center disabled:opacity-50"
-                data-testid="roomSettingsSaveButton"
+            <Button
+                variant="secondary"
+                class="m-0 w-full disabled:opacity-50"
+                dataTestId="roomSettingsSaveButton"
                 disabled={settingsSaving ||
                     (!settingsDirty && !permissionsDirty) ||
                     ($canEditName && editableName.trim().length === 0)}
                 onclick={saveSettings}
             >
                 {settingsSaving ? $LL.chat.roomPanel.settings.saving() : $LL.chat.roomPanel.settings.save()}
-            </button>
+            </Button>
         </div>
     {/if}
 </div>

--- a/play/src/front/Chat/Connection/Matrix/AccessSecretStorageDialog.svelte
+++ b/play/src/front/Chat/Connection/Matrix/AccessSecretStorageDialog.svelte
@@ -2,6 +2,7 @@
     import type { MatrixClient, SecretStorage } from "matrix-js-sdk";
     import Popup from "../../../Components/Modal/Popup.svelte";
     import resetKeyStorageConfirmationModal from "../../../Components/Menu/ResetKeyStorageConfirmationModal.svelte";
+    import Button from "../../../Components/UI/Button.svelte";
     import LL from "../../../../i18n/i18n-svelte";
     import { chatInputFocusStore } from "../../../Stores/ChatStore";
     import { MatrixSecurity } from "./MatrixSecurity";
@@ -170,13 +171,14 @@
         </div>
     {/snippet}
     {#snippet action()}
-        <button class="btn flex-1 justify-center hover:bg-white/10" onclick={cancelAccessSecretStorage}>
+        <Button class="flex-1 hover:bg-white/10" onclick={cancelAccessSecretStorage}>
             {$LL.chat.e2ee.accessSecretStorage.buttons.cancel()}
-        </button>
-        <button
+        </Button>
+        <Button
+            variant="secondary"
             disabled={confirmInputDisabled || isCheckingPassphrase}
-            class="btn btn-secondary disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
-            data-testid="confirmAccessSecretStorageButton"
+            class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1"
+            dataTestId="confirmAccessSecretStorageButton"
             onclick={() => checkAndSubmitRecoveryOrPassphraseIfValid()}
         >
             {#if isCheckingPassphrase}
@@ -184,6 +186,6 @@
             {:else}
                 {$LL.chat.e2ee.accessSecretStorage.buttons.confirm()}
             {/if}
-        </button>
+        </Button>
     {/snippet}
 </Popup>

--- a/play/src/front/Chat/Connection/Matrix/AskStartVerificationModal.svelte
+++ b/play/src/front/Chat/Connection/Matrix/AskStartVerificationModal.svelte
@@ -5,6 +5,7 @@
     import { Deferred } from "@workadventure/shared-utils";
     import { asError } from "catch-unknown";
     import Popup from "../../../Components/Modal/Popup.svelte";
+    import Button from "../../../Components/UI/Button.svelte";
     import LL from "../../../../i18n/i18n-svelte";
     import type { AskStartVerificationModalProps } from "./MatrixSecurity";
     import { matrixSecurity } from "./MatrixSecurity";
@@ -123,16 +124,17 @@
     {/snippet}
     {#snippet action()}
         {#if !errorLabel}
-            <button class="btn flex-1 justify-center bg-danger-900" onclick={refuseToStartVerification}>
+            <Button class="flex-1 bg-danger-900" onclick={refuseToStartVerification}>
                 {$LL.chat.askStartVerificationModal.ignore()}
-            </button>
-            <button
-                class="btn btn-secondary flex-1 justify-center bg-secondary"
-                data-testid="VerifyTheSessionButton"
+            </Button>
+            <Button
+                variant="secondary"
+                class="flex-1 bg-secondary"
+                dataTestId="VerifyTheSessionButton"
                 onclick={acceptToStartVerification}
             >
                 {$LL.chat.askStartVerificationModal.accept()}
-            </button>
+            </Button>
         {:else}
             <div>
                 {errorLabel}

--- a/play/src/front/Chat/Connection/Matrix/ChooseDeviceVerificationMethodModal.svelte
+++ b/play/src/front/Chat/Connection/Matrix/ChooseDeviceVerificationMethodModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import Popup from "../../../Components/Modal/Popup.svelte";
+    import Button from "../../../Components/UI/Button.svelte";
     import LL from "../../../../i18n/i18n-svelte";
     import { matrixSecurity } from "./MatrixSecurity";
     import { modals } from "@wa-modals";
@@ -35,17 +36,19 @@
         </div>
     {/snippet}
     {#snippet action()}
-        <button
-            data-testid="VerifyWithAnotherDeviceButton"
-            class="btn btn-secondary bg-secondary flex-1 justify-center"
+        <Button
+            dataTestId="VerifyWithAnotherDeviceButton"
+            variant="secondary"
+            class="bg-secondary flex-1"
             onclick={startVerificationWithOtherDevice}
             >{$LL.chat.chooseDeviceVerificationMethodModal.withOtherDevice()}
-        </button>
-        <button
-            data-testid="VerifyWithPassphraseButton"
-            class="btn btn-secondary bg-secondary flex-1 justify-center"
+        </Button>
+        <Button
+            dataTestId="VerifyWithPassphraseButton"
+            variant="secondary"
+            class="bg-secondary flex-1"
             onclick={startVerificationWithPassphrase}
             >{$LL.chat.chooseDeviceVerificationMethodModal.withPassphrase()}
-        </button>
+        </Button>
     {/snippet}
 </Popup>

--- a/play/src/front/Chat/Connection/Matrix/CreateRecoveryKeyDialog.svelte
+++ b/play/src/front/Chat/Connection/Matrix/CreateRecoveryKeyDialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { CryptoApi, GeneratedSecretStorageKey } from "matrix-js-sdk/lib/crypto-api";
     import Popup from "../../../Components/Modal/Popup.svelte";
+    import Button from "../../../Components/UI/Button.svelte";
     import LL from "../../../../i18n/i18n-svelte";
     import { chatInputFocusStore } from "../../../Stores/ChatStore";
     import { IconFileDownload } from "@wa-icons";
@@ -103,19 +104,21 @@
             {$LL.chat.e2ee.createRecoveryKey.buttons.cancel()}
         </button>
         {#if generatedSecretStorageKey === undefined}
-            <button
+            <Button
+                variant="secondary"
                 disabled={passphraseInput === undefined || passphraseInput?.trim().length === 0}
-                class="btn btn-secondary disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
+                class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1"
                 onclick={() => generateRecoveryKey(passphraseInput)}
                 >{$LL.chat.e2ee.createRecoveryKey.buttons.generate()}
-            </button>
+            </Button>
         {:else}
-            <button
+            <Button
+                variant="secondary"
                 disabled={!isPrivateKeyDownloaded}
-                class="btn btn-secondary disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
+                class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1"
                 onclick={closeModalAndContinueToWorkAdventure}
                 >{$LL.chat.e2ee.createRecoveryKey.buttons.continue()}
-            </button>
+            </Button>
         {/if}
     {/snippet}
 </Popup>

--- a/play/src/front/Chat/Connection/Matrix/DeviceVerificationModal.svelte
+++ b/play/src/front/Chat/Connection/Matrix/DeviceVerificationModal.svelte
@@ -2,6 +2,7 @@
     import type { Readable } from "svelte/store";
     import { get } from "svelte/store";
     import Popup from "../../../Components/Modal/Popup.svelte";
+    import Button from "../../../Components/UI/Button.svelte";
     import LL from "../../../../i18n/i18n-svelte";
     import ChatLoader from "../../Components/ChatLoader.svelte";
     import type { DeviceVerificationState } from "./MatrixSecurity";
@@ -94,29 +95,28 @@
     {/snippet}
     {#snippet action()}
         {#if current.status === "done"}
-            <button
-                data-testid="understoodButton"
-                class="btn btn-secondary flex-1 justify-center bg-secondary"
+            <Button
+                dataTestId="understoodButton"
+                variant="secondary"
+                class="flex-1 bg-secondary"
                 onclick={() => modals.close()}
                 >{$LL.chat.verificationEmojiDialog.understood()}
-            </button>
+            </Button>
         {:else if current.status === "error"}
             <span data-testid="errorEmojiLabel">
                 {$LL.chat.verificationEmojiDialog.error()}
             </span>
         {:else if current.status === "emoji" && !matchClicked}
-            <button
-                class="btn btn-danger flex-1 justify-center mx-4 py-1"
-                data-testid="mismatchButton"
+            <Button
+                variant="danger"
+                class="flex-1 mx-4 py-1"
+                dataTestId="mismatchButton"
                 onclick={mismatchAndCloseModal}
                 >{$LL.chat.verificationEmojiDialog.mismatch()}
-            </button>
-            <button
-                data-testid="matchButton"
-                class="btn btn-secondary flex-1 justify-center mx-4 my-2 py-1"
-                onclick={confirmEmoji}
+            </Button>
+            <Button dataTestId="matchButton" variant="secondary" class="flex-1 mx-4 my-2 py-1" onclick={confirmEmoji}
                 >{$LL.chat.verificationEmojiDialog.confirmation()}
-            </button>
+            </Button>
         {:else}
             {$LL.chat.verificationEmojiDialog.waitOtherDeviceConfirmation()}
         {/if}

--- a/play/src/front/Chat/Connection/Matrix/InteractiveAuthSSO.svelte
+++ b/play/src/front/Chat/Connection/Matrix/InteractiveAuthSSO.svelte
@@ -3,6 +3,7 @@
     import type { AuthDict, MatrixClient } from "matrix-js-sdk";
     import { AuthType } from "matrix-js-sdk";
     import LL from "../../../../i18n/i18n-svelte";
+    import Button from "../../../Components/UI/Button.svelte";
     import { INTERACTIVE_AUTH_PHASE } from "./InteractiveAuthPhase";
 
     interface Props {
@@ -72,11 +73,11 @@
     {$LL.chat.e2ee.interactiveAuth.buttons.cancel()}
 </button>
 {#if phase === INTERACTIVE_AUTH_PHASE.PRE_AUTH}
-    <button class="btn btn-secondary flex-1 justify-center" onclick={onStartAuthClick}>
+    <Button variant="secondary" class="flex-1" onclick={onStartAuthClick}>
         {$LL.chat.e2ee.interactiveAuth.buttons.continueSSO()}
-    </button>
+    </Button>
 {:else}
-    <button class="btn btn-secondary flex-1 justify-center" onclick={onConfirmClick}>
+    <Button variant="secondary" class="flex-1" onclick={onConfirmClick}>
         {$LL.chat.e2ee.interactiveAuth.buttons.finish()}
-    </button>
+    </Button>
 {/if}

--- a/play/src/front/Chat/Connection/Matrix/VerificationEmojiDialog.svelte
+++ b/play/src/front/Chat/Connection/Matrix/VerificationEmojiDialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import Popup from "../../../Components/Modal/Popup.svelte";
+    import Button from "../../../Components/UI/Button.svelte";
     import LL from "../../../../i18n/i18n-svelte";
     import type { VerificationEmojiDialogProps } from "./MatrixSecurity";
     import { IconVerify } from "@wa-icons";
@@ -101,30 +102,29 @@
             {#await donePromise}
                 {$LL.chat.verificationEmojiDialog.waitOtherDeviceConfirmation()}
             {:then}
-                <button
-                    data-testid="understoodButton"
-                    class="btn btn-secondary flex-1 justify-center bg-secondary"
+                <Button
+                    dataTestId="understoodButton"
+                    variant="secondary"
+                    class="flex-1 bg-secondary"
                     onclick={() => modals.close()}
                     >{$LL.chat.verificationEmojiDialog.understood()}
-                </button>
+                </Button>
             {:catch}
                 <span data-testid="errorEmojiLabel">
                     {$LL.chat.verificationEmojiDialog.error()}
                 </span>
             {/await}
         {:else}
-            <button
-                class="btn btn-danger flex-1 justify-center mx-4 py-1"
-                data-testid="mismatchButton"
+            <Button
+                variant="danger"
+                class="flex-1 mx-4 py-1"
+                dataTestId="mismatchButton"
                 onclick={mismatchAndCloseModal}
                 >{$LL.chat.verificationEmojiDialog.mismatch()}
-            </button>
-            <button
-                data-testid="matchButton"
-                class="btn btn-secondary flex-1 justify-center mx-4 my-2 py-1"
-                onclick={confirmEmoji}
+            </Button>
+            <Button dataTestId="matchButton" variant="secondary" class="flex-1 mx-4 my-2 py-1" onclick={confirmEmoji}
                 >{$LL.chat.verificationEmojiDialog.confirmation()}
-            </button>
+            </Button>
         {/if}
     {/snippet}
 </Popup>

--- a/play/src/front/Components/ActionBar/AvailabilityStatus/Modals/ConfirmationModal.svelte
+++ b/play/src/front/Components/ActionBar/AvailabilityStatus/Modals/ConfirmationModal.svelte
@@ -2,6 +2,7 @@
     import type { Snippet } from "svelte";
     import type { ConfirmationModalPropsInterface } from "../Interfaces/ConfirmationModalPropsInterface";
     import PopUpContainer from "../../../PopUp/PopUpContainer.svelte";
+    import Button from "../../../UI/Button.svelte";
     interface Props {
         props: ConfirmationModalPropsInterface;
         children?: Snippet;
@@ -37,9 +38,9 @@
 <PopUpContainer>
     {@render children?.()}
     <div class="buttons-wrapper flex items-center justify-center p-2 gap-2 pointer-events-auto mt-2">
-        <button class="btn btn-light btn-ghost btn-sm w-1/2 justify-center responsive-message" onclick={handleClose}
-            >{closeLabel}</button
+        <Button variant="light" appearance="ghost" size="sm" class="w-1/2 responsive-message" onclick={handleClose}
+            >{closeLabel}</Button
         >
-        <button class="btn btn-secondary btn-sm w-1/2 justify-center" onclick={handleAccept}>{acceptLabel}</button>
+        <Button variant="secondary" size="sm" class="w-1/2" onclick={handleAccept}>{acceptLabel}</Button>
     </div>
 </PopUpContainer>

--- a/play/src/front/Components/ActionBar/MediaSettingsList/MediaSettingsListHeader.svelte
+++ b/play/src/front/Components/ActionBar/MediaSettingsList/MediaSettingsListHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { LL } from "../../../../i18n/i18n-svelte";
+    import Button from "../../UI/Button.svelte";
 
     interface Props {
         mode?: "settings" | "background";
@@ -15,30 +16,32 @@
 <div class="flex flex-row gap-2 px-1">
     <div class="flex-1 flex text-xxs uppercase text-white/50 pb-0.5 pt-1 relative bold">
         <div class="group flex items-center relative z-10 w-full">
-            <button
-                class="btn btn-sm btn-ghost btn-light justify-center w-full rounded text-nowrap {mode === 'settings'
-                    ? '!bg-white/10'
-                    : ''}"
+            <Button
+                variant="light"
+                appearance="ghost"
+                size="sm"
+                class="w-full rounded text-nowrap {mode === 'settings' ? '!bg-white/10' : ''}"
                 onclick={() => {
                     mode = "settings";
                 }}
             >
                 {$LL.actionbar.background.settings()}
-            </button>
+            </Button>
         </div>
     </div>
     <div class="flex-1 flex text-xxs uppercase text-white/50 pb-0.5 pt-1 relative bold">
         <div class="group flex items-center relative z-10 w-full">
-            <button
-                class="btn btn-sm btn-ghost btn-light justify-center w-full rounded text-nowrap {mode === 'background'
-                    ? '!bg-white/10'
-                    : ''}"
+            <Button
+                variant="light"
+                appearance="ghost"
+                size="sm"
+                class="w-full rounded text-nowrap {mode === 'background' ? '!bg-white/10' : ''}"
                 onclick={() => {
                     mode = "background";
                 }}
             >
                 {$LL.actionbar.background.cameraBackground()}
-            </button>
+            </Button>
         </div>
     </div>
 </div>

--- a/play/src/front/Components/ActionBar/MediaSettingsList/MediaSettingsPanel.svelte
+++ b/play/src/front/Components/ActionBar/MediaSettingsList/MediaSettingsPanel.svelte
@@ -25,6 +25,7 @@
     import { LL } from "../../../../i18n/i18n-svelte";
     import { showHelpCameraSettings } from "../../../Stores/HelpSettingsStore";
     import InputSwitch from "../../Input/InputSwitch.svelte";
+    import Button from "../../UI/Button.svelte";
     import SectionDivider from "./SectionDivider.svelte";
     import SectionTitle from "./SectionTitle.svelte";
     import DeviceListItem from "./DeviceListItem.svelte";
@@ -151,19 +152,21 @@
             {#if $silentStore == false}
                 <div class="group flex items-center relative z-10 py-1 px-2 overflow-hidden">
                     {#if cameraDenied}
-                        <button class="btn btn-danger btn-sm w-full justify-center" onclick={showHelpCameraSettings}>
+                        <Button variant="danger" size="sm" class="w-full" onclick={showHelpCameraSettings}>
                             {$LL.actionbar.microphone.openSettings()}
-                        </button>
+                        </Button>
                     {:else}
-                        <button
-                            class="btn btn-danger btn-sm w-full justify-center"
+                        <Button
+                            variant="danger"
+                            size="sm"
+                            class="w-full"
                             onclick={() => {
                                 analyticsClient.camera();
                                 cameraClick();
                             }}
                         >
                             {$LL.actionbar.camera.activate()}
-                        </button>
+                        </Button>
                     {/if}
                 </div>
             {/if}
@@ -253,19 +256,21 @@
             {#if $silentStore == false}
                 <div class="group flex items-center relative z-10 py-1 px-2 overflow-hidden">
                     {#if microphoneDenied}
-                        <button class="btn btn-danger btn-sm w-full justify-center" onclick={showHelpCameraSettings}>
+                        <Button variant="danger" size="sm" class="w-full" onclick={showHelpCameraSettings}>
                             {$LL.actionbar.microphone.openSettings()}
-                        </button>
+                        </Button>
                     {:else}
-                        <button
-                            class="btn btn-danger btn-sm w-full justify-center"
+                        <Button
+                            variant="danger"
+                            size="sm"
+                            class="w-full"
                             onclick={() => {
                                 analyticsClient.microphone();
                                 microphoneClick();
                             }}
                         >
                             {$LL.actionbar.microphone.activate()}
-                        </button>
+                        </Button>
                     {/if}
                 </div>
             {/if}

--- a/play/src/front/Components/ActionsMenu/ActionsMenu.svelte
+++ b/play/src/front/Components/ActionsMenu/ActionsMenu.svelte
@@ -3,6 +3,7 @@
     import { onDestroy } from "svelte";
     import { actionsMenuStore } from "../../Stores/ActionsMenuStore";
     import ButtonClose from "../Input/ButtonClose.svelte";
+    import Button from "../UI/Button.svelte";
     import VisitCard from "../VisitCard/VisitCard.svelte";
 
     import type { ActionsMenuAction, ActionsMenuData } from "../../Stores/ActionsMenuStore";
@@ -108,11 +109,11 @@
                 class:flex-row={buttonsLayout === "row"}
             >
                 {#each sortedActions ?? [] as action (action.uuid)}
-                    <button
-                        type="button"
-                        class="btn btn-light btn-ghost text-nowrap justify-center w-full h-full !bg-white/10 hover:!bg-white/20 {action.style ??
-                            ''}"
-                        class:mx-2={buttonsLayout === "column"}
+                    <Button
+                        variant="light"
+                        appearance="ghost"
+                        class="text-nowrap w-full h-full !bg-white/10 hover:!bg-white/20 {action.style ??
+                            ''} {buttonsLayout === 'column' ? 'mx-2' : ''}"
                         onclick={(event) => {
                             analyticsClient.clickPropertyMapEditor(action.actionName, action.style);
                             event.preventDefault();
@@ -132,7 +133,7 @@
                             {/if}
                             {action.actionName}
                         </span>
-                    </button>
+                    </Button>
                 {/each}
             </div>
         {/if}

--- a/play/src/front/Components/ActionsMenu/WokaMenu.svelte
+++ b/play/src/front/Components/ActionsMenu/WokaMenu.svelte
@@ -4,6 +4,7 @@
     import { onDestroy, onMount } from "svelte";
     import { wokaMenuStore, wokaMenuProgressStore } from "../../Stores/WokaMenuStore";
     import ButtonClose from "../Input/ButtonClose.svelte";
+    import Button from "../UI/Button.svelte";
     import VisitCard from "../VisitCard/VisitCard.svelte";
     import WokaFromUserId from "../Woka/WokaFromUserId.svelte";
     import { analyticsClient } from "../../Administration/AnalyticsClient";
@@ -163,12 +164,13 @@
                 class:flex-wrap={buttonsLayout === "wrap"}
             >
                 {#each sortedActions ?? [] as action (action.uuid)}
-                    <button
-                        type="button"
-                        data-testid={action.testId}
-                        class="btn btn-light btn-ghost text-nowrap justify-center my-2 mx-1 min-w-0 {action.style ??
-                            ''}"
-                        class:mx-2={buttonsLayout === "column"}
+                    <Button
+                        dataTestId={action.testId}
+                        variant="light"
+                        appearance="ghost"
+                        class="text-nowrap my-2 mx-1 min-w-0 {action.style ?? ''} {buttonsLayout === 'column'
+                            ? 'mx-2'
+                            : ''}"
                         onclick={(event) => {
                             analyticsClient.clickPropertyMapEditor(action.actionName, action.style);
                             event.preventDefault();
@@ -187,13 +189,14 @@
                             {/if}
                             {action.actionName}
                         </span>
-                    </button>
+                    </Button>
                 {/each}
 
                 {#if !wokaMenuData.wokaName}
-                    <button
-                        type="button"
-                        class="btn btn-light btn-ghost text-nowrap justify-center my-2 mx-1 w-fit"
+                    <Button
+                        variant="light"
+                        appearance="ghost"
+                        class="text-nowrap my-2 mx-1 w-fit"
                         onclick={(event) => {
                             event.preventDefault();
                             event.stopPropagation();
@@ -201,7 +204,7 @@
                         }}
                     >
                         {$LL.actionbar.close()}
-                    </button>
+                    </Button>
                 {/if}
             </div>
         {/if}

--- a/play/src/front/Components/BrowserNotSupported/BrowserNotSupported.svelte
+++ b/play/src/front/Components/BrowserNotSupported/BrowserNotSupported.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { getBrowserInfo, getBrowserDisplayName } from "../../Utils/BrowserCompatibility";
     import { LL } from "../../../i18n/i18n-svelte";
+    import Button from "../UI/Button.svelte";
     import bgMap from "../images/map-exemple.png";
 
     let browserInfo = getBrowserInfo();
@@ -56,12 +57,12 @@
         </div>
 
         <div class="footer flex flex-row justify-evenly items-center bg-contrast/80 w-full p-4 gap-3 rounded-b-3xl">
-            <button class="btn btn-secondary flex-1" onclick={handleUpdateBrowser} data-testid="update-browser-button">
+            <Button variant="secondary" class="flex-1" onclick={handleUpdateBrowser} dataTestId="update-browser-button">
                 {$LL.warning.browserNotSupported.updateBrowser()}
-            </button>
-            <button class="btn btn-ghost btn-light flex-1" onclick={handleLeave} data-testid="leave-button">
+            </Button>
+            <Button variant="light" appearance="ghost" class="flex-1" onclick={handleLeave} dataTestId="leave-button">
                 {$LL.warning.browserNotSupported.leave()}
-            </button>
+            </Button>
         </div>
     </div>
 </div>

--- a/play/src/front/Components/Calendar/Calendar.svelte
+++ b/play/src/front/Components/Calendar/Calendar.svelte
@@ -10,6 +10,7 @@
     import outlookSvg from "../images/applications/outlook.svg";
     import calendarPng from "../images/applications/calendar.png";
     import ButtonClose from "../Input/ButtonClose.svelte";
+    import Button from "../UI/Button.svelte";
     import { userIsConnected } from "../../Stores/MenuStore";
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import { externalSvelteComponentService } from "../../Stores/Utils/externalSvelteComponentService";
@@ -98,11 +99,12 @@
                         <p class="text-xs text-left">{$LL.externalModule.teams.connectToYourTeams()}</p>
                         -->
                         {#if get(externalSvelteComponentService.getComponentsByZone("calendarButton")).size == 0}
-                            <button
-                                class="btn disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
+                            <Button
+                                class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1"
                                 onclick={goToLoginPage}
-                                >{$LL.menu.profile.login()}
-                            </button>
+                            >
+                                {$LL.menu.profile.login()}
+                            </Button>
                         {/if}
                     </div>
                 {/if}

--- a/play/src/front/Components/EnableCamera/EnableCameraScene.svelte
+++ b/play/src/front/Components/EnableCamera/EnableCameraScene.svelte
@@ -22,6 +22,7 @@
     import { gameManager } from "../../Phaser/Game/GameManager";
 
     import bgMap from "../images/map-exemple.png";
+    import Button from "../UI/Button.svelte";
     import HorizontalSoundMeterWidget from "./HorizontalSoundMeterWidget.svelte";
     import SelectMicrophone from "./SelectMicrophone.svelte";
     import SelectCamera from "./SelectCamera.svelte";
@@ -280,16 +281,13 @@
                 <section
                     class="container m-auto p-4 flex flex-col-reverse md:flex-row items-center justify-center space-y-2 md:space-y-0 md:space-x-4"
                 >
-                    <button
-                        type="submit"
-                        class="btn btn-light btn-lg btn-ghost w-full md:w-1/2
-              
-                     hidden">{$LL.actionbar.cancel()}</button
-                    >
+                    <Button type="submit" variant="light" appearance="ghost" size="lg" class="w-full md:w-1/2 hidden">
+                        {$LL.actionbar.cancel()}
+                    </Button>
                     <!-- TODO ACTION -->
-                    <button type="submit" class="btn btn-secondary btn-lg w-full md:w-1/2 block"
-                        >{$LL.menu.settings.save()}</button
-                    >
+                    <Button type="submit" variant="secondary" size="lg" class="w-full md:w-1/2 block">
+                        {$LL.menu.settings.save()}
+                    </Button>
                 </section>
                 {#if legalString}
                     <section class="terms-and-conditions h-fit z-40 text-center w-full">

--- a/play/src/front/Components/EnableCamera/SelectCamera.svelte
+++ b/play/src/front/Components/EnableCamera/SelectCamera.svelte
@@ -3,6 +3,7 @@
     import { LL } from "../../../i18n/i18n-svelte";
     import { StringUtils } from "../../Utils/StringUtils";
     import Chip from "../UI/Chip.svelte";
+    import Button from "../UI/Button.svelte";
     import { IconCheck, IconVideoOff } from "@wa-icons";
 
     let editMode = $state(false);
@@ -26,8 +27,9 @@
         <div class="grow pe-8 ps-2">
             {@render title?.()}
         </div>
-        <button
-            class="btn {!editMode ? 'btn-secondary' : 'btn-light btn-ghost'}"
+        <Button
+            variant={!editMode ? "secondary" : "light"}
+            appearance={!editMode ? "filled" : "ghost"}
             onclick={(event) => {
                 event.stopPropagation();
                 event.preventDefault();
@@ -35,7 +37,7 @@
             }}
         >
             {!editMode ? $LL.actionbar.edit() : $LL.actionbar.cancel()}
-        </button>
+        </Button>
     </div>
     <div class="flex w-full items-center justify-center">
         <div class="flex flex-wrap w-full items-center justify-center min-h-[129px]">

--- a/play/src/front/Components/EnableCamera/SelectMicrophone.svelte
+++ b/play/src/front/Components/EnableCamera/SelectMicrophone.svelte
@@ -3,6 +3,7 @@
     import { LL } from "../../../i18n/i18n-svelte";
     import { StringUtils } from "../../Utils/StringUtils";
     import Chip from "../UI/Chip.svelte";
+    import Button from "../UI/Button.svelte";
     import { IconMicrophoneOff, IconCheck } from "@wa-icons";
 
     let editMode = $state(false);
@@ -26,8 +27,9 @@
         <div class="grow pe-8 ps-2">
             {@render title?.()}
         </div>
-        <button
-            class="btn {!editMode ? 'btn-secondary' : 'btn-light btn-ghost'}"
+        <Button
+            variant={!editMode ? "secondary" : "light"}
+            appearance={!editMode ? "filled" : "ghost"}
             onclick={(event) => {
                 event.stopPropagation();
                 event.preventDefault();
@@ -35,7 +37,7 @@
             }}
         >
             {!editMode ? $LL.actionbar.edit() : $LL.actionbar.cancel()}
-        </button>
+        </Button>
     </div>
 
     <div class="flex w-full">

--- a/play/src/front/Components/EnableCamera/SelectSpeaker.svelte
+++ b/play/src/front/Components/EnableCamera/SelectSpeaker.svelte
@@ -2,6 +2,7 @@
     import { LL } from "../../../i18n/i18n-svelte";
     import { StringUtils } from "../../Utils/StringUtils";
     import Chip from "../UI/Chip.svelte";
+    import Button from "../UI/Button.svelte";
     import { IconCheck, IconUnMute } from "@wa-icons";
 
     let editMode = $state(false);
@@ -22,8 +23,9 @@
     <div class="text-lg bold flex items-center justify-center gap-3 mb-4 ps-2">
         <IconUnMute font-size="28" />
         <div class="grow pe-8 ps-2">{$LL.camera.editSpeaker()}</div>
-        <button
-            class="btn {!editMode ? 'btn-secondary' : 'btn-light btn-ghost'}"
+        <Button
+            variant={!editMode ? "secondary" : "light"}
+            appearance={!editMode ? "filled" : "ghost"}
             onclick={(event) => {
                 event.stopPropagation();
                 event.preventDefault();
@@ -31,7 +33,7 @@
             }}
         >
             {!editMode ? $LL.actionbar.edit() : $LL.actionbar.cancel()}
-        </button>
+        </Button>
     </div>
 
     <div class="flex items-center justify-center w-full">
@@ -75,10 +77,12 @@
                         </div>
                     </div>
                     {#if selectedDevice === speaker.deviceId}
-                        <button class="btn btn-secondary self-end" type="button">
-                            <!-- TODO HUGO -->
-                            <IconUnMute font-size="20" />
-                        </button>
+                        <Button variant="secondary" square class="self-end" type="button">
+                            {#snippet icon()}
+                                <!-- TODO HUGO -->
+                                <IconUnMute font-size="20" />
+                            {/snippet}
+                        </Button>
                     {/if}
                 </div>
             {/each}

--- a/play/src/front/Components/Exploration/MapList.svelte
+++ b/play/src/front/Components/Exploration/MapList.svelte
@@ -8,6 +8,8 @@
     import { scriptUtils } from "../../Api/ScriptUtils";
     import LL from "../../../i18n/i18n-svelte";
     import PopUpContainer from "../PopUp/PopUpContainer.svelte";
+    import Button from "../UI/Button.svelte";
+    import Chip from "../UI/Chip.svelte";
 
     interface RoomData {
         name: string;
@@ -160,11 +162,12 @@
                                                     {roomData.name}
                                                 </span>
                                                 {#if currentRoomUrl === new URL(roomData.roomUrl, window.location.href).toString()}
-                                                    <span
-                                                        class="chip z-20 chip-sm chip-secondary bg-secondary text-white rounded-[8px] absolute top-3 right-3"
+                                                    <Chip
+                                                        variant="secondary"
+                                                        class="z-20 bg-secondary text-white rounded-[8px] absolute top-3 right-3"
                                                     >
                                                         <div class="px-2">Active</div>
-                                                    </span>
+                                                    </Chip>
                                                 {/if}
                                             </div>
                                             <div class="py-2 text-center">
@@ -190,9 +193,9 @@
             </div>
             {#snippet buttons()}
                 <div class="flex flex-row justify-center w-full">
-                    <button class="btn btn-lg btn-secondary w-1/2 m-auto" onclick={close}>
+                    <Button size="lg" variant="secondary" class="w-1/2 m-auto" onclick={close}>
                         {$LL.mapEditor.listRoom.close()}
-                    </button>
+                    </Button>
                 </div>
             {/snippet}
         </PopUpContainer>

--- a/play/src/front/Components/HelpSettings/HelpCameraSettingsPopup.svelte
+++ b/play/src/front/Components/HelpSettings/HelpCameraSettingsPopup.svelte
@@ -4,6 +4,7 @@
     import { LL } from "../../../i18n/i18n-svelte";
     import { mediaPermissionDeniedStore } from "../../Stores/MediaStatusStore";
     import { popupStore } from "../../Stores/PopupStore";
+    import Button from "../UI/Button.svelte";
     import { IconInfoCircle } from "@wa-icons";
 
     let isAndroid = isAndroidFct();
@@ -89,8 +90,11 @@
         {/if}
     </section>
     <section class="flex row justify-center p-4 bg-contrast">
-        <button
-            class="btn btn-sm btn-border btn-success mr-2 w-full justify-center"
+        <Button
+            variant="success"
+            appearance="border"
+            size="sm"
+            class="mr-2 w-full"
             onclick={(event) => {
                 event.preventDefault();
                 allow();
@@ -103,10 +107,12 @@
             {:else}
                 {$LL.camera.help.allowMicrophone()}
             {/if}
-        </button>
-        <button
+        </Button>
+        <Button
             type="submit"
-            class="btn btn-danger btn-sm w-full justify-center"
+            variant="danger"
+            size="sm"
+            class="w-full"
             onclick={(event) => {
                 event.preventDefault();
                 close();
@@ -119,6 +125,6 @@
             {:else}
                 {$LL.camera.help.continueWithoutMicrophone()}
             {/if}
-        </button>
+        </Button>
     </section>
 </form>

--- a/play/src/front/Components/HelpSettings/HelpNotificationSettingPopup.svelte
+++ b/play/src/front/Components/HelpSettings/HelpNotificationSettingPopup.svelte
@@ -4,6 +4,7 @@
     import { getNavigatorType, isAndroid as isAndroidFct, NavigatorType } from "../../WebRtc/DeviceUtils";
     import { LL } from "../../../i18n/i18n-svelte";
     import { gameManager } from "../../Phaser/Game/GameManager";
+    import Button from "../UI/Button.svelte";
     import { IconInfoCircle } from "@wa-icons";
 
     let isAndroid = isAndroidFct();
@@ -70,24 +71,25 @@
         </div>
     </section>
     <section class="flex row justify-center p-4 bg-contrast">
-        <button
-            class="btn bg-white/10 hover:bg-white/20 mr-2 w-full justify-center"
+        <Button
+            class="bg-white/10 hover:bg-white/20 mr-2 w-full"
             onclick={(event) => {
                 event.preventDefault();
                 refresh();
             }}
         >
             {$LL.notification.help.refresh()}
-        </button>
-        <button
+        </Button>
+        <Button
             type="submit"
-            class="btn btn-danger w-full justify-center"
+            variant="danger"
+            class="w-full"
             onclick={(event) => {
                 event.preventDefault();
                 close();
             }}
         >
             {$LL.notification.help.continue()}
-        </button>
+        </Button>
     </section>
 </form>

--- a/play/src/front/Components/HelpSettings/HelpPopUpBlocked.svelte
+++ b/play/src/front/Components/HelpSettings/HelpPopUpBlocked.svelte
@@ -4,6 +4,7 @@
     import { LL } from "../../../i18n/i18n-svelte";
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { helpSettingsPopupBlockedStore } from "../../Stores/HelpSettingsPopupBlockedStore";
+    import Button from "../UI/Button.svelte";
 
     function getBackgroundColor() {
         if (!gameManager.currentStartedRoom) return undefined;
@@ -38,14 +39,15 @@
     </section>
 
     <section class="justify-center bottom-0 w-full bg-contrast p-4 flex flex-row space-x-4 mt-4 rounded-b-lg">
-        <button
-            class="btn btn-secondary grow"
+        <Button
+            variant="secondary"
+            class="grow"
             onclick={(event) => {
                 event.preventDefault();
                 close();
             }}
         >
             {$LL.warning.popupBlocked.done()}
-        </button>
+        </Button>
     </section>
 </form>

--- a/play/src/front/Components/HelpSettings/HelpWebRtcSettingsPopup.svelte
+++ b/play/src/front/Components/HelpSettings/HelpWebRtcSettingsPopup.svelte
@@ -8,6 +8,7 @@
     import { localUserStore } from "../../Connection/LocalUserStore";
     import Spinner from "../Icons/Spinner.svelte";
     import InputCheckbox from "../Input/InputCheckbox.svelte";
+    import Button from "../UI/Button.svelte";
 
     let notAskAgain = $state(false);
 
@@ -81,24 +82,25 @@
         />
     </section>
     <section class="justify-center bottom-0 w-full bg-contrast p-4 flex flex-row space-x-4 mt-4 rounded-b-lg">
-        <button
-            class="btn bg-white/10 hover:bg-white/20 grow"
+        <Button
+            class="bg-white/10 hover:bg-white/20 grow"
             onclick={(event) => {
                 event.preventDefault();
                 refresh();
             }}
         >
             {$LL.camera.webrtc.refresh()}
-        </button>
-        <button
+        </Button>
+        <Button
             type="submit"
-            class="btn btn-secondary grow"
+            variant="secondary"
+            class="grow"
             onclick={(event) => {
                 event.preventDefault();
                 close();
             }}
         >
             {$LL.camera.webrtc.continue()}
-        </button>
+        </Button>
     </section>
 </form>

--- a/play/src/front/Components/Icons/SettingIconBtn.svelte
+++ b/play/src/front/Components/Icons/SettingIconBtn.svelte
@@ -1,35 +1,44 @@
+<script lang="ts">
+    import Button from "../UI/Button.svelte";
+</script>
+
 <div>
-    <button
+    <Button
         aria-label="Settings"
-        class="btn btn-xs btn-secondary btn-square absolute top-0 bottom-2 m-auto h-9 right-1"
+        variant="secondary"
+        size="xs"
+        square
+        class="absolute top-0 bottom-2 m-auto h-9 right-1"
     >
-        <svg
-            class="btn-icon fill-inherit"
-            fill="none"
-            height="20"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="1.5"
-            viewBox="0 0 24 24"
-            width="20"
-            xmlns="http://www.w3.org/2000/svg"
-        >
-            <path d="M0 0h24v24H0z" fill="none" stroke="none" />
-            <path
-                d="M6 3a1 1 0 0 1 .993 .883l.007 .117v3.171a3.001 3.001 0 0 1 0 5.658v7.171a1 1 0 0 1 -1.993 .117l-.007 -.117v-7.17a3.002 3.002 0 0 1 -1.995 -2.654l-.005 -.176l.005 -.176a3.002 3.002 0 0 1 1.995 -2.654v-3.17a1 1 0 0 1 1 -1z"
-                fill="currentColor"
-                stroke-width="0"
-            />
-            <path
-                d="M12 3a1 1 0 0 1 .993 .883l.007 .117v9.171a3.001 3.001 0 0 1 0 5.658v1.171a1 1 0 0 1 -1.993 .117l-.007 -.117v-1.17a3.002 3.002 0 0 1 -1.995 -2.654l-.005 -.176l.005 -.176a3.002 3.002 0 0 1 1.995 -2.654v-9.17a1 1 0 0 1 1 -1z"
-                fill="currentColor"
-                stroke-width="0"
-            />
-            <path
-                d="M18 3a1 1 0 0 1 .993 .883l.007 .117v.171a3.001 3.001 0 0 1 0 5.658v10.171a1 1 0 0 1 -1.993 .117l-.007 -.117v-10.17a3.002 3.002 0 0 1 -1.995 -2.654l-.005 -.176l.005 -.176a3.002 3.002 0 0 1 1.995 -2.654v-.17a1 1 0 0 1 1 -1z"
-                fill="currentColor"
-                stroke-width="0"
-            />
-        </svg>
-    </button>
+        {#snippet icon()}
+            <svg
+                class="btn-icon fill-inherit"
+                fill="none"
+                height="20"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                viewBox="0 0 24 24"
+                width="20"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <path d="M0 0h24v24H0z" fill="none" stroke="none" />
+                <path
+                    d="M6 3a1 1 0 0 1 .993 .883l.007 .117v3.171a3.001 3.001 0 0 1 0 5.658v7.171a1 1 0 0 1 -1.993 .117l-.007 -.117v-7.17a3.002 3.002 0 0 1 -1.995 -2.654l-.005 -.176l.005 -.176a3.002 3.002 0 0 1 1.995 -2.654v-3.17a1 1 0 0 1 1 -1z"
+                    fill="currentColor"
+                    stroke-width="0"
+                />
+                <path
+                    d="M12 3a1 1 0 0 1 .993 .883l.007 .117v9.171a3.001 3.001 0 0 1 0 5.658v1.171a1 1 0 0 1 -1.993 .117l-.007 -.117v-1.17a3.002 3.002 0 0 1 -1.995 -2.654l-.005 -.176l.005 -.176a3.002 3.002 0 0 1 1.995 -2.654v-9.17a1 1 0 0 1 1 -1z"
+                    fill="currentColor"
+                    stroke-width="0"
+                />
+                <path
+                    d="M18 3a1 1 0 0 1 .993 .883l.007 .117v.171a3.001 3.001 0 0 1 0 5.658v10.171a1 1 0 0 1 -1.993 .117l-.007 -.117v-10.17a3.002 3.002 0 0 1 -1.995 -2.654l-.005 -.176l.005 -.176a3.002 3.002 0 0 1 1.995 -2.654v-.17a1 1 0 0 1 1 -1z"
+                    fill="currentColor"
+                    stroke-width="0"
+                />
+            </svg>
+        {/snippet}
+    </Button>
 </div>

--- a/play/src/front/Components/Input/SoundSelect.svelte
+++ b/play/src/front/Components/Input/SoundSelect.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import * as Sentry from "@sentry/svelte";
+    import Button from "../UI/Button.svelte";
     import Select from "./Select.svelte";
 
     interface Props {
@@ -57,7 +58,13 @@
 
 <div class={`flex items-end gap-2 ${outerClass}`.trim()}>
     <Select {id} bind:value {label} {options} onchange={handleChange} outerClass="flex-1" {disabled} />
-    <button class="btn btn-light btn-ghost mb-2" onclick={handlePlayClick} disabled={disabled || !getSoundUrl(value)}>
+    <Button
+        variant="light"
+        appearance="ghost"
+        class="mb-2"
+        onclick={handlePlayClick}
+        disabled={disabled || !getSoundUrl(value)}
+    >
         {playLabel}
-    </button>
+    </Button>
 </div>

--- a/play/src/front/Components/Login/LoginScene.svelte
+++ b/play/src/front/Components/Login/LoginScene.svelte
@@ -9,6 +9,7 @@
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { LL, locale } from "../../../i18n/i18n-svelte";
     import { NameNotValidError, NameTooLongError } from "../../Exception/NameError";
+    import Button from "../UI/Button.svelte";
 
     interface Props {
         game: Game;
@@ -146,12 +147,15 @@
             class="action flex h-fit justify-center m-0"
             class:opacity-50={(name.trim() === "" && startValidating) || errorName !== ""}
         >
-            <button
+            <Button
                 type="submit"
                 disabled={(name.trim() === "" && startValidating) || errorName !== ""}
-                class="mt-4 w-52 md:w-96 bold text-center block btn btn-secondary btn-lg loginSceneFormSubmit"
-                >{$LL.login.continue()}</button
+                variant="secondary"
+                size="lg"
+                class="mt-4 w-52 md:w-96 bold text-center block loginSceneFormSubmit"
             >
+                {$LL.login.continue()}
+            </Button>
         </section>
         {#if legalString}
             <section class="terms-and-conditions h-fit text-center w-full">

--- a/play/src/front/Components/MapEditor/ClaimPersonalAreaDialogBox.svelte
+++ b/play/src/front/Components/MapEditor/ClaimPersonalAreaDialogBox.svelte
@@ -6,6 +6,7 @@
     import { localUserStore } from "../../Connection/LocalUserStore";
     import PopUpContainer from "../PopUp/PopUpContainer.svelte";
     import Input from "../Input/Input.svelte";
+    import Button from "../UI/Button.svelte";
 
     let name = $state("");
     /** True if this user already owns another personal area on the map (may be replaced when claiming). */
@@ -56,17 +57,18 @@
             <p class="m-0 mt-2 max-w-xs">{$LL.area.personalArea.alreadyHavePersonalArea()}</p>
             {#snippet buttons()}
                 <div class="flex flex-row justify-center items-center w-full">
-                    <button
-                        data-testid="claimPersonalAreaReplaceConfirmButton"
+                    <Button
+                        dataTestId="claimPersonalAreaReplaceConfirmButton"
                         type="button"
-                        class="btn btn-secondary w-fit px-10"
+                        variant="secondary"
+                        class="w-fit px-10"
                         onclick={(event) => {
                             event.preventDefault();
                             replaceExistingConfirmed = true;
                         }}
                     >
                         {$LL.area.personalArea.buttons.confirm()}
-                    </button>
+                    </Button>
                 </div>
             {/snippet}
         </PopUpContainer>
@@ -82,25 +84,28 @@
             />
             {#snippet buttons()}
                 <div class="flex flex-row justify-center w-full gap-2">
-                    <button
+                    <Button
                         type="button"
-                        class="btn btn-outline w-fit px-10 hover:bg-contrast-600/50"
+                        class="btn-outline w-fit px-10 hover:bg-contrast-600/50"
                         onclick={(event) => {
                             event.preventDefault();
                             closeDialog();
                         }}
-                        >{$LL.area.personalArea.buttons.no()}
-                    </button>
-                    <button
-                        data-testid="claimPersonalAreaButton"
+                    >
+                        {$LL.area.personalArea.buttons.no()}
+                    </Button>
+                    <Button
+                        dataTestId="claimPersonalAreaButton"
                         type="button"
-                        class="btn btn-secondary w-fit px-10"
+                        variant="secondary"
+                        class="w-fit px-10"
                         onclick={() => {
                             mapEditorModeManager.claimPersonalArea(name);
                             closeDialog();
                         }}
-                        >{$LL.area.personalArea.buttons.yes()}
-                    </button>
+                    >
+                        {$LL.area.personalArea.buttons.yes()}
+                    </Button>
                 </div>
             {/snippet}
         </PopUpContainer>

--- a/play/src/front/Components/MapEditor/EntityEditor/CustomEntityEditionForm/CustomEntityEditionForm.svelte
+++ b/play/src/front/Components/MapEditor/EntityEditor/CustomEntityEditionForm/CustomEntityEditionForm.svelte
@@ -7,6 +7,7 @@
     import Select from "../../../Input/Select.svelte";
     import Input from "../../../Input/Input.svelte";
     import InputCheckbox from "../../../Input/InputCheckbox.svelte";
+    import Button from "../../../UI/Button.svelte";
     import LogoCollisionGrid from "./LogoCollisionGrid.svg";
     import EntityEditionCollisionGrid from "./EntityEditionCollisionGrid.svelte";
 
@@ -185,27 +186,31 @@
     {/if}
     <div class="flex gap-2 flex-wrap justify-center w-full text-sm">
         {#if !isUploadForm}
-            <button
-                class="btn-lg btn btn-danger w-full"
-                data-testid="removeEntity"
+            <Button
+                size="lg"
+                variant="danger"
+                class="w-full"
+                dataTestId="removeEntity"
                 onclick={() => removeEntity({ entityId: customEntity.id })}
-                >{$LL.mapEditor.entityEditor.buttons.delete()}</button
             >
+                {$LL.mapEditor.entityEditor.buttons.delete()}
+            </Button>
         {/if}
 
         <div class="flex gap-2 w-full mt-2">
-            <button class="btn-lg btn btn-contrast w-full" onclick={closeForm}
-                >{$LL.mapEditor.entityEditor.buttons.cancel()}</button
-            >
+            <Button size="lg" variant="contrast" class="w-full" onclick={closeForm}>
+                {$LL.mapEditor.entityEditor.buttons.cancel()}
+            </Button>
 
-            <button
-                class="btn-lg btn btn-secondary w-full"
-                data-testid="applyEntityModifications"
+            <Button
+                size="lg"
+                variant="secondary"
+                class="w-full"
+                dataTestId="applyEntityModifications"
                 onclick={() => applyEntityModifications(getModifiedCustomEntity())}
-                >{isUploadForm
-                    ? $LL.mapEditor.entityEditor.buttons.upload()
-                    : $LL.mapEditor.entityEditor.buttons.save()}</button
             >
+                {isUploadForm ? $LL.mapEditor.entityEditor.buttons.upload() : $LL.mapEditor.entityEditor.buttons.save()}
+            </Button>
         </div>
     </div>
 </div>

--- a/play/src/front/Components/MapEditor/EntityEditor/EntityEditorPicker.svelte
+++ b/play/src/front/Components/MapEditor/EntityEditor/EntityEditorPicker.svelte
@@ -16,6 +16,7 @@
     } from "../../../Stores/MapEditorStore";
     import Input from "../../Input/Input.svelte";
     import ButtonClose from "../../Input/ButtonClose.svelte";
+    import Button from "../../UI/Button.svelte";
     import CustomEntityEditionForm from "./CustomEntityEditionForm/CustomEntityEditionForm.svelte";
     import EntitiesGrid from "./EntitiesGrid.svelte";
     import EntityImage from "./EntityItem/EntityImage.svelte";
@@ -329,12 +330,16 @@
                             />
                         </div>
                         {#if pickedEntity.type === "Custom"}
-                            <button
-                                class="btn btn-secondary"
-                                data-testid="editEntity"
+                            <Button
+                                variant="secondary"
+                                dataTestId="editEntity"
                                 onclick={() => setIsEditingCustomEntity(true)}
-                                ><IconPencil font-size={16} />{$LL.mapEditor.entityEditor.buttons.editEntity()}</button
                             >
+                                {#snippet icon()}
+                                    <IconPencil font-size={16} />
+                                {/snippet}
+                                {$LL.mapEditor.entityEditor.buttons.editEntity()}
+                            </Button>
                         {/if}
                         <div class="absolute top-1 right-1 p-1">
                             <ButtonClose

--- a/play/src/front/Components/MapEditor/PropertyEditor/JitsiRoomConfigEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/JitsiRoomConfigEditor.svelte
@@ -6,6 +6,7 @@
     import Input from "../../Input/Input.svelte";
     import PopUpContainer from "../../PopUp/PopUpContainer.svelte";
     import ButtonClose from "../../Input/ButtonClose.svelte";
+    import Button from "../../UI/Button.svelte";
     import { modals } from "@wa-modals";
 
     let defaultConfig: JitsiRoomConfigData = {
@@ -107,12 +108,12 @@
 
                 {#snippet buttons()}
                     <div class="w-full flex justify-between gap-2 p-2">
-                        <button class=" btn btn-light btn-border w-full h-12" onclick={() => modals.close()}>
+                        <Button variant="light" appearance="border" class="w-full h-12" onclick={() => modals.close()}>
                             {$LL.mapEditor.properties.jitsiRoomProperty.jitsiRoomConfig.cancel()}
-                        </button>
-                        <button class=" btn btn-secondary w-full h-12" onclick={saveAndClose}>
+                        </Button>
+                        <Button variant="secondary" class="w-full h-12" onclick={saveAndClose}>
                             {$LL.mapEditor.properties.jitsiRoomProperty.jitsiRoomConfig.validate()}
-                        </button>
+                        </Button>
                     </div>
                 {/snippet}
             </PopUpContainer>
@@ -134,10 +135,6 @@
                 margin-bottom: 0.25em;
                 padding-top: 0.25em;
                 padding-bottom: 0.25em;
-            }
-
-            button {
-                padding: 0;
             }
         }
     }

--- a/play/src/front/Components/MapEditor/PropertyEditor/LivekitRoomConfigEditor.svelte
+++ b/play/src/front/Components/MapEditor/PropertyEditor/LivekitRoomConfigEditor.svelte
@@ -6,6 +6,7 @@
     import Input from "../../Input/Input.svelte";
     import PopUpContainer from "../../PopUp/PopUpContainer.svelte";
     import ButtonClose from "../../Input/ButtonClose.svelte";
+    import Button from "../../UI/Button.svelte";
     import { modals } from "@wa-modals";
 
     let defaultConfig: LivekitRoomConfigData = {
@@ -119,16 +120,17 @@
 
                 {#snippet buttons()}
                     <div class="w-full flex justify-between gap-2 p-2">
-                        <button class=" btn btn-light btn-border w-full h-12" onclick={() => modals.close()}>
+                        <Button variant="light" appearance="border" class="w-full h-12" onclick={() => modals.close()}>
                             {$LL.mapEditor.properties.livekitRoomProperty.livekitRoomConfig.cancel()}
-                        </button>
-                        <button
-                            class=" btn btn-secondary w-full h-12"
-                            data-testid="livekitRoomConfigValidateButton"
+                        </Button>
+                        <Button
+                            variant="secondary"
+                            class="w-full h-12"
+                            dataTestId="livekitRoomConfigValidateButton"
                             onclick={saveAndClose}
                         >
                             {$LL.mapEditor.properties.livekitRoomProperty.livekitRoomConfig.validate()}
-                        </button>
+                        </Button>
                     </div>
                 {/snippet}
             </PopUpContainer>
@@ -150,10 +152,6 @@
                 margin-bottom: 0.25em;
                 padding-top: 0.25em;
                 padding-bottom: 0.25em;
-            }
-
-            button {
-                padding: 0;
             }
         }
     }

--- a/play/src/front/Components/MapEditor/WAMSettingsEditor.svelte
+++ b/play/src/front/Components/MapEditor/WAMSettingsEditor.svelte
@@ -11,6 +11,7 @@
     } from "../../Stores/MapEditorStore";
     import { userIsAdminStore, userIsEditorStore } from "../../Stores/GameStore";
     import ButtonClose from "../Input/ButtonClose.svelte";
+    import Button from "../UI/Button.svelte";
     import Megaphone from "./ConfigureMyRoom/Megaphone.svelte";
     import RecordingSettings from "./ConfigureMyRoom/RecordingSettings.svelte";
     import RoomSettings from "./ConfigureMyRoom/RoomSettings.svelte";
@@ -127,15 +128,16 @@
 
         <div class="w-full h-fit flex items-center justify-center p-2 space-x-2 bg-contrast/50 pointer-events-auto">
             <div class="flex flex-row justify-content-center w-full gap-2">
-                <button
-                    class="btn btn-outline hover:bg-white/10 w-full close-window"
+                <Button
+                    class="btn-outline hover:bg-white/10 w-full close-window"
                     onclick={(event) => {
                         event.preventDefault();
                         event.stopPropagation();
                         close();
                     }}
-                    >close
-                </button>
+                >
+                    close
+                </Button>
             </div>
         </div>
     </div>

--- a/play/src/front/Components/MeetingInvitation/MeetingInvitationPopup.svelte
+++ b/play/src/front/Components/MeetingInvitation/MeetingInvitationPopup.svelte
@@ -2,6 +2,7 @@
     import { LL } from "../../../i18n/i18n-svelte";
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { meetingInvitationRequestStore } from "../../Stores/MeetingInvitationStore";
+    import Button from "../UI/Button.svelte";
     import WokaFromUserId from "../Woka/WokaFromUserId.svelte";
     import { IconUsersGroup } from "@wa-icons";
 
@@ -54,19 +55,21 @@
         </div>
     </div>
     <div class="flex items-center bg-contrast w-full justify-center flex-row">
-        <button
-            type="button"
-            class="btn btn-light btn-ghost text-nowrap justify-center my-2 mx-1 min-w-0 !border !border-solid !border-transparent hover:!bg-white/30"
+        <Button
+            variant="light"
+            appearance="ghost"
+            class="text-nowrap my-2 mx-1 min-w-0 !border !border-solid !border-transparent hover:!bg-white/30"
             onclick={onAccept}
         >
             {$LL.chat.accept()}
-        </button>
-        <button
-            type="button"
-            class="btn btn-light btn-ghost text-nowrap justify-center my-2 mx-1 min-w-0 !border !border-solid !border-transparent hover:!border hover:!border-solid hover:!border-white/30 hover:!bg-transparent"
+        </Button>
+        <Button
+            variant="light"
+            appearance="ghost"
+            class="text-nowrap my-2 mx-1 min-w-0 !border !border-solid !border-transparent hover:!border hover:!border-solid hover:!border-white/30 hover:!bg-transparent"
             onclick={onDecline}
         >
             {$LL.chat.decline()}
-        </button>
+        </Button>
     </div>
 </div>

--- a/play/src/front/Components/Menu/AboutRoomSubMenu.svelte
+++ b/play/src/front/Components/Menu/AboutRoomSubMenu.svelte
@@ -3,6 +3,7 @@
     import { onMount } from "svelte";
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { LL } from "../../../i18n/i18n-svelte";
+    import Button from "../UI/Button.svelte";
 
     let gameScene = gameManager.getCurrentGameScene();
 
@@ -69,8 +70,8 @@
         <h3 class="h5 text-white/50">{mapName}</h3>
         <p class="whitespace-pre-line italic text-white/50">{mapDescription}</p>
         {#if mapLink}
-            <a href={mapLink} class="btn btn-sm btn-secondary uppercase inline-block" target="_blank"
-                >{$LL.menu.about.mapLink()}</a
+            <Button href={mapLink} variant="secondary" size="sm" class="uppercase inline-block" target="_blank"
+                >{$LL.menu.about.mapLink()}</Button
             >
         {/if}
         <!-- svelte-ignore a11y_click_events_have_key_events -->

--- a/play/src/front/Components/Menu/ChatSubMenu.svelte
+++ b/play/src/front/Components/Menu/ChatSubMenu.svelte
@@ -5,6 +5,7 @@
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import { gameManager } from "../../Phaser/Game/GameManager";
     import InputCheckbox from "../Input/InputCheckbox.svelte";
+    import Button from "../UI/Button.svelte";
     import resetKeyStorageConfirmationModal from "./ResetKeyStorageConfirmationModal.svelte";
     import { modals } from "@wa-modals";
 
@@ -40,10 +41,8 @@
                     />
                 </div>
                 <section class="centered-column resizing-width m-auto resizing-text">
-                    <button
-                        type="button"
-                        class="btn p-2 bg-danger-900 min-w-[220px] flex justify-center items-center"
-                        onclick={openResetKeyStorage}>{$LL.menu.chat.resetKeyStorageUpButtonLabel()}</button
+                    <Button class="p-2 bg-danger-900 min-w-[220px] flex items-center" onclick={openResetKeyStorage}
+                        >{$LL.menu.chat.resetKeyStorageUpButtonLabel()}</Button
                     >
                 </section>
             {:else}
@@ -51,13 +50,8 @@
                     <p class="text-gray-400 w-full text-center pt-2">
                         {$LL.chat.requiresLoginForChat()}
                     </p>
-                    <a
-                        type="button"
-                        class="btn light flex justify-center items-center w-1/2"
-                        href="/login"
-                        onclick={() => analyticsClient.login()}
-                    >
-                        {$LL.menu.profile.login()}</a
+                    <Button class="light flex items-center w-1/2" href="/login" onclick={() => analyticsClient.login()}>
+                        {$LL.menu.profile.login()}</Button
                     >
                 </div>
             {/if}

--- a/play/src/front/Components/Menu/GuestSubMenu.svelte
+++ b/play/src/front/Components/Menu/GuestSubMenu.svelte
@@ -13,6 +13,7 @@
     } from "../../Stores/InvitePreferencesStore";
     import InputSwitch from "../Input/InputSwitch.svelte";
     import Select from "../Input/Select.svelte";
+    import Button from "../UI/Button.svelte";
     import { IconCheck, IconShare } from "@wa-icons";
 
     const TIMEOUT_COPY_LINK_BUTTON = 5000;
@@ -139,12 +140,14 @@
                 <div class="pb-4 text-lg font-semibold">
                     {$LL.menu.invite.description()}
                 </div>
-                <button type="button" class="btn btn-secondary w-full" onclick={shareLink}>
-                    <IconShare font-size="20" stroke="1.5" class="me-2" />
+                <Button variant="secondary" class="w-full" onclick={shareLink}>
+                    {#snippet icon()}
+                        <IconShare font-size="20" stroke="1.5" />
+                    {/snippet}
                     <span class="text-lg font-bold">
                         {$LL.menu.invite.share()}
                     </span>
-                </button>
+                </Button>
             </div>
         {/if}
         <div class="share-url w-full block mobile:hidden">
@@ -156,22 +159,23 @@
                     class="grow h-12 text-sm border-white bg-contrast rounded-md border border-solid border-white/20"
                     value={location.toString()}
                 />
-                <button
-                    type="button"
-                    class="flex items-center btn btn-sm absolute right-2 transition-all text-center justify-center {linkCopied
-                        ? 'btn-success'
-                        : 'btn-secondary'}"
+                <Button
+                    variant={linkCopied ? "success" : "secondary"}
+                    size="sm"
+                    class="flex items-center absolute right-2 transition-all text-center"
                     onclick={() => {
                         changeCopyLinkButtonStatus();
                         copyLink();
                     }}
                 >
-                    <span class="flex items-center justify-center {linkCopied ? '' : 'hidden'}">
-                        <IconCheck class="text-white" />
-                    </span>
+                    {#snippet icon()}
+                        <span class="flex items-center justify-center {linkCopied ? '' : 'hidden'}">
+                            <IconCheck class="text-white" />
+                        </span>
+                    {/snippet}
                     <div hidden={!linkCopied}>{$LL.menu.invite.copied()}</div>
                     <div hidden={linkCopied}>{$LL.menu.invite.copy()}</div>
-                </button>
+                </Button>
             </div>
         </div>
     </div>

--- a/play/src/front/Components/Menu/ResetKeyStorageConfirmationModal.svelte
+++ b/play/src/front/Components/Menu/ResetKeyStorageConfirmationModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import Popup from "../Modal/Popup.svelte";
+    import Button from "../UI/Button.svelte";
     import LL from "../../../i18n/i18n-svelte";
     import { matrixSecurity } from "../../Chat/Connection/Matrix/MatrixSecurity";
     import { modals } from "@wa-modals";
@@ -22,11 +23,12 @@
         </div>
     {/snippet}
     {#snippet action()}
-        <button class="btn flex-1 justify-center" onclick={() => modals.close()}
+        <Button class="flex-1" onclick={() => modals.close()}
             >{$LL.menu.chat.resetKeyStorageConfirmationModal.cancel()}
-        </button>
-        <button
-            class="btn btn-secondary disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
+        </Button>
+        <Button
+            variant="secondary"
+            class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1"
             onclick={() => {
                 modals.close();
                 matrixSecurity.setupNewKeyStorage().catch(() => {
@@ -35,6 +37,6 @@
             }}
         >
             {$LL.menu.chat.resetKeyStorageConfirmationModal.continue()}
-        </button>
+        </Button>
     {/snippet}
 </Popup>

--- a/play/src/front/Components/Modal/GlobalCommunicationModal.svelte
+++ b/play/src/front/Components/Modal/GlobalCommunicationModal.svelte
@@ -34,6 +34,7 @@
     import ButtonClose from "../Input/ButtonClose.svelte";
     import Select from "../Input/Select.svelte";
     import InputCheckbox from "../Input/InputCheckbox.svelte";
+    import Button from "../UI/Button.svelte";
     import { IconAlertTriangle, IconInfoCircle, IconMessageShare, IconMusicShare, IconSpeakerPhone } from "@wa-icons";
 
     let mainModal: HTMLDivElement;
@@ -254,13 +255,16 @@
                             {$LL.megaphone.modal.liveMessage.title()}
                         </h4>
 
-                        <button
-                            class="btn-lg btn btn-light btn-border mt-2 mb-4"
+                        <Button
+                            variant="light"
+                            appearance="border"
+                            size="lg"
+                            class="mt-2 mb-4"
                             onclick={activateLiveMessage}
                             disabled={!$megaphoneCanBeUsedStore}
                         >
                             {$LL.megaphone.modal.liveMessage.button()}
-                        </button>
+                        </Button>
 
                         {#if !$megaphoneCanBeUsedStore}
                             <p class="help-text !text-danger-800">
@@ -297,13 +301,16 @@
                             {$LL.megaphone.modal.textMessage.title()}
                         </h4>
 
-                        <button
-                            class="btn-lg btn btn-light btn-border mb-4"
+                        <Button
+                            variant="light"
+                            appearance="border"
+                            size="lg"
+                            class="mb-4"
                             onclick={activateInputText}
                             disabled={!$userIsAdminStore}
                         >
                             {$LL.megaphone.modal.textMessage.button()}
-                        </button>
+                        </Button>
 
                         {#if !$userIsAdminStore}
                             <p class="help-text !text-danger-800">
@@ -340,13 +347,16 @@
                             {$LL.megaphone.modal.audioMessage.title()}
                         </h4>
 
-                        <button
-                            class="btn-lg btn btn-light btn-border mb-4"
+                        <Button
+                            variant="light"
+                            appearance="border"
+                            size="lg"
+                            class="mb-4"
                             onclick={activateUploadAudio}
                             disabled={!$userIsAdminStore}
                         >
                             {$LL.megaphone.modal.audioMessage.button()}
-                        </button>
+                        </Button>
 
                         {#if !$userIsAdminStore}
                             <p class="help-text !text-danger-800">
@@ -402,15 +412,15 @@
                     </div>
                     <div class="flex justify-center">
                         <section class="centered-column">
-                            <button
-                                class="btn btn-light"
+                            <Button
+                                variant="light"
                                 onclick={(event) => {
                                     event.preventDefault();
                                     send();
                                 }}
                             >
                                 {$LL.menu.globalMessage.send()}
-                            </button>
+                            </Button>
                         </section>
                     </div>
                 </div>
@@ -527,9 +537,9 @@
                                 {$LL.megaphone.modal.liveMessage.startMegaphone()}
                             </button>
                         {:else}
-                            <button class="btn btn-danger" onclick={stopLive}>
+                            <Button variant="danger" onclick={stopLive}>
                                 {$LL.megaphone.modal.liveMessage.stopMegaphone()}
-                            </button>
+                            </Button>
                         {/if}
                     </div>
                 </div>

--- a/play/src/front/Components/Modal/LimitRoomModal.svelte
+++ b/play/src/front/Components/Modal/LimitRoomModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { fly } from "svelte/transition";
     import { ADMIN_URL } from "../../Enum/EnvironmentVariable";
+    import Button from "../UI/Button.svelte";
 
     function register() {
         window.open(`${ADMIN_URL}/second-step-register`, "_self");
@@ -21,15 +22,16 @@
     </section>
 
     <section class="justify-center bottom-0 w-full bg-contrast p-4 flex flex-row space-x-4 mt-4 rounded-b-lg">
-        <button
-            class="btn btn-secondary grow"
+        <Button
+            variant="secondary"
+            class="grow"
             onclick={(event) => {
                 event.preventDefault();
                 register();
             }}
         >
             Register
-        </button>
+        </Button>
     </section>
 </div>
 

--- a/play/src/front/Components/Modal/Modal.svelte
+++ b/play/src/front/Components/Modal/Modal.svelte
@@ -5,6 +5,7 @@
     import { modalIframeStore, modalVisibilityStore } from "../../Stores/ModalStore";
     import { isMediaBreakpointUp } from "../../Utils/BreakpointsUtils";
     import { gameManager } from "../../Phaser/Game/GameManager";
+    import Button from "../UI/Button.svelte";
     import { IconX, IconArrowsMaximize, IconArrowsMinimize } from "@wa-icons";
 
     let modalIframe: HTMLIFrameElement | undefined = $state();
@@ -84,30 +85,39 @@
         >
             {#if modalUrl != undefined}
                 {#if $modalIframeStore?.allowFullScreen}
-                    <button
-                        class="btn btn-light btn-ghost rounded hidden @lg/main-layout:block"
+                    <Button
+                        variant="light"
+                        appearance="ghost"
+                        square
+                        class="rounded hidden @lg/main-layout:block"
                         onclick={() => (isFullScreened = !isFullScreened)}
                     >
-                        {#if isFullScreened}
-                            <IconArrowsMinimize font-size="20" class="text-white" />
-                        {:else}
-                            <IconArrowsMaximize font-size="20" class="text-white" />
-                        {/if}
-                    </button>
+                        {#snippet icon()}
+                            {#if isFullScreened}
+                                <IconArrowsMinimize font-size="20" class="text-white" />
+                            {:else}
+                                <IconArrowsMaximize font-size="20" class="text-white" />
+                            {/if}
+                        {/snippet}
+                    </Button>
                 {/if}
             {/if}
             {#if $modalIframeStore?.closable == undefined || $modalIframeStore?.closable == true}
-                <button
+                <Button
                     onclick={(event) => {
                         event.preventDefault();
                         close();
                     }}
-                    class="btn btn-danger rounded m-0"
+                    variant="danger"
+                    square
+                    class="rounded m-0"
                     style={isFullScreened == true ? "" : "margin: 0px;"}
-                    data-testid="close-modal-button"
+                    dataTestId="close-modal-button"
                 >
-                    <IconX font-size="20" class="text-white" />
-                </button>
+                    {#snippet icon()}
+                        <IconX font-size="20" class="text-white" />
+                    {/snippet}
+                </Button>
             {/if}
         </div>
         {#if modalUrl != undefined}

--- a/play/src/front/Components/Modal/ObjectDetails.svelte
+++ b/play/src/front/Components/Modal/ObjectDetails.svelte
@@ -14,6 +14,7 @@
     import { AreaPreview } from "../../Phaser/Components/MapEditor/AreaPreview";
     import { gameManager } from "../../Phaser/Game/GameManager";
     import AddPropertyButtonWrapper from "../MapEditor/PropertyEditor/AddPropertyButtonWrapper.svelte";
+    import Button from "../UI/Button.svelte";
     import LL from "../../../i18n/i18n-svelte";
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import { warningMessageStore } from "../../Stores/ErrorStore";
@@ -216,12 +217,12 @@
             </div>
             <div class="buttons-wrapper flex items-center justify-center p-2 space-x-2 bg-contrast pointer-events-auto">
                 <div class="flex flex-row justify-center w-full gap-2">
-                    <button class="btn btn-outline w-full hover:bg-contrast-600/50" onclick={close}
+                    <Button class="btn-outline w-full hover:bg-contrast-600/50" onclick={close}
                         >{$LL.mapEditor.explorer.details.close()}
-                    </button>
-                    <button class="btn btn-secondary w-full whitespace-nowrap" onclick={goTo}>
+                    </Button>
+                    <Button variant="secondary" class="w-full whitespace-nowrap" onclick={goTo}>
                         {actionButtonText}
-                    </button>
+                    </Button>
                 </div>
             </div>
         {:else if $mapExplorationObjectSelectedStore instanceof AreaPreview}
@@ -240,12 +241,12 @@
             </div>
             <div class="buttons-wrapper flex items-center justify-center p-2 space-x-2 bg-contrast pointer-events-auto">
                 <div class="flex flex-row justify-center w-full gap-2">
-                    <button class="btn btn-outline w-full hover:bg-contrast-600/50" onclick={close}>
+                    <Button class="btn-outline w-full hover:bg-contrast-600/50" onclick={close}>
                         {$LL.mapEditor.explorer.details.close()}
-                    </button>
-                    <button class="btn btn-secondary w-full whitespace-nowrap" onclick={goTo}>
+                    </Button>
+                    <Button variant="secondary" class="w-full whitespace-nowrap" onclick={goTo}>
                         {actionButtonText}
-                    </button>
+                    </Button>
                 </div>
             </div>
         {/if}

--- a/play/src/front/Components/PopUp/FilePopup.svelte
+++ b/play/src/front/Components/PopUp/FilePopup.svelte
@@ -2,6 +2,7 @@
     import { onMount, onDestroy } from "svelte";
     import type { UserInputManager } from "../../Phaser/UserInput/UserInputManager";
     import LL from "../../../i18n/i18n-svelte";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -24,8 +25,8 @@
 <PopUpContainer reduceOnSmallScreen={true}>
     {message}
     {#snippet buttons()}
-        <button class="btn btn-secondary btn-sm w-full max-w-96 justify-center" onclick={click}>
+        <Button variant="secondary" size="sm" class="w-full max-w-96" onclick={click}>
             {$LL.mapEditor.properties.openFile.label()}
-        </button>
+        </Button>
     {/snippet}
 </PopUpContainer>

--- a/play/src/front/Components/PopUp/MuteDialogPopup.svelte
+++ b/play/src/front/Components/PopUp/MuteDialogPopup.svelte
@@ -3,6 +3,7 @@
     import { LL } from "../../../i18n/i18n-svelte";
     import type { SpaceUserExtended } from "../../Space/SpaceInterface";
     import Woka from "../Woka/Woka.svelte";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -32,22 +33,17 @@
         </div>
     </div>
     {#snippet buttons()}
-        <button
-            type="button"
-            class="btn btn-outline w-1/2 max-w-80 justify-center responsive-message refuse-request"
+        <Button
+            class="btn-outline w-1/2 max-w-80 responsive-message refuse-request"
             onclick={(event) => {
                 event.preventDefault();
                 refuseRequest();
             }}
         >
             {$LL.follow.interactMenu.no()}
-        </button>
-        <button
-            type="button"
-            class="btn btn-secondary w-1/2 max-w-80 justify-center responsive-message accept-request"
-            onclick={acceptRequest}
-        >
+        </Button>
+        <Button variant="secondary" class="w-1/2 max-w-80 responsive-message accept-request" onclick={acceptRequest}>
             {$LL.follow.interactMenu.yes()}
-        </button>
+        </Button>
     {/snippet}
 </PopUpContainer>

--- a/play/src/front/Components/PopUp/PopUpConnect.svelte
+++ b/play/src/front/Components/PopUp/PopUpConnect.svelte
@@ -2,6 +2,7 @@
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import LL from "../../../i18n/i18n-svelte";
     import { popupStore } from "../../Stores/PopupStore";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     function goToLogin() {
@@ -14,14 +15,11 @@
 <PopUpContainer reduceOnSmallScreen={true}>
     {$LL.mapEditor.entityEditor.errors.dragNotConnected()}
     {#snippet buttons()}
-        <button class="btn btn-secondary btn-sm w-full max-w-96 justify-center" onclick={goToLogin}>
+        <Button variant="secondary" size="sm" class="w-full max-w-96" onclick={goToLogin}>
             {$LL.actionbar.login()}
-        </button>
-        <button
-            class="btn btn-outline btn-sm w-full max-w-96 justify-center"
-            onclick={() => popupStore.removePopup("popupConnect")}
-        >
+        </Button>
+        <Button size="sm" class="btn-outline w-full max-w-96" onclick={() => popupStore.removePopup("popupConnect")}>
             {$LL.actionbar.cancel()}
-        </button>
+        </Button>
     {/snippet}
 </PopUpContainer>

--- a/play/src/front/Components/PopUp/PopUpCopyUrl.svelte
+++ b/play/src/front/Components/PopUp/PopUpCopyUrl.svelte
@@ -3,6 +3,7 @@
     import LL from "../../../i18n/i18n-svelte";
     import { popupStore } from "../../Stores/PopupStore";
     import { coWebsites } from "../../Stores/CoWebsiteStore";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
     import { IconX } from "@wa-icons";
 
@@ -33,11 +34,16 @@
 <PopUpContainer reduceOnSmallScreen={true}>
     {$LL.notification.urlCopiedToClipboard()}
     {#snippet buttons()}
-        <button
-            class="btn btn-secondary !p-0 w-8 h-8 items-center btn-sm absolute top-2 right-2 z-50 pointer-events-auto"
+        <Button
+            variant="secondary"
+            size="sm"
+            square
+            class="!p-0 w-8 h-8 items-center absolute top-2 right-2 z-50 pointer-events-auto"
             onclick={closeBanner}
         >
-            <IconX font-size="20" class="text-white" />
-        </button>
+            {#snippet icon()}
+                <IconX font-size="20" class="text-white" />
+            {/snippet}
+        </Button>
     {/snippet}
 </PopUpContainer>

--- a/play/src/front/Components/PopUp/PopUpDropFileEntity.svelte
+++ b/play/src/front/Components/PopUp/PopUpDropFileEntity.svelte
@@ -21,6 +21,7 @@
     import { isTodoListVisibleStore } from "../../Stores/TodoListStore";
     import { warningMessageStore } from "../../Stores/ErrorStore";
     import { EditorToolName } from "../../Phaser/Game/MapEditor/MapEditorModeManager";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
     import DropFileEntityPicker from "./DropFileEntityPicker.svelte";
 
@@ -148,15 +149,11 @@
     </div>
 
     {#snippet buttons()}
-        <button
-            class="btn btn-secondary btn-sm w-full max-w-96 justify-center"
-            onclick={onSave}
-            data-testid="dropFileSave"
-        >
+        <Button variant="secondary" size="sm" class="w-full max-w-96" onclick={onSave} dataTestId="dropFileSave">
             {$LL.mapEditor.entityEditor.buttons.save()}
-        </button>
-        <button class="btn bg-white/10 hover:bg-white/30 btn-sm w-full max-w-96 justify-center" onclick={removePopup}>
+        </Button>
+        <Button size="sm" class="bg-white/10 hover:bg-white/30 w-full max-w-96" onclick={removePopup}>
             {$LL.mapEditor.entityEditor.buttons.cancel()}
-        </button>
+        </Button>
     {/snippet}
 </PopUpContainer>

--- a/play/src/front/Components/PopUp/PopUpFollow.svelte
+++ b/play/src/front/Components/PopUp/PopUpFollow.svelte
@@ -2,6 +2,7 @@
     import { followRoleStore, followStateStore, followUsersStore } from "../../Stores/FollowStore";
     import LL from "../../../i18n/i18n-svelte";
     import { gameManager } from "../../Phaser/Game/GameManager";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -125,82 +126,87 @@
 
     {#snippet buttons()}
         {#if $followStateStore === "requesting" && $followRoleStore === "follower"}
-            <button
-                type="button"
-                class="btn btn-light btn-ghost w-1/2 justify-center"
+            <Button
+                variant="light"
+                appearance="ghost"
+                class="w-1/2"
                 onclick={(event) => {
                     event.preventDefault();
                     reset();
                 }}
             >
                 {$LL.follow.interactMenu.no()}
-            </button>
-            <button
-                type="button"
-                class="btn btn-secondary w-1/2 justify-center"
+            </Button>
+            <Button
+                variant="secondary"
+                class="w-1/2"
                 onclick={(event) => {
                     event.preventDefault();
                     acceptFollowRequest();
                 }}
             >
                 {$LL.follow.interactMenu.yes()}
-            </button>
+            </Button>
         {/if}
 
         {#if $followStateStore === "ending"}
-            <button
-                type="button"
-                class="btn btn-secondary w-1/2 justify-center"
+            <Button
+                variant="secondary"
+                class="w-1/2"
                 onclick={(event) => {
                     event.preventDefault();
                     reset();
                 }}
             >
                 {$LL.follow.interactMenu.yes()}
-            </button>
-            <button
-                type="button"
-                class="btn btn-light btn-ghost w-1/2 justify-center"
+            </Button>
+            <Button
+                variant="light"
+                appearance="ghost"
+                class="w-1/2"
                 onclick={(event) => {
                     event.preventDefault();
                     abortEnding();
                 }}
             >
                 {$LL.follow.interactMenu.no()}
-            </button>
+            </Button>
         {/if}
 
         {#if $followStateStore === "active" || $followStateStore === "ending"}
             {#if $followRoleStore === "follower"}
-                <button
-                    type="button"
-                    class="btn btn-sm btn-danger w-full justify-center"
+                <Button
+                    variant="danger"
+                    size="sm"
+                    class="w-full"
                     onclick={(event) => {
                         event.preventDefault();
                         reset();
                     }}
                     >{$LL.actionbar.help.unfollow.title()}
-                </button>
+                </Button>
             {:else if $followUsersStore.length === 1}
-                <button
-                    type="button"
-                    class="btn btn-sm btn-danger w-full justify-center"
+                <Button
+                    variant="danger"
+                    size="sm"
+                    class="w-full"
                     onclick={(event) => {
                         event.preventDefault();
                         reset();
                     }}
                     >{$LL.actionbar.help.unfollow.title()}
-                </button>
+                </Button>
             {:else if $followUsersStore.length > 2}
-                <button
-                    type="button"
-                    class="btn btn-sm btn-danger w-full justify-center"
+                <Button
+                    variant="danger"
+                    size="sm"
+                    class="w-full"
                     onclick={(event) => {
                         event.preventDefault();
                         reset();
                     }}
                     >{$LL.actionbar.cancel()}
-                </button>
+                </Button>
             {/if}
         {/if}
     {/snippet}

--- a/play/src/front/Components/PopUp/PopUpJitsi.svelte
+++ b/play/src/front/Components/PopUp/PopUpJitsi.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount, onDestroy } from "svelte";
     import type { UserInputManager } from "../../Phaser/UserInput/UserInputManager";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -23,6 +24,6 @@
 <PopUpContainer reduceOnSmallScreen={true}>
     {message}
     {#snippet buttons()}
-        <button class="btn btn-secondary btn-sm w-full max-w-96 justify-center" onclick={click}>Enter Jitsi</button>
+        <Button variant="secondary" size="sm" class="w-full max-w-96" onclick={click}>Enter Jitsi</Button>
     {/snippet}
 </PopUpContainer>

--- a/play/src/front/Components/PopUp/PopUpMessage.svelte
+++ b/play/src/front/Components/PopUp/PopUpMessage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import TextGlobalMessage from "../Menu/TextGlobalMessage.svelte";
     import { consoleGlobalMessageManagerVisibleStore } from "../../Stores/ConsoleGlobalMessageManagerStore";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -49,8 +50,8 @@
     </div>
     {#snippet buttons()}
         <!-- TODO -->
-        <button class="btn btn-light btn-ghost w-1/2 justify-center"> Send Message </button>
+        <Button variant="light" appearance="ghost" class="w-1/2">Send Message</Button>
         <!-- Mettre l'action du send message -->
-        <button class="btn btn-secondary w-1/2 justify-center" onclick={closeBanner}> Close </button>
+        <Button variant="secondary" class="w-1/2" onclick={closeBanner}>Close</Button>
     {/snippet}
 </PopUpContainer>

--- a/play/src/front/Components/PopUp/PopupCowebsite.svelte
+++ b/play/src/front/Components/PopUp/PopupCowebsite.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount, onDestroy } from "svelte";
     import type { UserInputManager } from "../../Phaser/UserInput/UserInputManager";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -23,6 +24,6 @@
 <PopUpContainer reduceOnSmallScreen={true}>
     {message}
     {#snippet buttons()}
-        <button class="btn btn-secondary btn-sm w-full max-w-96 justify-center" onclick={click}>Open Website</button>
+        <Button variant="secondary" size="sm" class="w-full max-w-96" onclick={click}>Open Website</Button>
     {/snippet}
 </PopUpContainer>

--- a/play/src/front/Components/PopUp/Recording/RecordingCompletedToast.svelte
+++ b/play/src/front/Components/PopUp/Recording/RecordingCompletedToast.svelte
@@ -6,6 +6,7 @@
     import AppsIcon from "../../Icons/AppsIcon.svelte";
     import { analyticsClient } from "../../../Administration/AnalyticsClient";
     import ToastContainer from "../../Toasts/ToastContainer.svelte";
+    import Button from "../../UI/Button.svelte";
 
     interface Props {
         toastUuid: string;
@@ -67,16 +68,18 @@
     </div>
 
     {#snippet buttons()}
-        <button class="btn btn-ghost btn-sm w-1/2" onclick={() => recordingStore.hideCompletedPopup()}>
+        <Button appearance="ghost" size="sm" class="w-1/2" onclick={() => recordingStore.hideCompletedPopup()}>
             {$LL.recording.close()}
-        </button>
-        <button
-            class="btn btn-secondary btn-sm w-1/2"
-            data-testid="recording-completed-modal-open-recordings-list-button"
+        </Button>
+        <Button
+            variant="secondary"
+            size="sm"
+            class="w-1/2"
+            dataTestId="recording-completed-modal-open-recordings-list-button"
             onclick={openRecordingList}
         >
             {$LL.recording.notification.viewRecordings()}
-        </button>
+        </Button>
     {/snippet}
 </ToastContainer>
 

--- a/play/src/front/Components/PopUp/Recording/RecordingsListModal.svelte
+++ b/play/src/front/Components/PopUp/Recording/RecordingsListModal.svelte
@@ -13,6 +13,7 @@
     import { VideoCoWebsite } from "../../../WebRtc/CoWebsite/VideoCoWebsite";
     import DownloadIcon from "../../Icons/DownloadIcon.svelte";
     import { localUserStore } from "../../../Connection/LocalUserStore";
+    import Button from "../../UI/Button.svelte";
     import { IconRefresh, IconTrash, IconCamera, IconLayoutGrid, IconList, IconPlayFilled, IconDots } from "@wa-icons";
 
     const connection: GameScene["connection"] = gameManager.getCurrentGameScene().connection;
@@ -261,9 +262,9 @@
                             !
                         </div>
                         <p class="m-0 text-[0.9375rem] text-red-300">{$LL.recording.errorFetchingRecordings()}</p>
-                        <button class="btn btn-secondary btn-sm" onclick={() => queryRecordings()}>
+                        <Button variant="secondary" size="sm" onclick={() => queryRecordings()}>
                             {$LL.recording.refresh()}
-                        </button>
+                        </Button>
                     </div>
                 {:else if recordings.length === 0}
                     <div class="flex flex-col items-center justify-center gap-3 py-8 px-4 text-center">

--- a/play/src/front/Components/PopUp/TutorialInstruction.svelte
+++ b/play/src/front/Components/PopUp/TutorialInstruction.svelte
@@ -4,6 +4,7 @@
     import ChevronRightIcon from "../Icons/ChevronRightIcon.svelte";
     import XIcon from "../Icons/XIcon.svelte";
     import { currentBannerIndex } from "../../Stores/PopupStore";
+    import Button from "../UI/Button.svelte";
     import PopUpContainer from "./PopUpContainer.svelte";
 
     interface Props {
@@ -31,39 +32,54 @@
 <PopUpContainer reduceOnSmallScreen={true}>
     <div class="flex p-3 sm:p-4 gap-2 sm:space-x-4 pointer-events-auto items-center">
         <div class="min-w-[2.5rem] sm:min-w-0">
-            <button
-                class="btn btn-light btn-ghost btn-sm min-h-10 min-w-10 sm:min-h-0 sm:min-w-0 p-2 {0 <
-                    $currentBannerIndex && $currentBannerIndex < 5
+            <Button
+                variant="light"
+                appearance="ghost"
+                size="sm"
+                square
+                class="min-h-10 min-w-10 sm:min-h-0 sm:min-w-0 p-2 {0 < $currentBannerIndex && $currentBannerIndex < 5
                     ? ''
                     : 'opacity-20'}"
                 id="chevron-left"
                 onclick={goToPreviousBanner}
                 aria-label="Previous"
             >
-                <ChevronLeftIcon height="h-4" width="w-4" />
-            </button>
+                {#snippet icon()}
+                    <ChevronLeftIcon height="h-4" width="w-4" />
+                {/snippet}
+            </Button>
         </div>
         <div class="grow flex justify-end">
-            <button
-                class="btn btn-light btn-ghost btn-sm min-h-10 min-w-10 sm:min-h-0 sm:min-w-0 p-2 {$currentBannerIndex ===
-                4
+            <Button
+                variant="light"
+                appearance="ghost"
+                size="sm"
+                square
+                class="min-h-10 min-w-10 sm:min-h-0 sm:min-w-0 p-2 {$currentBannerIndex === 4
                     ? 'opacity-20 disabled'
                     : ''}"
                 id="chevron-right"
                 onclick={goToNextBanner}
                 aria-label="Next"
             >
-                <ChevronRightIcon height="h-4" width="w-4" />
-            </button>
+                {#snippet icon()}
+                    <ChevronRightIcon height="h-4" width="w-4" />
+                {/snippet}
+            </Button>
         </div>
         <div class="min-w-[2.5rem] sm:min-w-0">
-            <button
-                class="btn btn-secondary btn-sm min-h-10 min-w-10 sm:min-h-0 sm:min-w-0 p-2"
+            <Button
+                variant="secondary"
+                size="sm"
+                square
+                class="min-h-10 min-w-10 sm:min-h-0 sm:min-w-0 p-2"
                 onclick={closeBanner}
                 aria-label="Close"
             >
-                <XIcon height="h-4" width="w-4" />
-            </button>
+                {#snippet icon()}
+                    <XIcon height="h-4" width="w-4" />
+                {/snippet}
+            </Button>
         </div>
     </div>
     <div class="flex flex-col sm:flex-row pb-4 px-4 sm:px-8 gap-3 sm:gap-4 sm:space-x-4 items-center sm:items-start">
@@ -223,13 +239,9 @@
                 class="btn btn-light btn-sm btn-ghost flex-1 min-h-10 sm:min-h-0 justify-center tutorial-btn-secondary"
                 >View full tutorial</button
             >
-            <button
-                data-testId="close-tutorial-button"
-                class="btn btn-secondary btn-sm flex-1 min-h-10 sm:min-h-0 justify-center"
-                onclick={closeBanner}
-            >
+            <Button variant="secondary" size="sm" class="flex-1 min-h-10 sm:min-h-0" onclick={closeBanner}>
                 Close
-            </button>
+            </Button>
         </div>
     {/snippet}
 </PopUpContainer>

--- a/play/src/front/Components/PwaInstall/PwaInstallScreen.svelte
+++ b/play/src/front/Components/PwaInstall/PwaInstallScreen.svelte
@@ -15,6 +15,7 @@
         neverShowPwaPage,
     } from "../../Stores/PwaInstallStore";
     import { detectIos, markPwaPromptNeverShow } from "../../Utils/PwaInstallEligibility";
+    import Button from "../UI/Button.svelte";
     import { IconApps, IconAppWindow, IconHistory } from "@wa-icons";
 
     let logo = $state(logoImg);
@@ -178,25 +179,28 @@
 
                 <div class="flex flex-col gap-4">
                     {#if $pwaInstallUiStore.deferredPrompt && !$pwaInstallUiStore.isIos}
-                        <button
+                        <Button
                             type="button"
-                            class="btn btn-secondary !text-lg"
+                            variant="secondary"
+                            class="!text-lg"
                             onclick={handleInstall}
                             disabled={$pwaInstallUiStore.installing}
-                            data-testid="pwa-install-button"
+                            dataTestId="pwa-install-button"
                         >
-                            <svg class="h-5 w-5 shrink-0 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
-                                    stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
-                                />
-                            </svg>
+                            {#snippet icon()}
+                                <svg class="h-5 w-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        stroke-width="2"
+                                        d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                                    />
+                                </svg>
+                            {/snippet}
                             {$pwaInstallUiStore.installing
                                 ? $LL.warning.pwaInstall.installing()
                                 : $LL.warning.pwaInstall.install()}
-                        </button>
+                        </Button>
                     {/if}
 
                     <button

--- a/play/src/front/Components/ReportMenu/BlockSubMenu.svelte
+++ b/play/src/front/Components/ReportMenu/BlockSubMenu.svelte
@@ -3,6 +3,7 @@
     import { blackListManager } from "../../WebRtc/BlackListManager";
     import { showReportScreenStore, userReportEmpty } from "../../Stores/ShowReportScreenStore";
     import { LL } from "../../../i18n/i18n-svelte";
+    import Button from "../UI/Button.svelte";
 
     interface Props {
         userUUID?: string;
@@ -39,16 +40,17 @@
     <section class="w-full">
         <h3 class="blue-title justify-start">{$LL.report.block.title()}</h3>
         <p>{$LL.report.block.content({ userName })}</p>
-        <button
+        <Button
             type="button"
-            data-testid="blockmenu-block-user-button"
-            class="btn btn-danger w-full"
+            dataTestId="blockmenu-block-user-button"
+            variant="danger"
+            class="w-full"
             onclick={(event) => {
                 event.preventDefault();
                 blockUser();
             }}
         >
             {userIsBlocked ? $LL.report.block.unblock() : $LL.report.block.block()}
-        </button>
+        </Button>
     </section>
 </div>

--- a/play/src/front/Components/ReportMenu/ReportSubMenu.svelte
+++ b/play/src/front/Components/ReportMenu/ReportSubMenu.svelte
@@ -3,6 +3,7 @@
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { LL } from "../../../i18n/i18n-svelte";
     import TextArea from "../Input/TextArea.svelte";
+    import Button from "../UI/Button.svelte";
 
     interface Props {
         userUUID?: string;
@@ -53,9 +54,10 @@
             {/if}
         </section>
         <section>
-            <button
+            <Button
                 type="submit"
-                class="btn btn-danger w-full"
+                variant="danger"
+                class="w-full"
                 onclick={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
@@ -63,7 +65,7 @@
                 }}
             >
                 {$LL.report.submit()}
-            </button>
+            </Button>
         </section>
     </form>
 </div>

--- a/play/src/front/Components/Toasts/BrowserNoSoundInfoToast.svelte
+++ b/play/src/front/Components/Toasts/BrowserNoSoundInfoToast.svelte
@@ -3,6 +3,7 @@
     import { LL } from "../../../i18n/i18n-svelte";
     import { userActivationManager } from "../../Stores/UserActivationStore";
     import { audioPlaybackStore } from "../../Stores/AudioPlaybackStore";
+    import Button from "../UI/Button.svelte";
     import ToastContainer from "./ToastContainer.svelte";
 
     let isRetrying = $state(false);
@@ -56,10 +57,12 @@
         </p>
     </div>
     {#snippet buttons()}
-        <button
+        <Button
             type="button"
-            class="btn btn-secondary btn-sm flex-1"
-            data-testid="audio-playback-retry"
+            variant="secondary"
+            size="sm"
+            class="flex-1"
+            dataTestId="audio-playback-retry"
             disabled={isRetrying}
             onclick={(event) => {
                 event.stopPropagation();
@@ -68,6 +71,6 @@
             }}
         >
             {$LL.statusModal.turnSoundOn()}
-        </button>
+        </Button>
     {/snippet}
 </ToastContainer>

--- a/play/src/front/Components/Toasts/NoMicrophoneSoundToast.svelte
+++ b/play/src/front/Components/Toasts/NoMicrophoneSoundToast.svelte
@@ -5,6 +5,7 @@
     import { usedMicrophoneDeviceIdStore } from "../../Stores/MediaStore";
     import { microphoneValidatedForDeviceIdStore } from "../../Stores/MicrophoneValidatedForDeviceIdStore";
     import { toastStore } from "../../Stores/ToastStoreSingleton";
+    import Button from "../UI/Button.svelte";
     import ToastContainer from "./ToastContainer.svelte";
 
     interface Props {
@@ -34,10 +35,11 @@
         </p>
     </div>
     {#snippet buttons()}
-        <button
-            type="button"
-            class="btn btn-ghost btn-sm flex-1"
-            data-testid="no-microphone-sound-ignore"
+        <Button
+            appearance="ghost"
+            size="sm"
+            class="flex-1"
+            dataTestId="no-microphone-sound-ignore"
             onclick={(event) => {
                 event.stopPropagation();
                 event.preventDefault();
@@ -45,11 +47,13 @@
             }}
         >
             {$LL.actionbar.microphone.ignore()}
-        </button>
-        <button
+        </Button>
+        <Button
             type="button"
-            class="btn btn-danger btn-sm flex-1"
-            data-testid="no-microphone-sound-open-settings"
+            variant="danger"
+            size="sm"
+            class="flex-1"
+            dataTestId="no-microphone-sound-open-settings"
             onclick={(event) => {
                 event.stopPropagation();
                 event.preventDefault();
@@ -57,6 +61,6 @@
             }}
         >
             {$LL.actionbar.microphone.openSettings()}
-        </button>
+        </Button>
     {/snippet}
 </ToastContainer>

--- a/play/src/front/Components/TodoList/TodoList.svelte
+++ b/play/src/front/Components/TodoList/TodoList.svelte
@@ -11,6 +11,7 @@
     import { analyticsClient } from "../../Administration/AnalyticsClient";
     import { externalSvelteComponentService } from "../../Stores/Utils/externalSvelteComponentService";
     import ExternalComponents from "../ExternalModules/ExternalComponents.svelte";
+    import Button from "../UI/Button.svelte";
     import TodoTask from "./TodoTask.svelte";
     import { IconChevronRight } from "@wa-icons";
 
@@ -75,11 +76,11 @@
                         <p class="text-xs text-left">{$LL.externalModule.teams.connectToYourTeams()}</p>
                         -->
                         {#if get(externalSvelteComponentService.getComponentsByZone("todoListButton")).size === 0}
-                            <button
-                                class="btn disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1 justify-center"
+                            <Button
+                                class="disabled:text-gray-400 disabled:bg-gray-500 bg-secondary flex-1"
                                 onclick={goToLoginPage}
                                 >{$LL.menu.profile.login()}
-                            </button>
+                            </Button>
                         {/if}
                     </div>
                 {/if}

--- a/play/src/front/Components/UI/Button.svelte
+++ b/play/src/front/Components/UI/Button.svelte
@@ -2,11 +2,16 @@
     import type { Snippet } from "svelte";
 
     interface Props {
+        // Omit for the design system's bare `.btn` look. Note `contrast` is NOT the same thing:
+        // it layers on hover/disabled rules, and combined with ghost the design system's own
+        // `.btn-ghost.btn-contrast` ends in `text-danger`, turning the button red.
         variant?: "primary" | "secondary" | "contrast" | "neutral" | "danger" | "warning" | "success" | "light";
         appearance?: "filled" | "border" | "ghost";
         size?: "xs" | "sm" | "lg";
         square?: boolean;
         inlineBlock?: boolean;
+        // Renders an <a> instead of a <button>, for links that look like buttons.
+        href?: string;
         type?: "button" | "submit" | "reset";
         disabled?: boolean;
         dataTestId?: string;
@@ -19,11 +24,12 @@
     }
 
     let {
-        variant = "contrast",
+        variant = undefined,
         appearance = "filled",
         size = undefined,
         square = false,
         inlineBlock = false,
+        href = undefined,
         type = "button",
         disabled = false,
         dataTestId = undefined,
@@ -34,23 +40,30 @@
         children,
         ...rest
     }: Props = $props();
+
+    // Spread rather than `data-testid={dataTestId}`: an explicit attribute would win over
+    // {...rest} and clobber a caller-supplied data-testid with undefined.
+    let testIdAttr = $derived(dataTestId ? { "data-testid": dataTestId } : {});
+
+    // Interpolating is safe here: every entry is a static design-system `@layer components`
+    // rule, not a utility that Tailwind's scanner has to find in the source.
+    let classes = $derived(
+        [
+            "btn",
+            variant && `btn-${variant}`,
+            appearance === "border" && "btn-border",
+            appearance === "ghost" && "btn-ghost",
+            square && "btn-square",
+            inlineBlock && "btn-inline-block",
+            size && `btn-${size}`,
+            className,
+        ]
+            .filter(Boolean)
+            .join(" "),
+    );
 </script>
 
-<button
-    {...rest}
-    {type}
-    class="btn btn-{variant} {className}"
-    class:btn-border={appearance === "border"}
-    class:btn-ghost={appearance === "ghost"}
-    class:btn-square={square}
-    class:btn-inline-block={inlineBlock}
-    class:btn-xs={size === "xs"}
-    class:btn-sm={size === "sm"}
-    class:btn-lg={size === "lg"}
-    data-testid={dataTestId}
-    {disabled}
-    {onclick}
->
+{#snippet body()}
     {#if icon}
         <!-- btn-icon is only self-center: flex keeps an inline svg out of the .btn line box. -->
         <span class="btn-icon flex items-center">{@render icon()}</span>
@@ -61,4 +74,14 @@
     {#if notification}
         {@render notification()}
     {/if}
-</button>
+{/snippet}
+
+{#if href}
+    <a {...rest} {...testIdAttr} {href} class={classes} aria-disabled={disabled || undefined} {onclick}>
+        {@render body()}
+    </a>
+{:else}
+    <button {...rest} {...testIdAttr} {type} class={classes} {disabled} {onclick}>
+        {@render body()}
+    </button>
+{/if}

--- a/play/src/front/Components/UI/Chip.svelte
+++ b/play/src/front/Components/UI/Chip.svelte
@@ -2,15 +2,40 @@
     import type { Snippet } from "svelte";
 
     interface Props {
-        size?: "xs" | "sm";
+        variant?: "primary" | "secondary" | "contrast" | "neutral" | "danger" | "warning" | "success" | "light";
+        appearance?: "filled" | "border" | "ghost";
+        size?: "xs" | "sm" | "lg";
         display?: "inline" | "inline-flex";
         class?: string;
         children?: Snippet;
     }
 
-    let { size = "sm", display = "inline", class: className = "", children }: Props = $props();
+    let {
+        variant = "neutral",
+        appearance = "filled",
+        size = "sm",
+        display = "inline",
+        class: className = "",
+        children,
+    }: Props = $props();
+
+    // Static design-system classes, so interpolation is safe.
+    let classes = $derived(
+        [
+            "chip",
+            `chip-${size}`,
+            `chip-${variant}`,
+            appearance === "border" && "chip-border",
+            appearance === "ghost" && "chip-ghost",
+            display,
+            "items-center rounded-sm",
+            className,
+        ]
+            .filter(Boolean)
+            .join(" "),
+    );
 </script>
 
-<span class={`chip chip-${size} chip-neutral ${display} items-center rounded-sm ${className}`}>
+<span class={classes}>
     <span class="chip-label inline-flex items-center leading-none">{@render children?.()}</span>
 </span>

--- a/play/src/front/Components/UI/DuplicateUserConnectedModal.svelte
+++ b/play/src/front/Components/UI/DuplicateUserConnectedModal.svelte
@@ -2,6 +2,7 @@
     import { duplicateUserConnectedStore } from "../../Stores/DuplicateUserConnectedStore";
     import { LL } from "../../../i18n/i18n-svelte";
     import { localUserStore } from "../../Connection/LocalUserStore";
+    import Button from "./Button.svelte";
 
     let dontRemindAgain = $state(false);
 
@@ -41,14 +42,14 @@
                 <span>{$LL.warning.duplicateUserConnected.dontRemindAgain()}</span>
             </label>
             <div class="mt-6 flex justify-center">
-                <button
+                <Button
                     type="button"
-                    class="btn btn-secondary"
+                    variant="secondary"
                     onclick={confirmAndContinue}
-                    data-testid="duplicate-user-confirm-continue"
+                    dataTestId="duplicate-user-confirm-continue"
                 >
                     {$LL.warning.duplicateUserConnected.confirmContinue()}
-                </button>
+                </Button>
             </div>
         </div>
     </div>

--- a/play/src/front/Components/Video/DesktopCapturerSourcePicker.svelte
+++ b/play/src/front/Components/Video/DesktopCapturerSourcePicker.svelte
@@ -6,6 +6,7 @@
         showDesktopCapturerSourcePicker,
     } from "../../Stores/ScreenSharingStore";
     import type { DesktopCapturerSource } from "../../Interfaces/DesktopAppInterfaces";
+    import Button from "../UI/Button.svelte";
 
     let desktopCapturerSources: DesktopCapturerSource[] = $state([]);
     let interval: ReturnType<typeof setInterval>;
@@ -56,7 +57,7 @@
 </script>
 
 <div class="source-picker" transition:fly={{ y: -50, duration: 500 }}>
-    <button type="button" class="btn danger close" onclick={cancel}>&times;</button>
+    <Button type="button" class="danger close" onclick={cancel}>&times;</Button>
     <h2>Select a Screen or Window to share!</h2>
     <section class="streams">
         {#each desktopCapturerSources as source (source.id)}

--- a/play/src/front/Components/Woka/WokaCustomizeScene.svelte
+++ b/play/src/front/Components/Woka/WokaCustomizeScene.svelte
@@ -11,6 +11,7 @@
     import HatIcon from "../Icons/HatIcon.svelte";
     import SwordIcon from "../Icons/SwordIcon.svelte";
     import ShuffleIcon from "../Icons/ShuffleIcon.svelte";
+    import Button from "../UI/Button.svelte";
     import WokaPreview from "./WokaPreview.svelte";
     import type { WokaBodyPart, WokaData, WokaTexture } from "./WokaTypes";
     import { getItemsPerRow } from "./ItemsPerRow";
@@ -292,13 +293,18 @@
                         />
 
                         <div class="mt-4 space-y-2">
-                            <button
-                                class="btn btn-sm btn-light btn-border w-full px-4 py-2 bg-white/10 text-white rounded hover:bg-white/10 flex flex-row items-center justify-center gap-2"
+                            <Button
+                                size="sm"
+                                variant="light"
+                                appearance="border"
+                                class="w-full px-4 py-2 bg-white/10 text-white rounded hover:bg-white/10 flex flex-row items-center gap-2"
                                 onclick={randomizeOutfit}
                             >
-                                <ShuffleIcon fillColor="white" width="w-4" height="h-4" />
+                                {#snippet icon()}
+                                    <ShuffleIcon fillColor="white" width="w-4" height="h-4" />
+                                {/snippet}
                                 <span>{$LL.woka.customWoka.randomize()}</span>
-                            </button>
+                            </Button>
                         </div>
                     </div>
                     <div class="flex flex-col gap-0 mb-4 w-full lg:w-fit sm:hidden">

--- a/play/src/front/Components/Woka/WokaSelectScene.svelte
+++ b/play/src/front/Components/Woka/WokaSelectScene.svelte
@@ -4,6 +4,7 @@
     import { gameManager } from "../../Phaser/Game/GameManager";
     import { localUserStore } from "../../Connection/LocalUserStore";
     import { ABSOLUTE_PUSHER_URL } from "../../Enum/ComputedConst";
+    import Button from "../UI/Button.svelte";
     import WokaPreview from "./WokaPreview.svelte";
     import type { WokaCollection, WokaData, WokaTexture } from "./WokaTypes";
     import { getItemsPerRow } from "./ItemsPerRow";
@@ -230,13 +231,18 @@
                         />
 
                         <div class="mt-4 space-y-2">
-                            <button
-                                class="btn btn-sm btn-light btn-border w-full px-4 py-2 text-white rounded hover:bg-white/10 flex flex-row items-center justify-center gap-2"
+                            <Button
+                                size="sm"
+                                variant="light"
+                                appearance="border"
+                                class="w-full px-4 py-2 text-white rounded hover:bg-white/10 flex flex-row items-center gap-2"
                                 onclick={randomizeOutfit}
                             >
-                                <IconShuffle font-size="20" class="text-white" />
+                                {#snippet icon()}
+                                    <IconShuffle font-size="20" class="text-white" />
+                                {/snippet}
                                 <span>{$LL.woka.selectWoka.randomize()}</span>
-                            </button>
+                            </Button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
> Re-opens #6371 **directly onto `master`**. #6371 was accidentally merged into `fix/poll-create-dialog-design-system` (#6363) instead of `master`, so its changes never reached `master`. #6363 is now merged, so this PR is rebased onto `master` and contains **only** the component-migration work — the `Button`/`Chip`/`InputGroupLabel` wrappers it depends on already landed with #6363.

## Why

#6363 introduced the design-system component wrappers (`Button`, etc.). This applies the **same rule across `play`**: anything carrying a DS class on a raw element now goes through a component, so the DS surface lives in one reviewable place instead of being copy-pasted.

## What changed

**`Button` gains** an `href` mode (links styled as buttons) and — importantly — its **default variant is now `undefined`, not `contrast`**. A bare `.btn` must stay bare: the DS's own `.btn-ghost.btn-contrast` rule ends in `text-danger`, so defaulting to `contrast` turned plain ghost buttons **red**. (Caught by a subagent mid-migration; verified in `buttons.css`.)

**128 of 152 raw `<button class="btn">` call sites migrated** to `<Button>`, across 69 files.

**The 24 left raw are deliberate** — each would *silently lose styling* if moved onto a component, so leaving them raw is the correct call, not an oversight:
- a `<style>` block targets the button's class or the bare `button` tag (Svelte drops scoped CSS when the class lands on a component);
- `bind:this` / floating-UI anchors;
- `!important` colour overrides that must reach the text node, which the DS's `.btn-label` span would re-assert over.

**Also migrated:**
- `.input-label` group labels → `<InputGroupLabel>` (CreateRoomModal, CreateFolderModal). The genuine `<label for>` and two `SettingsSubMenu` heading-misuses are left raw on purpose.
- `.chip` → `<Chip>`, after **extending Chip to the full DS surface** (variant / appearance / lg size). Its 4 existing callers keep the neutral default unchanged.
- the inert `wa-searchbar` token (defined in no CSS anywhere) dropped from `ChatHeader` and `MessageInputBar`.

**Left raw, reported, not a clean fit** — and their wrapper components are therefore **not shipped** (they'd be dead code):
- the two `.avatar` boxes (`Message`, `TypingUsers`) wrap the existing domain component `Chat/Components/Avatar.svelte` — a name collision, and they need an `id` the wrapper doesn't expose;
- MapList's `.input-search` relies on a `peer` sibling relationship with its icon and on `type="text"`, which a wrapper `<div>` would break.

## Verification

`svelte-check`, `eslint`, `prettier`, `typecheck` all clean on the changed files. **All 285 test ids preserved** (verified by a before/after diff). No behaviour, wording, or i18n changes.

**Not verified visually** (build/vitest can't run on the dev host — rolldown's darwin binding is absent), hence the `deploy` label and CI E2E as the real gate. Genuine visual deltas worth a look on the deployed env: icon↔text spacing now comes from `.btn`'s own `gap` (was `mr-1`/`mr-2`), and a few icon-only buttons became `square` (aspect-square padding).

## Follow-up

The hard-case migration (#6372, `refactor/design-system-hard-cases`) is stacked on this branch and will be rebased on top once this lands.
