### PR TITLE
feat(map-editor): sort explorer zones and objects by name

### DIFF
--- a/play/src/front/Components/Exploration/Explorer.svelte
+++ b/play/src/front/Components/Exploration/Explorer.svelte
@@ -40,6 +40,24 @@
         if ($mapExplorationAreasStore) areasListFiltered.set($mapExplorationAreasStore);
     }
 
+    // Name used to display and sort an entity: its custom name if set, otherwise the prefab name.
+    function getEntityDisplayName(entity: Entity): string {
+        const name = entity.getEntityData().name;
+        return name && name !== "" ? name : entity.getPrefab().name;
+    }
+
+    // Name used to display and sort an area (may be an empty string when the area has no name).
+    function getAreaDisplayName(area: AreaPreview): string {
+        return area.getAreaData().name;
+    }
+
+    // Sort the filtered entries alphabetically by display name (case-insensitive, natural number order).
+    function sortByName<T>(entries: Iterable<[string, T]>, getName: (item: T) => string): Array<[string, T]> {
+        return [...entries].sort(([, a], [, b]) =>
+            getName(a).localeCompare(getName(b), undefined, { sensitivity: "base", numeric: true }),
+        );
+    }
+
     function onChangeFilterHandle() {
         entitiesListFiltered.set(new Map());
         for (let [key, entity] of $mapExplorationEntitiesStore) {
@@ -398,7 +416,7 @@
 
             {#if entityListActive && $entitiesListFiltered.size > 0}
                 <div class="entity-items p-2 flex flex-col">
-                    {#each [...$entitiesListFiltered] as [key, entity] (key)}
+                    {#each sortByName($entitiesListFiltered, getEntityDisplayName) as [key, entity] (key)}
                         <!-- svelte-ignore a11y_click_events_have_key_events -->
                         <!-- svelte-ignore a11y_no_static_element_interactions -->
                         <div
@@ -487,7 +505,7 @@
             {#if areaListActive && $areasListFiltered.size > 0}
                 <div class="area-items p-2 flex flex-col">
                     {#if $areasListFiltered.size > 0}
-                        {#each [...$areasListFiltered] as [key, area] (key)}
+                        {#each sortByName($areasListFiltered, getAreaDisplayName) as [key, area] (key)}
                             <!-- svelte-ignore a11y_click_events_have_key_events -->
                             <!-- svelte-ignore a11y_no_static_element_interactions -->
                             <div


### PR DESCRIPTION
## What

In the room **explorer** (map editor), the searchable **objects** (entities) and **zones** (areas) lists were rendered in their raw insertion order. This PR sorts both lists **alphabetically by name** so they're easier to scan and find.

## Details

- Added a small generic `sortByName()` helper plus `getEntityDisplayName()` / `getAreaDisplayName()` in `Explorer.svelte`, and applied them to the two `{#each}` blocks that render the entity and area lists.
- The entity sort reuses the exact display-name logic already used by the rows: the entity's custom name when set, otherwise the prefab name — so the order matches what the user sees.
- Sorting is **case-insensitive** and uses **natural number ordering** (`localeCompare` with `{ sensitivity: "base", numeric: true }`), so e.g. `item2` comes before `item10`.
- Sorting is applied at render time from the already-filtered stores, so it stays in sync with the search box and property filters with no change to the filtering logic.

## Screenshots

_Behavioral change only — the two lists in the explorer panel are now ordered A→Z._

## Verification

- `svelte-check` on `play`: **0 errors** in `Explorer.svelte` (after regenerating typesafe-i18n types).
- `eslint` on the modified file: clean.
- `prettier --check`: clean.