### PR TITLE
fix(play): close the Share popup when its button is hidden or on click/tap outside

### DIFF
--- a/play/src/front/Components/ActionBar/MenuIcons/InviteMenuItem.svelte
+++ b/play/src/front/Components/ActionBar/MenuIcons/InviteMenuItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onDestroy } from "svelte";
     import { inviteUserActivated } from "../../../Stores/MenuStore";
     import ActionBarButton from "../ActionBarButton.svelte";
     import LL from "../../../../i18n/i18n-svelte";
@@ -15,29 +16,45 @@
 
     let { first = undefined, last = undefined, classList = undefined }: Props = $props();
 
-    let displayTooltip = true;
     let closeFloatingUi: (() => void) | undefined = undefined;
     let triggerElement: HTMLElement | undefined = $state(undefined);
 
-    function showInviteScreen() {
-        if (!displayTooltip) {
-            closeFloatingUi?.();
-            closeFloatingUi = undefined;
-        } else if (triggerElement) {
-            analyticsClient.openInvite();
-            closeFloatingUi = showFloatingUi(
-                triggerElement,
-                GuestSubMenu,
-                {},
-                {
-                    placement: "bottom",
-                },
-                12,
-                true,
-            );
-        }
-        displayTooltip = !displayTooltip;
+    function closeInviteMenu(): void {
+        // Reset the handle before closing: close() calls back into onClose synchronously.
+        const close = closeFloatingUi;
+        closeFloatingUi = undefined;
+        close?.();
     }
+
+    function showInviteScreen() {
+        if (closeFloatingUi !== undefined) {
+            closeInviteMenu();
+            return;
+        }
+        if (triggerElement === undefined) {
+            return;
+        }
+        analyticsClient.openInvite();
+        closeFloatingUi = showFloatingUi(
+            triggerElement,
+            GuestSubMenu,
+            {},
+            {
+                placement: "bottom",
+            },
+            12,
+            true,
+            true,
+            () => {
+                closeFloatingUi = undefined;
+            },
+        );
+    }
+
+    // The popup is rendered by FloatingUiPopupList at the root of the app, so it outlives this
+    // component. The action bar is unmounted whenever the chat or the map editor leaves less than
+    // 285px of room, which would otherwise strand the popup with no way to close it.
+    onDestroy(closeInviteMenu);
 </script>
 
 {#if $inviteUserActivated}

--- a/play/src/front/Components/ActionBar/MenuIcons/InviteMenuItem.test.ts
+++ b/play/src/front/Components/ActionBar/MenuIcons/InviteMenuItem.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushSync, mount, unmount } from "svelte";
+import { get, readable, writable } from "svelte/store";
+import { floatingUiComponents } from "../../../Utils/svelte-floatingui-show";
+import InviteMenuItem from "./InviteMenuItem.svelte";
+
+// jsdom has neither ResizeObserver nor IntersectionObserver, which autoUpdate() relies on.
+vi.mock("@floating-ui/dom", () => ({
+    autoUpdate: () => () => {},
+    computePosition: () => Promise.resolve({ x: 0, y: 0, placement: "bottom", middlewareData: {} }),
+    arrow: () => ({}),
+    flip: () => ({}),
+    shift: () => ({}),
+    offset: () => ({}),
+    limitShift: () => ({}),
+}));
+
+vi.mock("../../../Stores/MenuStore", () => ({
+    inviteUserActivated: writable(true),
+}));
+
+vi.mock("../../../Administration/AnalyticsClient", () => ({
+    analyticsClient: { openInvite: vi.fn() },
+}));
+
+vi.mock("../../Menu/GuestSubMenu.svelte", () => ({
+    default: () => undefined,
+}));
+
+vi.mock("../../../../i18n/i18n-svelte", () => ({
+    default: readable({ menu: { invite: { share: () => "Share" } } }),
+}));
+
+let target: HTMLElement;
+
+function clickShareButton() {
+    const button = target.querySelector("button");
+    if (button === null) {
+        throw new Error("The share button was not rendered");
+    }
+    button.click();
+}
+
+/**
+ * FloatingUiPopupList renders the popup and applies the registered action to its content node.
+ * Doing it by hand is what arms the click-outside listener.
+ */
+function mountPopupContent(): HTMLElement {
+    const entry = [...get(floatingUiComponents).values()][0];
+    if (entry === undefined) {
+        throw new Error("No popup was registered");
+    }
+    const content = document.createElement("div");
+    document.body.appendChild(content);
+    entry.action(content);
+    return content;
+}
+
+beforeEach(() => {
+    target = document.createElement("div");
+    document.body.appendChild(target);
+});
+
+afterEach(() => {
+    target.remove();
+    floatingUiComponents.set(new Map());
+});
+
+describe("InviteMenuItem", () => {
+    it("opens and closes the popup when the button is toggled", async () => {
+        const component = mount(InviteMenuItem, { target });
+        flushSync();
+
+        clickShareButton();
+        expect(get(floatingUiComponents).size).toBe(1);
+
+        clickShareButton();
+        expect(get(floatingUiComponents).size).toBe(0);
+
+        await unmount(component);
+    });
+
+    it("closes the popup when the button is destroyed", async () => {
+        // The action bar is unmounted as soon as the chat or the map editor leaves less than 285px
+        // of room. The popup is rendered at the root of the app, so without an onDestroy it would
+        // stay on screen with no button left to close it.
+        const component = mount(InviteMenuItem, { target });
+        flushSync();
+
+        clickShareButton();
+        expect(get(floatingUiComponents).size).toBe(1);
+
+        await unmount(component);
+
+        expect(get(floatingUiComponents).size).toBe(0);
+    });
+
+    it("reopens the popup on the next click after a click outside closed it", async () => {
+        const component = mount(InviteMenuItem, { target });
+        flushSync();
+
+        clickShareButton();
+        mountPopupContent();
+
+        document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+        expect(get(floatingUiComponents).size).toBe(0);
+
+        // A single click has to be enough: if the component tracked its open state separately from
+        // the close handle, this click would be swallowed by a stale "close" branch.
+        clickShareButton();
+        expect(get(floatingUiComponents).size).toBe(1);
+
+        await unmount(component);
+    });
+
+    it("does not close the popup when the button itself is clicked", async () => {
+        const component = mount(InviteMenuItem, { target });
+        flushSync();
+
+        clickShareButton();
+        mountPopupContent();
+
+        // The click-outside listener must ignore mousedown on the trigger, otherwise it would race
+        // with the button's own toggle and reopen the popup immediately.
+        const button = target.querySelector("button");
+        button?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+        expect(get(floatingUiComponents).size).toBe(1);
+
+        await unmount(component);
+    });
+});

--- a/play/src/front/Utils/svelte-floatingui-show.test.ts
+++ b/play/src/front/Utils/svelte-floatingui-show.test.ts
@@ -1,7 +1,18 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { get } from "svelte/store";
 import type { WorkAdventureComponent } from "../../types/component";
 import { floatingUiComponents, showFloatingUi } from "./svelte-floatingui-show";
+
+// jsdom has neither ResizeObserver nor IntersectionObserver, which autoUpdate() relies on.
+vi.mock("@floating-ui/dom", () => ({
+    autoUpdate: () => () => {},
+    computePosition: () => Promise.resolve({ x: 0, y: 0, placement: "bottom", middlewareData: {} }),
+    arrow: () => ({}),
+    flip: () => ({}),
+    shift: () => ({}),
+    offset: () => ({}),
+    limitShift: () => ({}),
+}));
 
 const TestComponent = (() => undefined) as unknown as WorkAdventureComponent;
 const referenceNode = {} as Element;
@@ -25,5 +36,66 @@ describe("showFloatingUi", () => {
         expect([...get(floatingUiComponents).values()][0]?.zIndex).toBe(1100);
 
         close();
+    });
+});
+
+describe("showFloatingUi closeOnClickOutside", () => {
+    /**
+     * Arm the click-outside listener the way FloatingUiPopupList does: mount the popup with a real
+     * reference node, then run the registered content action against a real content node.
+     */
+    function open(onClose?: () => void) {
+        const reference = document.createElement("div");
+        const content = document.createElement("div");
+        document.body.append(reference, content);
+
+        showFloatingUi(reference, TestComponent, {}, undefined, 0, false, true, onClose);
+        const entry = [...get(floatingUiComponents).values()][0];
+        if (entry === undefined) {
+            throw new Error("No popup was registered");
+        }
+        entry.action(content);
+        return { reference, content };
+    }
+
+    // jsdom does not implement TouchEvent; the handler only reads e.target, so a generic Event of
+    // type "touchstart" fires the same listener.
+    const touchStart = () => new Event("touchstart", { bubbles: true });
+
+    it("closes on a mousedown outside the reference and content", () => {
+        open();
+
+        document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+
+        expect(get(floatingUiComponents).size).toBe(0);
+    });
+
+    it("closes on a touchstart outside (mobile, where the canvas swallows mousedown)", () => {
+        open();
+
+        document.body.dispatchEvent(touchStart());
+
+        expect(get(floatingUiComponents).size).toBe(0);
+    });
+
+    it("does not close when the reference or the content is touched", () => {
+        const { reference, content } = open();
+
+        reference.dispatchEvent(touchStart());
+        content.dispatchEvent(touchStart());
+
+        expect(get(floatingUiComponents).size).toBe(1);
+    });
+
+    it("calls onClose once when a tap fires touchstart then a compatibility mousedown", () => {
+        const onClose = vi.fn();
+        open(onClose);
+
+        // A single tap on most mobile browsers emits touchstart followed by a mousedown.
+        document.body.dispatchEvent(touchStart());
+        document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+
+        expect(get(floatingUiComponents).size).toBe(0);
+        expect(onClose).toHaveBeenCalledTimes(1);
     });
 });

--- a/play/src/front/Utils/svelte-floatingui-show.ts
+++ b/play/src/front/Utils/svelte-floatingui-show.ts
@@ -40,8 +40,15 @@ export function showFloatingUi(
     let arrowNode: HTMLElement | undefined;
     let contentNode: HTMLElement | undefined;
     let cleanup: (() => void) | null = null;
+    let closed = false;
 
     const close = () => {
+        // A single tap fires touchstart then a compatibility mousedown, so the click-outside
+        // handler can call this twice; keep it idempotent so onClose runs at most once.
+        if (closed) {
+            return;
+        }
+        closed = true;
         cleanup?.();
         cleanup = null;
         floatingUiComponents.update((components) => {
@@ -56,22 +63,26 @@ export function showFloatingUi(
         //options = { ...initOptions, ...contentOptions };
         initFloatingUi();
 
-        let clickOutsideHandler: ((e: MouseEvent) => void) | undefined;
+        let clickOutsideHandler: ((e: MouseEvent | TouchEvent) => void) | undefined;
         if (closeOnClickOutside) {
-            clickOutsideHandler = (e: MouseEvent) => {
+            clickOutsideHandler = (e: MouseEvent | TouchEvent) => {
                 const target = e.target as Node;
                 if (referenceNode.contains(target) || (contentNode && contentNode.contains(target))) {
                     return;
                 }
                 close();
             };
+            // Listen to touchstart too: on the game canvas Phaser swallows the compatibility
+            // mousedown, so a mousedown-only listener never fires on touch devices.
             document.addEventListener("mousedown", clickOutsideHandler);
+            document.addEventListener("touchstart", clickOutsideHandler);
         }
 
         return {
             destroy() {
                 if (clickOutsideHandler) {
                     document.removeEventListener("mousedown", clickOutsideHandler);
+                    document.removeEventListener("touchstart", clickOutsideHandler);
                 }
                 deinitFloatingUi();
             },

--- a/play/vite.config.ts
+++ b/play/vite.config.ts
@@ -75,6 +75,8 @@ export default defineConfig(({ mode }) => {
             tsconfigPaths(),
         ],
         resolve: {
+            // Without this, vitest resolves Svelte to its server build and mount() is unavailable.
+            conditions: mode === "test" ? ["browser"] : undefined,
             alias: {
                 events: "events",
                 "@wa-icons": fileURLToPath(new URL("./src/front/Components/Icons.ts", import.meta.url)),


### PR DESCRIPTION
## Problem

On mobile, opening the **Share** popup and then opening the chat left the popup on screen with no way to close it.

## Root cause

`showFloatingUi()` registers the popup in a global store that `FloatingUiPopupList` renders at the **root** of the app, so the popup's lifetime is decoupled from the button that opened it. `InviteMenuItem` kept the returned `close()` handle in a local variable but had no `onDestroy`, so when the button was unmounted the handle was lost and the popup was stranded.

The action bar is unmounted entirely by `{#if !$hideActionBarStoreBecauseOfChatBar}`. That store is true when `windowSize.width - chatSidebarWidth < 285` — with `INITIAL_SIDEBAR_WIDTH = 335` that means **any viewport under ~620px** with the chat open, and it **also triggers when the map editor opens**. So it is not strictly a mobile-only or chat-only bug; a narrow desktop window reproduces it too.

The lock-up was total because all three escape hatches were missing at once: the toggle button was gone, click-outside was disabled, and `GuestSubMenu` has no close button of its own.

## Fix

Two commits:

1. **`InviteMenuItem`** — close the popup on `onDestroy`, matching `ProfileMenu` and five other `showFloatingUi` callers. `displayTooltip` is dropped in favour of the close handle as the single source of truth (keeping it alongside the new `onClose` would desync it on an outside-close and swallow the next click). Also turns on `closeOnClickOutside` as a net.

2. **`svelte-floatingui-show`** — the click-outside listener only watched `mousedown`. On the game canvas Phaser's default `input.touch.capture` preventDefaults the touch and swallows the compatibility `mousedown`, so a tap outside never closed the popup on touch devices. Now listens to `touchstart` too (the pattern already used in `UserActionButton`), and `close()` is made idempotent since one tap fires both `touchstart` and a compatibility `mousedown`. This hardens click-outside for **all** floating-ui popups.

## Tests

- New component test (`InviteMenuItem.test.ts`) using Svelte 5's `mount`/`unmount`/`flushSync` — proves the popup closes on destroy and reopens cleanly. Confirmed to fail against the pre-fix component.
- New click-outside cases in `svelte-floatingui-show.test.ts` — mousedown/touchstart outside close, touches on the reference/content don't, and `onClose` fires once on a touchstart+mousedown tap. The touchstart case fails against the pre-fix helper.
- The `resolve.conditions: ["browser"]` (test mode only) line in `vite.config.ts` lets vitest resolve Svelte's client build so components can be mounted.
- Full `play` vitest suite green; `eslint src/ tests/` clean.

## Not in scope (follow-up)

`RoomUserList.svelte` and `EmojiButton.svelte` open floating-ui popups without an `onDestroy` — same latent bug, worth a separate change.
